### PR TITLE
Add wishlist categories

### DIFF
--- a/app/routes/resources+/wishlist-categories.tsx
+++ b/app/routes/resources+/wishlist-categories.tsx
@@ -1,0 +1,14 @@
+import { type ActionFunctionArgs, json } from '@remix-run/node'
+import { requireUserId } from '#app/utils/auth.server.ts'
+import { createCategory } from '#app/utils/wishlist.server.ts'
+
+export async function action({ request }: ActionFunctionArgs) {
+  const userId = await requireUserId(request)
+  const formData = await request.formData()
+  const name = formData.get('name')
+  if (typeof name !== 'string' || !name) {
+    return json({ error: 'Name required' }, { status: 400 })
+  }
+  const category = await createCategory(userId, name)
+  return json({ category })
+}

--- a/app/routes/users+/$username_+/wishlist.tsx
+++ b/app/routes/users+/$username_+/wishlist.tsx
@@ -11,16 +11,34 @@ export const loader = async ({ params, request }: LoaderFunctionArgs) => {
 
 	const userId = await requireUserId(request)
 	await requireUsersShareAGroup({ userId, username: username! })
-	const user = await prisma.user.findFirst({
-		select: {
-			id: true,
-			name: true,
-			username: true,
-			wishlistItems: { select: { id: true, title: true, ownerId: true } },
-			image: { select: { id: true } },
-		},
-		where: { username },
-	})
+        const user = await prisma.user.findFirst({
+                select: {
+                        id: true,
+                        name: true,
+                        username: true,
+                        wishlistItems: {
+                                select: { id: true, title: true, ownerId: true },
+                                where: { categoryId: null },
+                        },
+                        wishlistCategories: {
+                                orderBy: { position: 'asc' },
+                                select: {
+                                        id: true,
+                                        name: true,
+                                        position: true,
+                                        items: {
+                                                select: {
+                                                        id: true,
+                                                        title: true,
+                                                        ownerId: true,
+                                                },
+                                        },
+                                },
+                        },
+                        image: { select: { id: true } },
+                },
+                where: { username },
+        })
 
 	invariantResponse(user, 'User not found', { status: 404 })
 

--- a/app/routes/wishlist+/__wishlist-item-editor.server.tsx
+++ b/app/routes/wishlist+/__wishlist-item-editor.server.tsx
@@ -20,9 +20,9 @@ export async function action({ request }: ActionFunctionArgs) {
 		createMemoryUploadHandler({ maxPartSize: MAX_UPLOAD_SIZE }),
 	)
 
-	const submission = await parseWithZod(formData, {
-		schema: WishlistItemSchema.superRefine(async (data, ctx) => {
-			if (!data.id) return
+        const submission = await parseWithZod(formData, {
+                schema: WishlistItemSchema.superRefine(async (data, ctx) => {
+                        if (!data.id) return
 
 			const wishlistItem = await prisma.wishlistItem.findUnique({
 				select: { id: true },
@@ -34,13 +34,13 @@ export async function action({ request }: ActionFunctionArgs) {
 					message: 'Wishlist item not found',
 				})
 			}
-		}).transform(async ({ ...data }) => {
-			return {
-				...data,
-			}
-		}),
-		async: true,
-	})
+                }).transform(async ({ ...data }) => {
+                        return {
+                                ...data,
+                        }
+                }),
+                async: true,
+        })
 
 	if (submission.status !== 'success') {
 		return json(submission.reply(), {
@@ -48,19 +48,21 @@ export async function action({ request }: ActionFunctionArgs) {
 		})
 	}
 
-	const { id: wishlistItemId, value } = submission.value
+        const { id: wishlistItemId, value, categoryId } = submission.value
 
-	await prisma.wishlistItem.upsert({
-		select: { id: true, owner: { select: { username: true } } },
-		where: { id: wishlistItemId ?? '__new_wishlist_item__' },
-		create: {
-			ownerId: userId,
-			title: value,
-		},
-		update: {
-			title: value,
-		},
-	})
+        await prisma.wishlistItem.upsert({
+                select: { id: true, owner: { select: { username: true } } },
+                where: { id: wishlistItemId ?? '__new_wishlist_item__' },
+                create: {
+                        ownerId: userId,
+                        title: value,
+                        categoryId,
+                },
+                update: {
+                        title: value,
+                        categoryId,
+                },
+        })
 
 	return json(submission.reply())
 }

--- a/app/routes/wishlist+/__wishlist-item-editor.tsx
+++ b/app/routes/wishlist+/__wishlist-item-editor.tsx
@@ -15,14 +15,17 @@ const valueMinLength = 1
 const valueMaxLength = 255
 
 export const WishlistItemSchema = z.object({
-	id: z.string().optional(),
-	value: z.string().min(valueMinLength).max(valueMaxLength),
+        id: z.string().optional(),
+        value: z.string().min(valueMinLength).max(valueMaxLength),
+        categoryId: z.string().optional(),
 })
 
 export function WishlistItemEditor({
 	wishlistItem,
 }: {
-	wishlistItem?: SerializeFrom<Pick<WishlistItem, 'id' | 'title'>>
+        wishlistItem?: SerializeFrom<Pick<WishlistItem, 'id' | 'title' | 'categoryId'>> & {
+                categoryId?: string | null
+        }
 }) {
 	const actionData = useActionData<typeof action>()
 	const isPending = useIsPending()
@@ -42,9 +45,10 @@ export function WishlistItemEditor({
 		onValidate({ formData }) {
 			return parseWithZod(formData, { schema: WishlistItemSchema })
 		},
-		defaultValue: {
-			value: wishlistItem?.title ?? '',
-		},
+               defaultValue: {
+                        value: wishlistItem?.title ?? '',
+                        categoryId: wishlistItem?.categoryId ?? undefined,
+                },
 	})
 
 	return (
@@ -62,9 +66,12 @@ export function WishlistItemEditor({
 					rather than the first button in the form (which is delete/add image).
 				*/}
 				<button type="submit" className="hidden" />
-				{wishlistItem ? (
-					<input type="hidden" name="id" value={wishlistItem.id} />
-				) : null}
+                                {wishlistItem ? (
+                                        <input type="hidden" name="id" value={wishlistItem.id} />
+                                ) : null}
+                                {fields.categoryId ? (
+                                        <input {...getInputProps(fields.categoryId, { type: 'hidden' })} />
+                                ) : null}
 				<div className="flex flex-col gap-1">
 					<Field
 						className="w-80"

--- a/app/routes/wishlist+/__wishlist.tsx
+++ b/app/routes/wishlist+/__wishlist.tsx
@@ -3,7 +3,7 @@ import {
 	type UserImage,
 	type WishlistItem as WishlistItemType,
 } from '@prisma/client'
-import { Link } from '@remix-run/react'
+import { Link, useFetcher } from '@remix-run/react'
 import { getUserImgSrc } from '#app/utils/misc.tsx'
 import { WishlistItem } from './__wishlist-item'
 import { WishlistItemEditor } from './__wishlist-item-editor'
@@ -12,13 +12,20 @@ export function Wishlist({
 	user,
 	isOwner,
 }: {
-	user: Pick<User, 'username' | 'name'> & {
-		image: Pick<UserImage, 'id'> | null
-		wishlistItems: Pick<WishlistItemType, 'id' | 'title' | 'ownerId'>[]
-	}
+        user: Pick<User, 'username' | 'name'> & {
+                image: Pick<UserImage, 'id'> | null
+                wishlistItems: Pick<WishlistItemType, 'id' | 'title' | 'ownerId'>[]
+                wishlistCategories: {
+                        id: string
+                        name: string
+                        position: number
+                        items: Pick<WishlistItemType, 'id' | 'title' | 'ownerId'>[]
+                }[]
+        }
 	isOwner: boolean
 }) {
-	const displayName = user.name ?? user.username
+       const displayName = user.name ?? user.username
+       const addCategoryFetcher = useFetcher()
 	return (
 		<div>
 			<Link
@@ -34,31 +41,59 @@ export function Wishlist({
 					{displayName}'s Wishlist
 				</h1>
 			</Link>
-			<div>
-				{isOwner && <WishlistItemEditor />}
-				{user.wishlistItems.length === 0 ? (
-					<div className="flex w-full flex-col items-center justify-center">
-						{isOwner ? (
-							<p className="text-center text-base text-slate-500">
-								Looks like you don't have any items in your wishlist yet! You
-								don't want stuff? Really?
-							</p>
-						) : (
-							<p className="text-center text-base text-slate-500">
-								{displayName} doesn't have any items in their wishlist yet!
-							</p>
-						)}
-					</div>
-				) : (
-					<ul className="overflow-y-auto overflow-x-hidden pb-12">
-						{user.wishlistItems.map((wishlistItem) => (
-							<li key={wishlistItem.id}>
-								<WishlistItem wishlistItem={wishlistItem} />
-							</li>
-						))}
-					</ul>
-				)}
-			</div>
+                        <div className="space-y-4">
+                                {isOwner && (
+                                        <addCategoryFetcher.Form method="POST" action="/resources/wishlist-categories" className="flex gap-2">
+                                                <input name="name" className="flex-1 rounded border px-2" placeholder="New category" />
+                                                <button type="submit">➕ Add category</button>
+                                        </addCategoryFetcher.Form>
+                                )}
+                                {isOwner && <WishlistItemEditor />}
+                                {user.wishlistCategories.map((category) => (
+                                        <div key={category.id} className="rounded-md border p-2">
+                                                <div className="mb-2 flex items-center justify-between">
+                                                        <h2 className="font-semibold">{category.name}</h2>
+                                                        {isOwner && (
+                                                                <WishlistItemEditor wishlistItem={{ categoryId: category.id, id: '', title: '' }} />
+                                                        )}
+                                                </div>
+                                                {category.items.length ? (
+                                                        <ul className="overflow-x-hidden pb-2">
+                                                                {category.items.map((wishlistItem) => (
+                                                                        <li key={wishlistItem.id}>
+                                                                                <WishlistItem wishlistItem={wishlistItem} />
+                                                                        </li>
+                                                                ))}
+                                                        </ul>
+                                                ) : (
+                                                        <p className="text-sm text-slate-500">No items</p>
+                                                )}
+                                        </div>
+                                ))}
+                                {user.wishlistItems.length ? (
+                                        <ul className="overflow-y-auto overflow-x-hidden pb-12">
+                                                {user.wishlistItems.map((wishlistItem) => (
+                                                        <li key={wishlistItem.id}>
+                                                                <WishlistItem wishlistItem={wishlistItem} />
+                                                        </li>
+                                                ))}
+                                        </ul>
+                                ) : null}
+                                {user.wishlistItems.length === 0 && user.wishlistCategories.length === 0 && (
+                                        <div className="flex w-full flex-col items-center justify-center">
+                                                {isOwner ? (
+                                                        <p className="text-center text-base text-slate-500">
+                                                                Looks like you don't have any items in your wishlist yet! You
+                                                                don't want stuff? Really?
+                                                        </p>
+                                                ) : (
+                                                        <p className="text-center text-base text-slate-500">
+                                                                {displayName} doesn't have any items in their wishlist yet!
+                                                        </p>
+                                                )}
+                                        </div>
+                                )}
+                        </div>
 		</div>
 	)
 }

--- a/app/routes/wishlist+/index.tsx
+++ b/app/routes/wishlist+/index.tsx
@@ -9,16 +9,34 @@ import { action } from './__wishlist-item-editor.server'
 
 export async function loader({ request }: LoaderFunctionArgs) {
 	const userId = await requireUserId(request)
-	const user = await prisma.user.findFirst({
-		select: {
-			id: true,
-			name: true,
-			username: true,
-			wishlistItems: { select: { id: true, title: true, ownerId: true } },
-			image: { select: { id: true } },
-		},
-		where: { id: userId },
-	})
+        const user = await prisma.user.findFirst({
+                select: {
+                        id: true,
+                        name: true,
+                        username: true,
+                        wishlistItems: {
+                                select: { id: true, title: true, ownerId: true },
+                                where: { categoryId: null },
+                        },
+                        wishlistCategories: {
+                                orderBy: { position: 'asc' },
+                                select: {
+                                        id: true,
+                                        name: true,
+                                        position: true,
+                                        items: {
+                                                select: {
+                                                        id: true,
+                                                        title: true,
+                                                        ownerId: true,
+                                                },
+                                        },
+                                },
+                        },
+                        image: { select: { id: true } },
+                },
+                where: { id: userId },
+        })
 
 	invariantResponse(user, 'User not found', { status: 404 })
 

--- a/app/utils/wishlist.server.test.ts
+++ b/app/utils/wishlist.server.test.ts
@@ -1,0 +1,33 @@
+/**
+ * @vitest-environment node
+ */
+import { expect, test } from 'vitest'
+import { prisma } from './db.server'
+import { createCategory, addItemToCategory, listCategories } from './wishlist.server'
+import { createUser, createPassword } from '#tests/db-utils.ts'
+
+// @vitest-environment node
+
+test('create category and add item', async () => {
+  const userData = createUser()
+  const user = await prisma.user.create({
+    data: {
+      ...userData,
+      password: { create: createPassword() },
+      roles: { connect: { name: 'user' } },
+    },
+    select: { id: true },
+  })
+
+  const category = await createCategory(user.id, 'Test Cat')
+  const item = await prisma.wishlistItem.create({
+    data: { ownerId: user.id, title: 'gift' },
+    select: { id: true },
+  })
+
+  await addItemToCategory(item.id, category.id)
+
+  const categories = await listCategories(user.id)
+  expect(categories).toHaveLength(1)
+  expect(categories[0]?.items[0]?.id).toBe(item.id)
+})

--- a/app/utils/wishlist.server.ts
+++ b/app/utils/wishlist.server.ts
@@ -1,0 +1,23 @@
+import { prisma } from './db.server.ts'
+
+export async function createCategory(ownerId: string, name: string) {
+  const position =
+    (await prisma.wishlistCategory.count({ where: { ownerId } })) + 1
+  return prisma.wishlistCategory.create({
+    data: { ownerId, name, position },
+  })
+}
+
+export async function listCategories(ownerId: string) {
+  return prisma.wishlistCategory.findMany({
+    where: { ownerId },
+    orderBy: { position: 'asc' },
+    include: { items: true },
+  })
+}
+
+export async function addItemToCategory(itemId: string, categoryId: string) {
+  return prisma.wishlistItem.update({ where: { id: itemId }, data: { categoryId } })
+}
+
+// TODO moveItemBetweenCategories

--- a/prisma/migrations/20250605154243_add_wishlist_categories/migration.sql
+++ b/prisma/migrations/20250605154243_add_wishlist_categories/migration.sql
@@ -1,0 +1,31 @@
+-- CreateTable
+CREATE TABLE "WishlistCategory" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "ownerId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "position" INTEGER NOT NULL,
+    CONSTRAINT "WishlistCategory_ownerId_fkey" FOREIGN KEY ("ownerId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_WishlistItem" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    "ownerId" TEXT NOT NULL,
+    "categoryId" TEXT,
+    "title" TEXT NOT NULL,
+    "url" TEXT,
+    "notes" TEXT,
+    "priority" INTEGER,
+    "isLink" BOOLEAN NOT NULL DEFAULT false,
+    CONSTRAINT "WishlistItem_ownerId_fkey" FOREIGN KEY ("ownerId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "WishlistItem_categoryId_fkey" FOREIGN KEY ("categoryId") REFERENCES "WishlistCategory" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+INSERT INTO "new_WishlistItem" ("createdAt", "id", "isLink", "notes", "ownerId", "priority", "title", "updatedAt", "url") SELECT "createdAt", "id", "isLink", "notes", "ownerId", "priority", "title", "updatedAt", "url" FROM "WishlistItem";
+DROP TABLE "WishlistItem";
+ALTER TABLE "new_WishlistItem" RENAME TO "WishlistItem";
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -11,20 +11,21 @@ datasource db {
 }
 
 model User {
-  id            String         @id @default(cuid())
-  email         String         @unique
-  username      String         @unique
-  name          String?
-  createdAt     DateTime       @default(now())
-  updatedAt     DateTime       @updatedAt
-  image         UserImage?
-  password      Password?
-  roles         Role[]
-  sessions      Session[]
-  connections   Connection[]
-  birthday      DateTime?
-  address       Address?
-  wishlistItems WishlistItem[]
+  id                 String             @id @default(cuid())
+  email              String             @unique
+  username           String             @unique
+  name               String?
+  createdAt          DateTime           @default(now())
+  updatedAt          DateTime           @updatedAt
+  image              UserImage?
+  password           Password?
+  roles              Role[]
+  sessions           Session[]
+  connections        Connection[]
+  birthday           DateTime?
+  address            Address?
+  wishlistItems      WishlistItem[]
+  wishlistCategories WishlistCategory[]
 
   // Relations
   giftGroups       UsersInGiftGroups[]
@@ -98,11 +99,24 @@ model WishlistItem {
   owner   User   @relation(fields: [ownerId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   ownerId String
 
+  category   WishlistCategory? @relation(fields: [categoryId], references: [id], onDelete: SetNull, onUpdate: Cascade)
+  categoryId String?
+
   title    String
   url      String?
   notes    String?
   priority Int? // optional for sorting or importance
   isLink   Boolean @default(false)
+}
+
+model WishlistCategory {
+  id       String @id @default(cuid())
+  owner    User   @relation(fields: [ownerId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  ownerId  String
+  name     String
+  position Int
+
+  items WishlistItem[]
 }
 
 model UserImage {

--- a/tests/e2e/wishlist-category.test.ts
+++ b/tests/e2e/wishlist-category.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from '#tests/playwright-utils.ts'
+
+test('user can create wishlist category and add item', async ({ page, login }) => {
+  await login()
+  await page.goto('/wishlist')
+
+  await page.getByPlaceholder('New category').fill('Books')
+  await page.getByRole('button', { name: /add category/i }).click()
+  await expect(page.getByRole('heading', { name: 'Books' })).toBeVisible()
+
+  const itemInputs = page.getByPlaceholder('Add item to your wishlist')
+  await itemInputs.nth(1).fill('My Book')
+  await page.getByRole('button', { name: 'Add Item' }).nth(1).click()
+  await expect(page.getByText('My Book')).toBeVisible()
+})


### PR DESCRIPTION
## Summary
- add WishlistCategory model with migration
- relate WishlistItem to optional categories
- support categories in wishlist loaders and views
- implement basic category creation form and helpers
- add unit and e2e tests for new functionality

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test -- --run`
- `npm run test:e2e:run` *(fails: Command output truncated)*

------
https://chatgpt.com/codex/tasks/task_e_6841ba103580832abe70059710ce679b