### PR TITLE
fix: use numeric verification codes

### DIFF
--- a/app/components/forms.tsx
+++ b/app/components/forms.tsx
@@ -1,5 +1,5 @@
 import { useInputControl } from '@conform-to/react';
-import { REGEXP_ONLY_DIGITS_AND_CHARS, type OTPInputProps } from 'input-otp';
+import { REGEXP_ONLY_DIGITS, type OTPInputProps } from 'input-otp';
 import React, { useId } from 'react';
 import { Checkbox, type CheckboxProps } from './ui/checkbox.tsx';
 import {
@@ -92,7 +92,7 @@ export const OTPField = ({
     <div className={className}>
       <Label htmlFor={id} {...labelProps} />
       <InputOTP
-        pattern={REGEXP_ONLY_DIGITS_AND_CHARS}
+        pattern={REGEXP_ONLY_DIGITS}
         maxLength={6}
         id={id}
         aria-invalid={errorId ? true : undefined}

--- a/app/routes/_auth+/verify.server.ts
+++ b/app/routes/_auth+/verify.server.ts
@@ -89,8 +89,7 @@ export async function prepareVerification({
 
   const { otp, ...verificationConfig } = generateTOTP({
     algorithm: 'SHA256',
-    // Leaving off 0, O, and I on purpose to avoid confusing users.
-    charSet: 'ABCDEFGHJKLMNPQRSTUVWXYZ123456789',
+    charSet: '0123456789',
     period,
   });
   const verificationData = {

--- a/tests/e2e/onboarding.test.ts
+++ b/tests/e2e/onboarding.test.ts
@@ -5,7 +5,7 @@ import { readEmail } from '#tests/mocks/utils.ts';
 import { createUser, expect, test as base } from '#tests/playwright-utils.ts';
 
 const URL_REGEX = /(?<url>https?:\/\/[^\s$.?#].[^\s]*)/;
-const CODE_REGEX = /Here's your verification code: (?<code>[\d\w]+)/;
+const CODE_REGEX = /Here's your verification code: (?<code>\d+)/;
 function extractUrl(text: string) {
   const match = text.match(URL_REGEX);
   return match?.groups?.url;

--- a/tests/e2e/settings-profile.test.ts
+++ b/tests/e2e/settings-profile.test.ts
@@ -5,7 +5,7 @@ import { prisma } from '#app/utils/db.server.ts';
 import { readEmail } from '#tests/mocks/utils.ts';
 import { expect, test, createUser, waitFor } from '#tests/playwright-utils.ts';
 
-const CODE_REGEX = /Here's your verification code: (?<code>[\d\w]+)/;
+const CODE_REGEX = /Here's your verification code: (?<code>\d+)/;
 
 test('Users can update their basic info', async ({ page, login }) => {
   await login();


### PR DESCRIPTION
## Summary
- restrict verification codes to numeric digits
- limit OTP input to digits only
- adjust tests for numeric verification codes

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run typecheck`
- `npm run validate` *(fails: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68b0979c5f20832a9627da583aaff636