### PR TITLE
feat: expose Sentry DSN to public env

### DIFF
--- a/app/utils/env.server.ts
+++ b/app/utils/env.server.ts
@@ -9,7 +9,7 @@ const schema = z.object({
   HONEYPOT_SECRET: z.string(),
   CACHE_DATABASE_PATH: z.string(),
   // If you plan on using Sentry, uncomment this line
-  // SENTRY_DSN: z.string(),
+  SENTRY_DSN: z.string(),
   // If you plan to use Resend, uncomment this line
   // RESEND_API_KEY: z.string(),
   // If you plan to use GitHub auth, remove the default:
@@ -47,7 +47,7 @@ export function init() {
  * be included in the client.
  * @returns all public ENV variables
  */
-export function getEnv() {
+export function getPublicEnv() {
   return {
     MODE: process.env.NODE_ENV,
     SENTRY_DSN: process.env.SENTRY_DSN,
@@ -55,7 +55,9 @@ export function getEnv() {
   };
 }
 
-type ENV = ReturnType<typeof getEnv>;
+export { getPublicEnv as getEnv };
+
+type ENV = ReturnType<typeof getPublicEnv>;
 
 declare global {
   var ENV: ENV;


### PR DESCRIPTION
## Summary
- validate SENTRY_DSN in env schema
- expose SENTRY_DSN via getPublicEnv for client/server Sentry init

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm test -- --run`
- `npm run validate` *(fails: Remix Vite plugin not found in Vite config)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b6e19ea8832aade712f53e4f6b5b