### PR TITLE
chore(deps): enable automerge for non-major updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"]
+  "extends": ["config:recommended"],
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "automerge": true,
+      "automergeType": "pr"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- configure Renovate to automatically merge minor, patch, and similar dependency updates when checks pass

## Testing
- `npm test -- --run`
- `npm run typecheck`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc42981388832a858d701d107edbbe