### PR TITLE
fix: handle groups new route

### DIFF
--- a/app/routes/groups+/new.tsx
+++ b/app/routes/groups+/new.tsx
@@ -1,1 +1,78 @@
+import { json, type LoaderFunctionArgs } from '@remix-run/node';
+import { Form, Link } from '@remix-run/react';
+import { useState } from 'react';
+import { LuUsers } from 'react-icons/lu';
+import { Button } from '#app/components/ui/button.tsx';
+import { Heading } from '#app/components/ui/heading.tsx';
+import { Input } from '#app/components/ui/input.tsx';
+import { Label } from '#app/components/ui/label.tsx';
+import { Textarea } from '#app/components/ui/textarea.tsx';
+import { Flex, Text } from '#app/components/ui-kit';
+import { requireUserId } from '#app/utils/auth.server.ts';
+import { nameMaxLength, descriptionMaxLength } from './__group-editor.tsx';
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  await requireUserId(request);
+  return json({});
+}
+
+const NewGroupRoute = () => {
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+
+  return (
+    <div className="container flex flex-col gap-6 py-8">
+      <Heading>
+        <Flex gap={2} align="center">
+          <LuUsers className="text-primary" />
+          <Text size="xl" weight="bold">
+            Create Group
+          </Text>
+        </Flex>
+      </Heading>
+      <Form method="POST" className="grid gap-4">
+        <div className="grid gap-1">
+          <Label htmlFor="group-name">Group Name</Label>
+          <Input
+            id="group-name"
+            name="name"
+            placeholder="e.g., College Friends, Family, Work Team"
+            minLength={1}
+            maxLength={nameMaxLength}
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            autoComplete="off"
+            required
+          />
+          <div className="text-xs text-muted-foreground">
+            {name.length}/{nameMaxLength} characters
+          </div>
+        </div>
+        <div className="grid gap-1">
+          <Label htmlFor="group-description">Description</Label>
+          <Textarea
+            id="group-description"
+            name="description"
+            placeholder="What's this group for? Who are the members?"
+            maxLength={descriptionMaxLength}
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+          />
+          <div className="text-xs text-muted-foreground">
+            {description.length}/{descriptionMaxLength} characters
+          </div>
+        </div>
+        <div className="grid grid-cols-2 gap-3 sm:flex sm:justify-end">
+          <Button asChild type="button" variant="outline">
+            <Link to="/groups">Cancel</Link>
+          </Button>
+          <Button type="submit">Create</Button>
+        </div>
+      </Form>
+    </div>
+  );
+};
+
+export default NewGroupRoute;
+
 export { action } from './__group-editor.server';

--- a/app/utils/env.server.ts
+++ b/app/utils/env.server.ts
@@ -8,8 +8,8 @@ const schema = z.object({
   INTERNAL_COMMAND_TOKEN: z.string(),
   HONEYPOT_SECRET: z.string(),
   CACHE_DATABASE_PATH: z.string(),
-  // If you plan on using Sentry, uncomment this line
-  SENTRY_DSN: z.string(),
+  // If you plan on using Sentry, uncomment the line below
+  SENTRY_DSN: z.string().optional(),
   // If you plan to use Resend, uncomment this line
   // RESEND_API_KEY: z.string(),
   // If you plan to use GitHub auth, remove the default:


### PR DESCRIPTION
## Summary
- allow SENTRY_DSN env variable to be optional so app runs without Sentry
- add loader and page for /groups/new to handle GET requests and create a new group

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test --silent -- --run`
- `npm run test:e2e` *(fails: No chromium-based browser found)*

------
https://chatgpt.com/codex/tasks/task_e_68c18e72ba7c832a8479a96c090ded14