### PR TITLE
fix: refine mobile bottom navigation

### DIFF
--- a/app/components/__tests__/bottom-nav.test.tsx
+++ b/app/components/__tests__/bottom-nav.test.tsx
@@ -5,7 +5,7 @@
 import { createRemixStub } from '@remix-run/testing';
 import { render, screen, within } from '@testing-library/react';
 import React from 'react';
-import { vi, describe, test, expect } from 'vitest';
+import { afterEach, vi, describe, test, expect } from 'vitest';
 
 // Mock UI primitives so tests are resilient and focused on semantics
 vi.mock('../ui/button.tsx', () => ({
@@ -23,9 +23,19 @@ vi.mock('../ui/icon.tsx', () => ({
   ),
 }));
 
+vi.mock('#app/utils/user.ts', () => ({
+  useOptionalUser: vi.fn(),
+}));
+
+import { useOptionalUser } from '#app/utils/user.ts';
+
 import { BottomNav } from '../nav/bottom/bottom-nav.tsx';
 
 describe('<BottomNav />', () => {
+  afterEach(() => {
+    vi.mocked(useOptionalUser).mockReset();
+  });
+
   test('renders a navigation landmark', () => {
     const App = createRemixStub([
       {
@@ -39,7 +49,9 @@ describe('<BottomNav />', () => {
     expect(nav).toBeInTheDocument();
   });
 
-  test('contains a list with exactly two navigation items', () => {
+  test('contains a list with exactly three navigation items when authenticated', () => {
+    vi.mocked(useOptionalUser).mockReturnValue({ id: 'user1' } as any);
+
     const App = createRemixStub([
       {
         path: '/',
@@ -52,10 +64,12 @@ describe('<BottomNav />', () => {
 
     const list = within(nav).getByRole('list');
     const items = within(list).getAllByRole('listitem');
-    expect(items).toHaveLength(2);
+    expect(items).toHaveLength(3);
   });
 
-  test('buttons have accessible names', () => {
+  test('contains only one navigation item when unauthenticated', () => {
+    vi.mocked(useOptionalUser).mockReturnValue(null);
+
     const App = createRemixStub([
       {
         path: '/',
@@ -64,8 +78,28 @@ describe('<BottomNav />', () => {
     ]);
 
     render(<App />);
+    const nav = screen.getByRole('navigation');
+
+    const list = within(nav).getByRole('list');
+    const items = within(list).getAllByRole('listitem');
+    expect(items).toHaveLength(1);
+  });
+
+  test('buttons have accessible names', () => {
+    vi.mocked(useOptionalUser).mockReturnValue({ id: 'user1' } as any);
+
+    const App = createRemixStub([
+      {
+        path: '/',
+        Component: () => <BottomNav />,
+      },
+    ]);
+
+    render(<App />);
+    const home = screen.getByRole('link', { name: /home/i });
     const wishlist = screen.getByRole('link', { name: /wishlist/i });
     const groups = screen.getByRole('link', { name: /groups/i });
+    expect(home).toBeInTheDocument();
     expect(wishlist).toBeInTheDocument();
     expect(groups).toBeInTheDocument();
   });

--- a/app/components/nav/bottom/bottom-nav-link.tsx
+++ b/app/components/nav/bottom/bottom-nav-link.tsx
@@ -3,9 +3,9 @@ import { type ReactNode } from 'react';
 import { cn } from '#app/utils/misc.tsx';
 
 const activeClassName =
-  'shadow-inner ring-2 ring-inset ring-accent text-foreground bg-accent/50';
+  'bg-brand-gradient text-primary-foreground shadow-inner';
 const inactiveClassName =
-  'text-muted-foreground hover:bg-muted hover:text-foreground';
+  'text-muted-foreground hover:bg-accent hover:text-accent-foreground';
 
 export const BottomNavLink = ({
   to,
@@ -23,7 +23,7 @@ export const BottomNavLink = ({
       aria-label={label}
       className={({ isActive }) =>
         cn(
-          'flex h-full w-full items-center justify-center hover:bg-accent hover:text-foreground',
+          'inline-flex h-full w-full items-center justify-center p-2 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
           isActive ? activeClassName : inactiveClassName,
         )
       }

--- a/app/components/nav/bottom/bottom-nav.tsx
+++ b/app/components/nav/bottom/bottom-nav.tsx
@@ -1,5 +1,6 @@
 import { type ReactNode } from 'react';
-import { LuHeart, LuUsers } from 'react-icons/lu';
+import { LuHeart, LuUsers, LuHouse } from 'react-icons/lu';
+import { useOptionalUser } from '#app/utils/user.ts';
 import { BottomNavLink } from './bottom-nav-link.tsx';
 
 const links: {
@@ -8,19 +9,24 @@ const links: {
   label: string;
   needsAuth: boolean;
 }[] = [
+  { to: '/', icon: <LuHouse />, label: 'Home', needsAuth: false },
   { to: '/wishlist', icon: <LuHeart />, label: 'Wishlist', needsAuth: true },
   { to: '/groups', icon: <LuUsers />, label: 'Groups', needsAuth: true },
 ];
 
 export const BottomNav = () => {
+  const user = useOptionalUser();
+
   return (
     <nav className="fixed bottom-0 left-0 w-full border-t border-surface-border bg-surface text-foreground sm:hidden">
       <ul className="h-bottom-nav flex divide-x divide-border">
-        {links.map((link) => (
-          <li className="flex-1" key={link.to}>
-            <BottomNavLink to={link.to} icon={link.icon} label={link.label} />
-          </li>
-        ))}
+        {links
+          .filter((l) => !l.needsAuth || user)
+          .map((link) => (
+            <li className="flex-1" key={link.to}>
+              <BottomNavLink to={link.to} icon={link.icon} label={link.label} />
+            </li>
+          ))}
       </ul>
     </nav>
   );

--- a/app/components/wishlist/wishlist.tsx
+++ b/app/components/wishlist/wishlist.tsx
@@ -99,7 +99,7 @@ export const Wishlist = ({
           )}
         </div>
       </div>
-      <div className="container min-h-0 flex-1 py-8 pb-bottom-nav sm:pb-0">
+      <div className="container min-h-0 flex-1 py-8">
         <Stack gap={4}>
           {categories.map((category) => {
             const items = user.wishlistItems.filter(

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -207,7 +207,7 @@ const App = () => {
       <div className="flex h-dvh min-h-0 flex-col">
         <TopBar />
 
-        <div className="to-background-muted min-h-0 flex-1 bg-gradient-to-br from-background sm:overflow-y-auto">
+        <div className="to-background-muted min-h-0 flex-1 bg-gradient-to-br from-background pb-bottom-nav sm:overflow-y-auto sm:pb-0">
           <Outlet />
         </div>
 

--- a/app/routes/groups+/index.tsx
+++ b/app/routes/groups+/index.tsx
@@ -103,7 +103,7 @@ const GroupsIndex = () => {
       </div>
 
       {/* Content */}
-      <div className="container min-h-0 flex-1 py-8 pb-bottom-nav sm:pb-0">
+      <div className="container min-h-0 flex-1 py-8">
         {groups.length === 0 ? (
           <div className="mx-auto max-w-lg">{EmptyState}</div>
         ) : (
@@ -120,7 +120,7 @@ const GroupsIndex = () => {
       </div>
 
       {/* Floating create button for mobile */}
-      <div className="fixed bottom-[calc(theme(spacing.4)+env(safe-area-inset-bottom)+4rem)] right-4 z-40 sm:hidden">
+      <div className="fixed bottom-[calc(theme(spacing.4)+theme(spacing.bottom-nav))] right-4 z-40 sm:hidden">
         <CreateGroupDialog>
           <Button
             type="button"

--- a/app/routes/wishlist+/__wishlist-item-editor.tsx
+++ b/app/routes/wishlist+/__wishlist-item-editor.tsx
@@ -197,7 +197,7 @@ export const WishlistItemEditor = React.forwardRef<
                   onClick={() => setMode('create')}
                   aria-label="Add Item"
                   title="Add Item"
-                  className="fixed bottom-[calc(theme(spacing.4)+env(safe-area-inset-bottom)+4rem)] right-4 z-40 h-14 w-14 rounded-full border bg-primary text-primary-foreground shadow-lg sm:hidden"
+                  className="fixed bottom-[calc(theme(spacing.4)+theme(spacing.bottom-nav))] right-4 z-40 h-14 w-14 rounded-full border bg-primary text-primary-foreground shadow-lg sm:hidden"
                 >
                   <Icon name="plus" />
                 </Button>

--- a/app/styles/tailwind.css
+++ b/app/styles/tailwind.css
@@ -72,7 +72,7 @@
     --pool: 174 66% 47%; /* #2EC4B6 in HSL */
     --pool-foreground: 0 0% 100%;
     /* Height of bottom nav including safe area for PWAs/iOS */
-    --bottom-nav-height: calc(4rem + env(safe-area-inset-bottom));
+    --bottom-nav-height: calc(3rem + env(safe-area-inset-bottom));
     --header-height: 4rem;
 
     --brand-gradient-start: var(--gift);


### PR DESCRIPTION
## Summary
- mock authentication state in bottom nav tests
- verify bottom nav renders three links when logged in and only home when logged out
- shrink mobile bottom navigation to 3rem with extra padding so content doesn't overlap
- restyle bottom nav links to drop rounded corners and use a sunken active state

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm test -- --run` *(fails: Server-only module referenced by client)*
- `npm run test:e2e` *(fails: No chromium-based browser found on the system)*

------
https://chatgpt.com/codex/tasks/task_e_68c6d9bd529c832a80ec0c76a92ca5d6