### PR TITLE
fix: ensure mobile layout background extends beyond viewport

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -161,7 +161,7 @@ const Document = ({
   env?: Record<string, string>;
 }) => {
   return (
-    <html lang="en" className={`${theme} h-full overflow-x-hidden`}>
+    <html lang="en" className={`${theme} min-h-full overflow-x-hidden`}>
       <head>
         <ClientHintCheck nonce={nonce} />
         <Meta />
@@ -173,7 +173,7 @@ const Document = ({
         <meta name="csp-nonce" content={nonce} />
         <Links />
       </head>
-      <body className="h-full text-foreground">
+      <body className="min-h-full bg-background text-foreground">
         {children}
         <script
           nonce={nonce}
@@ -204,7 +204,7 @@ const App = () => {
 
   return (
     <Document nonce={nonce} theme={theme} env={data.ENV}>
-      <div className="flex h-dvh min-h-0 flex-col">
+      <div className="flex min-h-[100dvh] flex-col">
         <TopBar />
 
         <div className="to-background-muted min-h-0 flex-1 bg-gradient-to-br from-background pb-bottom-nav sm:overflow-y-auto sm:pb-0">


### PR DESCRIPTION
## Summary
- ensure the document element uses a full-height background so dark mode fills past the initial viewport
- update the root layout container to grow with content so the gradient and bottom padding cover long pages on mobile

## Testing
- npm run lint *(passes with existing Playwright warnings)*
- npm run typecheck
- npm test -- --run *(fails: existing vitest vite:import-analysis error in tests/setup/db-setup.ts)*
- npm run test:e2e:run *(fails: mock server requires SENTRY_DSN which is unset in the environment and subsequent timeouts)*
- npm run test:e2e *(fails: Playwright UI mode requires an X server in this environment)*
- npm run validate *(fails: same vitest error and downstream build failure during validate)*

------
https://chatgpt.com/codex/tasks/task_e_68c8a2494c7c832a95e566f9e86d2a6d