### PR TITLE
fix: align mobile overscroll backgrounds

### DIFF
--- a/app/styles/tailwind.css
+++ b/app/styles/tailwind.css
@@ -74,6 +74,9 @@
     /* Height of bottom nav including safe area for PWAs/iOS */
     --bottom-nav-height: calc(3rem + env(safe-area-inset-bottom));
     --header-height: 4rem;
+    --overscroll-top-stop: calc(
+      var(--header-height) + env(safe-area-inset-top, 0px) + 1rem
+    );
 
     --brand-gradient-start: var(--gift);
     --brand-gradient-end: 356 75% 62;
@@ -132,6 +135,19 @@
 
     --brand-gradient-start: 345 82.7% 40.8%;
     --brand-gradient-end: 0 100% 68%;
+  }
+
+  html {
+    background-color: hsl(var(--surface));
+    background-image: linear-gradient(
+      to bottom,
+      hsl(var(--surface)) 0,
+      hsl(var(--surface)) var(--overscroll-top-stop),
+      hsl(var(--background)) var(--overscroll-top-stop),
+      hsl(var(--background)) 100%
+    );
+    background-repeat: no-repeat;
+    background-attachment: scroll;
   }
 }
 


### PR DESCRIPTION
## Summary
- add an overscroll gradient to the html background so the top pull-to-refresh area matches the surface color
- transition the overscroll gradient to the page background to keep the bottom stretch color consistent with the content panel

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68caf979363c832a9585643e5d87db6c