### PR TITLE
feat: update add friend button icon

### DIFF
--- a/app/routes/groups+/$giftGroupId_+/members.tsx
+++ b/app/routes/groups+/$giftGroupId_+/members.tsx
@@ -1,4 +1,6 @@
 import { Link, useFetcher, useRouteLoaderData } from '@remix-run/react';
+import { LuUserPlus } from 'react-icons/lu';
+
 import { RoleBadge } from '#app/components/groups/RoleBadge.tsx';
 import { Avatar } from '#app/components/ui/avatar.tsx';
 import { Button } from '#app/components/ui/button.tsx';
@@ -103,7 +105,14 @@ const GroupMembersRoute = () => {
                 ) : null}
 
                 {/* Add friend UI (stub) */}
-                <Button className="ml-2" size="sm">Add Friend</Button>
+                <Button
+                  aria-label="Add friend"
+                  className="ml-2 h-8 w-8 md:h-9 md:w-auto md:px-3"
+                  size="icon"
+                >
+                  <LuUserPlus aria-hidden className="h-4 w-4 md:mr-2" />
+                  <span className="hidden md:inline">Add friend</span>
+                </Button>
               </div>
             </li>
           );


### PR DESCRIPTION
## Summary
- import the LuUserPlus icon for the add friend action
- render the button as icon-only on mobile and with text on larger screens

## Testing
- npm run lint
  - shows existing Playwright locator warnings


------
https://chatgpt.com/codex/tasks/task_e_68cc168dead8832a91bd88834eab8118