### PR TITLE
feat: add install banner for pwa

### DIFF
--- a/app/components/pwa-install-banner.tsx
+++ b/app/components/pwa-install-banner.tsx
@@ -5,11 +5,13 @@ import { Button } from '#app/components/ui/button.tsx';
 import {
   type InstallCapability,
   type InstallOutcome,
+  type ManualInstallPlatform,
 } from '#app/hooks/use-pwa-install-prompt.ts';
 
 export type PwaInstallBannerProps = {
   capability: InstallCapability;
   manualHref?: string;
+  manualPlatform?: ManualInstallPlatform | null;
   onDismiss: () => void;
   onPromptInstall?: () => Promise<InstallOutcome> | InstallOutcome;
   isPrompting?: boolean;
@@ -18,29 +20,36 @@ export type PwaInstallBannerProps = {
 export const PwaInstallBanner = ({
   capability,
   manualHref,
+  manualPlatform,
   onDismiss,
   onPromptInstall,
   isPrompting = false,
 }: PwaInstallBannerProps) => {
   const message = useMemo(() => {
     if (capability === 'manual') {
+      if (manualPlatform === 'ios-chrome') {
+        return 'Add GiftPool to your Home Screen from Chrome so it behaves like an app.';
+      }
       return 'Add GiftPool to your Home Screen from Safari so it behaves like an app.';
     }
     if (capability === 'unsupported') {
       return 'GiftPool works best when installed, but this browser does not expose an install option.';
     }
     return 'Install GiftPool on this device for faster access and an app-like experience.';
-  }, [capability]);
+  }, [capability, manualPlatform]);
 
   const detail = useMemo(() => {
     if (capability === 'manual') {
+      if (manualPlatform === 'ios-chrome') {
+        return 'Follow the Chrome on iOS steps to add GiftPool from the share menu at the top.';
+      }
       return 'Follow the guided steps to add GiftPool from the iOS share sheet.';
     }
     if (capability === 'unsupported') {
       return 'Try visiting on a supported browser or device if you want an app-like shortcut.';
     }
     return null;
-  }, [capability]);
+  }, [capability, manualPlatform]);
 
   return (
     <div className="border-b border-border bg-primary/10">

--- a/app/hooks/use-pwa-install-prompt.ts
+++ b/app/hooks/use-pwa-install-prompt.ts
@@ -14,6 +14,7 @@ export type InstallOutcome =
   | 'unavailable'
   | 'error'
   | 'manual';
+export type ManualInstallPlatform = 'ios-safari' | 'ios-chrome';
 export type InstallCapability = 'prompt' | 'manual' | 'unsupported';
 
 const isStandalone = () => {
@@ -25,24 +26,29 @@ const isStandalone = () => {
   return Boolean(mediaQueryList?.matches || navigatorStandalone);
 };
 
-const detectManualInstallPlatform = (): 'ios' | null => {
+const detectManualInstallPlatform = (): ManualInstallPlatform | null => {
   if (typeof window === 'undefined') return null;
   if (isStandalone()) return null;
 
   const userAgent = window.navigator.userAgent.toLowerCase();
   const isIos = /iphone|ipad|ipod/.test(userAgent);
-  const isStandaloneCapableSafari =
-    isIos &&
+  if (!isIos) return null;
+
+  if (userAgent.includes('crios')) {
+    return 'ios-chrome';
+  }
+
+  const isSafari =
     userAgent.includes('safari') &&
-    !userAgent.includes('crios') &&
     !userAgent.includes('fxios') &&
-    !userAgent.includes('chrome') &&
     !userAgent.includes('edgios') &&
     !userAgent.includes('opios');
 
-  if (!isStandaloneCapableSafari) return null;
+  if (isSafari) {
+    return 'ios-safari';
+  }
 
-  return 'ios';
+  return null;
 };
 
 export const usePwaInstallPrompt = () => {
@@ -52,7 +58,9 @@ export const usePwaInstallPrompt = () => {
   const [isDismissed, setIsDismissed] = useState(false);
   const [isInstalled, setIsInstalled] = useState(false);
   const [isPrompting, setIsPrompting] = useState(false);
-  const [manualPlatform, setManualPlatform] = useState<'ios' | null>(null);
+  const [manualPlatform, setManualPlatform] = useState<ManualInstallPlatform | null>(
+    null,
+  );
 
   useEffect(() => {
     if (typeof window === 'undefined') return;

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -217,6 +217,7 @@ const App = () => {
     capability: installCapability,
     dismissBanner: dismissInstallBanner,
     isPrompting,
+    manualPlatform,
     promptInstall,
     shouldShowBanner: showPwaInstallBanner,
   } = usePwaInstallPrompt();
@@ -261,7 +262,12 @@ const App = () => {
               <PwaInstallBanner
                 capability={installCapability}
                 isPrompting={isPrompting}
-                manualHref="/pwa-install"
+                manualHref={
+                  installCapability === 'manual' && manualPlatform
+                    ? `/pwa-install?platform=${manualPlatform}`
+                    : '/pwa-install'
+                }
+                manualPlatform={manualPlatform}
                 onDismiss={dismissInstallBanner}
                 onPromptInstall={handleInstallClick}
               />

--- a/app/routes/pwa-install.tsx
+++ b/app/routes/pwa-install.tsx
@@ -1,27 +1,61 @@
 import { type MetaFunction } from '@remix-run/node';
-import { Link } from '@remix-run/react';
+import { Link, useSearchParams } from '@remix-run/react';
 
 import { Button } from '#app/components/ui/button.tsx';
 import { Card } from '#app/components/ui/card.tsx';
 
-const steps = [
+const instructionSets = [
   {
-    title: 'Open the share sheet',
+    id: 'ios-safari',
+    title: 'Safari on iPhone or iPad',
     description:
-      'In Safari, tap the share icon (the square with the upward arrow) in the bottom toolbar.',
-    icon: '📤',
+      'Safari exposes the share sheet along the bottom of the screen. Use it to add GiftPool to your Home Screen.',
+    steps: [
+      {
+        title: 'Open the share sheet',
+        description:
+          'Tap the share icon (the square with the upward arrow) in the bottom toolbar.',
+        icon: '📤',
+      },
+      {
+        title: 'Choose “Add to Home Screen”',
+        description:
+          'Scroll the sheet until you find “Add to Home Screen” and tap it to open the preview screen.',
+        icon: '➕',
+      },
+      {
+        title: 'Confirm and tap “Add”',
+        description:
+          'Adjust the name if you like, then press “Add”. GiftPool will appear alongside your other apps.',
+        icon: '✅',
+      },
+    ],
   },
   {
-    title: 'Choose “Add to Home Screen”',
+    id: 'ios-chrome',
+    title: 'Chrome on iPhone or iPad',
     description:
-      'Scroll the sheet until you find “Add to Home Screen” and tap it to open the preview screen.',
-    icon: '➕',
-  },
-  {
-    title: 'Confirm and tap “Add”',
-    description:
-      'Adjust the name if you like, then press “Add”. GiftPool will appear alongside your other apps.',
-    icon: '✅',
+      'Chrome offers the same install capability, but the share button lives in the top-right of the toolbar.',
+    steps: [
+      {
+        title: 'Open Chrome’s share menu',
+        description:
+          'Tap the share icon (the square with the upward arrow) next to the address bar at the top of the screen.',
+        icon: '📤',
+      },
+      {
+        title: 'Find “Add to Home Screen”',
+        description:
+          'Scroll or search within the share sheet until you see “Add to Home Screen”, then tap it.',
+        icon: '➕',
+      },
+      {
+        title: 'Confirm and tap “Add”',
+        description:
+          'Edit the shortcut name if you like, then press “Add” to place GiftPool alongside your other apps.',
+        icon: '✅',
+      },
+    ],
   },
 ] as const;
 
@@ -29,15 +63,12 @@ export const meta: MetaFunction = () => [
   { title: 'Add GiftPool to your Home Screen' },
   {
     name: 'description',
-    content: 'Step-by-step guide for installing GiftPool as a Progressive Web App on iOS devices.',
+    content:
+      'Step-by-step guide for installing GiftPool as a Progressive Web App on iOS devices using Safari or Chrome.',
   },
 ];
 
-const StepCard = ({
-  description,
-  icon,
-  title,
-}: (typeof steps)[number]) => {
+const StepCard = ({ description, icon, title }: StepCardProps) => {
   return (
     <Card className="h-full space-y-4">
       <div className="flex items-center gap-3">
@@ -47,14 +78,46 @@ const StepCard = ({
         >
           {icon}
         </span>
-        <h2 className="text-lg font-semibold">{title}</h2>
+        <h3 className="text-lg font-semibold">{title}</h3>
       </div>
       <p className="text-sm text-muted-foreground">{description}</p>
     </Card>
   );
 };
 
+type StepCardProps = (typeof instructionSets)[number]['steps'][number];
+
+const InstructionSection = ({
+  description,
+  id,
+  isHighlighted,
+  steps,
+  title,
+}: (typeof instructionSets)[number] & { isHighlighted: boolean }) => {
+  return (
+    <section
+      id={id}
+      className={`space-y-6 rounded-lg border border-border/60 bg-card/60 p-6 shadow-sm transition-shadow ${
+        isHighlighted ? 'ring-2 ring-primary' : ''
+      }`}
+    >
+      <div className="space-y-2">
+        <h2 className="text-2xl font-semibold">{title}</h2>
+        <p className="text-sm text-muted-foreground">{description}</p>
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {steps.map((step) => (
+          <StepCard key={step.title} {...step} />
+        ))}
+      </div>
+    </section>
+  );
+};
+
 const PwaInstallInstructions = () => {
+  const [searchParams] = useSearchParams();
+  const activePlatform = searchParams.get('platform');
+
   return (
     <div className="mx-auto flex w-full max-w-4xl flex-col gap-8 px-4 py-10 sm:py-16">
       <header className="space-y-4 text-center">
@@ -68,14 +131,18 @@ const PwaInstallInstructions = () => {
             Add GiftPool to your Home Screen
           </h1>
           <p className="text-base text-muted-foreground sm:text-lg">
-            These steps work best on iPhone or iPad using Safari.
+            These steps walk you through adding GiftPool using Safari or Chrome on iOS.
           </p>
         </div>
       </header>
 
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {steps.map((step) => (
-          <StepCard key={step.title} {...step} />
+      <div className="space-y-6">
+        {instructionSets.map((instructionSet) => (
+          <InstructionSection
+            key={instructionSet.id}
+            {...instructionSet}
+            isHighlighted={instructionSet.id === activePlatform}
+          />
         ))}
       </div>
 


### PR DESCRIPTION
## Summary
- add a dedicated hook to handle PWA install prompt availability and lifecycle
- show a dismissible install banner at the top of the app when installation is possible

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f519c0fadc832ab54fa08eafc2a483