### PR TITLE
Hide empty default wishlist section for viewers

### DIFF
--- a/app/components/wishlist/wishlist.test.tsx
+++ b/app/components/wishlist/wishlist.test.tsx
@@ -180,6 +180,79 @@ describe('Wishlist components', () => {
     );
   });
 
+  it('hides default category for viewers when it has no items', async () => {
+    const App = createRemixStub([
+      {
+        path: '/',
+        Component: () => (
+          <Wishlist
+            isOwner={false}
+            user={{
+              username: 'jim',
+              name: 'Jim',
+              image: { id: 'img1' },
+              wishlistItems: [],
+              wishlistCategories: [
+                { id: 'cat1', name: 'Books', order: 0 },
+                { id: 'cat2', name: 'Games', order: 1 },
+              ],
+            }}
+          />
+        ),
+      },
+    ]);
+
+    render(<App />);
+
+    await screen.findByText(
+      "Jim doesn't have any items in their wishlist yet!",
+    );
+    expect(
+      screen.queryByRole('heading', {
+        name: /default \(uncategorized\)/i,
+      }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows default category for viewers when it has items', async () => {
+    const App = createRemixStub([
+      {
+        path: '/',
+        Component: () => (
+          <Wishlist
+            isOwner={false}
+            user={{
+              username: 'jim',
+              name: 'Jim',
+              image: { id: 'img1' },
+              wishlistItems: [
+                {
+                  id: 'item-1',
+                  title: 'Default item',
+                  ownerId: 'user2',
+                  note: null,
+                  url: null,
+                  type: 'text',
+                  categoryId: null,
+                  purchase: null,
+                  updatedAt: new Date(),
+                },
+              ],
+              wishlistCategories: [],
+            }}
+          />
+        ),
+      },
+    ]);
+
+    render(<App />);
+
+    await screen.findByRole('heading', {
+      name: /default \(uncategorized\).*1/i,
+    });
+    await screen.findByText('Default item');
+  });
+
   it('renders empty categories', async () => {
     const App = createRemixStub([
       {

--- a/app/components/wishlist/wishlist.tsx
+++ b/app/components/wishlist/wishlist.tsx
@@ -84,10 +84,17 @@ export const Wishlist = ({
   isOwner: boolean;
 }) => {
   const displayName = user.name ?? user.username;
+  const hasDefaultItems = user.wishlistItems.some(
+    (item) => item.categoryId === null,
+  );
   const categories = [
     { id: null, name: 'Default (Uncategorized)', order: -1 },
     ...user.wishlistCategories,
-  ];
+  ].filter((category) => {
+    if (category.id !== null) return true;
+    if (isOwner) return true;
+    return hasDefaultItems;
+  });
 
   const [collapsed, setCollapsed] = useState<Record<string, boolean>>({});
   const [editingId, setEditingId] = useState<string | null>(null);


### PR DESCRIPTION
## Summary
- hide the default wishlist category for viewers when it has no items
- keep default category visible when items exist and ensure coverage with new unit tests

## Testing
- npm test -- app/components/wishlist/wishlist.test.tsx

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b15f7c59c832a89d4d69c7f0795d4)