### PR TITLE
feat: make friend summaries open wishlists

### DIFF
--- a/app/components/friends/friend-summary.test.tsx
+++ b/app/components/friends/friend-summary.test.tsx
@@ -1,0 +1,54 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { createRemixStub } from '@remix-run/testing';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, test, vi } from 'vitest';
+import { FriendSummary } from './friend-summary.tsx';
+
+vi.mock('../ui/avatar.tsx', () => ({
+  Avatar: ({ user }: { user: { username: string } }) => (
+    <div data-testid="avatar" aria-hidden="true">
+      avatar-{user.username}
+    </div>
+  ),
+}));
+
+describe('<FriendSummary />', () => {
+  const user = {
+    id: 'user-1',
+    username: 'taylor',
+    name: 'Taylor Swift',
+    image: { id: 'img-1', altText: 'Taylor' },
+  };
+
+  test('links the profile summary to the wishlist', () => {
+    const App = createRemixStub([
+      {
+        path: '/',
+        Component: () => (
+          <FriendSummary
+            user={user}
+            displayName={user.name!}
+            mutualGroups={[
+              { id: '1', name: 'Swifties' },
+              { id: '2', name: 'Music Club' },
+            ]}
+            extraGroupCount={2}
+          />
+        ),
+      },
+    ]);
+
+    render(<App />);
+
+    const button = screen.getByRole('button', { name: /taylor swift/i });
+    expect(button).toHaveAttribute('type', 'button');
+    expect(screen.getByText('@taylor')).toBeInTheDocument();
+    expect(screen.getByText('Swifties')).toBeInTheDocument();
+    expect(screen.getByText('+2')).toBeInTheDocument();
+    expect(screen.getByTestId('avatar')).toBeInTheDocument();
+  });
+});

--- a/app/components/friends/friend-summary.tsx
+++ b/app/components/friends/friend-summary.tsx
@@ -1,0 +1,51 @@
+import { Avatar } from '#app/components/ui/avatar.tsx';
+
+export type FriendSummaryProps = {
+  user: {
+    id: string;
+    username: string;
+    name: string | null;
+    image: { id: string; altText: string | null } | null;
+  };
+  displayName: string;
+  mutualGroups?: { id: string; name: string }[];
+  extraGroupCount?: number;
+};
+
+export const FriendSummary = ({
+  user,
+  displayName,
+  mutualGroups = [],
+  extraGroupCount = 0,
+}: FriendSummaryProps) => {
+  return (
+    <button
+      type="button"
+      onClick={() => window.location.assign(`/users/${user.username}/wishlist`)}
+      className="flex flex-1 items-center gap-4 rounded-lg outline-none transition focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+    >
+      <Avatar size="s" image={user.image} user={user} />
+      <div className="min-w-0">
+        <div className="truncate font-medium text-foreground">{displayName}</div>
+        <div className="truncate text-sm text-muted-foreground">@{user.username}</div>
+        {mutualGroups.length > 0 ? (
+          <div className="mt-1 flex flex-wrap gap-1">
+            {mutualGroups.map((g) => (
+              <span
+                key={g.id}
+                className="inline-flex items-center rounded-full bg-secondary px-2 py-0.5 text-[11px] text-muted-foreground"
+              >
+                {g.name}
+              </span>
+            ))}
+            {extraGroupCount > 0 ? (
+              <span className="inline-flex items-center rounded-full bg-secondary px-2 py-0.5 text-[11px] text-muted-foreground">
+                +{extraGroupCount}
+              </span>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+    </button>
+  );
+};

--- a/app/routes/friends.tsx
+++ b/app/routes/friends.tsx
@@ -18,6 +18,7 @@ import {
   FriendActionButton,
   type RelationshipSnapshot,
 } from '#app/components/friends/friend-action-button.tsx';
+import { FriendSummary } from '#app/components/friends/friend-summary.tsx';
 import { useNotificationsStore } from '#app/components/notifications/notifications-context.tsx';
 import { Avatar } from '#app/components/ui/avatar.tsx';
 import { Button } from '#app/components/ui/button.tsx';
@@ -663,32 +664,12 @@ const FriendsRoute = () => {
                           onRemove={async () => {}}
                           rightActions={null}
                         >
-                          <Avatar size="s" image={user.image} user={user} />
-                          <div className="min-w-0 flex-1">
-                            <div className="truncate font-medium text-foreground">
-                              {displayName}
-                            </div>
-                            <div className="truncate text-sm text-muted-foreground">
-                              @{user.username}
-                            </div>
-                            {chips.length > 0 ? (
-                              <div className="mt-1 flex flex-wrap gap-1">
-                                {chips.map((g) => (
-                                  <span
-                                    key={g.id}
-                                    className="inline-flex items-center rounded-full bg-secondary px-2 py-0.5 text-[11px] text-muted-foreground"
-                                  >
-                                    {g.name}
-                                  </span>
-                                ))}
-                                {mu && mu.more > 0 ? (
-                                  <span className="inline-flex items-center rounded-full bg-secondary px-2 py-0.5 text-[11px] text-muted-foreground">
-                                    +{mu.more}
-                                  </span>
-                                ) : null}
-                              </div>
-                            ) : null}
-                          </div>
+                      <FriendSummary
+                        user={user}
+                        displayName={displayName}
+                        mutualGroups={chips}
+                        extraGroupCount={mu?.more ?? 0}
+                      />
                           <div className="flex items-center gap-2">
                             <Button
                               asChild
@@ -794,32 +775,12 @@ const FriendsRoute = () => {
                         onRemove={async () => {}}
                         rightActions={null}
                       >
-                        <Avatar size="s" image={user.image} user={user} />
-                        <div className="min-w-0 flex-1">
-                          <div className="truncate font-medium text-foreground">
-                            {displayName}
-                          </div>
-                          <div className="truncate text-sm text-muted-foreground">
-                            @{user.username}
-                          </div>
-                          {chips.length > 0 ? (
-                            <div className="mt-1 flex flex-wrap gap-1">
-                              {chips.map((g) => (
-                                <span
-                                  key={g.id}
-                                  className="inline-flex items-center rounded-full bg-secondary px-2 py-0.5 text-[11px] text-muted-foreground"
-                                >
-                                  {g.name}
-                                </span>
-                              ))}
-                              {mu && mu.more > 0 ? (
-                                <span className="inline-flex items-center rounded-full bg-secondary px-2 py-0.5 text-[11px] text-muted-foreground">
-                                  +{mu.more}
-                                </span>
-                              ) : null}
-                            </div>
-                          ) : null}
-                        </div>
+                        <FriendSummary
+                          user={user}
+                          displayName={displayName}
+                          mutualGroups={chips}
+                          extraGroupCount={mu?.more ?? 0}
+                        />
                         <div className="flex items-center gap-2">
                           <Button
                             asChild

--- a/tests/e2e/friends-list.test.ts
+++ b/tests/e2e/friends-list.test.ts
@@ -1,0 +1,53 @@
+import { prisma } from '#app/utils/db.server.ts';
+import { createPassword, createUser } from '#tests/db-utils.ts';
+import { expect, test } from '#tests/playwright-utils.ts';
+
+test('friend summary links navigate to the wishlist', async ({ page, login }) => {
+  const createdUserIds: string[] = [];
+  const viewerData = createUser();
+  const friendData = createUser();
+
+  const [viewer, friend] = await Promise.all([
+    prisma.user.create({
+      select: { id: true, username: true, name: true },
+      data: {
+        ...viewerData,
+        roles: { connect: { name: 'user' } },
+        password: { create: createPassword(viewerData.username) },
+      },
+    }),
+    prisma.user.create({
+      select: { id: true, username: true, name: true },
+      data: {
+        ...friendData,
+        roles: { connect: { name: 'user' } },
+        password: { create: createPassword(friendData.username) },
+      },
+    }),
+  ]);
+
+  createdUserIds.push(viewer.id, friend.id);
+
+  const pair =
+    viewer.id < friend.id
+      ? { userAId: viewer.id, userBId: friend.id }
+      : { userAId: friend.id, userBId: viewer.id };
+
+  await prisma.friendship.create({ data: pair });
+
+  try {
+    await login({ id: viewer.id });
+    await page.goto('/friends');
+
+    const friendSummaryButton = page.getByRole('button', {
+      name: new RegExp(friend.name!, 'i'),
+    });
+    await expect(friendSummaryButton).toBeVisible();
+    await friendSummaryButton.click();
+
+    await expect(page).toHaveURL(`/users/${friend.username}/wishlist`);
+  } finally {
+    await prisma.friendship.deleteMany({ where: { userAId: pair.userAId, userBId: pair.userBId } });
+    await prisma.user.deleteMany({ where: { id: { in: createdUserIds } } });
+  }
+});


### PR DESCRIPTION
## Summary
- add FriendSummary component to render clickable friend info
- update friends page to use FriendSummary and navigate to wishlists
- add unit and Playwright tests for friend summary navigation

## Testing
- npm test -- friend-summary
- SENTRY_DSN=http://example.com DATABASE_URL=file:$(pwd)/tests/prisma/data.1.db DATABASE_PATH=$(pwd)/tests/prisma/data.1.db CACHE_DATABASE_PATH=$(pwd)/tests/prisma/cache.db SESSION_SECRET=SESSION_SECRET INTERNAL_COMMAND_TOKEN=INTERNAL_COMMAND_TOKEN HONEYPOT_SECRET=HONEYPOT_SECRET CI=true npx playwright test friends-list.test.ts --project=chromium


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c46cd2e74832ab0bb82dd9a49b009)