### PR TITLE
Deduplicate wishlist item success toasts

### DIFF
--- a/app/components/toaster.test.tsx
+++ b/app/components/toaster.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render } from '@testing-library/react';
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { resetToastHistory, useToast } from './toaster.tsx';
+import type { Toast } from '#app/utils/toast.server.ts';
+import { toast as sonnerToast } from 'sonner';
+
+vi.mock('sonner', () => {
+  const success = vi.fn();
+  const error = vi.fn();
+  const message = vi.fn();
+
+  return {
+    toast: { success, error, message },
+  };
+});
+
+beforeEach(() => {
+  resetToastHistory();
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+const TestToast = ({ toast }: { toast: Toast }) => {
+  useToast(toast);
+  return null;
+};
+
+describe('useToast', () => {
+  test('deduplicates identical toasts across instances', () => {
+    vi.useFakeTimers();
+    const toast: Toast = {
+      id: 'toast-1',
+      type: 'success',
+      title: 'Item added',
+      description: 'Wishlist item added.',
+    };
+
+    render(
+      <>
+        <TestToast toast={toast} />
+        <TestToast toast={toast} />
+      </>,
+    );
+
+    vi.runAllTimers();
+    vi.useRealTimers();
+
+    expect(sonnerToast.success).toHaveBeenCalledTimes(1);
+    expect(sonnerToast.success).toHaveBeenCalledWith(toast.title, {
+      description: toast.description,
+      id: toast.id,
+    });
+  });
+
+  test('shows new toasts when the id changes', () => {
+    vi.useFakeTimers();
+    const firstToast: Toast = {
+      id: 'toast-1',
+      type: 'success',
+      title: 'First',
+      description: 'First toast',
+    };
+    const secondToast: Toast = {
+      id: 'toast-2',
+      type: 'success',
+      title: 'Second',
+      description: 'Second toast',
+    };
+
+    render(
+      <>
+        <TestToast toast={firstToast} />
+        <TestToast toast={secondToast} />
+      </>,
+    );
+
+    vi.runAllTimers();
+    vi.useRealTimers();
+
+    expect(sonnerToast.success).toHaveBeenCalledTimes(2);
+    expect(sonnerToast.success).toHaveBeenNthCalledWith(1, firstToast.title, {
+      description: firstToast.description,
+      id: firstToast.id,
+    });
+    expect(sonnerToast.success).toHaveBeenNthCalledWith(2, secondToast.title, {
+      description: secondToast.description,
+      id: secondToast.id,
+    });
+  });
+});

--- a/app/components/toaster.tsx
+++ b/app/components/toaster.tsx
@@ -1,22 +1,33 @@
 import { useEffect } from 'react';
 import { toast as showToast } from 'sonner';
+import type { Toast } from '#app/utils/toast.server.ts';
 
-type Toast = {
-  description: string;
-  id: string;
-  title?: string;
-  type: 'message' | 'success' | 'error';
-};
+const displayedToastIds: string[] = [];
+const MAX_TRACKED_TOASTS = 50;
 
 export function useToast(toast?: Toast | null) {
   useEffect(() => {
-    if (toast) {
-      setTimeout(() => {
-        showToast[toast.type](toast.title, {
-          id: toast.id,
-          description: toast.description,
-        });
-      }, 0);
+    if (!toast) return;
+
+    const toastId = toast.id ?? JSON.stringify(toast);
+    if (displayedToastIds.includes(toastId)) return;
+
+    displayedToastIds.push(toastId);
+    if (displayedToastIds.length > MAX_TRACKED_TOASTS) {
+      displayedToastIds.shift();
     }
+
+    const timeoutId = setTimeout(() => {
+      showToast[toast.type](toast.title, {
+        id: toastId,
+        description: toast.description,
+      });
+    }, 0);
+
+    return () => clearTimeout(timeoutId);
   }, [toast]);
+}
+
+export function resetToastHistory() {
+  displayedToastIds.length = 0;
 }

--- a/app/routes/wishlist+/__wishlist-item-editor.server.tsx
+++ b/app/routes/wishlist+/__wishlist-item-editor.server.tsx
@@ -1,4 +1,5 @@
 import { parseWithZod } from '@conform-to/zod';
+import { createId as cuid } from '@paralleldrive/cuid2';
 import {
   unstable_createMemoryUploadHandler as createMemoryUploadHandler,
   json,
@@ -171,6 +172,7 @@ export async function action({ request }: ActionFunctionArgs) {
   const toast =
     intent === 'save-add-another'
       ? {
+          id: cuid(),
           type: 'success' as const,
           title: 'Item added',
           description: 'Wishlist item added.',

--- a/tests/e2e/wishlist.test.ts
+++ b/tests/e2e/wishlist.test.ts
@@ -24,7 +24,9 @@ test('users can add wishlist items', async ({ page, login }) => {
   await page.getByLabel('Title').fill('Second Item');
   await page.getByRole('button', { name: /save & add another/i }).click();
 
-  await expect(page.getByText('Wishlist item added.').first()).toBeVisible();
+  const successToast = page.getByText('Wishlist item added.', { exact: true });
+  await expect(successToast.first()).toBeVisible();
+  await expect(successToast).toHaveCount(1);
   await expect(page.getByRole('dialog')).toBeVisible(); // still open
   await expect(page.getByLabel('Title')).toHaveValue('');
   await expect(page.getByText('Second Item').first()).toBeVisible();


### PR DESCRIPTION
## Summary
- prevent duplicate toast rendering by tracking shown toast ids and exposing a reset helper for tests
- assign unique toast ids when adding wishlist items so duplicated components share the same notification
- add unit coverage for toast deduping and tighten wishlist e2e expectations for single success toast

## Testing
- npm test -- --run app/components/toaster.test.tsx
- npm run test:e2e:run -- --project=chromium tests/e2e/wishlist.test.ts *(fails: Playwright browsers not installed in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c590ca358832a88f270c9d65dedf1)