### PR TITLE
Fix mobile bottom sheet scroll lock after closing wishlist editor

### DIFF
--- a/app/components/ui/mobile-bottom-sheet.tsx
+++ b/app/components/ui/mobile-bottom-sheet.tsx
@@ -43,6 +43,14 @@ const MobileBottomSheetContent = React.forwardRef<
   const dragStartSnapRef = React.useRef<'peek' | 'full'>('peek');
   const closeRef = React.useRef<HTMLButtonElement>(null);
 
+  React.useEffect(() => {
+    return () => {
+      const body = document.body;
+      body.style.removeProperty('overflow');
+      body.style.removeProperty('paddingRight');
+    };
+  }, []);
+
   const bindHandleDrag = useDrag(
     ({
       first,

--- a/app/routes/wishlist+/route.tsx
+++ b/app/routes/wishlist+/route.tsx
@@ -9,8 +9,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
 const WishlistRoute = () => {
   return (
-    <main className="h-full min-h-0 overflow-y-auto">
-      <div className="grid h-full min-h-0 w-full rounded-none text-surface-foreground shadow-sm">
+    <main className="w-full">
+      <div className="grid w-full rounded-none text-surface-foreground shadow-sm">
         <Outlet />
       </div>
     </main>

--- a/tests/e2e/wishlist-mobile.test.ts
+++ b/tests/e2e/wishlist-mobile.test.ts
@@ -1,0 +1,41 @@
+import { expect, test } from '#tests/playwright-utils.ts';
+
+test.describe('wishlist mobile experience', () => {
+  test.use({ viewport: { width: 390, height: 844 } });
+
+  test('body scroll is restored after closing the add-item sheet', async ({
+    page,
+    login,
+  }) => {
+    await login();
+
+    await page.goto('/wishlist');
+    await page.waitForLoadState('networkidle');
+
+    await page.getByRole('button', { name: /^Add Item$/ }).click();
+    await expect(page.getByRole('dialog')).toBeVisible();
+
+    await page.getByLabel('Title').fill('Mobile Overflow Check');
+    await page.getByRole('button', { name: /^save$/i }).click();
+
+    await expect(page.getByRole('dialog')).toHaveCount(0);
+
+    const inlineOverflow = await page.evaluate(() => document.body.style.overflow);
+    const inlinePaddingRight = await page.evaluate(
+      () => document.body.style.paddingRight,
+    );
+
+    expect(inlineOverflow).toBe('');
+    expect(inlinePaddingRight).toBe('');
+
+    const reachedBottom = await page.evaluate(() => {
+      window.scrollTo(0, document.documentElement.scrollHeight);
+      return (
+        window.scrollY + window.innerHeight >=
+        document.documentElement.scrollHeight - 1
+      );
+    });
+
+    expect(reachedBottom).toBe(true);
+  });
+});

--- a/tests/e2e/wishlist-mobile.test.ts
+++ b/tests/e2e/wishlist-mobile.test.ts
@@ -28,14 +28,19 @@ test.describe('wishlist mobile experience', () => {
     expect(inlineOverflow).toBe('');
     expect(inlinePaddingRight).toBe('');
 
-    const reachedBottom = await page.evaluate(() => {
+    const { reachedBottom, mainOverflowY } = await page.evaluate(() => {
+      const main = document.querySelector('main');
+      const overflowY = main ? getComputedStyle(main).overflowY : '';
+
       window.scrollTo(0, document.documentElement.scrollHeight);
-      return (
+      const atBottom =
         window.scrollY + window.innerHeight >=
-        document.documentElement.scrollHeight - 1
-      );
+        document.documentElement.scrollHeight - 1;
+
+      return { reachedBottom: atBottom, mainOverflowY: overflowY };
     });
 
     expect(reachedBottom).toBe(true);
+    expect(mainOverflowY).not.toBe('auto');
   });
 });


### PR DESCRIPTION
## Summary
- clear leftover body scroll lock styles when the mobile add-item sheet unmounts
- add a mobile viewport e2e test to ensure wishlist add-item flow restores scrolling

## Testing
- npm run test:e2e -- --grep "body scroll" *(fails: Chromium not installed in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c5f80b41c832ab1b6d7b17af77754)