### PR TITLE
perf(nav): delay skeleton swap and make bottom-nav optimistic

### DIFF
--- a/PERFORMANCE_INVESTIGATION.md
+++ b/PERFORMANCE_INVESTIGATION.md
@@ -218,14 +218,6 @@ Only fill this in if Phase 1 + 2 + 3 Tier 1/2 don't solve the issue. Keep in min
 
 ---
 
-## Fix Log
-
-> Every fix lands here with a one-line description and a "before/after" note once verified.
-
-- _(none yet)_
-
----
-
 ## Findings Log
 
 > Append newest entries at the top. Include date, source (sentry/fly/code), and concrete numbers.
@@ -305,11 +297,28 @@ Only fill this in if Phase 1 + 2 + 3 Tier 1/2 don't solve the issue. Keep in min
 - **Before:** `/friends.data` wait 18.5 s, `/__manifest` wait up to 6.6 s, static JS wait 26 s, health check failures during repro. Prisma primary-key lookup observed at 1139 ms.
 - **After:** TBD once PR 1 ships and we get real traffic samples. Will re-capture a HAR on the same flow and compare.
 
+### PR 2 — Tier 2 nav flicker + Sentry sample-rate trim (2026-04-10)
+- **`app/root.tsx`** — gated the skeleton swap (`WishlistRouteSkeleton` / `FriendsRouteSkeleton`) behind `useSpinDelay({ delay: 400, minDuration: 300 })`. Fast navigations (now normal on the bigger machine) keep rendering `<Outlet />` and never flicker through a skeleton; only genuinely slow transitions fall back to skeletons, and when they do they stay visible long enough to not strobe. Also mounted the existing (but previously unused) `<EpicProgress />` top progress bar in the root layout so every navigation gets a non-flickery loading indicator.
+- **`app/components/nav/bottom/bottom-nav-link.tsx`** — optimistic active state. Pulls `useNavigation()` + `useLocation()` and, during a pending route change, treats the nav *target* as active and the currently-rendered route as inactive. Kills the "I clicked Wishlist but Friends still looks selected" illusion. Dropped the now-redundant `pendingClassName` and the `label…` suffix since the optimistic highlight already communicates intent.
+- **`app/utils/monitoring.client.tsx`** — dropped `tracesSampleRate` from `1.0` → `0.1`, removed `browserProfilingIntegration` (we weren't reading the profiles). 10% sampling is still plenty for a low-traffic app and cuts browser-side Sentry overhead by an order of magnitude.
+- **`server/utils/monitoring.ts`** — same treatment: `tracesSampleRate` / `tracesSampler` → `0.1`, removed `nodeProfilingIntegration` (and its import of `@sentry/profiling-node`). Node profiling on a shared CPU adds real overhead; we can turn it back on per-investigation if needed.
+- **Not touched this PR (deferred to PR 3):** root loader trim (`roles.permissions` nested select is still read by `userHasRole` / `userHasPermission` elsewhere — killing it at the root would break those call sites; needs a more careful refactor), `/__manifest` caching, and removing the unused `@opentelemetry/*` dependencies.
+- **Before:** skeleton flickered in cached-nav case; bottom nav stayed on the previously-active tab during a pending nav; Sentry sampled 100% of traces on both client and server plus ran both browser and node profilers.
+- **After:** TBD — will re-capture HAR on the same friends → wishlist flow and confirm subjective "frozen" feel is gone.
+
 ---
 
 ## Session Log
 
 > Short summary of what was accomplished in each session and what the next session should pick up.
+
+### 2026-04-10 Session 3 — PR 2 (Tier 2 code fixes)
+- Branched `perf/tier-2-nav-flicker-root-loader` off `perf/tier-1-machine-resize` (stacked PR).
+- Fixed the root-layout skeleton flicker by gating it behind `useSpinDelay`, and mounted the previously-unused `EpicProgress` top progress bar.
+- Fixed the "stuck on Friends" illusion by giving `BottomNavLink` an optimistic active state driven by `useNavigation()`.
+- Trimmed Sentry sample rates (1.0 → 0.1) on both client and server, and removed both profiling integrations to stop taxing the box.
+- **Dropped** the root-loader trim: `userHasRole` / `userHasPermission` (used by `user-dropdown.tsx` and `wishlist-item.tsx`) still read `user.roles[*].permissions[*]`, so pruning the select at root would break them. Needs a separate refactor → pushed to PR 3.
+- **Next session:** get PR 2 reviewed + merged, re-capture a HAR on prod to validate Tier 1+2 numbers, then scope PR 3 (root loader trim, `/__manifest` caching, drop unused `@opentelemetry/*` deps).
 
 ### 2026-04-10 Session 2 — Root cause identified
 - Received HAR + Firefox profile from the user (gitignored immediately).

--- a/app/components/nav/bottom/bottom-nav-link.test.tsx
+++ b/app/components/nav/bottom/bottom-nav-link.test.tsx
@@ -1,0 +1,179 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import { Home } from 'lucide-react';
+import React from 'react';
+import type ReactRouter from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const useNavigationMock = vi.fn();
+const useLocationMock = vi.fn();
+
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual<typeof ReactRouter>('react-router');
+  return {
+    ...actual,
+    useNavigation: () => useNavigationMock(),
+    useLocation: () => useLocationMock(),
+    // Stub NavLink so the test controls what `isActive` gets passed to the
+    // render props. We always pass `isActive: true` because the BottomNavLink
+    // is supposed to IGNORE it during a pending-to-different-route nav — the
+    // override is the behavior under test.
+    NavLink: ({
+      className,
+      children,
+      to,
+      ...rest
+    }: {
+      className?:
+        | string
+        | ((args: { isActive: boolean; isPending: boolean }) => string);
+      children?:
+        | React.ReactNode
+        | ((args: {
+            isActive: boolean;
+            isPending: boolean;
+          }) => React.ReactNode);
+      to: string;
+      'aria-label'?: string;
+    }) => {
+      const classStr =
+        typeof className === 'function'
+          ? className({ isActive: true, isPending: false })
+          : (className ?? '');
+      const content =
+        typeof children === 'function'
+          ? children({ isActive: true, isPending: false })
+          : children;
+      return (
+        <a href={to} className={classStr} {...rest}>
+          {content}
+        </a>
+      );
+    },
+  };
+});
+
+import { BottomNavLink } from './bottom-nav-link.tsx';
+
+const activeClassName = 'text-primary';
+const inactiveClassName = 'text-muted-foreground';
+
+beforeEach(() => {
+  useNavigationMock.mockReset();
+  useLocationMock.mockReset();
+});
+
+describe('<BottomNavLink /> optimistic active state', () => {
+  it('falls back to the NavLink isActive prop when there is no pending navigation', () => {
+    useNavigationMock.mockReturnValue({ state: 'idle', location: undefined });
+    useLocationMock.mockReturnValue({
+      pathname: '/',
+      search: '',
+      hash: '',
+    });
+
+    render(<BottomNavLink to="/wishlist" icon={Home} label="Wishlist" />);
+
+    const link = screen.getByRole('link', { name: 'Wishlist' });
+    // NavLink stub passes isActive=true, no pending nav → effective active stays true.
+    expect(link.className).toContain(activeClassName);
+    expect(link.className).not.toContain(inactiveClassName);
+  });
+
+  it('marks the pending target as active even though NavLink reports isActive=false for it', () => {
+    useNavigationMock.mockReturnValue({
+      state: 'loading',
+      location: { pathname: '/wishlist', search: '', hash: '' },
+    });
+    useLocationMock.mockReturnValue({
+      pathname: '/friends',
+      search: '',
+      hash: '',
+    });
+
+    render(<BottomNavLink to="/wishlist" icon={Home} label="Wishlist" />);
+
+    // We're navigating FROM /friends TO /wishlist. The wishlist link should
+    // become active immediately, regardless of what NavLink's isActive says.
+    const link = screen.getByRole('link', { name: 'Wishlist' });
+    expect(link.className).toContain(activeClassName);
+  });
+
+  it('deactivates the previously-active tab during a pending nav away from it', () => {
+    useNavigationMock.mockReturnValue({
+      state: 'loading',
+      location: { pathname: '/wishlist', search: '', hash: '' },
+    });
+    useLocationMock.mockReturnValue({
+      pathname: '/friends',
+      search: '',
+      hash: '',
+    });
+
+    // The Friends link is the one we're leaving. NavLink stub still reports
+    // isActive=true, but our optimistic override should force it inactive.
+    render(<BottomNavLink to="/friends" icon={Home} label="Friends" />);
+
+    const link = screen.getByRole('link', { name: 'Friends' });
+    expect(link.className).toContain(inactiveClassName);
+    expect(link.className).not.toContain(activeClassName);
+  });
+
+  it('treats a sub-route navigation as targeting its parent tab', () => {
+    useNavigationMock.mockReturnValue({
+      state: 'loading',
+      location: { pathname: '/wishlist/123', search: '', hash: '' },
+    });
+    useLocationMock.mockReturnValue({
+      pathname: '/friends',
+      search: '',
+      hash: '',
+    });
+
+    render(<BottomNavLink to="/wishlist" icon={Home} label="Wishlist" />);
+
+    // matchesPath should treat /wishlist/123 as a match for the /wishlist tab.
+    const link = screen.getByRole('link', { name: 'Wishlist' });
+    expect(link.className).toContain(activeClassName);
+  });
+
+  it('ignores same-route revalidations (form submissions) so tabs do not re-skin', () => {
+    useNavigationMock.mockReturnValue({
+      state: 'loading',
+      location: { pathname: '/wishlist', search: '', hash: '' },
+    });
+    useLocationMock.mockReturnValue({
+      pathname: '/wishlist',
+      search: '',
+      hash: '',
+    });
+
+    render(<BottomNavLink to="/friends" icon={Home} label="Friends" />);
+
+    // Same-route revalidation should not count as a pending nav; the Friends
+    // link should fall back to whatever NavLink reports (isActive=true via
+    // our stub).
+    const link = screen.getByRole('link', { name: 'Friends' });
+    expect(link.className).toContain(activeClassName);
+  });
+
+  it('handles the "/" home link via exact match (does not false-match other routes)', () => {
+    useNavigationMock.mockReturnValue({
+      state: 'loading',
+      location: { pathname: '/wishlist', search: '', hash: '' },
+    });
+    useLocationMock.mockReturnValue({
+      pathname: '/friends',
+      search: '',
+      hash: '',
+    });
+
+    render(<BottomNavLink to="/" icon={Home} label="Home" />);
+
+    // Navigating to /wishlist should NOT make the Home ("/") link active.
+    const link = screen.getByRole('link', { name: 'Home' });
+    expect(link.className).toContain(inactiveClassName);
+  });
+});

--- a/app/components/nav/bottom/bottom-nav-link.test.tsx
+++ b/app/components/nav/bottom/bottom-nav-link.test.tsx
@@ -4,7 +4,7 @@
 import { render, screen } from '@testing-library/react';
 import { Home } from 'lucide-react';
 import React from 'react';
-import type ReactRouter from 'react-router';
+import type * as ReactRouter from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const useNavigationMock = vi.fn();

--- a/app/components/nav/bottom/bottom-nav-link.tsx
+++ b/app/components/nav/bottom/bottom-nav-link.tsx
@@ -51,14 +51,16 @@ export const BottomNavLink = ({
 
   // Only treat a nav as "in flight" if it's targeting a different route.
   // Form submissions / same-route revalidations should not re-skin the tabs.
-  const pendingToDifferentRoute =
+  const pendingTargetPath =
     navigation.state === 'loading' &&
     navigation.location != null &&
-    navigation.location.pathname !== location.pathname;
+    navigation.location.pathname !== location.pathname
+      ? navigation.location.pathname
+      : null;
 
   const isPendingTarget =
-    pendingToDifferentRoute &&
-    matchesPath(to, navigation.location!.pathname);
+    pendingTargetPath !== null && matchesPath(to, pendingTargetPath);
+  const pendingToDifferentRoute = pendingTargetPath !== null;
 
   return (
     <NavLink

--- a/app/components/nav/bottom/bottom-nav-link.tsx
+++ b/app/components/nav/bottom/bottom-nav-link.tsx
@@ -1,10 +1,9 @@
 import { type LucideIcon } from 'lucide-react';
-import { NavLink } from 'react-router';
+import { NavLink, useLocation, useNavigation } from 'react-router';
 import { cn } from '#app/utils/misc.tsx';
 
 const activeClassName = 'text-primary';
 const inactiveClassName = 'text-muted-foreground';
-const pendingClassName = 'text-primary/80';
 const baseClassName =
   'flex h-full w-full flex-col items-center justify-center gap-1 px-1 py-2 text-[10px] font-medium leading-tight transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background';
 
@@ -26,10 +25,17 @@ function BottomNavLinkContent({
         className={cn('h-5 w-5', isPending && 'animate-pulse')}
         strokeWidth={isActive ? 2.4 : 2}
       />
-      <span>{isPending ? `${label}…` : label}</span>
+      <span>{label}</span>
     </>
   );
 }
+
+// Determine whether `to` matches `pathname` the way NavLink's isActive would:
+// exact match for "/" and prefix match (with a "/" boundary) for everything else.
+const matchesPath = (to: string, pathname: string) => {
+  if (to === '/') return pathname === '/';
+  return pathname === to || pathname.startsWith(`${to}/`);
+};
 
 export const BottomNavLink = ({
   to,
@@ -40,29 +46,52 @@ export const BottomNavLink = ({
   icon: LucideIcon;
   label: string;
 }) => {
+  const navigation = useNavigation();
+  const location = useLocation();
+
+  // Only treat a nav as "in flight" if it's targeting a different route.
+  // Form submissions / same-route revalidations should not re-skin the tabs.
+  const pendingToDifferentRoute =
+    navigation.state === 'loading' &&
+    navigation.location != null &&
+    navigation.location.pathname !== location.pathname;
+
+  const isPendingTarget =
+    pendingToDifferentRoute &&
+    matchesPath(to, navigation.location!.pathname);
+
   return (
     <NavLink
       to={to}
       prefetch="intent"
       aria-label={label}
-      className={({ isActive, isPending }) =>
-        cn(
+      className={({ isActive }) => {
+        // Optimistic active state: during a route change, the target tab
+        // immediately becomes active and the previously-active tab becomes
+        // inactive. This fixes the "clicked Wishlist but Friends still looks
+        // selected" illusion while the loader is running.
+        const effectiveActive = pendingToDifferentRoute
+          ? isPendingTarget
+          : isActive;
+        return cn(
           baseClassName,
-          isActive
-            ? activeClassName
-            : isPending
-              ? pendingClassName
-              : inactiveClassName,
-        )
-      }
+          effectiveActive ? activeClassName : inactiveClassName,
+        );
+      }}
     >
-      {({ isActive, isPending }) => (
-        <BottomNavLinkContent
-          icon={icon}
-          label={label}
-          isActive={isActive}
-          isPending={isPending} />
-      )}
+      {({ isActive }) => {
+        const effectiveActive = pendingToDifferentRoute
+          ? isPendingTarget
+          : isActive;
+        return (
+          <BottomNavLinkContent
+            icon={icon}
+            label={label}
+            isActive={effectiveActive}
+            isPending={isPendingTarget}
+          />
+        );
+      }}
     </NavLink>
   );
 };

--- a/app/root.test.tsx
+++ b/app/root.test.tsx
@@ -62,6 +62,10 @@ vi.mock('./components/notifications/notifications-context.tsx', () => ({
   ),
 }));
 
+vi.mock('./components/progress-bar.tsx', () => ({
+  EpicProgress: () => <div data-testid="epic-progress" />,
+}));
+
 vi.mock('./components/pwa-install-banner.tsx', () => ({
   PwaInstallBanner: () => <div>install banner</div>,
 }));
@@ -205,6 +209,10 @@ beforeEach(() => {
 
 describe('app/root.tsx', () => {
   it('renders the friends route skeleton during a pending friends navigation', () => {
+    // `useSpinDelay` intentionally returns true on SSR (there is no prior
+    // content to flash against, so showing the skeleton immediately is
+    // correct on the server). The client-side delay-gating is what prevents
+    // the flicker we're fixing — that path isn't exercised by SSR tests.
     const markup = renderToStaticMarkup(<AppWithProviders />);
 
     expect(markup).toContain('data-testid="friends-route-skeleton"');

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -26,6 +26,7 @@ import {
 } from 'react-router';
 import { HoneypotProvider } from 'remix-utils/honeypot/react';
 import { toast } from 'sonner';
+import { useSpinDelay } from 'spin-delay';
 import { z } from 'zod';
 import appleTouchIconAssetUrl from './assets/favicons/apple-touch-icon.png';
 import faviconAssetUrl from './assets/favicons/favicon.svg';
@@ -33,6 +34,7 @@ import { GeneralErrorBoundary } from './components/error-boundary.tsx';
 import { BottomNav } from './components/nav/bottom/bottom-nav.tsx';
 import { TopBar } from './components/nav/top-bar.tsx';
 import { NotificationsProvider } from './components/notifications/notifications-context.tsx';
+import { EpicProgress } from './components/progress-bar.tsx';
 import { PwaInstallBanner } from './components/pwa-install-banner.tsx';
 import { useToast } from './components/toaster.tsx';
 import { href as iconsHref } from './components/ui/icon.tsx';
@@ -385,10 +387,20 @@ const App = () => {
     navigation.state === 'loading' &&
     isRouteChangeNavigation &&
     isFriendsNavigationTarget;
+  // Only show skeletons when the nav is slow enough to notice. Fast
+  // transitions should just swap content to avoid a flicker of skeleton.
+  const showWishlistSkeleton = useSpinDelay(isWishlistNavigationPending, {
+    delay: 400,
+    minDuration: 300,
+  });
+  const showFriendsSkeleton = useSpinDelay(isFriendsNavigationPending, {
+    delay: 400,
+    minDuration: 300,
+  });
   let routeContent = <Outlet />;
-  if (isWishlistNavigationPending) {
+  if (showWishlistSkeleton) {
     routeContent = <WishlistRouteSkeleton />;
-  } else if (isFriendsNavigationPending) {
+  } else if (showFriendsSkeleton) {
     routeContent = <FriendsRouteSkeleton />;
   }
   return (
@@ -429,6 +441,7 @@ const App = () => {
 
             <Footer />
           </div>
+          <EpicProgress />
           <EpicToaster closeButton position="top-center" theme={theme} />
         </NotificationsProvider>
       </I18nProvider>

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -378,30 +378,30 @@ const App = () => {
     targetLocation != null &&
     (targetLocation.pathname === '/wishlist' ||
       /^\/users\/[^/]+\/wishlist$/.test(targetLocation.pathname));
-  const isWishlistNavigationPending =
-    navigation.state === 'loading' &&
-    isRouteChangeNavigation &&
-    isWishlistNavigationTarget;
   const isFriendsNavigationTarget = targetLocation?.pathname === '/friends';
-  const isFriendsNavigationPending =
+  const hasSkeletonTarget =
+    isWishlistNavigationTarget || isFriendsNavigationTarget;
+  const isSkeletonNavigationPending =
     navigation.state === 'loading' &&
     isRouteChangeNavigation &&
-    isFriendsNavigationTarget;
-  // Only show skeletons when the nav is slow enough to notice. Fast
-  // transitions should just swap content to avoid a flicker of skeleton.
-  const showWishlistSkeleton = useSpinDelay(isWishlistNavigationPending, {
-    delay: 400,
-    minDuration: 300,
-  });
-  const showFriendsSkeleton = useSpinDelay(isFriendsNavigationPending, {
+    hasSkeletonTarget;
+  // Gate the skeleton swap behind a small delay so fast navigations don't
+  // flicker through a skeleton. Use a SINGLE useSpinDelay for the overall
+  // "should a skeleton be visible" question; pick which skeleton off the
+  // current navigation target so that if the user redirects mid-flight
+  // (e.g. clicks Friends while a wishlist nav is still winding down) we
+  // always render the skeleton for the route they're actually going to.
+  const showSkeleton = useSpinDelay(isSkeletonNavigationPending, {
     delay: 400,
     minDuration: 300,
   });
   let routeContent = <Outlet />;
-  if (showWishlistSkeleton) {
-    routeContent = <WishlistRouteSkeleton />;
-  } else if (showFriendsSkeleton) {
-    routeContent = <FriendsRouteSkeleton />;
+  if (showSkeleton) {
+    if (isWishlistNavigationTarget) {
+      routeContent = <WishlistRouteSkeleton />;
+    } else if (isFriendsNavigationTarget) {
+      routeContent = <FriendsRouteSkeleton />;
+    }
   }
   return (
     <Document nonce={nonce} theme={theme} env={data.ENV}>

--- a/app/utils/monitoring.client.tsx
+++ b/app/utils/monitoring.client.tsx
@@ -2,7 +2,6 @@ import {
   init as sentryInit,
   reactRouterTracingIntegration,
   replayIntegration,
-  browserProfilingIntegration,
 } from '@sentry/react-router';
 
 export function init() {
@@ -22,16 +21,12 @@ export function init() {
       }
       return event;
     },
-    integrations: [
-      reactRouterTracingIntegration(),
-      replayIntegration(),
-      browserProfilingIntegration(),
-    ],
+    integrations: [reactRouterTracingIntegration(), replayIntegration()],
 
-    // Set tracesSampleRate to 1.0 to capture 100%
-    // of transactions for performance monitoring.
-    // We recommend adjusting this value in production
-    tracesSampleRate: 1.0,
+    // Sample 10% of transactions in production. The previous 100% rate was
+    // creating measurable overhead on a small Fly machine while providing
+    // more data than we actually consume.
+    tracesSampleRate: 0.1,
 
     // Capture Replay for 10% of all sessions,
     // plus for 100% of sessions with an error

--- a/server/utils/monitoring.ts
+++ b/server/utils/monitoring.ts
@@ -1,11 +1,13 @@
-import { nodeProfilingIntegration } from '@sentry/profiling-node';
 import * as Sentry from '@sentry/react-router';
 
 export function init() {
   Sentry.init({
     dsn: process.env.SENTRY_DSN,
     environment: process.env.NODE_ENV,
-    tracesSampleRate: process.env.NODE_ENV === 'production' ? 1 : 0,
+    // Sample 10% of transactions in production. The previous 100% rate was
+    // expensive on a small Fly machine while producing more data than we
+    // actually consume.
+    tracesSampleRate: process.env.NODE_ENV === 'production' ? 0.1 : 0,
     denyUrls: [
       /\/resources\/healthcheck/,
       // TODO: be smarter about the public assets...
@@ -16,17 +18,13 @@ export function init() {
       /\/favicon.ico/,
       /\/site\.webmanifest/,
     ],
-    integrations: [
-      Sentry.httpIntegration(),
-      Sentry.prismaIntegration(),
-      nodeProfilingIntegration(),
-    ],
+    integrations: [Sentry.httpIntegration(), Sentry.prismaIntegration()],
     tracesSampler(samplingContext) {
       // ignore healthcheck transactions by other services (consul, etc.)
       if (samplingContext.request?.url?.includes('/resources/healthcheck')) {
         return 0;
       }
-      return 1;
+      return 0.1;
     },
     beforeSendTransaction(event) {
       // ignore all healthcheck related transactions


### PR DESCRIPTION
## Summary

Tier 2 of the performance investigation (see `PERFORMANCE_INVESTIGATION.md`). Fixes three symptoms the user reported in production:

1. **Friends page flicker** — cached content → skeleton → final content
2. **"Stuck on Friends" illusion** — clicked Wishlist but the bottom nav still highlighted Friends
3. **Sentry overhead** — 100% trace sampling + browser and node profiling on a shared-CPU box

## Changes

- **`app/root.tsx`** — gate the `<Outlet />` → skeleton swap behind `useSpinDelay({ delay: 400, minDuration: 300 })`. Fast navigations keep rendering `<Outlet />` and never flicker through a skeleton; only genuinely slow transitions fall back to skeletons. Mounted the existing (previously unused) `<EpicProgress />` top progress bar so every navigation still has a loading indicator.
- **`app/components/nav/bottom/bottom-nav-link.tsx`** — optimistic active state via `useNavigation()` + `useLocation()`. During a pending route change, the target tab becomes active and the previously-active tab goes inactive, killing the "clicked Wishlist but Friends is still highlighted" illusion.
- **`app/utils/monitoring.client.tsx`** — `tracesSampleRate` 1.0 → 0.1, dropped `browserProfilingIntegration`.
- **`server/utils/monitoring.ts`** — same treatment: `tracesSampleRate` / `tracesSampler` → 0.1, dropped `nodeProfilingIntegration` (and its `@sentry/profiling-node` import).
- **`PERFORMANCE_INVESTIGATION.md`** — Fix Log entry for PR 2, Session 3 log entry, deduped an empty Fix Log heading.

## Not in this PR (deferred to PR 3)

- **Root loader trim** — originally planned to drop the `roles.permissions` nested select, but `userHasRole` / `userHasPermission` (consumed by `user-dropdown.tsx` and `wishlist-item.tsx`) still read it. Needs a more careful refactor.
- **`/__manifest` caching** — HAR showed 16 calls/session with two over 4 s.
- **Dropping unused `@opentelemetry/*` deps** — they're in `package.json` but never init'd.

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm test -- --run app/root.test.tsx` — passes (updated to mock the new `progress-bar.tsx` import and added a clarifying comment about why `useSpinDelay` still renders the skeleton on SSR)
- [ ] After merge + deploy: re-capture a HAR on the same friends → wishlist repro and compare against the PR 1 baseline in the investigation doc
- [ ] After merge + deploy: subjective feel — click around production for 5 min and confirm the "frozen" sensation is gone