### PR TITLE
feat(friends): revamp page layout — clickable rows, birthdays, mutual groups

### DIFF
--- a/app/components/friends/friend-action-button.tsx
+++ b/app/components/friends/friend-action-button.tsx
@@ -362,23 +362,24 @@ export const FriendActionButton = ({
           </Button>
         );
       case 'PENDING_OUTGOING':
+        // Drop the disabled "Request sent" pseudo-button — the row's
+        // location in the Pending requests section already conveys that
+        // status, so the pill is dead weight that fights with the real
+        // Cancel action for visual attention. Just keep the actionable
+        // Cancel button.
         return (
-          <div className={cn('flex items-center gap-2', className)}>
-            <Button size={buttonSize} variant="secondary" disabled>
-              {t('friends.requestSent')}
-            </Button>
-            <Button
-              size={buttonSize}
-              variant="ghost"
-              onClick={handleCancelRequestClick}
-              disabled={isPending('cancel') || !canCancelOutgoing}
-            >
-              {isPending('cancel') ? (
-                <LuLoader className="mr-2 h-4 w-4 animate-spin" aria-hidden />
-              ) : null}
-              {t('friends.cancelRequest')}
-            </Button>
-          </div>
+          <Button
+            size={buttonSize}
+            variant="secondary"
+            className={cn('gap-2', className)}
+            onClick={handleCancelRequestClick}
+            disabled={isPending('cancel') || !canCancelOutgoing}
+          >
+            {isPending('cancel') ? (
+              <LuLoader className="h-4 w-4 animate-spin" aria-hidden />
+            ) : null}
+            {t('friends.cancelRequest')}
+          </Button>
         );
       case 'PENDING_INCOMING':
         return (

--- a/app/components/friends/friend-row.test.tsx
+++ b/app/components/friends/friend-row.test.tsx
@@ -1,0 +1,167 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { createRoutesStub } from 'react-router';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { FriendRow, type FriendRowEntry } from './friend-row.tsx';
+
+vi.mock('../ui/avatar.tsx', () => ({
+  Avatar: ({ user }: { user: { username: string } }) => (
+    <div data-testid="avatar">{user.username}</div>
+  ),
+}));
+
+const baseUser: FriendRowEntry['user'] = {
+  id: 'user-1',
+  username: 'alex',
+  name: 'Alex Carter',
+  birthday: null,
+  image: null,
+};
+
+const baseFriend: FriendRowEntry = {
+  friendshipId: 'friendship-1',
+  user: baseUser,
+  mutualGroups: [],
+};
+
+function renderRow(
+  override: Partial<FriendRowEntry> = {},
+  onRemove = vi.fn(),
+) {
+  const friend: FriendRowEntry = {
+    ...baseFriend,
+    ...override,
+    user: { ...baseUser, ...(override.user ?? {}) },
+  };
+  const App = createRoutesStub([
+    {
+      path: '/',
+      Component: () => (
+        <FriendRow
+          friend={friend}
+          displayName={friend.user.name ?? friend.user.username}
+          onRemove={onRemove}
+        />
+      ),
+    },
+    {
+      path: '/users/:username/wishlist',
+      Component: () => <div>wishlist for friend</div>,
+    },
+    {
+      path: '/users/:username',
+      Component: () => <div>profile for friend</div>,
+    },
+  ]);
+  render(<App initialEntries={['/']} />);
+  return { onRemove };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-04-10T12:00:00.000Z'));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('<FriendRow />', () => {
+  it('renders the displayName and @username', () => {
+    renderRow();
+    expect(screen.getByText('Alex Carter')).toBeInTheDocument();
+    expect(screen.getByText('@alex')).toBeInTheDocument();
+  });
+
+  it('exposes a click target on the whole card via an aria-labelled link', () => {
+    renderRow();
+    const link = screen.getByRole('link', {
+      name: "View Alex Carter's wishlist",
+    });
+    expect(link).toHaveAttribute('href', '/users/alex/wishlist');
+  });
+
+  it('shows a birthday badge for friends within the 60-day window', () => {
+    // Birthday in 5 days (Apr 15) — should surface
+    renderRow({
+      user: {
+        ...baseUser,
+        birthday: new Date(1990, 3, 15),
+      },
+    });
+    expect(screen.getByText('Apr 15')).toBeInTheDocument();
+  });
+
+  it('renders a "Tomorrow" badge when the birthday is exactly 1 day away', () => {
+    renderRow({
+      user: {
+        ...baseUser,
+        birthday: new Date(1990, 3, 11),
+      },
+    });
+    expect(screen.getByText('Tomorrow')).toBeInTheDocument();
+  });
+
+  it('does not render a birthday badge when the next birthday is far in the future', () => {
+    // Birthday in ~80 days
+    renderRow({
+      user: {
+        ...baseUser,
+        birthday: new Date(1990, 5, 30),
+      },
+    });
+    // Just check there's no cake-emoji label.
+    expect(screen.queryByText(/Jun 30/)).not.toBeInTheDocument();
+  });
+
+  it('renders mutual group chips', () => {
+    renderRow({
+      mutualGroups: [
+        { id: 'g1', name: 'The Crew' },
+        { id: 'g2', name: 'Book Club' },
+      ],
+    });
+    expect(screen.getByText('The Crew')).toBeInTheDocument();
+    expect(screen.getByText('Book Club')).toBeInTheDocument();
+  });
+
+  it('caps mutual group chips at 3 with a +N indicator', () => {
+    renderRow({
+      mutualGroups: [
+        { id: 'g1', name: 'A' },
+        { id: 'g2', name: 'B' },
+        { id: 'g3', name: 'C' },
+        { id: 'g4', name: 'D' },
+        { id: 'g5', name: 'E' },
+      ],
+    });
+    expect(screen.getByText('A')).toBeInTheDocument();
+    expect(screen.getByText('B')).toBeInTheDocument();
+    expect(screen.getByText('C')).toBeInTheDocument();
+    expect(screen.queryByText('D')).not.toBeInTheDocument();
+    expect(screen.getByText('+2')).toBeInTheDocument();
+  });
+
+  it('opens the remove confirm dialog from the actions menu and calls onRemove', async () => {
+    vi.useRealTimers();
+    const user = userEvent.setup();
+    const { onRemove } = renderRow();
+
+    await user.click(
+      screen.getByRole('button', { name: 'Actions for Alex Carter' }),
+    );
+    await user.click(
+      await screen.findByRole('menuitem', { name: /remove friend/i }),
+    );
+    await user.click(
+      await screen.findByRole('button', { name: 'Remove friend' }),
+    );
+
+    expect(onRemove).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/components/friends/friend-row.tsx
+++ b/app/components/friends/friend-row.tsx
@@ -1,0 +1,246 @@
+import { useState } from 'react';
+import {
+  LuCake,
+  LuEllipsisVertical,
+  LuTrash,
+  LuUser,
+  LuUsers,
+} from 'react-icons/lu';
+import { Link } from 'react-router';
+
+import { Avatar } from '#app/components/ui/avatar.tsx';
+import { Button } from '#app/components/ui/button.tsx';
+import { Card } from '#app/components/ui/card.tsx';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '#app/components/ui/dialog.tsx';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '#app/components/ui/dropdown-menu.tsx';
+import { cn } from '#app/utils/misc.tsx';
+import { Text } from '../ui-kit/text.tsx';
+
+export type FriendRowEntry = {
+  friendshipId: string;
+  user: {
+    id: string;
+    username: string;
+    name: string | null;
+    birthday: Date | string | null;
+    image: { id: string; altText: string | null } | null;
+  };
+  mutualGroups: Array<{ id: string; name: string }>;
+};
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+// Compute the next occurrence of this birthday's month/day in the future,
+// returning the full date and how many days from today it is. Returns null
+// when the friend hasn't set a birthday.
+function getUpcomingBirthday(birthday: Date | string | null) {
+  if (!birthday) return null;
+  const parsed = birthday instanceof Date ? birthday : new Date(birthday);
+  if (Number.isNaN(parsed.getTime())) return null;
+  const now = new Date();
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const candidate = new Date(
+    today.getFullYear(),
+    parsed.getMonth(),
+    parsed.getDate(),
+  );
+  if (candidate.getTime() < today.getTime()) {
+    candidate.setFullYear(candidate.getFullYear() + 1);
+  }
+  const daysUntil = Math.round(
+    (candidate.getTime() - today.getTime()) / MS_PER_DAY,
+  );
+  return { date: candidate, daysUntil };
+}
+
+function formatBirthdayLabel(date: Date, daysUntil: number) {
+  if (daysUntil === 0) return 'Today!';
+  if (daysUntil === 1) return 'Tomorrow';
+  return new Intl.DateTimeFormat('en', {
+    month: 'short',
+    day: 'numeric',
+  }).format(date);
+}
+
+// Days within which we surface a friend's birthday on the row right slot.
+// Matches the Home Upcoming Birthdays card window so the two views agree.
+export const BIRTHDAY_VISIBILITY_DAYS = 60;
+
+export function FriendRow({
+  friend,
+  displayName,
+  onRemove,
+}: {
+  friend: FriendRowEntry;
+  displayName: string;
+  onRemove: () => void;
+}) {
+  const { user, mutualGroups } = friend;
+  const upcoming = getUpcomingBirthday(user.birthday);
+  const birthdaySoon =
+    upcoming && upcoming.daysUntil <= BIRTHDAY_VISIBILITY_DAYS
+      ? upcoming
+      : null;
+  const visibleGroups = mutualGroups.slice(0, 3);
+  const extraGroupCount = Math.max(0, mutualGroups.length - visibleGroups.length);
+  const [removeOpen, setRemoveOpen] = useState(false);
+
+  return (
+    <Card
+      variant="default"
+      padding="none"
+      data-testid="friend-row"
+      className={cn(
+        'group relative min-w-0 cursor-pointer overflow-hidden rounded-xl border border-border/80 bg-card shadow-sm transition-shadow',
+        'hover:border-border hover:shadow-md',
+        'focus-within:border-border focus-within:shadow-md',
+      )}
+    >
+      {/*
+       * Whole-card click target. Same absolute click-catcher pattern as
+       * the wishlist row primitive: a Link with `inset-0` covers the
+       * entire card so any tap navigates to the friend's wishlist, while
+       * the action menu in the right slot re-enables pointer events for
+       * itself via `pointer-events-auto`.
+       */}
+      <Link
+        to={`/users/${user.username}/wishlist`}
+        prefetch="intent"
+        aria-label={`View ${displayName}'s wishlist`}
+        className="absolute inset-0 rounded-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+      />
+
+      <div className="pointer-events-none relative flex items-center gap-3 p-3 sm:gap-4 sm:p-4">
+        <Avatar size="m" image={user.image} user={user} />
+        <div className="flex min-w-0 flex-1 flex-col items-start gap-1 text-left">
+          <div className="flex w-full min-w-0 flex-wrap items-baseline gap-x-2 gap-y-0.5">
+            <Text
+              size="base"
+              weight="medium"
+              className="min-w-0 max-w-full truncate text-foreground"
+            >
+              {displayName}
+            </Text>
+            <Text size="xs" className="truncate text-muted-foreground">
+              @{user.username}
+            </Text>
+          </div>
+          {visibleGroups.length > 0 ? (
+            <div className="flex flex-wrap gap-1">
+              {visibleGroups.map((group) => (
+                <span
+                  key={group.id}
+                  className="inline-flex max-w-[12rem] items-center gap-1 truncate rounded-full bg-muted/60 px-2 py-0.5 text-[11px] font-medium text-muted-foreground"
+                >
+                  <LuUsers className="h-3 w-3 flex-shrink-0" aria-hidden />
+                  <span className="truncate">{group.name}</span>
+                </span>
+              ))}
+              {extraGroupCount > 0 ? (
+                <span className="inline-flex items-center rounded-full bg-muted/60 px-2 py-0.5 text-[11px] font-medium text-muted-foreground">
+                  +{extraGroupCount}
+                </span>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+
+        {birthdaySoon ? (
+          <div
+            className="hidden flex-shrink-0 items-center gap-1 rounded-full bg-amber-100 px-2.5 py-1 text-[11px] font-semibold text-amber-900 ring-1 ring-inset ring-amber-200 sm:flex"
+            aria-label={`Birthday ${formatBirthdayLabel(birthdaySoon.date, birthdaySoon.daysUntil)}`}
+          >
+            <LuCake className="h-3.5 w-3.5" aria-hidden />
+            <span>
+              {formatBirthdayLabel(birthdaySoon.date, birthdaySoon.daysUntil)}
+            </span>
+          </div>
+        ) : null}
+
+        <div className="pointer-events-auto relative flex flex-shrink-0 items-center">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                aria-label={`Actions for ${displayName}`}
+                className="h-10 w-10 rounded-lg border border-transparent text-muted-foreground transition hover:bg-muted hover:text-foreground"
+                onClick={(event) => event.stopPropagation()}
+              >
+                <LuEllipsisVertical className="h-4 w-4" aria-hidden />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent
+              align="end"
+              sideOffset={8}
+              className="min-w-[12rem]"
+              onClick={(event) => event.stopPropagation()}
+            >
+              <DropdownMenuItem asChild className="gap-2 px-2 py-2 text-sm">
+                <Link to={`/users/${user.username}`}>
+                  <LuUser className="h-4 w-4 text-muted-foreground" aria-hidden />
+                  View profile
+                </Link>
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                className="gap-2 px-2 py-2 text-sm text-red-600 focus:text-red-700"
+                onSelect={(event) => {
+                  // Stop the menu's default close+activation; we want to
+                  // open our controlled confirm dialog instead.
+                  event.preventDefault();
+                  setRemoveOpen(true);
+                }}
+              >
+                <LuTrash className="h-4 w-4" aria-hidden />
+                Remove friend
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </div>
+
+      <Dialog open={removeOpen} onOpenChange={setRemoveOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Remove {displayName}?</DialogTitle>
+          </DialogHeader>
+          <DialogDescription>
+            This will end your friendship with {displayName}. You can always
+            send them a new friend request later.
+          </DialogDescription>
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button type="button" variant="secondary">
+                Cancel
+              </Button>
+            </DialogClose>
+            <Button
+              type="button"
+              variant="destructive"
+              onClick={() => {
+                onRemove();
+                setRemoveOpen(false);
+              }}
+            >
+              Remove friend
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </Card>
+  );
+}

--- a/app/components/friends/friend-row.tsx
+++ b/app/components/friends/friend-row.tsx
@@ -83,11 +83,11 @@ export function FriendRow({
   friend,
   displayName,
   onRemove,
-}: {
+}: Readonly<{
   friend: FriendRowEntry;
   displayName: string;
   onRemove: () => void;
-}) {
+}>) {
   const { user, mutualGroups } = friend;
   const upcoming = getUpcomingBirthday(user.birthday);
   const birthdaySoon =

--- a/app/i18n/dictionaries/en.ts
+++ b/app/i18n/dictionaries/en.ts
@@ -37,7 +37,6 @@ export const en = {
     add: 'Add Friend',
     accept: 'Accept',
     reject: 'Reject',
-    requestSent: 'Request sent',
     cancelRequest: 'Cancel request',
     friends: 'Friends',
     remove: 'Remove friend',

--- a/app/routes/friends.test.tsx
+++ b/app/routes/friends.test.tsx
@@ -186,9 +186,13 @@ vi.mock('#app/components/ui/dialog.tsx', () => ({
   DialogContent: ({ children }: { children: React.ReactNode }) => (
     <div role="dialog">{children}</div>
   ),
+  DialogDescription: ({ children }: { children: React.ReactNode }) => (
+    <p>{children}</p>
+  ),
   DialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   DialogTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogClose: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
 vi.mock('#app/components/ui/empty-state.tsx', () => ({
@@ -240,6 +244,7 @@ type FriendUser = {
   image: { altText: string | null; id: string } | null;
   name: string | null;
   username: string;
+  birthday: Date | null;
 };
 
 function createUser(id: string, username: string, name = username): FriendUser {
@@ -248,6 +253,7 @@ function createUser(id: string, username: string, name = username): FriendUser {
     image: null,
     name,
     username,
+    birthday: null,
   };
 }
 
@@ -256,6 +262,7 @@ function createFriend(friendshipId: string, username: string, name = username) {
     createdAt: new Date('2026-03-31T00:00:00.000Z'),
     friendshipId,
     user: createUser(`${friendshipId}-user`, username, name),
+    mutualGroups: [] as Array<{ id: string; name: string }>,
   };
 }
 
@@ -667,14 +674,21 @@ describe('/friends route helpers', () => {
 });
 
 describe('/friends route rendering', () => {
-  it('renders add tab, invite link controls, and QR dialog', async () => {
-    renderFriendsRoute({ entry: '/friends?tab=add' });
+  it('opens the Add friend dialog with invite link controls and QR', async () => {
+    // The Add friends panel is now tucked behind a primary "Add friend"
+    // button at the top of the page instead of being permanently expanded.
+    renderFriendsRoute();
 
-    expect(await screen.findByText('Add friends')).toBeInTheDocument();
+    await userEvent.click(
+      await screen.findByRole('button', { name: 'Add friend' }),
+    );
+    await waitFor(() => {
+      expect(friendPrefetchSpy).toHaveBeenCalledWith(['alex']);
+    });
+
     expect(
       await screen.findByRole('textbox', { name: 'Friend invite link' }),
     ).toBeInTheDocument();
-    expect(friendPrefetchSpy).toHaveBeenCalledWith(['alex']);
 
     await userEvent.click(screen.getByRole('button', { name: 'Copy invite link' }));
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
@@ -685,20 +699,6 @@ describe('/friends route rendering', () => {
     await waitFor(() => {
       expect(screen.getByAltText('Friend invite QR')).toBeInTheDocument();
     });
-  });
-
-  it('renders requests tab, selection mode, and batch actions', async () => {
-    renderFriendsRoute({ entry: '/friends?tab=requests' });
-
-    await expect(
-      screen.findAllByRole('button', { name: 'Select' }),
-    ).resolves.toHaveLength(2);
-    await userEvent.click((await screen.findAllByRole('button', { name: 'Select' }))[0]!);
-    expect(screen.getByLabelText('Select @sam')).toBeInTheDocument();
-    await userEvent.click(screen.getByLabelText('Select @sam'));
-    expect(screen.getAllByText('1 selected').length).toBeGreaterThan(0);
-    expect(screen.getByRole('button', { name: 'Accept (1)' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Decline (1)' })).toBeInTheDocument();
   });
 
   it('filters friends and uses virtualization for long lists', async () => {
@@ -714,7 +714,10 @@ describe('/friends route rendering', () => {
       },
     });
 
-    const filterInput = await screen.findByRole('textbox', { name: 'Search' });
+    // The search input only renders when there are >8 friends.
+    const filterInput = await screen.findByRole('textbox', {
+      name: 'Search friends',
+    });
     await userEvent.type(filterInput, 'friend 2');
     expect(screen.getByText('Friend 2')).toBeInTheDocument();
     expect(screen.queryByText('Friend 40')).not.toBeInTheDocument();
@@ -760,60 +763,12 @@ describe('/friends route rendering', () => {
     });
   });
 
-  it('removes a friend on success', async () => {
-    renderFriendsRoute({
-      data: {
-        friends: [createFriend('friendship-1', 'alex', 'Alex')],
-        incoming: [],
-        outgoing: [],
-      },
-    });
-
-    await screen.findByText('Alex');
-    await userEvent.click((await screen.findAllByText('confirm Remove friend'))[0]!);
-    await waitFor(() => {
-      expect(screen.queryByText('Alex')).not.toBeInTheDocument();
-    });
-    expect(globalThis.fetch).toHaveBeenCalledWith(
-      '/api/friends/remove',
-      expect.any(Object),
-    );
-  });
-
-  it('shows an error toast when removing a friend fails', async () => {
-    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input: RequestInfo | URL) => {
-      const url = typeof input === 'string' ? input : input.toString();
-      if (url.includes('/api/friends/invite')) {
-        return new Response(
-          JSON.stringify({ inviteUrl: 'https://giftpool.app/friends/accept/abc' }),
-          { status: 200, headers: { 'Content-Type': 'application/json' } },
-        );
-      }
-      if (url.includes('/api/friends/remove')) {
-        return new Response(null, { status: 500 });
-      }
-      return new Response(JSON.stringify({ ok: true }), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      });
-    });
-
-    renderFriendsRoute({
-      data: {
-        friends: [createFriend('friendship-2', 'sam', 'Sam')],
-        incoming: [],
-        outgoing: [],
-      },
-    });
-
-    await userEvent.click((await screen.findAllByText('confirm Remove friend'))[0]!);
-    await waitFor(() => {
-      expect(toastError).toHaveBeenCalledWith('Something went wrong. Try again.');
-    });
-  });
-
   it('shows empty search results after the debounced lookup settles', async () => {
-    renderFriendsRoute({ entry: '/friends?tab=add' });
+    renderFriendsRoute();
+
+    await userEvent.click(
+      await screen.findByRole('button', { name: 'Add friend' }),
+    );
 
     const input = await screen.findByPlaceholderText('e.g. alice');
     await userEvent.type(input, 'zoe');
@@ -832,18 +787,5 @@ describe('/friends route rendering', () => {
     });
 
     expect(await screen.findByText('No friends yet')).toBeInTheDocument();
-  });
-
-  it('shows the empty requests state when no requests exist', async () => {
-    renderFriendsRoute({
-      data: {
-        friends: [createFriend('friendship-1', 'alex', 'Alex')],
-        incoming: [],
-        outgoing: [],
-      },
-      entry: '/friends?tab=requests',
-    });
-
-    expect(await screen.findByText('No requests')).toBeInTheDocument();
   });
 });

--- a/app/routes/friends.tsx
+++ b/app/routes/friends.tsx
@@ -1,12 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import {
-  LuCopy,
-  LuHeart,
-  LuLink,
-  LuQrCode,
-  LuTrash,
-  LuUser,
-} from 'react-icons/lu';
+import { LuCopy, LuLink, LuPlus, LuQrCode } from 'react-icons/lu';
 import { Link, Outlet, useLoaderData, useSearchParams,
   type ClientLoaderFunctionArgs,
   type LoaderFunctionArgs,
@@ -16,14 +9,14 @@ import {
   FriendActionButton,
   type RelationshipSnapshot,
 } from '#app/components/friends/friend-action-button.tsx';
-import { FriendSummary } from '#app/components/friends/friend-summary.tsx';
+import { FriendRow as FriendRowCard } from '#app/components/friends/friend-row.tsx';
 import { useNotificationsStore } from '#app/components/notifications/notifications-context.tsx';
 import { Avatar } from '#app/components/ui/avatar.tsx';
 import { Button } from '#app/components/ui/button.tsx';
-import { ConfirmDialog } from '#app/components/ui/confirm-dialog.tsx';
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
@@ -91,61 +84,6 @@ type FriendRequestRowProps = Readonly<{
   selectMode: boolean;
   user: RequestListEntryUser;
 }>;
-type IncomingRequestSectionProps = Readonly<{
-  incoming: IncomingEntry[];
-  isSelectMode: boolean;
-  onStateChange: (
-    requestId: string,
-    user: IncomingEntry['fromUser'],
-  ) => (snapshot: RelationshipSnapshot) => void;
-  onToggleMode: () => void;
-  onToggleSelected: (requestId: string, selected: boolean) => void;
-  selectedIncoming: Set<string>;
-  t: TranslateFn;
-}>;
-type OutgoingRequestSectionProps = Readonly<{
-  isSelectMode: boolean;
-  onStateChange: (
-    requestId: string,
-    user: OutgoingEntry['toUser'],
-  ) => (snapshot: RelationshipSnapshot) => void;
-  onToggleMode: () => void;
-  onToggleSelected: (requestId: string, selected: boolean) => void;
-  outgoing: OutgoingEntry[];
-  selectedOutgoing: Set<string>;
-  t: TranslateFn;
-}>;
-type RequestSelectionBarProps = Readonly<{
-  onAccept: () => void;
-  onCancel: () => void;
-  onDecline: () => void;
-  selectedIncoming: Set<string>;
-  selectedOutgoing: Set<string>;
-}>;
-type FriendRowActionsProps = Readonly<{
-  displayName: string;
-  friend: FriendEntry;
-  onRemove: (friend: FriendEntry) => Promise<void>;
-  t: TranslateFn;
-}>;
-type FriendRowProps = Readonly<{
-  friend: FriendEntry;
-  mutuals: Record<
-    string,
-    {
-      groups: Array<{
-        id: string;
-        name: string;
-      }>;
-      more: number;
-    }
-  >;
-  onClose: () => void;
-  onOpen: () => void;
-  onRemove: (friend: FriendEntry) => Promise<void>;
-  open: boolean;
-  t: TranslateFn;
-}>;
 type SearchResultRowProps = Readonly<{
   onOutgoingCreated?: (
     requestId: string,
@@ -178,37 +116,6 @@ type InviteQrDialogProps = Readonly<{
   qrDataUrl: string | null;
 }>;
 type FriendsTab = 'add' | 'requests' | 'friends';
-type FriendsMobileHeaderProps = Readonly<{
-  activeTab: FriendsTab;
-  friendsFilter: string;
-  onFriendsFilterChange: (value: string) => void;
-  onTabChange: (value: FriendsTab) => void;
-}>;
-type FriendsRequestsPanelProps = Readonly<{
-  acceptSelectedIncoming: () => Promise<void>;
-  anySelected: boolean;
-  cancelSelectedOutgoing: () => Promise<void>;
-  declineSelectedIncoming: () => Promise<void>;
-  incomingSelectMode: boolean;
-  incomingState: IncomingEntry[];
-  onHandleIncomingSelection: (requestId: string, selected: boolean) => void;
-  onHandleOutgoingSelection: (requestId: string, selected: boolean) => void;
-  onHandleIncomingTransition: (
-    requestId: string,
-    user: IncomingEntry['fromUser'],
-  ) => (snapshot: RelationshipSnapshot) => void;
-  onHandleOutgoingTransition: (
-    requestId: string,
-    user: OutgoingEntry['toUser'],
-  ) => (snapshot: RelationshipSnapshot) => void;
-  onToggleIncomingSelectMode: () => void;
-  onToggleOutgoingSelectMode: () => void;
-  outgoingSelectMode: boolean;
-  outgoingState: OutgoingEntry[];
-  selectedIncoming: Set<string>;
-  selectedOutgoing: Set<string>;
-  t: TranslateFn;
-}>;
 type FriendsListSectionProps = Readonly<{
   activeTab: FriendsTab;
   filteredFriends: FriendEntry[];
@@ -248,6 +155,9 @@ export function buildFriendEntry(
     friendshipId: friendshipId ?? requestId,
     createdAt: new Date(),
     user,
+    // Optimistic entries (just-accepted friend requests) start without
+    // mutual-groups data. The next loader run will fill them in.
+    mutualGroups: [],
   };
 }
 
@@ -374,6 +284,53 @@ export function filterFriends(
   });
 }
 
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+const BIRTHDAY_SORT_WINDOW_DAYS = 60;
+
+// Days from `today` until this friend's next birthday (clamped to a year).
+// Returns Infinity for friends without a birthday — they sort to the bottom.
+function daysUntilNextBirthday(birthday: Date | string | null, today: Date) {
+  if (!birthday) return Number.POSITIVE_INFINITY;
+  const parsed = birthday instanceof Date ? birthday : new Date(birthday);
+  if (Number.isNaN(parsed.getTime())) return Number.POSITIVE_INFINITY;
+  const candidate = new Date(
+    today.getFullYear(),
+    parsed.getMonth(),
+    parsed.getDate(),
+  );
+  if (candidate.getTime() < today.getTime()) {
+    candidate.setFullYear(candidate.getFullYear() + 1);
+  }
+  return Math.round((candidate.getTime() - today.getTime()) / MS_PER_DAY);
+}
+
+// Sort friends so the people you most need to think about gifting come
+// first: anyone whose birthday is within the next 60 days, ordered by
+// soonest first; everyone else falls back to alphabetical by display
+// name. Stable enough to look ordered, useful enough that the list
+// surfaces something actionable above the fold.
+export function sortFriendsByUpcomingBirthday(
+  friends: FriendEntry[],
+  now: Date = new Date(),
+): FriendEntry[] {
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const withMeta = friends.map((friend, index) => ({
+    friend,
+    days: daysUntilNextBirthday(friend.user.birthday, today),
+    name: (friend.user.name ?? friend.user.username).toLowerCase(),
+    index,
+  }));
+  withMeta.sort((a, b) => {
+    const aSoon = a.days <= BIRTHDAY_SORT_WINDOW_DAYS;
+    const bSoon = b.days <= BIRTHDAY_SORT_WINDOW_DAYS;
+    if (aSoon && bSoon) return a.days - b.days || a.name.localeCompare(b.name);
+    if (aSoon) return -1;
+    if (bSoon) return 1;
+    return a.name.localeCompare(b.name);
+  });
+  return withMeta.map((entry) => entry.friend);
+}
+
 export function toggleSelection(set: Set<string>, id: string, selected: boolean) {
   const next = new Set(set);
   if (selected) next.add(id);
@@ -481,233 +438,6 @@ function FriendRequestRow({
         />
       )}
     </li>
-  );
-}
-
-function IncomingRequestSection({
-  incoming,
-  isSelectMode,
-  onStateChange,
-  onToggleMode,
-  onToggleSelected,
-  selectedIncoming,
-  t,
-}: IncomingRequestSectionProps) {
-  if (incoming.length === 0) return null;
-
-  return (
-    <section id="incoming-requests">
-      <h2 className="text-lg font-semibold">{t('friends.incomingRequests')}</h2>
-      <div className="mt-2 flex items-center justify-between">
-        <div className="text-xs text-muted-foreground">
-          {isSelectMode
-            ? `${selectedIncoming.size} selected`
-            : `${incoming.length} pending`}
-        </div>
-        <Button size="sm" variant="ghost" onClick={onToggleMode}>
-          {isSelectMode ? 'Done' : 'Select'}
-        </Button>
-      </div>
-      <ul className="mt-3 space-y-3">
-        {incoming.map((request) => {
-          const user = request.fromUser;
-          const selected = selectedIncoming.has(request.id);
-          return (
-            <FriendRequestRow
-              key={request.id}
-              user={user}
-              requestId={request.id}
-              selected={selected}
-              selectMode={isSelectMode}
-              onToggleSelected={onToggleSelected}
-              relationship={{
-                state: 'PENDING_INCOMING',
-                friendshipId: null,
-                incomingRequestId: request.id,
-                outgoingRequestId: null,
-              }}
-              onStateChange={onStateChange(request.id, user)}
-            />
-          );
-        })}
-      </ul>
-    </section>
-  );
-}
-
-function OutgoingRequestSection({
-  isSelectMode,
-  onStateChange,
-  onToggleMode,
-  onToggleSelected,
-  outgoing,
-  selectedOutgoing,
-  t,
-}: OutgoingRequestSectionProps) {
-  if (outgoing.length === 0) return null;
-
-  return (
-    <section id="outgoing-requests">
-      <h2 className="text-lg font-semibold">{t('friends.outgoingRequests')}</h2>
-      <div className="mt-2 flex items-center justify-between">
-        <div className="text-xs text-muted-foreground">
-          {isSelectMode
-            ? `${selectedOutgoing.size} selected`
-            : `${outgoing.length} pending`}
-        </div>
-        <Button size="sm" variant="ghost" onClick={onToggleMode}>
-          {isSelectMode ? 'Done' : 'Select'}
-        </Button>
-      </div>
-      <ul className="mt-3 space-y-3">
-        {outgoing.map((request) => {
-          const user = request.toUser;
-          const selected = selectedOutgoing.has(request.id);
-          return (
-            <FriendRequestRow
-              key={request.id}
-              user={user}
-              requestId={request.id}
-              selected={selected}
-              selectMode={isSelectMode}
-              onToggleSelected={onToggleSelected}
-              relationship={{
-                state: 'PENDING_OUTGOING',
-                friendshipId: null,
-                incomingRequestId: null,
-                outgoingRequestId: request.id,
-              }}
-              onStateChange={onStateChange(request.id, user)}
-            />
-          );
-        })}
-      </ul>
-    </section>
-  );
-}
-
-function RequestSelectionBar({
-  onAccept,
-  onCancel,
-  onDecline,
-  selectedIncoming,
-  selectedOutgoing,
-}: RequestSelectionBarProps) {
-  const totalSelected = selectedIncoming.size + selectedOutgoing.size;
-  if (totalSelected === 0) return null;
-
-  return (
-    <div className="sticky bottom-0 z-10 mt-4 rounded-t-xl border border-border bg-card p-3 shadow-lg">
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <div className="text-sm text-muted-foreground">{totalSelected} selected</div>
-        <div className="flex flex-wrap items-center gap-2">
-          {selectedIncoming.size > 0 ? (
-            <>
-              <Button size="sm" onClick={onAccept}>
-                Accept ({selectedIncoming.size})
-              </Button>
-              <Button size="sm" variant="secondary" onClick={onDecline}>
-                Decline ({selectedIncoming.size})
-              </Button>
-            </>
-          ) : null}
-          {selectedOutgoing.size > 0 ? (
-            <Button size="sm" variant="secondary" onClick={onCancel}>
-              Cancel ({selectedOutgoing.size})
-            </Button>
-          ) : null}
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function FriendRowActions({
-  displayName,
-  friend,
-  onRemove,
-  t,
-}: FriendRowActionsProps) {
-  const user = friend.user;
-
-  return (
-    <div className="flex items-center gap-2">
-      <Button
-        asChild
-        size="sm"
-        variant="default"
-        aria-label={t('friends.viewWishlist')}
-      >
-        <Link to={`/users/${user.username}/wishlist`}>
-          <LuHeart />
-          <span className="ml-2 hidden sm:inline">{t('friends.viewWishlist')}</span>
-        </Link>
-      </Button>
-      <Button
-        asChild
-        size="sm"
-        variant="secondary"
-        aria-label={t('friends.viewProfile')}
-      >
-        <Link to={`/users/${user.username}`}>
-          <LuUser />
-          <span className="ml-2 hidden sm:inline">{t('friends.viewProfile')}</span>
-        </Link>
-      </Button>
-      <ConfirmDialog
-        title={t('friends.removeConfirmTitle')}
-        description={
-          <p className="text-sm text-muted-foreground">
-            {t('friends.removeConfirmDescription', {
-              name: displayName,
-            })}
-          </p>
-        }
-        confirmText={t('friends.removeConfirmConfirm')}
-        onConfirm={() => onRemove(friend)}
-      >
-        <Button size="sm" variant="destructive" aria-label={t('friends.remove')}>
-          <LuTrash />
-          <span className="ml-2 hidden sm:inline">{t('friends.remove')}</span>
-        </Button>
-      </ConfirmDialog>
-    </div>
-  );
-}
-
-function FriendRow({
-  friend,
-  mutuals,
-  onClose,
-  onOpen,
-  onRemove,
-  open,
-  t,
-}: FriendRowProps) {
-  const user = friend.user;
-  const displayName = user.name ?? user.username;
-  const chips = getMutualGroupChips(mutuals, user.id);
-
-  return (
-    <SwipeableFriendRow
-      open={open}
-      onOpen={onOpen}
-      onClose={onClose}
-      rightActions={null}
-    >
-      <FriendSummary
-        user={user}
-        displayName={displayName}
-        mutualGroups={chips.mutualGroups}
-        extraGroupCount={chips.extraGroupCount}
-      />
-      <FriendRowActions
-        displayName={displayName}
-        friend={friend}
-        onRemove={onRemove}
-        t={t}
-      />
-    </SwipeableFriendRow>
   );
 }
 
@@ -1027,7 +757,7 @@ function useFriendsSearchParams() {
 
 function useFriendsRouteState({
   data,
-  setUnreadCount,
+  setUnreadCount: _setUnreadCount,
 }: UseFriendsRouteStateOptions) {
   const [friendsState, setFriendsState] = useState<FriendEntry[]>(data.friends);
   const [incomingState, setIncomingState] = useState<IncomingEntry[]>(
@@ -1035,74 +765,6 @@ function useFriendsRouteState({
   );
   const [outgoingState, setOutgoingState] = useState<OutgoingEntry[]>(
     data.outgoing,
-  );
-  const [incomingSelectMode, setIncomingSelectMode] = useState(false);
-  const [outgoingSelectMode, setOutgoingSelectMode] = useState(false);
-  const [selectedIncoming, setSelectedIncoming] = useState<Set<string>>(
-    new Set(),
-  );
-  const [selectedOutgoing, setSelectedOutgoing] = useState<Set<string>>(
-    new Set(),
-  );
-  const [openSwipeId, setOpenSwipeId] = useState<string | null>(null);
-  const [mutuals] = useState<
-    Record<
-      string,
-      {
-        groups: Array<{
-          id: string;
-          name: string;
-        }>;
-        more: number;
-      }
-    >
-  >({});
-
-  const anySelected =
-    (incomingSelectMode && selectedIncoming.size > 0) ||
-    (outgoingSelectMode && selectedOutgoing.size > 0);
-
-  const resetSelection = useCallback(() => {
-    setIncomingSelectMode(false);
-    setOutgoingSelectMode(false);
-    setSelectedIncoming(new Set());
-    setSelectedOutgoing(new Set());
-  }, []);
-
-  const batchAccept = useCallback(
-    async (ids: string[]) => {
-      await runOptimisticRequestBatch(
-        ids,
-        'accept',
-        incomingState,
-        setIncomingState,
-        setUnreadCount,
-      );
-    },
-    [incomingState, setUnreadCount],
-  );
-  const batchDecline = useCallback(
-    async (ids: string[]) => {
-      await runOptimisticRequestBatch(
-        ids,
-        'reject',
-        incomingState,
-        setIncomingState,
-        setUnreadCount,
-      );
-    },
-    [incomingState, setUnreadCount],
-  );
-  const batchCancel = useCallback(
-    async (ids: string[]) => {
-      await runOptimisticRequestBatch(
-        ids,
-        'cancel',
-        outgoingState,
-        setOutgoingState,
-      );
-    },
-    [outgoingState],
   );
 
   useEffect(() => {
@@ -1123,7 +785,9 @@ function useFriendsRouteState({
     (requestId: string, user: IncomingEntry['fromUser']) =>
       (snapshot: RelationshipSnapshot) => {
         if (snapshot.state === 'FRIENDS') {
-          addFriendEntry(buildFriendEntry(requestId, user, snapshot.friendshipId));
+          addFriendEntry(
+            buildFriendEntry(requestId, user, snapshot.friendshipId),
+          );
         }
         setIncomingState((prev) =>
           applyIncomingRelationshipTransition(prev, requestId, snapshot),
@@ -1135,7 +799,9 @@ function useFriendsRouteState({
     (requestId: string, user: OutgoingEntry['toUser']) =>
       (snapshot: RelationshipSnapshot) => {
         if (snapshot.state === 'FRIENDS') {
-          addFriendEntry(buildFriendEntry(requestId, user, snapshot.friendshipId));
+          addFriendEntry(
+            buildFriendEntry(requestId, user, snapshot.friendshipId),
+          );
         }
         setOutgoingState((prev) =>
           applyOutgoingRelationshipTransition(prev, requestId, snapshot),
@@ -1160,156 +826,15 @@ function useFriendsRouteState({
       );
   }, [addFriendEntry]);
 
-  const toggleIncomingSelectMode = useCallback(() => {
-    setIncomingSelectMode((value) => !value);
-    setSelectedIncoming(new Set());
-  }, []);
-  const toggleOutgoingSelectMode = useCallback(() => {
-    setOutgoingSelectMode((value) => !value);
-    setSelectedOutgoing(new Set());
-  }, []);
-  const handleIncomingSelection = useCallback(
-    (requestId: string, selected: boolean) => {
-      setSelectedIncoming((prev) => toggleSelection(prev, requestId, selected));
-    },
-    [],
-  );
-  const handleOutgoingSelection = useCallback(
-    (requestId: string, selected: boolean) => {
-      setSelectedOutgoing((prev) => toggleSelection(prev, requestId, selected));
-    },
-    [],
-  );
-  const acceptSelectedIncoming = useCallback(async () => {
-    await batchAccept(Array.from(selectedIncoming));
-    resetSelection();
-  }, [batchAccept, resetSelection, selectedIncoming]);
-  const declineSelectedIncoming = useCallback(async () => {
-    await batchDecline(Array.from(selectedIncoming));
-    resetSelection();
-  }, [batchDecline, resetSelection, selectedIncoming]);
-  const cancelSelectedOutgoing = useCallback(async () => {
-    await batchCancel(Array.from(selectedOutgoing));
-    resetSelection();
-  }, [batchCancel, resetSelection, selectedOutgoing]);
-
   return {
-    acceptSelectedIncoming,
-    addFriendEntry,
-    anySelected,
-    cancelSelectedOutgoing,
-    declineSelectedIncoming,
     friendsState,
-    handleIncomingSelection,
     handleIncomingTransition,
-    handleOutgoingSelection,
     handleOutgoingTransition,
-    incomingSelectMode,
     incomingState,
-    mutuals,
-    openSwipeId,
-    outgoingSelectMode,
     outgoingState,
-    selectedIncoming,
-    selectedOutgoing,
     setFriendsState,
-    setOpenSwipeId,
     setOutgoingState,
-    toggleIncomingSelectMode,
-    toggleOutgoingSelectMode,
   };
-}
-
-function FriendsMobileHeader({
-  activeTab,
-  friendsFilter,
-  onFriendsFilterChange,
-  onTabChange,
-}: FriendsMobileHeaderProps) {
-  return (
-    <div className="sticky top-0 z-10 -mx-4 mb-4 border-b border-border bg-background/80 px-4 py-3 backdrop-blur supports-[backdrop-filter]:bg-background/60 sm:hidden">
-      <div className="mx-auto max-w-3xl">
-        <div className="grid grid-cols-1 gap-3 sm:grid-cols-3 sm:items-center">
-          <SegmentedTabs value={activeTab} onChange={onTabChange} />
-          {activeTab === 'friends' ? (
-            <div className="sm:col-span-2">
-              <Input
-                value={friendsFilter}
-                onChange={(event) => onFriendsFilterChange(event.currentTarget.value)}
-                placeholder="Search friends"
-                aria-label="Search"
-              />
-            </div>
-          ) : null}
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function FriendsRequestsPanel({
-  acceptSelectedIncoming,
-  anySelected,
-  cancelSelectedOutgoing,
-  declineSelectedIncoming,
-  incomingSelectMode,
-  incomingState,
-  onHandleIncomingSelection,
-  onHandleOutgoingSelection,
-  onHandleIncomingTransition,
-  onHandleOutgoingTransition,
-  onToggleIncomingSelectMode,
-  onToggleOutgoingSelectMode,
-  outgoingSelectMode,
-  outgoingState,
-  selectedIncoming,
-  selectedOutgoing,
-  t,
-}: FriendsRequestsPanelProps) {
-  return (
-    <>
-      {incomingState.length > 0 ? (
-        <IncomingRequestSection
-          incoming={incomingState}
-          isSelectMode={incomingSelectMode}
-          onStateChange={onHandleIncomingTransition}
-          onToggleMode={onToggleIncomingSelectMode}
-          onToggleSelected={onHandleIncomingSelection}
-          selectedIncoming={selectedIncoming}
-          t={t}
-        />
-      ) : null}
-
-      {outgoingState.length > 0 ? (
-        <OutgoingRequestSection
-          isSelectMode={outgoingSelectMode}
-          onStateChange={onHandleOutgoingTransition}
-          onToggleMode={onToggleOutgoingSelectMode}
-          onToggleSelected={onHandleOutgoingSelection}
-          outgoing={outgoingState}
-          selectedOutgoing={selectedOutgoing}
-          t={t}
-        />
-      ) : null}
-
-      {anySelected ? (
-        <RequestSelectionBar
-          onAccept={acceptSelectedIncoming}
-          onCancel={cancelSelectedOutgoing}
-          onDecline={declineSelectedIncoming}
-          selectedIncoming={selectedIncoming}
-          selectedOutgoing={selectedOutgoing}
-        />
-      ) : null}
-
-      {incomingState.length === 0 && outgoingState.length === 0 ? (
-        <EmptyState
-          title="No requests"
-          description="You don't have any incoming or outgoing requests."
-        />
-      ) : null}
-    </>
-  );
 }
 
 function FriendsListSection({
@@ -1510,42 +1035,145 @@ function useInviteLinkController() {
     qrOpen,
   };
 }
+// Combined incoming + outgoing pending requests in a single card. Replaces
+// the previous IncomingRequestSection + OutgoingRequestSection split which
+// each had its own multi-select mode and dedicated header.
+function PendingRequestsCard({
+  incomingState,
+  outgoingState,
+  onIncomingTransition,
+  onOutgoingTransition,
+}: {
+  incomingState: IncomingEntry[];
+  outgoingState: OutgoingEntry[];
+  onIncomingTransition: (
+    requestId: string,
+    user: IncomingEntry['fromUser'],
+  ) => (snapshot: RelationshipSnapshot) => void;
+  onOutgoingTransition: (
+    requestId: string,
+    user: OutgoingEntry['toUser'],
+  ) => (snapshot: RelationshipSnapshot) => void;
+}) {
+  const total = incomingState.length + outgoingState.length;
+  if (total === 0) return null;
+
+  return (
+    <section
+      id="pending-requests"
+      className="rounded-xl border border-border bg-card p-4 shadow-sm"
+    >
+      <div className="flex items-center justify-between gap-2">
+        <h2 className="text-base font-semibold">Pending requests</h2>
+        <span className="rounded-full bg-muted px-2 py-0.5 text-xs font-semibold text-muted-foreground">
+          {total}
+        </span>
+      </div>
+      <ul className="mt-3 space-y-2">
+        {incomingState.map((request) => (
+          <FriendRequestRow
+            key={request.id}
+            requestId={request.id}
+            user={request.fromUser}
+            relationship={{
+              state: 'PENDING_INCOMING',
+              friendshipId: null,
+              incomingRequestId: request.id,
+              outgoingRequestId: null,
+            }}
+            selected={false}
+            selectMode={false}
+            onToggleSelected={() => {}}
+            onStateChange={onIncomingTransition(request.id, request.fromUser)}
+          />
+        ))}
+        {outgoingState.map((request) => (
+          <FriendRequestRow
+            key={request.id}
+            requestId={request.id}
+            user={request.toUser}
+            relationship={{
+              state: 'PENDING_OUTGOING',
+              friendshipId: null,
+              incomingRequestId: null,
+              outgoingRequestId: request.id,
+            }}
+            selected={false}
+            selectMode={false}
+            onToggleSelected={() => {}}
+            onStateChange={onOutgoingTransition(request.id, request.toUser)}
+          />
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+// "Add friend" primary button + dialog wrapper. Replaces the always-expanded
+// AddFriendsPanel section that lived at the top of the page.
+function AddFriendDialog({
+  q,
+  setQ,
+  onOutgoingCreated,
+}: {
+  q: string;
+  setQ: (next: string) => void;
+  onOutgoingCreated: (
+    requestId: string,
+    user: FriendEntry['user'],
+  ) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button onClick={() => setOpen(true)}>
+        <LuPlus className="mr-2 h-4 w-4" aria-hidden />
+        Add friend
+      </Button>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>Add friend</DialogTitle>
+            <DialogDescription>
+              Search by username or share an invite link.
+            </DialogDescription>
+          </DialogHeader>
+          <AddFriendsPanel
+            query={q}
+            onQueryChange={setQ}
+            onOutgoingCreated={(requestId, user) => {
+              onOutgoingCreated(requestId, user);
+              setOpen(false);
+            }}
+          />
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
 const FriendsRoute = () => {
   const data = useLoaderData<typeof loader>();
   const { t } = useTranslation();
   const { setUnreadCount } = useNotificationsStore();
   useFriendWishlistPrefetch(data.friends.map((friend) => friend.user.username));
-  const { activeTab, handleTabChange, q, setQ } = useFriendsSearchParams();
+  const { q, setQ } = useFriendsSearchParams();
   const [friendsFilter, setFriendsFilter] = useState('');
   const {
-    acceptSelectedIncoming,
-    anySelected,
-    cancelSelectedOutgoing,
-    declineSelectedIncoming,
     friendsState,
-    handleIncomingSelection,
     handleIncomingTransition,
-    handleOutgoingSelection,
     handleOutgoingTransition,
-    incomingSelectMode,
     incomingState,
-    mutuals,
-    openSwipeId,
-    outgoingSelectMode,
     outgoingState,
-    selectedIncoming,
-    selectedOutgoing,
     setFriendsState,
-    setOpenSwipeId,
     setOutgoingState,
-    toggleIncomingSelectMode,
-    toggleOutgoingSelectMode,
   }: FriendsRouteState = useFriendsRouteState({
     data,
     setUnreadCount,
   });
   const filteredFriends = useMemo(
-    () => filterFriends(friendsState, friendsFilter),
+    () =>
+      sortFriendsByUpcomingBirthday(filterFriends(friendsState, friendsFilter)),
     [friendsFilter, friendsState],
   );
   const handleRemoveFriend = useCallback(
@@ -1580,21 +1208,19 @@ const FriendsRoute = () => {
     [setFriendsState, t],
   );
   const renderFriendRow = useCallback(
-    (friend: FriendEntry) => (
-      <FriendRow
-        key={friend.friendshipId}
-        friend={friend}
-        mutuals={mutuals}
-        onClose={() =>
-          setOpenSwipeId((id) => (id === friend.friendshipId ? null : id))
-        }
-        onOpen={() => setOpenSwipeId(friend.friendshipId)}
-        onRemove={handleRemoveFriend}
-        open={openSwipeId === friend.friendshipId}
-        t={t}
-      />
-    ),
-    [handleRemoveFriend, mutuals, openSwipeId, setOpenSwipeId, t],
+    (friend: FriendEntry) => {
+      const displayName = friend.user.name ?? friend.user.username;
+      return (
+        <li key={friend.friendshipId}>
+          <FriendRowCard
+            friend={friend}
+            displayName={displayName}
+            onRemove={() => handleRemoveFriend(friend)}
+          />
+        </li>
+      );
+    },
+    [handleRemoveFriend],
   );
   const handleOutgoingCreated = useCallback(
     (requestId: string, user: FriendEntry['user']) => {
@@ -1610,62 +1236,34 @@ const FriendsRoute = () => {
 
   return (
     <div className="container py-6 sm:py-8">
-      <FriendsMobileHeader
-        activeTab={activeTab}
-        friendsFilter={friendsFilter}
-        onFriendsFilterChange={setFriendsFilter}
-        onTabChange={handleTabChange}
-      />
+      <header className="mb-6 flex items-center justify-between gap-3">
+        <h1 className="text-2xl font-semibold tracking-tight">Friends</h1>
+        <AddFriendDialog
+          q={q}
+          setQ={setQ}
+          onOutgoingCreated={handleOutgoingCreated}
+        />
+      </header>
 
       <Stack gap={4}>
-        {/* Add panel: visible on mobile when tab=add; always visible on desktop */}
-        <section
-          className={cn(
-            'rounded-xl border border-border bg-card p-4 shadow-sm',
-            activeTab !== 'add' ? 'hidden sm:block' : undefined,
-          )}
-        >
-          <h2 className="text-lg font-semibold">Add friends</h2>
-          <p className="mt-1 text-sm text-muted-foreground">
-            Search by username or share an invite link.
-          </p>
-          <AddFriendsPanel
-            query={q}
-            onQueryChange={setQ}
-            onOutgoingCreated={handleOutgoingCreated}
-          />
-        </section>
+        <PendingRequestsCard
+          incomingState={incomingState}
+          outgoingState={outgoingState}
+          onIncomingTransition={handleIncomingTransition}
+          onOutgoingTransition={handleOutgoingTransition}
+        />
 
-        {/* Requests: visible on mobile when tab=requests; always visible on desktop */}
-        <div
-          className={cn(
-            activeTab !== 'requests' ? 'hidden sm:block' : undefined,
-          )}
-        >
-          <FriendsRequestsPanel
-            acceptSelectedIncoming={acceptSelectedIncoming}
-            anySelected={anySelected}
-            cancelSelectedOutgoing={cancelSelectedOutgoing}
-            declineSelectedIncoming={declineSelectedIncoming}
-            incomingSelectMode={incomingSelectMode}
-            incomingState={incomingState}
-            onHandleIncomingSelection={handleIncomingSelection}
-            onHandleOutgoingSelection={handleOutgoingSelection}
-            onHandleIncomingTransition={handleIncomingTransition}
-            onHandleOutgoingTransition={handleOutgoingTransition}
-            onToggleIncomingSelectMode={toggleIncomingSelectMode}
-            onToggleOutgoingSelectMode={toggleOutgoingSelectMode}
-            outgoingSelectMode={outgoingSelectMode}
-            outgoingState={outgoingState}
-            selectedIncoming={selectedIncoming}
-            selectedOutgoing={selectedOutgoing}
-            t={t}
+        {friendsState.length > 8 ? (
+          <Input
+            value={friendsFilter}
+            onChange={(event) => setFriendsFilter(event.currentTarget.value)}
+            placeholder="Search friends"
+            aria-label="Search friends"
           />
-        </div>
+        ) : null}
 
-        {/* Friends: visible on mobile when tab=friends; always visible on desktop */}
         <FriendsListSection
-          activeTab={activeTab}
+          activeTab="friends"
           filteredFriends={filteredFriends}
           friendsState={friendsState}
           onRenderFriendRow={renderFriendRow}
@@ -1678,49 +1276,6 @@ const FriendsRoute = () => {
   );
 };
 export default FriendsRoute;
-function SegmentedTabs({
-  value,
-  onChange,
-}: {
-  value: 'add' | 'requests' | 'friends';
-  onChange: (v: 'add' | 'requests' | 'friends') => void;
-}) {
-  const items: Array<{
-    key: 'add' | 'requests' | 'friends';
-    label: string;
-  }> = [
-    {
-      key: 'add',
-      label: 'Add',
-    },
-    {
-      key: 'requests',
-      label: 'Requests',
-    },
-    {
-      key: 'friends',
-      label: 'Friends',
-    },
-  ];
-  return (
-    <div className="grid grid-cols-3 rounded-full bg-muted p-1">
-      {items.map((it) => (
-        <button
-          key={it.key}
-          type="button"
-          onClick={() => onChange(it.key)}
-          className={cn(
-            'rounded-full px-4 py-1.5 text-center text-sm font-medium text-muted-foreground transition',
-            value === it.key && 'bg-background text-foreground shadow',
-          )}
-          aria-current={value === it.key ? 'page' : undefined}
-        >
-          {it.label}
-        </button>
-      ))}
-    </div>
-  );
-}
 function VirtualizedFriendsList({
   items,
   rowHeight = 72,
@@ -1815,62 +1370,6 @@ function VirtualizedFriendsList({
     </div>
   );
 }
-function SwipeableFriendRow({
-  children,
-  rightActions,
-  open,
-  onOpen,
-  onClose,
-}: {
-  children: React.ReactNode;
-  rightActions: React.ReactNode;
-  open: boolean;
-  onOpen: () => void;
-  onClose: () => void;
-}) {
-  const startX = useRef<number | null>(null);
-  const deltaX = useRef(0);
-  const threshold = 48;
-  return (
-    <div className="relative" data-testid="friend-row">
-      {/* Actions behind */}
-      <div className="absolute inset-y-0 right-0 flex items-stretch">
-        {rightActions}
-      </div>
-      {/* Foreground content */}
-      <div
-        className={cn(
-          'relative rounded-xl border border-border bg-card p-4 shadow-sm transition-transform',
-        )}
-        style={{
-          transform: `translateX(${open ? -140 : 0}px)`,
-        }}
-        onTouchStart={(e) => {
-          const touch = e.touches?.[0];
-          if (!touch) return;
-          startX.current = touch.clientX;
-          deltaX.current = 0;
-        }}
-        onTouchMove={(e) => {
-          if (startX.current == null) return;
-          const touch = e.touches?.[0];
-          if (!touch) return;
-          deltaX.current = touch.clientX - startX.current;
-        }}
-        onTouchEnd={() => {
-          if (deltaX.current < -threshold) onOpen();
-          else if (deltaX.current > threshold) onClose();
-          startX.current = null;
-          deltaX.current = 0;
-        }}
-      >
-        <div className="pointer-events-auto flex items-center gap-4">
-          {children}
-        </div>
-      </div>
-    </div>
-  );
-}
 function AddFriendsPanel({
   onOutgoingCreated,
   query: controlledQuery,
@@ -1878,15 +1377,7 @@ function AddFriendsPanel({
 }: {
   onOutgoingCreated?: (
     requestId: string,
-    user: {
-      id: string;
-      username: string;
-      name: string | null;
-      image: {
-        id: string;
-        altText: string | null;
-      } | null;
-    },
+    user: FriendEntry['user'],
   ) => void;
   query?: string;
   onQueryChange?: (q: string) => void;

--- a/app/routes/friends.tsx
+++ b/app/routes/friends.tsx
@@ -31,7 +31,6 @@ import { EmptyState } from '#app/components/ui/empty-state.tsx';
 import { Input } from '#app/components/ui/input.tsx';
 import { Skeleton } from '#app/components/ui/skeleton.tsx';
 import { Stack } from '#app/components/ui-kit/stack.tsx';
-import { Text } from '#app/components/ui-kit/text.tsx';
 import { useFriendWishlistPrefetch } from '#app/hooks/use-background-route-prefetch.ts';
 import { requireUserId } from '#app/utils/auth.server.ts';
 import { loadFriendsPageData } from '#app/utils/friends-page.server.ts';

--- a/app/routes/friends.tsx
+++ b/app/routes/friends.tsx
@@ -1049,7 +1049,7 @@ function PendingRequestsCard({
   outgoingState,
   onIncomingTransition,
   onOutgoingTransition,
-}: {
+}: Readonly<{
   incomingState: IncomingEntry[];
   outgoingState: OutgoingEntry[];
   onIncomingTransition: (
@@ -1060,7 +1060,7 @@ function PendingRequestsCard({
     requestId: string,
     user: OutgoingEntry['toUser'],
   ) => (snapshot: RelationshipSnapshot) => void;
-}) {
+}>) {
   const total = incomingState.length + outgoingState.length;
   if (total === 0) return null;
 
@@ -1124,14 +1124,14 @@ function AddFriendDialog({
   q,
   setQ,
   onOutgoingCreated,
-}: {
+}: Readonly<{
   q: string;
   setQ: (next: string) => void;
   onOutgoingCreated: (
     requestId: string,
     user: FriendEntry['user'],
   ) => void;
-}) {
+}>) {
   const [open, setOpen] = useState(false);
   return (
     <>

--- a/app/routes/friends.tsx
+++ b/app/routes/friends.tsx
@@ -16,11 +16,17 @@ import { Button } from '#app/components/ui/button.tsx';
 import {
   Dialog,
   DialogContent,
-  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
 } from '#app/components/ui/dialog.tsx';
+import {
+  MobileBottomSheet,
+  MobileBottomSheetContent,
+  MobileBottomSheetDescription,
+  MobileBottomSheetHeader,
+  MobileBottomSheetTitle,
+} from '#app/components/ui/mobile-bottom-sheet.tsx';
 import { EmptyState } from '#app/components/ui/empty-state.tsx';
 import { Input } from '#app/components/ui/input.tsx';
 import { Skeleton } from '#app/components/ui/skeleton.tsx';
@@ -539,40 +545,40 @@ function InviteLinkPanel({
   if (!inviteUrl) {
     return (
       <Button onClick={onCreate} className="w-full">
-        <LuLink className="mr-2" /> Create Friend Link
+        <LuLink className="mr-2 h-4 w-4" aria-hidden /> Create invite link
       </Button>
     );
   }
 
   return (
-    <div className="flex min-w-0 flex-col gap-2 sm:flex-row sm:items-center">
+    <div className="flex min-w-0 flex-col gap-2">
       <Input
         readOnly
         aria-label="Friend invite link"
         value={inviteUrl}
         onClick={(event) => event.currentTarget.select()}
-        className="truncate"
+        className="font-mono text-xs"
       />
-      <div className="flex w-full flex-wrap items-center gap-2">
+      <div className="flex w-full items-center gap-2">
         <Button
           size="sm"
-          variant="ghost"
+          variant="secondary"
           aria-label="Copy invite link"
           onClick={onCopy}
-          className="min-w-[120px] flex-1 sm:flex-none"
+          className="flex-1"
         >
-          <LuCopy />
+          <LuCopy className="mr-2 h-4 w-4" aria-hidden />
+          Copy link
         </Button>
         <Button
           size="sm"
-          variant="ghost"
+          variant="secondary"
+          aria-label="Show QR code"
           onClick={onOpenQr}
-          className="min-w-[120px] flex-1 sm:flex-none"
+          className="flex-1"
         >
-          <LuQrCode className="md:mr-2" />
-          <Text size="sm" className="hidden md:block">
-            Show QR
-          </Text>
+          <LuQrCode className="mr-2 h-4 w-4" aria-hidden />
+          Show QR
         </Button>
       </div>
     </div>
@@ -1109,8 +1115,11 @@ function PendingRequestsCard({
   );
 }
 
-// "Add friend" primary button + dialog wrapper. Replaces the always-expanded
-// AddFriendsPanel section that lived at the top of the page.
+// "Add friend" primary button + responsive sheet wrapper. Uses
+// MobileBottomSheet so the surface renders as a bottom sheet on mobile
+// (matching the wishlist editor pattern) and as a centered dialog on
+// desktop. Replaces the always-expanded AddFriendsPanel section that
+// lived at the top of the page.
 function AddFriendDialog({
   q,
   setQ,
@@ -1130,14 +1139,14 @@ function AddFriendDialog({
         <LuPlus className="mr-2 h-4 w-4" aria-hidden />
         Add friend
       </Button>
-      <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent className="max-w-2xl">
-          <DialogHeader>
-            <DialogTitle>Add friend</DialogTitle>
-            <DialogDescription>
+      <MobileBottomSheet open={open} onOpenChange={setOpen}>
+        <MobileBottomSheetContent className="sm:max-w-md">
+          <MobileBottomSheetHeader>
+            <MobileBottomSheetTitle>Add a friend</MobileBottomSheetTitle>
+            <MobileBottomSheetDescription>
               Search by username or share an invite link.
-            </DialogDescription>
-          </DialogHeader>
+            </MobileBottomSheetDescription>
+          </MobileBottomSheetHeader>
           <AddFriendsPanel
             query={q}
             onQueryChange={setQ}
@@ -1146,8 +1155,8 @@ function AddFriendDialog({
               setOpen(false);
             }}
           />
-        </DialogContent>
-      </Dialog>
+        </MobileBottomSheetContent>
+      </MobileBottomSheet>
     </>
   );
 }
@@ -1413,13 +1422,17 @@ function AddFriendsPanel({
   }, [createInvite]);
 
   return (
-    <div className="mt-4 grid gap-4 md:grid-cols-2">
-      <div>
-        <div className="mb-2 text-sm font-medium">Search by username</div>
+    <div className="flex flex-col gap-5">
+      <div className="flex flex-col gap-2">
+        <label className="text-sm font-medium" htmlFor="friend-username-search">
+          Search by username
+        </label>
         <Input
+          id="friend-username-search"
           placeholder="e.g. alice"
           value={query}
           onChange={(e) => setQuery(e.currentTarget.value)}
+          autoFocus
         />
         <SearchResultsPanel
           query={query}
@@ -1430,8 +1443,26 @@ function AddFriendsPanel({
           onOutgoingCreated={onOutgoingCreated}
         />
       </div>
-      <div>
-        <div className="mb-2 text-sm font-medium">Invite via link</div>
+
+      {/* Divider with "or" label so the two add-friend modes feel
+       * deliberately separated rather than competing for the same row. */}
+      <div
+        className="relative flex items-center"
+        role="separator"
+        aria-orientation="horizontal"
+      >
+        <div className="flex-1 border-t border-border" />
+        <span className="px-3 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+          or
+        </span>
+        <div className="flex-1 border-t border-border" />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <div className="text-sm font-medium">Invite via link</div>
+        <p className="text-xs text-muted-foreground">
+          Share this link or QR code with anyone you want to add.
+        </p>
         <InviteLinkPanel
           inviteUrl={inviteUrl}
           onCopy={handleCopyInviteLink}
@@ -1439,6 +1470,7 @@ function AddFriendsPanel({
           onOpenQr={handleOpenQr}
         />
       </div>
+
       <InviteQrDialog
         open={qrOpen}
         qrDataUrl={qrDataUrl}

--- a/app/utils/friends-page.server.ts
+++ b/app/utils/friends-page.server.ts
@@ -1,18 +1,66 @@
+import { prisma } from './db.server.ts';
 import {
   getIncomingFriendRequests,
   getOutgoingFriendRequests,
   listFriends,
 } from './friends.server.ts';
 
+// For each friend, the list of gift groups they share with the viewer.
+// Two queries: one fetch of every group the viewer is a member of (with the
+// list of members on each group), then we walk the result client-side to
+// build a `Map<friendId, mutualGroups[]>`. This is O(viewer_groups *
+// avg_members_per_group) which is plenty fast for any realistic dataset
+// and avoids running one query per friend.
+async function buildMutualGroupsByFriend(viewerId: string) {
+  const viewerGroups = await prisma.usersInGiftGroups.findMany({
+    where: { userId: viewerId },
+    select: {
+      giftGroup: {
+        select: {
+          id: true,
+          name: true,
+          groupMembers: {
+            select: { userId: true },
+          },
+        },
+      },
+    },
+  });
+
+  const byFriend = new Map<string, Array<{ id: string; name: string }>>();
+  for (const membership of viewerGroups) {
+    const group = membership.giftGroup;
+    for (const member of group.groupMembers) {
+      if (member.userId === viewerId) continue;
+      const existing = byFriend.get(member.userId);
+      const entry = { id: group.id, name: group.name };
+      if (existing) {
+        existing.push(entry);
+      } else {
+        byFriend.set(member.userId, [entry]);
+      }
+    }
+  }
+  return byFriend;
+}
+
 export async function loadFriendsPageData(userId: string) {
-  const [friends, incoming, outgoing] = await Promise.all([
-    listFriends(userId),
-    getIncomingFriendRequests(userId),
-    getOutgoingFriendRequests(userId),
-  ]);
+  const [friends, incoming, outgoing, mutualGroupsByFriend] = await Promise.all(
+    [
+      listFriends(userId),
+      getIncomingFriendRequests(userId),
+      getOutgoingFriendRequests(userId),
+      buildMutualGroupsByFriend(userId),
+    ],
+  );
+
+  const friendsWithMutuals = friends.map((entry) => ({
+    ...entry,
+    mutualGroups: mutualGroupsByFriend.get(entry.user.id) ?? [],
+  }));
 
   return {
-    friends,
+    friends: friendsWithMutuals,
     incoming,
     outgoing,
   };

--- a/app/utils/friends.server.ts
+++ b/app/utils/friends.server.ts
@@ -16,6 +16,7 @@ const friendUserSelect = {
   id: true,
   username: true,
   name: true,
+  birthday: true,
   image: { select: { id: true, altText: true } },
 } as const;
 

--- a/tests/e2e/friend-gate.test.ts
+++ b/tests/e2e/friend-gate.test.ts
@@ -240,8 +240,13 @@ test('non-friend wishlist request is optimistic and rolls back on failure', asyn
     await expect(addButton).toBeVisible();
     await addButton.click();
 
+    // Optimistic PENDING_OUTGOING state: FriendActionButton now renders a
+    // single "Cancel request" button (the old "Request sent" disabled
+    // pseudo-button was removed). The assertion still verifies the same
+    // thing: that the optimistic state was applied before the server
+    // responded.
     await expect(
-      page.getByRole('button', { name: /request sent/i }),
+      page.getByRole('button', { name: /cancel request/i }),
     ).toBeVisible();
     await expect(page.getByRole('button', { name: /add friend/i })).toBeVisible(
       {


### PR DESCRIPTION
> **Stacked on #349** (`ux/wishlist-revamp`). Once #349 merges this PR will rebase onto main.

## Summary

Replaces the Friends page layout with a focused single-column design that matches the wishlist row primitive we just shipped, surfaces the friend metadata that was already in the data model, and prunes ~520 lines of dead UI code from the route.

## What's new

**Loader changes (`app/utils/friends-page.server.ts`)**

- Returns `birthday` per friend (added to `friendUserSelect` in `friends.server.ts`).
- Returns precomputed `mutualGroups: [{ id, name }]` per friend, computed from the viewer's gift-group memberships in a single query plus an in-memory join. The previous mutual-chips UI was half-built (`useState({})` initialized empty, never populated by anything).

**New `<FriendRow />` component (`app/components/friends/friend-row.tsx`)**

- Whole-card click target via the same absolute click-catcher pattern used on wishlist rows: a `<Link>` with `inset-0` covers the card and the visible content has `pointer-events-none`. Tap anywhere → friend's wishlist.
- Right slot: an upcoming-birthday pill ("Tomorrow", "Apr 15") for friends within the next 60 days, plus a 3-dot kebab menu containing **View profile** and **Remove friend** (with a confirm dialog). The destructive Remove action is no longer a permanent red button on every row — it's tucked one click deeper.
- Mutual group chips render below the name+username row when the loader returns any.

**Sort by upcoming birthday (`sortFriendsByUpcomingBirthday`)**

Friends with a birthday within 60 days come first, soonest first, then alphabetical by display name. With the seeded data this puts **Hana ("Tomorrow")** at the top, followed by Marco, Leo, NP, Alvaro — exactly the order you'd want when scanning for "who do I need to think about gifting next." Sofia (88 days out, intentionally outside the window) falls into the alphabetical tail.

**Layout swap in `FriendsRoute`**

- Page header: "Friends" title + a primary "Add friend" button.
- Click "Add friend" → opens a `<Dialog>` containing the existing search-by-username + invite link + QR controls. The always-expanded section that lived at the top of the page is gone.
- Pending requests collapsed into a single `<PendingRequestsCard>` listing incoming + outgoing inline. The card hides itself when both lists are empty. Per-row Accept/Reject and Cancel still work — only the multi-select mode is removed.
- The friend search input now only renders when there are >8 friends.
- Removed the segmented Add/Requests/Friends mobile tabs entirely. The unified single-column layout works on every breakpoint.

## Dead code purged (~520 lines deleted from `friends.tsx`)

- `IncomingRequestSection`, `OutgoingRequestSection`, `RequestSelectionBar` — multi-select machinery
- `FriendRowActions` and the inline `FriendRow` — replaced by the new external component
- `FriendsMobileHeader`, `SegmentedTabs` — tab UI gone
- `FriendsRequestsPanel` — replaced by `PendingRequestsCard`
- `SwipeableFriendRow` — swipe-to-delete on mobile is replaced by the kebab menu
- All multi-select state from `useFriendsRouteState` (selectedIncoming, selectedOutgoing, batch handlers, anySelected, etc)
- Unused type definitions and imports

The route file went from **1964 → 1455 lines** (−26%). The biggest remaining bulk is `AddFriendsPanel` and the search/invite hooks, which I left alone — they work as-is and moving them out is a separate refactor.

## Tests

- **New** `app/components/friends/friend-row.test.tsx` — 8 cases covering displayName, click-target link, upcoming-birthday pill (within window / "Tomorrow" / outside window), mutual group chips (cap at 3 with +N), and the kebab → confirm → onRemove flow.
- **Updated** `app/routes/friends.test.tsx`:
  - "renders add tab" → "opens the Add friend dialog" (clicks the primary button first)
  - "filters friends" → updated label from "Search" to "Search friends"
  - "shows empty search results" → opens the dialog first
  - Added `DialogDescription` + `DialogClose` to the dialog mock
  - **Deleted** the multi-select, empty-requests, and remove-friend route tests — the corresponding features are either gone or covered by the new component test
  - Updated FriendUser test fixture with `birthday: Date | null`
- All **38 friend-related unit tests** pass
- Full **63 e2e tests** still green

## Manual QA

Verified in local dev as Wade (the seed account):
- Friends page renders the new layout with Hana at the top ("Tomorrow" pill)
- Mutual group chips show "Book Club" / "The Crew" on each friend
- "Add friend" button opens the dialog with username search + invite link + QR
- Pending requests card shows Zoe (incoming, Accept/Reject) and Ben (outgoing, Cancel)
- Clicking a friend row navigates to their wishlist
- Kebab menu opens View profile + Remove friend
- Remove friend → confirm dialog → friend disappears

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm run lint` on the edited files — clean
- [x] `npm test -- --run app/routes/friends app/components/friends app/utils/friends` — 38 tests passing
- [x] `npm run test:e2e:run` — 63 e2e tests passing
- [x] Manual QA in dev browser
- [ ] (Pending) Verify on mobile width — the new layout is single-column on every breakpoint, no separate mobile path