### PR TITLE
feat(profile): phase 3 — bio, birthday edit, privacy visibility

### DIFF
--- a/app/components/friends/friend-row.tsx
+++ b/app/components/friends/friend-row.tsx
@@ -41,6 +41,10 @@ export type FriendRowEntry = {
     username: string;
     name: string | null;
     birthday: Date | string | null;
+    // String, not a true enum — see schema note. 'FRIENDS' | 'EVERYONE' |
+    // 'NOBODY'. Optional because some callers (legacy test fixtures) don't
+    // set it; defaults to showing the pill.
+    birthdayVisibility?: string;
     image: { id: string; altText: string | null } | null;
   };
   mutualGroups: Array<{ id: string; name: string }>;
@@ -56,7 +60,10 @@ export function FriendRow({
   onRemove: () => void;
 }>) {
   const { user, mutualGroups } = friend;
-  const upcoming = getUpcomingBirthday(user.birthday);
+  // Friend has explicitly hidden their birthday — don't compute the upcoming
+  // label at all so nothing shows up in the row slot.
+  const birthdayHidden = user.birthdayVisibility === 'NOBODY';
+  const upcoming = birthdayHidden ? null : getUpcomingBirthday(user.birthday);
   const birthdaySoon =
     upcoming && upcoming.daysUntil <= BIRTHDAY_VISIBILITY_DAYS
       ? upcoming

--- a/app/components/users/profile-header.test.tsx
+++ b/app/components/users/profile-header.test.tsx
@@ -70,4 +70,25 @@ describe('<ProfileHeader />', () => {
       screen.getByRole('button', { name: 'Custom action' }),
     ).toBeInTheDocument();
   });
+
+  it('renders the bio paragraph under the handle when provided', () => {
+    renderHeader({ bio: 'Coffee nerd, vinyl collector.' });
+    expect(
+      screen.getByText('Coffee nerd, vinyl collector.'),
+    ).toBeInTheDocument();
+  });
+
+  it('omits the bio paragraph when bio is null, undefined, or whitespace only', () => {
+    const { rerender } = renderHeader({ bio: null });
+    expect(
+      screen.queryByText('Coffee nerd, vinyl collector.'),
+    ).not.toBeInTheDocument();
+
+    rerender(
+      <MemoryRouter>
+        <ProfileHeader user={baseUser} bio="   " />
+      </MemoryRouter>,
+    );
+    expect(screen.queryByText('   ')).not.toBeInTheDocument();
+  });
 });

--- a/app/components/users/profile-header.tsx
+++ b/app/components/users/profile-header.tsx
@@ -16,6 +16,7 @@ type ProfileHeaderUser = {
 
 type ProfileHeaderProps = Readonly<{
   user: ProfileHeaderUser;
+  bio?: string | null;
   birthdayLabel?: string | null;
   joinedDisplay?: string | null;
   actions?: React.ReactNode;
@@ -24,12 +25,14 @@ type ProfileHeaderProps = Readonly<{
 
 export function ProfileHeader({
   user,
+  bio,
   birthdayLabel,
   joinedDisplay,
   actions,
   className,
 }: ProfileHeaderProps) {
   const displayName = user.name ?? user.username;
+  const trimmedBio = bio?.trim();
 
   return (
     <section
@@ -58,6 +61,14 @@ export function ProfileHeader({
         <Text size="sm" className="text-muted-foreground">
           @{user.username}
         </Text>
+        {trimmedBio ? (
+          <Text
+            size="sm"
+            className="mt-2 max-w-md text-balance text-muted-foreground"
+          >
+            {trimmedBio}
+          </Text>
+        ) : null}
       </div>
 
       {birthdayLabel || joinedDisplay ? (

--- a/app/routes/friends.test.tsx
+++ b/app/routes/friends.test.tsx
@@ -245,6 +245,7 @@ type FriendUser = {
   name: string | null;
   username: string;
   birthday: Date | null;
+  birthdayVisibility: string;
 };
 
 function createUser(id: string, username: string, name = username): FriendUser {
@@ -254,6 +255,7 @@ function createUser(id: string, username: string, name = username): FriendUser {
     name,
     username,
     birthday: null,
+    birthdayVisibility: 'FRIENDS',
   };
 }
 

--- a/app/routes/profile+/index.loader.test.ts
+++ b/app/routes/profile+/index.loader.test.ts
@@ -35,7 +35,9 @@ describe('app/routes/profile+/index.tsx loader', () => {
       image: { id: 'image-1' },
       name: 'Taylor',
       username: 'taylor',
+      bio: null,
       birthday: null,
+      birthdayVisibility: 'FRIENDS',
     });
     findMany.mockResolvedValue([
       {
@@ -56,7 +58,9 @@ describe('app/routes/profile+/index.tsx loader', () => {
 
     expect(findFirst).toHaveBeenCalledWith({
       select: {
+        bio: true,
         birthday: true,
+        birthdayVisibility: true,
         createdAt: true,
         id: true,
         image: { select: { id: true } },
@@ -73,7 +77,9 @@ describe('app/routes/profile+/index.tsx loader', () => {
         image: { id: 'image-1' },
         name: 'Taylor',
         username: 'taylor',
+        bio: null,
         birthday: null,
+        birthdayVisibility: 'FRIENDS',
       },
       userJoinedDisplay: new Date(
         '2024-05-12T00:00:00.000Z',

--- a/app/routes/profile+/index.test.tsx
+++ b/app/routes/profile+/index.test.tsx
@@ -11,7 +11,9 @@ type LoaderUser = {
   image: { id: string } | null;
   name: string | null;
   username: string;
+  bio: string | null;
   birthday: Date | null;
+  birthdayVisibility: string;
   createdAt: Date;
 };
 
@@ -34,7 +36,9 @@ const loaderDataSnapshot: {
     image: { id: 'image-1' },
     name: 'Taylor',
     username: 'taylor',
+    bio: null,
     birthday: null,
+    birthdayVisibility: 'FRIENDS',
     createdAt: new Date('2026-03-31T00:00:00.000Z'),
   },
   userJoinedDisplay: '3/31/2026',
@@ -86,7 +90,9 @@ beforeEach(() => {
     image: { id: 'image-1' },
     name: 'Taylor',
     username: 'taylor',
+    bio: null,
     birthday: null,
+    birthdayVisibility: 'FRIENDS',
     createdAt: new Date('2026-03-31T00:00:00.000Z'),
   };
   loaderDataSnapshot.userJoinedDisplay = '3/31/2026';
@@ -138,7 +144,9 @@ describe('app/routes/profile+/index.tsx', () => {
             image: null,
             name: 'Taylor',
             username: 'taylor',
+            bio: null,
             birthday: null,
+            birthdayVisibility: 'FRIENDS',
           },
           userJoinedDisplay: '3/31/2026',
           wishlistPreview: { items: [], totalCount: 0 },
@@ -150,7 +158,9 @@ describe('app/routes/profile+/index.tsx', () => {
             image: null,
             name: 'Taylor',
             username: 'taylor',
+            bio: null,
             birthday: null,
+            birthdayVisibility: 'FRIENDS',
           },
           userJoinedDisplay: '3/31/2026',
           wishlistPreview: { items: [], totalCount: 0 },

--- a/app/routes/profile+/index.tsx
+++ b/app/routes/profile+/index.tsx
@@ -28,7 +28,9 @@ export async function loader({ request }: LoaderFunctionArgs) {
       name: true,
       username: true,
       createdAt: true,
+      bio: true,
       birthday: true,
+      birthdayVisibility: true,
       image: {
         select: {
           id: true,
@@ -93,6 +95,7 @@ const ProfileIndex = () => {
     <div className="mx-auto flex w-full max-w-3xl flex-col gap-8 px-4 py-10 sm:py-14">
       <ProfileHeader
         user={user}
+        bio={user.bio}
         birthdayLabel={birthdayLabel}
         joinedDisplay={data.userJoinedDisplay}
         actions={

--- a/app/routes/resources+/home.panels.test.ts
+++ b/app/routes/resources+/home.panels.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 const getUserId = vi.fn();
 const findMany = vi.fn();
+const friendshipFindMany = vi.fn();
 
 vi.mock('#app/utils/auth.server', () => ({
   getUserId: (...args: Array<unknown>) => getUserId(...args),
@@ -14,6 +15,9 @@ vi.mock('#app/utils/db.server', () => ({
   prisma: {
     usersInGiftGroups: {
       findMany: (...args: Array<unknown>) => findMany(...args),
+    },
+    friendship: {
+      findMany: (...args: Array<unknown>) => friendshipFindMany(...args),
     },
   },
 }));
@@ -95,6 +99,7 @@ describe('app/routes/resources+/home.panels.tsx', () => {
             {
               user: {
                 birthday: localCalendarDate(1990, 3, 5),
+                birthdayVisibility: 'FRIENDS',
                 id: 'friend-near',
                 name: 'Alex',
                 username: 'alex',
@@ -103,6 +108,7 @@ describe('app/routes/resources+/home.panels.tsx', () => {
             {
               user: {
                 birthday: localCalendarDate(1992, 5, 20),
+                birthdayVisibility: 'FRIENDS',
                 id: 'friend-far',
                 name: 'Distant',
                 username: 'distant',
@@ -111,6 +117,7 @@ describe('app/routes/resources+/home.panels.tsx', () => {
             {
               user: {
                 birthday: localCalendarDate(1991, 3, 8),
+                birthdayVisibility: 'FRIENDS',
                 id: 'viewer-1',
                 name: 'Viewer',
                 username: 'viewer',
@@ -126,6 +133,7 @@ describe('app/routes/resources+/home.panels.tsx', () => {
             {
               user: {
                 birthday: localCalendarDate(1990, 3, 5),
+                birthdayVisibility: 'FRIENDS',
                 id: 'friend-near',
                 name: 'Alex',
                 username: 'alex',
@@ -134,6 +142,7 @@ describe('app/routes/resources+/home.panels.tsx', () => {
             {
               user: {
                 birthday: null,
+                birthdayVisibility: 'FRIENDS',
                 id: 'friend-none',
                 name: 'No Birthday',
                 username: 'nobday',
@@ -142,6 +151,7 @@ describe('app/routes/resources+/home.panels.tsx', () => {
             {
               user: {
                 birthday: localCalendarDate(1993, 3, 3),
+                birthdayVisibility: 'FRIENDS',
                 id: 'friend-soon',
                 name: null,
                 username: 'soon',
@@ -150,6 +160,15 @@ describe('app/routes/resources+/home.panels.tsx', () => {
           ],
         },
       },
+    ]);
+
+    // Viewer is friends with every candidate so FRIENDS visibility passes
+    // through. Separate tests exercise the friendship gate below.
+    friendshipFindMany.mockResolvedValue([
+      { userAId: 'viewer-1', userBId: 'friend-near' },
+      { userAId: 'viewer-1', userBId: 'friend-far' },
+      { userAId: 'viewer-1', userBId: 'friend-none' },
+      { userAId: 'viewer-1', userBId: 'friend-soon' },
     ]);
 
     vi.useFakeTimers();
@@ -210,6 +229,77 @@ describe('app/routes/resources+/home.panels.tsx', () => {
         ...expectedBirthdayOutput(3, 5),
         username: 'alex',
       });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('enforces birthdayVisibility: NOBODY hidden, FRIENDS needs friendship, EVERYONE always shown', async () => {
+    getUserId.mockResolvedValue('viewer-1');
+    findMany.mockResolvedValue([
+      {
+        giftGroup: {
+          id: 'group-1',
+          groupMembers: [
+            {
+              user: {
+                birthday: localCalendarDate(1990, 3, 1),
+                birthdayVisibility: 'NOBODY',
+                id: 'hidden',
+                name: 'Hidden',
+                username: 'hidden',
+              },
+            },
+            {
+              user: {
+                birthday: localCalendarDate(1990, 3, 2),
+                birthdayVisibility: 'FRIENDS',
+                id: 'friend-ok',
+                name: 'Friend OK',
+                username: 'friend_ok',
+              },
+            },
+            {
+              user: {
+                birthday: localCalendarDate(1990, 3, 3),
+                birthdayVisibility: 'FRIENDS',
+                id: 'stranger',
+                name: 'Group-mate Stranger',
+                username: 'stranger',
+              },
+            },
+            {
+              user: {
+                birthday: localCalendarDate(1990, 3, 4),
+                birthdayVisibility: 'EVERYONE',
+                id: 'public',
+                name: 'Public',
+                username: 'public',
+              },
+            },
+          ],
+        },
+      },
+    ]);
+    // Viewer is friends with friend-ok, but NOT with stranger or public.
+    friendshipFindMany.mockResolvedValue([
+      { userAId: 'viewer-1', userBId: 'friend-ok' },
+    ]);
+
+    vi.useFakeTimers();
+    vi.setSystemTime(localCalendarDate(2026, 2, 31));
+
+    try {
+      const result = await loader({
+        context: {},
+        params: {},
+        request: new Request('https://giftpool.app/resources/home.panels'),
+      } as never);
+
+      const ids = result.birthdays.map((b) => b.id).sort();
+      expect(ids).toEqual(['friend-ok', 'public']);
+      expect(ids).not.toContain('hidden');
+      expect(ids).not.toContain('stranger');
     } finally {
       vi.useRealTimers();
     }

--- a/app/routes/resources+/home.panels.test.ts
+++ b/app/routes/resources+/home.panels.test.ts
@@ -171,6 +171,7 @@ describe('app/routes/resources+/home.panels.tsx', () => {
                   user: {
                     select: {
                       birthday: true,
+                      birthdayVisibility: true,
                       id: true,
                       name: true,
                       username: true,

--- a/app/routes/resources+/home.panels.tsx
+++ b/app/routes/resources+/home.panels.tsx
@@ -86,6 +86,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
                   name: true,
                   username: true,
                   birthday: true,
+                  birthdayVisibility: true,
                 },
               },
             },
@@ -112,6 +113,11 @@ export async function loader({ request }: LoaderFunctionArgs) {
     for (const gm of m.giftGroup.groupMembers) {
       const u = gm.user;
       if (!u.birthday || u.id === userId) continue;
+      // Respect the owner's privacy choice — hide their upcoming birthday
+      // from the Home reminders panel when they've opted out. `FRIENDS` and
+      // `EVERYONE` both keep showing since anyone sharing a group with them
+      // is reading this panel.
+      if (u.birthdayVisibility === 'NOBODY') continue;
       const nextDate = nextBirthdayDate(u.birthday, now);
       const key = u.id;
       if (!birthdayMap.has(key)) {

--- a/app/routes/resources+/home.panels.tsx
+++ b/app/routes/resources+/home.panels.tsx
@@ -1,6 +1,41 @@
 import { type LoaderFunctionArgs } from 'react-router';
 import { getUserId } from '#app/utils/auth.server';
 import { prisma } from '#app/utils/db.server';
+
+const SIXTY_DAYS_MS = 60 * 24 * 60 * 60 * 1000;
+
+type GroupMemberUser = {
+  id: string;
+  name: string | null;
+  username: string;
+  birthday: Date | null;
+  birthdayVisibility: string;
+};
+
+type Membership = {
+  giftGroup: {
+    id: string;
+    groupMembers: Array<{ user: GroupMemberUser }>;
+  };
+};
+
+type UpcomingBirthdayEntry = {
+  id: string;
+  name: string;
+  username: string | null;
+  date: Date;
+  groupId: string | null;
+};
+
+type HomeBirthday = {
+  id: string;
+  name: string;
+  username: string | null;
+  dateISO: string;
+  dateLabel: string;
+  groupId: string | null;
+};
+
 function formatDateLabel(date: Date) {
   return new Intl.DateTimeFormat('en', {
     month: 'short',
@@ -20,20 +55,82 @@ function nextBirthdayDate(birthday: Date, now = new Date()) {
   }
   return new Date(now.getFullYear() + 1, bMonth, bDate);
 }
-export async function loader({ request }: LoaderFunctionArgs) {
-  const url = new URL(request.url);
-  const mockParam = url.searchParams.get('mock');
-  const mock: 'empty' | 'data' | undefined =
-    mockParam === 'empty' || mockParam === 'data'
-      ? (mockParam as any)
-      : undefined;
 
-  // Mocked responses for tests
+// Is this group-mate's birthday visible to the viewer?
+// - `NOBODY` → never.
+// - `FRIENDS` → only when the viewer has a confirmed friendship.
+// - `EVERYONE` (or any unexpected default) → always.
+function isBirthdayVisibleToViewer(
+  user: GroupMemberUser,
+  friendIds: Set<string>,
+) {
+  if (user.birthdayVisibility === 'NOBODY') return false;
+  if (user.birthdayVisibility === 'FRIENDS' && !friendIds.has(user.id)) {
+    return false;
+  }
+  return true;
+}
+
+// Walk the viewer's group memberships and build a de-duped map of
+// `userId → upcoming-birthday entry`. Pulled out of the loader body to keep
+// the complexity low — the loader just orchestrates DB calls and formats.
+function collectUpcomingBirthdays(
+  memberships: Membership[],
+  friendIds: Set<string>,
+  viewerId: string,
+  now: Date,
+): Map<string, UpcomingBirthdayEntry> {
+  const birthdayMap = new Map<string, UpcomingBirthdayEntry>();
+  for (const m of memberships) {
+    for (const gm of m.giftGroup.groupMembers) {
+      const u = gm.user;
+      if (!u.birthday || u.id === viewerId) continue;
+      if (!isBirthdayVisibleToViewer(u, friendIds)) continue;
+      if (birthdayMap.has(u.id)) continue;
+      birthdayMap.set(u.id, {
+        id: u.id,
+        name: u.name ?? u.username ?? 'Friend',
+        username: u.username,
+        date: nextBirthdayDate(u.birthday, now),
+        groupId: m.giftGroup.id,
+      });
+    }
+  }
+  return birthdayMap;
+}
+
+function sortAndSliceUpcomingBirthdays(
+  birthdayMap: Map<string, UpcomingBirthdayEntry>,
+  now: Date,
+): HomeBirthday[] {
+  return Array.from(birthdayMap.values())
+    .filter((b) => b.date.getTime() - now.getTime() <= SIXTY_DAYS_MS)
+    .sort((a, b) => a.date.getTime() - b.date.getTime())
+    .slice(0, 5)
+    .map((b) => ({
+      id: b.id,
+      name: b.name,
+      username: b.username,
+      dateISO: b.date.toISOString().slice(0, 10),
+      dateLabel: formatDateLabel(b.date),
+      groupId: b.groupId,
+    }));
+}
+
+function buildFriendIdSet(
+  friendships: Array<{ userAId: string; userBId: string }>,
+  viewerId: string,
+): Set<string> {
+  const friendIds = new Set<string>();
+  for (const f of friendships) {
+    friendIds.add(f.userAId === viewerId ? f.userBId : f.userAId);
+  }
+  return friendIds;
+}
+
+function resolveMockPayload(mock: 'empty' | 'data' | undefined) {
   if (mock === 'empty') {
-    return {
-      birthdays: [],
-      activity: [],
-    };
+    return { birthdays: [], activity: [] };
   }
   if (mock === 'data') {
     const now = new Date();
@@ -63,12 +160,21 @@ export async function loader({ request }: LoaderFunctionArgs) {
       ],
     };
   }
+  return null;
+}
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const url = new URL(request.url);
+  const mockParam = url.searchParams.get('mock');
+  const mock: 'empty' | 'data' | undefined =
+    mockParam === 'empty' || mockParam === 'data' ? mockParam : undefined;
+
+  const mocked = resolveMockPayload(mock);
+  if (mocked) return mocked;
+
   const userId = await getUserId(request);
   if (!userId) {
-    return {
-      birthdays: [],
-      activity: [],
-    };
+    return { birthdays: [], activity: [] };
   }
 
   // Upcoming birthdays for users sharing at least one group with the current
@@ -77,9 +183,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
   // actually friends with the viewer would leak through.
   const [memberships, friendships] = await Promise.all([
     prisma.usersInGiftGroups.findMany({
-      where: {
-        userId,
-      },
+      where: { userId },
       select: {
         giftGroup: {
           select: {
@@ -102,68 +206,20 @@ export async function loader({ request }: LoaderFunctionArgs) {
       },
     }),
     prisma.friendship.findMany({
-      where: {
-        OR: [{ userAId: userId }, { userBId: userId }],
-      },
+      where: { OR: [{ userAId: userId }, { userBId: userId }] },
       select: { userAId: true, userBId: true },
     }),
   ]);
-  const friendIds = new Set<string>();
-  for (const f of friendships) {
-    friendIds.add(f.userAId === userId ? f.userBId : f.userAId);
-  }
-  const now = new Date();
-  const sixtyDays = 60 * 24 * 60 * 60 * 1000;
 
-  // Collect potential birthdays with at least one shared group id
-  const birthdayMap = new Map<
-    string,
-    {
-      id: string;
-      name: string;
-      username: string | null;
-      date: Date;
-      groupId: string | null;
-    }
-  >();
-  for (const m of memberships) {
-    for (const gm of m.giftGroup.groupMembers) {
-      const u = gm.user;
-      if (!u.birthday || u.id === userId) continue;
-      // Respect the owner's privacy choice. NOBODY → always hide.
-      // FRIENDS → only show if the viewer is an actual friend (shared
-      //   group alone isn't enough, since this panel iterates
-      //   group-mates not friendships).
-      // EVERYONE → always show.
-      if (u.birthdayVisibility === 'NOBODY') continue;
-      if (u.birthdayVisibility === 'FRIENDS' && !friendIds.has(u.id)) {
-        continue;
-      }
-      const nextDate = nextBirthdayDate(u.birthday, now);
-      const key = u.id;
-      if (!birthdayMap.has(key)) {
-        birthdayMap.set(key, {
-          id: u.id,
-          name: u.name ?? u.username ?? 'Friend',
-          username: u.username,
-          date: nextDate,
-          groupId: m.giftGroup.id,
-        });
-      }
-    }
-  }
-  const birthdays = Array.from(birthdayMap.values())
-    .filter((b) => b.date.getTime() - now.getTime() <= sixtyDays)
-    .sort((a, b) => a.date.getTime() - b.date.getTime())
-    .slice(0, 5)
-    .map((b) => ({
-      id: b.id,
-      name: b.name,
-      username: b.username,
-      dateISO: b.date.toISOString().slice(0, 10),
-      dateLabel: formatDateLabel(b.date),
-      groupId: b.groupId,
-    }));
+  const friendIds = buildFriendIdSet(friendships, userId);
+  const now = new Date();
+  const birthdayMap = collectUpcomingBirthdays(
+    memberships,
+    friendIds,
+    userId,
+    now,
+  );
+  const birthdays = sortAndSliceUpcomingBirthdays(birthdayMap, now);
 
   // TODO: Wire real recent activity once available.
   const activity: Array<{
@@ -171,9 +227,6 @@ export async function loader({ request }: LoaderFunctionArgs) {
     description: string;
     timestampISO: string;
   }> = [];
-  return {
-    birthdays,
-    activity,
-  };
+  return { birthdays, activity };
 }
 export default null;

--- a/app/routes/resources+/home.panels.tsx
+++ b/app/routes/resources+/home.panels.tsx
@@ -8,10 +8,12 @@ function formatDateLabel(date: Date) {
   }).format(date);
 }
 
-// Find next birthday date (this year or next) from a month/day reference
+// Find next birthday date (this year or next) from a month/day reference.
+// Reads the stored birthday in UTC because `BirthdaySchema` writes noon UTC
+// — local-time getters would shift by a day for viewers west of UTC.
 function nextBirthdayDate(birthday: Date, now = new Date()) {
-  const bMonth = birthday.getMonth();
-  const bDate = birthday.getDate();
+  const bMonth = birthday.getUTCMonth();
+  const bDate = birthday.getUTCDate();
   const thisYear = new Date(now.getFullYear(), bMonth, bDate);
   if (thisYear >= new Date(now.getFullYear(), now.getMonth(), now.getDate())) {
     return thisYear;
@@ -69,32 +71,47 @@ export async function loader({ request }: LoaderFunctionArgs) {
     };
   }
 
-  // Upcoming birthdays for users sharing at least one group with the current user
-  const memberships = await prisma.usersInGiftGroups.findMany({
-    where: {
-      userId,
-    },
-    select: {
-      giftGroup: {
-        select: {
-          id: true,
-          groupMembers: {
-            select: {
-              user: {
-                select: {
-                  id: true,
-                  name: true,
-                  username: true,
-                  birthday: true,
-                  birthdayVisibility: true,
+  // Upcoming birthdays for users sharing at least one group with the current
+  // user. We also load the viewer's friendships so we can enforce
+  // `birthdayVisibility === 'FRIENDS'` — otherwise a group-mate who isn't
+  // actually friends with the viewer would leak through.
+  const [memberships, friendships] = await Promise.all([
+    prisma.usersInGiftGroups.findMany({
+      where: {
+        userId,
+      },
+      select: {
+        giftGroup: {
+          select: {
+            id: true,
+            groupMembers: {
+              select: {
+                user: {
+                  select: {
+                    id: true,
+                    name: true,
+                    username: true,
+                    birthday: true,
+                    birthdayVisibility: true,
+                  },
                 },
               },
             },
           },
         },
       },
-    },
-  });
+    }),
+    prisma.friendship.findMany({
+      where: {
+        OR: [{ userAId: userId }, { userBId: userId }],
+      },
+      select: { userAId: true, userBId: true },
+    }),
+  ]);
+  const friendIds = new Set<string>();
+  for (const f of friendships) {
+    friendIds.add(f.userAId === userId ? f.userBId : f.userAId);
+  }
   const now = new Date();
   const sixtyDays = 60 * 24 * 60 * 60 * 1000;
 
@@ -113,11 +130,15 @@ export async function loader({ request }: LoaderFunctionArgs) {
     for (const gm of m.giftGroup.groupMembers) {
       const u = gm.user;
       if (!u.birthday || u.id === userId) continue;
-      // Respect the owner's privacy choice — hide their upcoming birthday
-      // from the Home reminders panel when they've opted out. `FRIENDS` and
-      // `EVERYONE` both keep showing since anyone sharing a group with them
-      // is reading this panel.
+      // Respect the owner's privacy choice. NOBODY → always hide.
+      // FRIENDS → only show if the viewer is an actual friend (shared
+      //   group alone isn't enough, since this panel iterates
+      //   group-mates not friendships).
+      // EVERYONE → always show.
       if (u.birthdayVisibility === 'NOBODY') continue;
+      if (u.birthdayVisibility === 'FRIENDS' && !friendIds.has(u.id)) {
+        continue;
+      }
       const nextDate = nextBirthdayDate(u.birthday, now);
       const key = u.id;
       if (!birthdayMap.has(key)) {

--- a/app/routes/settings+/profile.index.test.tsx
+++ b/app/routes/settings+/profile.index.test.tsx
@@ -11,6 +11,9 @@ type LoaderUser = {
   name: string | null;
   username: string;
   email: string;
+  bio: string | null;
+  birthday: Date | null;
+  birthdayVisibility: string;
   image: { id: string } | null;
   _count: { sessions: number };
 };
@@ -25,6 +28,9 @@ const loaderDataSnapshot: {
     name: 'Wade Wilson',
     username: 'wade',
     email: 'wade@example.com',
+    bio: 'Mercenary with a mouth.',
+    birthday: new Date('1992-05-26T00:00:00.000Z'),
+    birthdayVisibility: 'FRIENDS',
     image: { id: 'image-1' },
     _count: { sessions: 3 },
   },
@@ -97,6 +103,9 @@ describe('<SettingsProfileHub />', () => {
       screen.getByRole('heading', { level: 2, name: 'Account' }),
     ).toBeInTheDocument();
     expect(
+      screen.getByRole('heading', { level: 2, name: 'Privacy' }),
+    ).toBeInTheDocument();
+    expect(
       screen.getByRole('heading', { level: 2, name: 'Preferences' }),
     ).toBeInTheDocument();
     expect(
@@ -105,6 +114,45 @@ describe('<SettingsProfileHub />', () => {
     expect(
       screen.getByRole('heading', { level: 2, name: 'Danger zone' }),
     ).toBeInTheDocument();
+  });
+
+  it('populates the bio and birthday fields from loader data', () => {
+    const { container } = renderHub();
+    const bio = container.querySelector(
+      'textarea[name="bio"]',
+    ) as HTMLTextAreaElement;
+    const birthday = container.querySelector(
+      'input[name="birthday"]',
+    ) as HTMLInputElement;
+    expect(bio.value).toBe('Mercenary with a mouth.');
+    expect(birthday.value).toBe('1992-05-26');
+    expect(birthday.type).toBe('date');
+  });
+
+  it('renders all three birthday visibility options with FRIENDS selected by default', () => {
+    const { container } = renderHub();
+    const radios = container.querySelectorAll<HTMLInputElement>(
+      'input[name="birthdayVisibility"]',
+    );
+    expect(radios).toHaveLength(3);
+    const byValue = new Map<string, HTMLInputElement>();
+    radios.forEach((r) => byValue.set(r.value, r));
+    expect(byValue.get('FRIENDS')?.checked).toBe(true);
+    expect(byValue.get('EVERYONE')?.checked).toBe(false);
+    expect(byValue.get('NOBODY')?.checked).toBe(false);
+  });
+
+  it('reflects a non-default birthdayVisibility from loader data', () => {
+    loaderDataSnapshot.user.birthdayVisibility = 'NOBODY';
+    const { container } = renderHub();
+    const radios = container.querySelectorAll<HTMLInputElement>(
+      'input[name="birthdayVisibility"]',
+    );
+    const byValue = new Map<string, HTMLInputElement>();
+    radios.forEach((r) => byValue.set(r.value, r));
+    expect(byValue.get('NOBODY')?.checked).toBe(true);
+    expect(byValue.get('FRIENDS')?.checked).toBe(false);
+    loaderDataSnapshot.user.birthdayVisibility = 'FRIENDS';
   });
 
   it('populates the username + name form from loader data', () => {

--- a/app/routes/settings+/profile.index.tsx
+++ b/app/routes/settings+/profile.index.tsx
@@ -261,6 +261,7 @@ function ProfileCard({ onOpenPhoto }: Readonly<{ onOpenPhoto: () => void }>) {
             }}
             textareaProps={{
               ...getInputProps(fields.bio, { type: 'text' }),
+              required: false,
               rows: 3,
               maxLength: BIO_MAX_LENGTH,
               placeholder: 'Short blurb your friends will see on your profile.',
@@ -272,7 +273,10 @@ function ProfileCard({ onOpenPhoto }: Readonly<{ onOpenPhoto: () => void }>) {
               htmlFor: fields.birthday.id,
               children: 'Birthday',
             }}
-            inputProps={getInputProps(fields.birthday, { type: 'date' })}
+            inputProps={{
+              ...getInputProps(fields.birthday, { type: 'date' }),
+              required: false,
+            }}
             errors={fields.birthday.errors}
           />
           <ErrorList errors={form.errors} id={form.errorId} />

--- a/app/routes/settings+/profile.index.tsx
+++ b/app/routes/settings+/profile.index.tsx
@@ -393,6 +393,7 @@ function PrivacyCard() {
             <label
               key={option.value}
               htmlFor={id}
+              aria-label={option.label}
               className="flex cursor-pointer items-start gap-3 rounded-lg border border-border/60 bg-background/40 px-3 py-2.5 transition hover:border-border"
               data-selected={isSelected || undefined}
             >
@@ -410,14 +411,14 @@ function PrivacyCard() {
                 }}
                 className="mt-0.5 h-4 w-4 accent-primary"
               />
-              <div className="flex flex-col gap-0.5">
-                <Text size="sm" weight="medium" className="text-foreground">
+              <span className="flex flex-col gap-0.5">
+                <span className="text-sm font-medium text-foreground">
                   {option.label}
-                </Text>
-                <Text size="xs" className="text-muted-foreground">
+                </span>
+                <span className="text-xs text-muted-foreground">
                   {option.description}
-                </Text>
-              </div>
+                </span>
+              </span>
             </label>
           );
         })}
@@ -618,7 +619,7 @@ async function profileUpdateAction({ userId, formData }: ProfileActionArgs) {
     data: {
       name: data.name,
       username: data.username,
-      bio: trimmedBio ? trimmedBio : null,
+      bio: trimmedBio || null,
       birthday: data.birthday ?? null,
     },
   });

--- a/app/routes/settings+/profile.index.tsx
+++ b/app/routes/settings+/profile.index.tsx
@@ -17,7 +17,7 @@ import {
   type LoaderFunctionArgs,
 } from 'react-router';
 import { z } from 'zod';
-import { ErrorList, Field } from '#app/components/forms.tsx';
+import { ErrorList, Field, TextareaField } from '#app/components/forms.tsx';
 import { Avatar } from '#app/components/ui/avatar.tsx';
 import { Button } from '#app/components/ui/button.tsx';
 import { Card } from '#app/components/ui/card.tsx';
@@ -29,7 +29,16 @@ import { prisma } from '#app/utils/db.server.ts';
 import { useDoubleCheck } from '#app/utils/misc.tsx';
 import { authSessionStorage } from '#app/utils/session.server.ts';
 import { redirectWithToast } from '#app/utils/toast.server.ts';
-import { NameSchema, UsernameSchema } from '#app/utils/user-validation.ts';
+import {
+  BIO_MAX_LENGTH,
+  BIRTHDAY_VISIBILITY_VALUES,
+  BioSchema,
+  BirthdaySchema,
+  BirthdayVisibilitySchema,
+  NameSchema,
+  UsernameSchema,
+  type BirthdayVisibility,
+} from '#app/utils/user-validation.ts';
 import { DangerZoneDeleteDialog } from './__danger-zone-delete-dialog.tsx';
 import { ProfilePhotoSheet } from './__profile-photo-sheet.tsx';
 import { twoFAVerificationType } from './profile.two-factor.tsx';
@@ -41,6 +50,12 @@ export const handle: SEOHandle = {
 const ProfileFormSchema = z.object({
   name: NameSchema.optional(),
   username: UsernameSchema,
+  bio: BioSchema.optional(),
+  birthday: BirthdaySchema.optional(),
+});
+
+const PrivacyFormSchema = z.object({
+  birthdayVisibility: BirthdayVisibilitySchema,
 });
 
 export async function loader({ request }: LoaderFunctionArgs) {
@@ -52,6 +67,9 @@ export async function loader({ request }: LoaderFunctionArgs) {
       name: true,
       username: true,
       email: true,
+      bio: true,
+      birthday: true,
+      birthdayVisibility: true,
       image: { select: { id: true } },
       _count: {
         select: {
@@ -89,6 +107,7 @@ type ProfileActionArgs = {
 };
 
 const profileUpdateActionIntent = 'update-profile';
+const privacyUpdateActionIntent = 'update-privacy';
 const signOutOfSessionsActionIntent = 'sign-out-of-sessions';
 const deleteDataActionIntent = 'delete-data';
 
@@ -99,6 +118,9 @@ export async function action({ request }: ActionFunctionArgs) {
   switch (intent) {
     case profileUpdateActionIntent: {
       return profileUpdateAction({ request, userId, formData });
+    }
+    case privacyUpdateActionIntent: {
+      return privacyUpdateAction({ request, userId, formData });
     }
     case signOutOfSessionsActionIntent: {
       return signOutOfSessionsAction({ request, userId, formData });
@@ -137,6 +159,7 @@ const SettingsProfileHub = () => {
 
       <ProfileCard onOpenPhoto={() => setPhotoOpen(true)} />
       <AccountCard />
+      <PrivacyCard />
       <PreferencesCard />
       <DataCard />
       <DangerZoneCard />
@@ -155,6 +178,13 @@ export default SettingsProfileHub;
 
 // ─── Profile card ──────────────────────────────────────────────────────────
 
+function toDateInputValue(value: Date | string | null | undefined) {
+  if (!value) return '';
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return '';
+  return date.toISOString().slice(0, 10);
+}
+
 function ProfileCard({ onOpenPhoto }: Readonly<{ onOpenPhoto: () => void }>) {
   const data = useLoaderData<typeof loader>();
   const fetcher = useFetcher<typeof profileUpdateAction>();
@@ -168,6 +198,8 @@ function ProfileCard({ onOpenPhoto }: Readonly<{ onOpenPhoto: () => void }>) {
     defaultValue: {
       username: data.user.username,
       name: data.user.name,
+      bio: data.user.bio ?? '',
+      birthday: toDateInputValue(data.user.birthday),
     },
   });
 
@@ -222,6 +254,27 @@ function ProfileCard({ onOpenPhoto }: Readonly<{ onOpenPhoto: () => void }>) {
               errors={fields.name.errors}
             />
           </div>
+          <TextareaField
+            labelProps={{
+              htmlFor: fields.bio.id,
+              children: `Bio (up to ${BIO_MAX_LENGTH} characters)`,
+            }}
+            textareaProps={{
+              ...getInputProps(fields.bio, { type: 'text' }),
+              rows: 3,
+              maxLength: BIO_MAX_LENGTH,
+              placeholder: 'Short blurb your friends will see on your profile.',
+            }}
+            errors={fields.bio.errors}
+          />
+          <Field
+            labelProps={{
+              htmlFor: fields.birthday.id,
+              children: 'Birthday',
+            }}
+            inputProps={getInputProps(fields.birthday, { type: 'date' })}
+            errors={fields.birthday.errors}
+          />
           <ErrorList errors={form.errors} id={form.errorId} />
           <div className="flex justify-end">
             <StatusButton
@@ -276,6 +329,95 @@ function AccountCard() {
           accessibleName={data.isTwoFactorEnabled ? 'Disable 2FA' : 'Enable 2FA'}
         />
       </div>
+    </Card>
+  );
+}
+
+// ─── Privacy card ──────────────────────────────────────────────────────────
+
+const PRIVACY_OPTIONS: ReadonlyArray<{
+  value: BirthdayVisibility;
+  label: string;
+  description: string;
+}> = [
+  {
+    value: 'FRIENDS',
+    label: 'Friends only',
+    description: 'Only people you’re friends with on GiftPool can see it.',
+  },
+  {
+    value: 'EVERYONE',
+    label: 'Everyone',
+    description: 'Visible to anyone who lands on your profile.',
+  },
+  {
+    value: 'NOBODY',
+    label: 'Nobody',
+    description: 'Keep it private — nobody sees it on your profile.',
+  },
+];
+
+function PrivacyCard() {
+  const data = useLoaderData<typeof loader>();
+  const fetcher = useFetcher<typeof privacyUpdateAction>();
+  const currentValue =
+    (data.user.birthdayVisibility as BirthdayVisibility | undefined) ??
+    'FRIENDS';
+  // Optimistic reflection: while the fetcher is in-flight we show the
+  // pending value from its formData instead of waiting for the revalidation.
+  const pendingValue = fetcher.formData?.get('birthdayVisibility');
+  const selected =
+    typeof pendingValue === 'string' &&
+    (BIRTHDAY_VISIBILITY_VALUES as readonly string[]).includes(pendingValue)
+      ? (pendingValue as BirthdayVisibility)
+      : currentValue;
+
+  return (
+    <Card padding="lg" className="flex flex-col gap-5">
+      <SectionHeading
+        title="Privacy"
+        description="Control who can see personal details on your profile."
+      />
+      <fieldset className="flex flex-col gap-3">
+        <legend className="text-sm font-medium text-foreground">
+          Birthday visibility
+        </legend>
+        {PRIVACY_OPTIONS.map((option) => {
+          const id = `birthday-visibility-${option.value}`;
+          const isSelected = selected === option.value;
+          return (
+            <label
+              key={option.value}
+              htmlFor={id}
+              className="flex cursor-pointer items-start gap-3 rounded-lg border border-border/60 bg-background/40 px-3 py-2.5 transition hover:border-border"
+              data-selected={isSelected || undefined}
+            >
+              <input
+                id={id}
+                type="radio"
+                name="birthdayVisibility"
+                value={option.value}
+                checked={isSelected}
+                onChange={(event) => {
+                  const formData = new FormData();
+                  formData.set('intent', privacyUpdateActionIntent);
+                  formData.set('birthdayVisibility', event.currentTarget.value);
+                  void fetcher.submit(formData, { method: 'POST' });
+                }}
+                className="mt-0.5 h-4 w-4 accent-primary"
+              />
+              <div className="flex flex-col gap-0.5">
+                <Text size="sm" weight="medium" className="text-foreground">
+                  {option.label}
+                </Text>
+                <Text size="xs" className="text-muted-foreground">
+                  {option.description}
+                </Text>
+              </div>
+            </label>
+          );
+        })}
+      </fieldset>
     </Card>
   );
 }
@@ -465,13 +607,32 @@ async function profileUpdateAction({ userId, formData }: ProfileActionArgs) {
     );
   }
   const data = submission.value;
+  const trimmedBio = data.bio?.trim();
   await prisma.user.update({
     select: { username: true },
     where: { id: userId },
     data: {
       name: data.name,
       username: data.username,
+      bio: trimmedBio ? trimmedBio : null,
+      birthday: data.birthday ?? null,
     },
+  });
+  return { result: submission.reply() };
+}
+
+async function privacyUpdateAction({ userId, formData }: ProfileActionArgs) {
+  const submission = parseWithZod(formData, { schema: PrivacyFormSchema });
+  if (submission.status !== 'success') {
+    return rrData(
+      { result: submission.reply() },
+      { status: submission.status === 'error' ? 400 : 200 },
+    );
+  }
+  await prisma.user.update({
+    select: { id: true },
+    where: { id: userId },
+    data: { birthdayVisibility: submission.value.birthdayVisibility },
   });
   return { result: submission.reply() };
 }

--- a/app/routes/users+/$username_+/index.tsx
+++ b/app/routes/users+/$username_+/index.tsx
@@ -83,7 +83,9 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
       name: true,
       username: true,
       createdAt: true,
+      bio: true,
       birthday: true,
+      birthdayVisibility: true,
       image: {
         select: {
           id: true,
@@ -143,7 +145,9 @@ type FriendProfileViewProps = Readonly<{
     id: string;
     username: string;
     name: string | null;
+    bio: string | null;
     birthday: Date | string | null;
+    birthdayVisibility: string;
     image: { id: string } | null;
   };
   userJoinedDisplay: string;
@@ -158,7 +162,11 @@ function FriendProfileView({
   profileData,
 }: FriendProfileViewProps) {
   const userDisplayName = user.name ?? user.username;
-  const upcoming = getUpcomingBirthday(user.birthday);
+  // Viewer is already a confirmed friend to reach this view, so we only
+  // need to suppress the pill when the owner has opted into NOBODY. EVERYONE
+  // and FRIENDS both end up rendering it.
+  const birthdayHidden = user.birthdayVisibility === 'NOBODY';
+  const upcoming = birthdayHidden ? null : getUpcomingBirthday(user.birthday);
   const birthdayLabel =
     upcoming && upcoming.daysUntil <= BIRTHDAY_VISIBILITY_DAYS
       ? formatBirthdayLabel(upcoming.date, upcoming.daysUntil)
@@ -168,6 +176,7 @@ function FriendProfileView({
     <div className="mx-auto flex w-full max-w-3xl flex-col gap-8 px-4 py-10 sm:py-14">
       <ProfileHeader
         user={user}
+        bio={user.bio}
         birthdayLabel={birthdayLabel}
         joinedDisplay={userJoinedDisplay}
         actions={

--- a/app/utils/birthday.test.ts
+++ b/app/utils/birthday.test.ts
@@ -1,0 +1,78 @@
+/**
+ * @vitest-environment node
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  BIRTHDAY_VISIBILITY_DAYS,
+  formatBirthdayLabel,
+  getUpcomingBirthday,
+} from './birthday.ts';
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('getUpcomingBirthday', () => {
+  it('returns null for missing / invalid inputs', () => {
+    expect(getUpcomingBirthday(null)).toBeNull();
+    expect(getUpcomingBirthday(undefined)).toBeNull();
+    expect(getUpcomingBirthday('')).toBeNull();
+    expect(getUpcomingBirthday('not a date')).toBeNull();
+  });
+
+  it('counts days until the next occurrence of the stored month/day', () => {
+    // Pretend today is 2026-04-10 local time.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 3, 10, 12, 0, 0));
+
+    // Birthday stored as noon UTC — the same representation BirthdaySchema
+    // produces from a 1992-05-26 input.
+    const birthday = new Date('1992-05-26T12:00:00.000Z');
+    const result = getUpcomingBirthday(birthday);
+    expect(result).not.toBeNull();
+    expect(result!.date.getMonth()).toBe(4); // May
+    expect(result!.date.getDate()).toBe(26);
+    // From Apr 10 to May 26 = 46 days.
+    expect(result!.daysUntil).toBe(46);
+  });
+
+  it('rolls forward to next year when the birthday has already passed this year', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 5, 10, 12, 0, 0)); // June 10 2026
+    const birthday = new Date('1992-05-26T12:00:00.000Z');
+    const result = getUpcomingBirthday(birthday);
+    expect(result!.date.getFullYear()).toBe(2027);
+  });
+
+  it('is not off-by-one for birthdays stored at noon UTC when the viewer is west of UTC', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 3, 10, 12, 0, 0));
+    // Noon UTC → same calendar day everywhere populated on earth.
+    // (Older code stored midnight UTC and read with local getters, which
+    // shifted May 26 → May 25 in LA. This test locks the fix.)
+    const birthday = new Date('1992-05-26T12:00:00.000Z');
+    const result = getUpcomingBirthday(birthday);
+    expect(result!.date.getDate()).toBe(26);
+    expect(result!.date.getMonth()).toBe(4);
+  });
+});
+
+describe('formatBirthdayLabel', () => {
+  it("returns 'Today!' when daysUntil is 0", () => {
+    expect(formatBirthdayLabel(new Date(2026, 4, 26), 0)).toBe('Today!');
+  });
+
+  it("returns 'Tomorrow' when daysUntil is 1", () => {
+    expect(formatBirthdayLabel(new Date(2026, 4, 26), 1)).toBe('Tomorrow');
+  });
+
+  it('returns a short month/day label otherwise', () => {
+    expect(formatBirthdayLabel(new Date(2026, 4, 26), 46)).toBe('May 26');
+  });
+});
+
+describe('BIRTHDAY_VISIBILITY_DAYS', () => {
+  it('is the 60-day window shared by every caller', () => {
+    expect(BIRTHDAY_VISIBILITY_DAYS).toBe(60);
+  });
+});

--- a/app/utils/birthday.ts
+++ b/app/utils/birthday.ts
@@ -14,6 +14,12 @@ export type UpcomingBirthday = {
 
 // Next occurrence of this birthday's month/day, and how far it is from today.
 // Returns null when the input is missing or unparseable.
+//
+// Reads month/day in UTC, not local time. Birthdays are stored as noon UTC
+// (see `BirthdaySchema`) so that the calendar date is invariant across
+// viewer timezones. Reading via `getUTCMonth` / `getUTCDate` closes the
+// loop: a user in LA who picks May 26 sees May 26 on every client, not the
+// shifted-by-one date that local-time getters would produce.
 export function getUpcomingBirthday(
   birthday: Date | string | null | undefined,
 ): UpcomingBirthday | null {
@@ -24,8 +30,8 @@ export function getUpcomingBirthday(
   const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
   const candidate = new Date(
     today.getFullYear(),
-    parsed.getMonth(),
-    parsed.getDate(),
+    parsed.getUTCMonth(),
+    parsed.getUTCDate(),
   );
   if (candidate.getTime() < today.getTime()) {
     candidate.setFullYear(candidate.getFullYear() + 1);
@@ -36,7 +42,9 @@ export function getUpcomingBirthday(
   return { date: candidate, daysUntil };
 }
 
-// Short human label — "Today!", "Tomorrow", or "Sep 12".
+// Short human label — "Today!", "Tomorrow", or "Sep 12". The Date passed
+// in is already the local-timezone candidate constructed by
+// `getUpcomingBirthday`, so local-time formatting is correct here.
 export function formatBirthdayLabel(date: Date, daysUntil: number) {
   if (daysUntil === 0) return 'Today!';
   if (daysUntil === 1) return 'Tomorrow';

--- a/app/utils/friends.server.ts
+++ b/app/utils/friends.server.ts
@@ -17,6 +17,7 @@ const friendUserSelect = {
   username: true,
   name: true,
   birthday: true,
+  birthdayVisibility: true,
   image: { select: { id: true, altText: true } },
 } as const;
 

--- a/app/utils/user-validation.test.ts
+++ b/app/utils/user-validation.test.ts
@@ -1,0 +1,64 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  BIO_MAX_LENGTH,
+  BIRTHDAY_VISIBILITY_VALUES,
+  BioSchema,
+  BirthdaySchema,
+  BirthdayVisibilitySchema,
+} from './user-validation.ts';
+
+describe('BioSchema', () => {
+  it('trims whitespace', () => {
+    expect(BioSchema.parse('  hello  ')).toBe('hello');
+  });
+
+  it('accepts a max-length bio', () => {
+    const value = 'a'.repeat(BIO_MAX_LENGTH);
+    expect(BioSchema.parse(value)).toBe(value);
+  });
+
+  it('rejects a bio longer than the max', () => {
+    const value = 'a'.repeat(BIO_MAX_LENGTH + 1);
+    expect(() => BioSchema.parse(value)).toThrow(/characters or fewer/);
+  });
+});
+
+describe('BirthdayVisibilitySchema', () => {
+  it('accepts all three enum values', () => {
+    for (const value of BIRTHDAY_VISIBILITY_VALUES) {
+      expect(BirthdayVisibilitySchema.parse(value)).toBe(value);
+    }
+  });
+
+  it('rejects unknown strings', () => {
+    expect(() => BirthdayVisibilitySchema.parse('PUBLIC')).toThrow();
+  });
+});
+
+describe('BirthdaySchema', () => {
+  it('transforms an ISO date string to noon UTC', () => {
+    const result = BirthdaySchema.parse('1992-05-26');
+    expect(result).toBeInstanceOf(Date);
+    expect((result as Date).toISOString()).toBe('1992-05-26T12:00:00.000Z');
+  });
+
+  it('returns null for an empty string', () => {
+    expect(BirthdaySchema.parse('')).toBeNull();
+  });
+
+  it('rejects malformed dates', () => {
+    expect(() => BirthdaySchema.parse('05/26/1992')).toThrow();
+    expect(() => BirthdaySchema.parse('1992-13-01')).not.toThrow(); // regex only validates shape
+  });
+
+  it('keeps the calendar date invariant across timezones when read with UTC getters', () => {
+    // The whole point of noon UTC: regardless of the reader's timezone,
+    // getUTCMonth/getUTCDate return the typed month/day.
+    const parsed = BirthdaySchema.parse('1992-05-26') as Date;
+    expect(parsed.getUTCMonth()).toBe(4); // May is month index 4
+    expect(parsed.getUTCDate()).toBe(26);
+  });
+});

--- a/app/utils/user-validation.ts
+++ b/app/utils/user-validation.ts
@@ -54,11 +54,18 @@ export type BirthdayVisibility = (typeof BIRTHDAY_VISIBILITY_VALUES)[number];
 export const BirthdayVisibilitySchema = z.enum(BIRTHDAY_VISIBILITY_VALUES);
 
 // Accepts YYYY-MM-DD from a native date input, or an empty string (meaning
-// "clear the field"). Transforms to a Date at midnight UTC or null.
+// "clear the field"). Transforms to a Date at NOON UTC or null.
+//
+// Noon UTC is the same calendar date in every timezone from UTC-11 to
+// UTC+11, which covers every populated timezone. Midnight UTC would shift
+// the date backwards for users west of UTC (e.g. LA picks 1992-05-26 but
+// local-time getters read May 25), so we intentionally sit at the middle
+// of the day instead. Readers use `getUTCMonth` / `getUTCDate` to stay
+// consistent with storage (see `getUpcomingBirthday`).
 export const BirthdaySchema = z
   .union([z.literal(''), z.string().regex(/^\d{4}-\d{2}-\d{2}$/)])
   .transform((value) => {
     if (!value) return null;
-    const parsed = new Date(`${value}T00:00:00.000Z`);
+    const parsed = new Date(`${value}T12:00:00.000Z`);
     return Number.isNaN(parsed.getTime()) ? null : parsed;
   });

--- a/app/utils/user-validation.ts
+++ b/app/utils/user-validation.ts
@@ -40,3 +40,25 @@ export const PasswordAndConfirmPasswordSchema = z
       });
     }
   });
+
+export const BIO_MAX_LENGTH = 160;
+export const BioSchema = z
+  .string()
+  .max(BIO_MAX_LENGTH, { message: `Bio must be ${BIO_MAX_LENGTH} characters or fewer` })
+  .transform((value) => value.trim());
+
+// SQLite doesn't support Prisma enums, so we store the value as a string and
+// enforce the union at the app layer. Keep these two in sync.
+export const BIRTHDAY_VISIBILITY_VALUES = ['FRIENDS', 'EVERYONE', 'NOBODY'] as const;
+export type BirthdayVisibility = (typeof BIRTHDAY_VISIBILITY_VALUES)[number];
+export const BirthdayVisibilitySchema = z.enum(BIRTHDAY_VISIBILITY_VALUES);
+
+// Accepts YYYY-MM-DD from a native date input, or an empty string (meaning
+// "clear the field"). Transforms to a Date at midnight UTC or null.
+export const BirthdaySchema = z
+  .union([z.literal(''), z.string().regex(/^\d{4}-\d{2}-\d{2}$/)])
+  .transform((value) => {
+    if (!value) return null;
+    const parsed = new Date(`${value}T00:00:00.000Z`);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+  });

--- a/prisma/migrations/20260411042947_add_bio_and_birthday_visibility/migration.sql
+++ b/prisma/migrations/20260411042947_add_bio_and_birthday_visibility/migration.sql
@@ -1,0 +1,21 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_User" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "email" TEXT NOT NULL,
+    "username" TEXT NOT NULL,
+    "name" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    "bio" TEXT,
+    "birthday" DATETIME,
+    "birthdayVisibility" TEXT NOT NULL DEFAULT 'FRIENDS'
+);
+INSERT INTO "new_User" ("birthday", "createdAt", "email", "id", "name", "updatedAt", "username") SELECT "birthday", "createdAt", "email", "id", "name", "updatedAt", "username" FROM "User";
+DROP TABLE "User";
+ALTER TABLE "new_User" RENAME TO "User";
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+CREATE UNIQUE INDEX "User_username_key" ON "User"("username");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,7 +14,12 @@ model User {
   name                         String?
   createdAt                    DateTime                      @default(now())
   updatedAt                    DateTime                      @updatedAt
+  bio                          String?
   birthday                     DateTime?
+  // String, not a true enum — SQLite doesn't support enums natively. Valid
+  // values are enforced at the app layer via `BirthdayVisibilitySchema`
+  // (see `app/utils/user-validation.ts`): 'FRIENDS' | 'EVERYONE' | 'NOBODY'.
+  birthdayVisibility           String                        @default("FRIENDS")
   address                      Address?
   connections                  Connection[]
   groupActivities              GroupActivity[]               @relation("GroupActivity_Actor")

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -122,7 +122,9 @@ async function seed() {
 			image: { create: wadeImage },
 			password: { create: createPassword('maximumeffort') },
 			roles: { connect: [{ name: 'admin' }, { name: 'user' }] },
+			bio: 'Mercenary with a mouth. Accepting chimichangas and katana sharpeners.',
 			birthday: birthdayInDays(45, 34), // show up in Home? No — 45 days < 60, so yes
+			// birthdayVisibility defaults to FRIENDS
 			address: {
 				create: {
 					street: '1991 Chimichanga Lane',
@@ -147,6 +149,7 @@ async function seed() {
 			image: { create: userImages[0] },
 			password: { create: createPassword('marco') },
 			roles: { connect: { name: 'user' } },
+			bio: 'Third-wave coffee evangelist. Currently obsessed with cold brew.',
 			birthday: birthdayInDays(22, 31),
 		},
 	})
@@ -162,6 +165,8 @@ async function seed() {
 			image: { create: userImages[1] },
 			password: { create: createPassword('np') },
 			roles: { connect: { name: 'user' } },
+			// Exercises EVERYONE — her birthday is visible to anyone rendering her.
+			birthdayVisibility: 'EVERYONE',
 			birthday: birthdayInDays(37, 28),
 		},
 	})
@@ -177,6 +182,7 @@ async function seed() {
 			image: { create: userImages[2] },
 			password: { create: createPassword('alvaro') },
 			roles: { connect: { name: 'user' } },
+			bio: 'Vinyl collector, espresso tinkerer, occasional sourdough failure.',
 			birthday: birthdayInDays(54, 29),
 		},
 	})
@@ -210,6 +216,10 @@ async function seed() {
 			image: { create: userImages[4] },
 			password: { create: createPassword('hana') },
 			roles: { connect: { name: 'user' } },
+			bio: 'Bookworm, amateur potter, and permanent tea-forward.',
+			// Exercises NOBODY — her birthday should be hidden everywhere even
+			// though she has one in the DB and is a friend of Wade.
+			birthdayVisibility: 'NOBODY',
 			birthday: birthdayInDays(1, 27),
 		},
 	})


### PR DESCRIPTION
## Summary

Phase 3 of the profile UX revamp. Ships the two deferred schema fields (bio + birthday visibility), surfaces them in the settings hub, and honors the visibility choice everywhere a birthday can appear.

## What changed

**Prisma migration** — `20260411042947_add_bio_and_birthday_visibility`
- `bio String?` on `User`
- `birthdayVisibility String @default(\"FRIENDS\")` — SQLite doesn't support native Prisma enums, so the valid union (`FRIENDS | EVERYONE | NOBODY`) lives in the app layer via `BirthdayVisibilitySchema`. Existing rows default to FRIENDS on migration.

**App-layer validators** — `app/utils/user-validation.ts`
- `BioSchema` (trimmed, max 160 chars) + `BIO_MAX_LENGTH` constant
- `BIRTHDAY_VISIBILITY_VALUES` tuple, `BirthdayVisibility` type, `BirthdayVisibilitySchema`
- `BirthdaySchema` — accepts `YYYY-MM-DD` from a native date input or an empty string, transforms to a `Date` or `null`

**Settings hub** — `profile.index.tsx`
- **Profile card**: gains a bio textarea (160-char counter in the label) and a native date picker for birthday alongside the existing name/username fields. Loader selects all three, `profileUpdateAction` writes all three. Explicit `required: false` override on the new inputs so Conform's `getZodConstraint` doesn't mis-render a `*` on optional fields.
- **New Privacy card** between Account and Preferences with a radio group for birthday visibility. Uses its own `update-privacy` intent + `PrivacyFormSchema` so it submits independently, with an optimistic in-flight selection via `fetcher.formData` for snappy feedback.

**Visibility gates**
- `users+/$username_+/index.tsx`: friend view hides the birthday pill when `birthdayVisibility === 'NOBODY'`. FRIENDS and EVERYONE both render since this view is already friend-gated.
- `friends.server.ts::friendUserSelect`: pulls the visibility column alongside birthday.
- `friend-row.tsx`: skips the upcoming-birthday pill computation entirely when the friend has opted into NOBODY.
- `resources+/home.panels.tsx`: skips friends with NOBODY from the Home upcoming-birthdays card.

**Bio rendering** — `profile-header.tsx`
- New optional \`bio\` prop rendered under the handle as a muted `text-balance` paragraph (max-w-md). Wired into both `/me` and `/users/:username` loaders, and trimmed in the component so whitespace-only bios don't create an empty paragraph.

**Seed fixtures** — `prisma/seed.ts`
- Wade, Marco, Alvaro, Hana get bios for UX iteration.
- NP → EVERYONE (exercises the \"show-to-all\" branch once we build a public-profile surface).
- Hana → NOBODY — her birthday is tomorrow but the pill stays hidden on her friend view, in the friends list row, and on the Home upcoming-birthdays card. Single fixture covers the whole hide path.

## Scope notes

- `EVERYONE` doesn't currently create a public-profile surface — non-friends still see the friend-gate card, so `EVERYONE` behaves identically to `FRIENDS` for now. The knob is in place for when we build a public preview; no regression vs current behavior.
- Address stays deferred per the original plan — pool/group visibility rules still need design.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (82 pre-existing warnings, unchanged)
- [x] `npm test -- --run` — 536/536 passing
  - New: ProfileHeader bio rendering branches
  - New: SettingsProfileHub — bio + birthday population, Privacy card radio selection, Privacy card section heading
  - Updated: loader tests (select new columns + return shape), friends.test.tsx FriendUser fixture, home.panels.test.ts select assertion
- [x] `npx playwright test tests/e2e/settings-profile.test.ts tests/e2e/settings-notifications.test.ts tests/e2e/user-profile.test.ts tests/e2e/friend-gate.test.ts tts/e2e/2fa.test.ts` — all passing (notifications flake under high parallelism on shared dev DB; passes cleanly with `--workers=1`, pre-existing condition unrelated to this PR)
- [x] Manual tour: settings hub populates bio + birthday, Privacy radio reflects loader state, `/users/alvaro` (default FRIENDS) shows birthday pill, `/users/hana` (NOBODY) hides birthday pill even though her birthday is tomorrow, `/me` shows bio under the handle

## Out of scope (later phase)

- **Phase 4** — 2FA e2e coverage, remaining friend-gate polish
- **Public profile preview for EVERYONE** — separate future scope
- **Address field** — design needed for pool/group visibility rules