### PR TITLE
test(profile): phase 4 — 2fa disable + friend-gate state-branch e2e coverage

### DIFF
--- a/tests/e2e/2fa.test.ts
+++ b/tests/e2e/2fa.test.ts
@@ -1,4 +1,5 @@
 import { faker } from '@faker-js/faker';
+import { prisma } from '#app/utils/db.server.ts';
 import { generateTOTP } from '#app/utils/totp.server.ts';
 import { expect, test } from '#tests/playwright-utils.ts';
 
@@ -49,4 +50,67 @@ test('Users can add 2FA to their account and use it when logging in', async ({
   await expect(
     page.getByRole('link', { name: user.name ?? user.username }),
   ).toBeVisible();
+});
+
+test('Users can disable 2FA after enabling it', async ({ page, login }) => {
+  const password = faker.internet.password();
+  const user = await login({ password });
+
+  // ── Enable 2FA first so we have something to disable. We don't re-verify
+  // the whole enable flow here — that's what the sibling test is for — so
+  // the assertions only cover the disable path.
+  await page.goto('/settings/profile/two-factor');
+  const main = page.getByRole('main');
+  await main.getByRole('button', { name: /enable 2fa/i }).click();
+  const otpUriString = await main
+    .getByLabel(/One-Time Password URI/i)
+    .innerText();
+  const options = Object.fromEntries(new URL(otpUriString).searchParams);
+  await main
+    .getByRole('textbox', { name: /code/i })
+    .fill(generateTOTP(options).otp);
+  await main.getByRole('button', { name: /submit/i }).click();
+  await expect(main).toHaveText(/You have enabled two-factor authentication./i);
+
+  // ── Navigate to the disable sub-route via the visible link on the 2FA
+  // landing page, exercising the real entry point users take.
+  await main.getByRole('link', { name: /disable 2fa/i }).click();
+
+  // ── Disabling 2FA requires a recent verification — the initial enable
+  // verify doesn't count, so we get bounced to /verify first. Re-enter the
+  // TOTP, then the disable page loads for real.
+  await expect(page).toHaveURL(/\/verify\?type=2fa/);
+  await page
+    .getByRole('textbox', { name: /code/i })
+    .fill(generateTOTP(options).otp);
+  await page.getByRole('button', { name: /submit/i }).click();
+  await expect(page).toHaveURL(/\/settings\/profile\/two-factor\/disable$/);
+
+  // ── useDoubleCheck gates the action button: first click flips the label
+  // to "Are you sure?", second click submits. Verify both transitions.
+  const disableButton = main.getByRole('button', { name: /disable 2fa/i });
+  await expect(disableButton).toBeVisible();
+  await disableButton.click();
+
+  const confirmButton = main.getByRole('button', { name: /are you sure/i });
+  await expect(confirmButton).toBeVisible();
+  await confirmButton.click();
+
+  // ── On success we get redirected back to the 2FA landing page with a
+  // toast, and the main content should flip back to the "not enabled" copy.
+  await expect(page).toHaveURL(/\/settings\/profile\/two-factor$/);
+  await expect(
+    main.getByRole('button', { name: /enable 2fa/i }),
+  ).toBeVisible();
+  await expect(
+    main.getByRole('link', { name: /disable 2fa/i }),
+  ).toHaveCount(0);
+
+  // ── Double-check at the data layer: the verification row should be gone.
+  const verificationRow = await prisma.verification.findUnique({
+    where: {
+      target_type: { type: '2fa', target: user.id },
+    },
+  });
+  expect(verificationRow).toBeNull();
 });

--- a/tests/e2e/friend-gate.test.ts
+++ b/tests/e2e/friend-gate.test.ts
@@ -270,3 +270,201 @@ test('non-friend wishlist request is optimistic and rolls back on failure', asyn
     await prisma.user.deleteMany({ where: { id: { in: createdUserIds } } });
   }
 });
+
+// ── Helper: seed a pair of users + a pending FriendRequest in one direction.
+// Returns the ids/usernames callers need to drive the test and the request id
+// for cleanup. Keeps the state-branch tests below compact.
+async function seedPendingRequest({
+  direction,
+}: {
+  direction: 'incoming' | 'outgoing';
+}) {
+  const viewerData = createUser();
+  const targetData = createUser();
+
+  const [viewer, target] = await Promise.all([
+    prisma.user.create({
+      select: { id: true, username: true, name: true },
+      data: {
+        ...viewerData,
+        roles: { connect: { name: 'user' } },
+        password: { create: createPassword(viewerData.username) },
+      },
+    }),
+    prisma.user.create({
+      select: { id: true, username: true, name: true },
+      data: {
+        ...targetData,
+        roles: { connect: { name: 'user' } },
+        password: { create: createPassword(targetData.username) },
+      },
+    }),
+  ]);
+
+  const fromUserId = direction === 'incoming' ? target.id : viewer.id;
+  const toUserId = direction === 'incoming' ? viewer.id : target.id;
+
+  const request = await prisma.friendRequest.create({
+    select: { id: true },
+    data: { fromUserId, toUserId, status: 'PENDING' },
+  });
+
+  return { viewer, viewerData, target, request };
+}
+
+async function cleanupPair(viewerId: string, targetId: string) {
+  await prisma.friendRequest.deleteMany({
+    where: {
+      OR: [
+        { fromUserId: viewerId, toUserId: targetId },
+        { fromUserId: targetId, toUserId: viewerId },
+      ],
+    },
+  });
+  await prisma.friendship.deleteMany({
+    where: {
+      OR: [
+        { userAId: viewerId, userBId: targetId },
+        { userAId: targetId, userBId: viewerId },
+      ],
+    },
+  });
+  await prisma.user.deleteMany({ where: { id: { in: [viewerId, targetId] } } });
+}
+
+test('incoming friend request: gate shows accept/reject copy and Accept creates a friendship', async ({
+  page,
+}) => {
+  const { viewer, viewerData, target } = await seedPendingRequest({
+    direction: 'incoming',
+  });
+
+  try {
+    await loginWithPassword(page, {
+      username: viewerData.username,
+      password: viewerData.username,
+    });
+    await page.goto(`/users/${target.username}`);
+
+    await expect(
+      page.getByRole('heading', {
+        name: new RegExp(`${target.name} wants to be friends`, 'i'),
+      }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('button', {
+        name: new RegExp(`Accept friend request from ${target.name}`, 'i'),
+      }),
+    ).toBeVisible();
+
+    await page
+      .getByRole('button', {
+        name: new RegExp(`Accept friend request from ${target.name}`, 'i'),
+      })
+      .click();
+
+    // Optimistic state: the button flips to the `FRIENDS` variant.
+    await expect(
+      page.getByRole('button', { name: /^friends$/i }).first(),
+    ).toBeVisible();
+
+    // Server-side: friendship row exists, pending request is gone.
+    const friendship = await prisma.friendship.findFirst({
+      where: {
+        OR: [
+          { userAId: viewer.id, userBId: target.id },
+          { userAId: target.id, userBId: viewer.id },
+        ],
+      },
+    });
+    expect(friendship).not.toBeNull();
+  } finally {
+    await cleanupPair(viewer.id, target.id);
+  }
+});
+
+test('incoming friend request: Reject cancels the pending request', async ({
+  page,
+}) => {
+  const { viewer, viewerData, target, request } = await seedPendingRequest({
+    direction: 'incoming',
+  });
+
+  try {
+    await loginWithPassword(page, {
+      username: viewerData.username,
+      password: viewerData.username,
+    });
+    await page.goto(`/users/${target.username}`);
+
+    await page
+      .getByRole('button', {
+        name: new RegExp(`Reject friend request from ${target.name}`, 'i'),
+      })
+      .click();
+
+    // Optimistic state: after reject the gate flips back to NONE, which
+    // shows the "Send friend request" / "Add Friend" variant again.
+    await expect(
+      page.getByRole('button', { name: /add friend/i }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Server-side: the PENDING request is no longer pending.
+    const row = await prisma.friendRequest.findUnique({
+      where: { id: request.id },
+    });
+    expect(row?.status).not.toBe('PENDING');
+
+    // No friendship was created.
+    const friendship = await prisma.friendship.findFirst({
+      where: {
+        OR: [
+          { userAId: viewer.id, userBId: target.id },
+          { userAId: target.id, userBId: viewer.id },
+        ],
+      },
+    });
+    expect(friendship).toBeNull();
+  } finally {
+    await cleanupPair(viewer.id, target.id);
+  }
+});
+
+test('outgoing friend request: gate shows waiting copy and Cancel returns to NONE', async ({
+  page,
+}) => {
+  const { viewer, viewerData, target, request } = await seedPendingRequest({
+    direction: 'outgoing',
+  });
+
+  try {
+    await loginWithPassword(page, {
+      username: viewerData.username,
+      password: viewerData.username,
+    });
+    await page.goto(`/users/${target.username}`);
+
+    await expect(
+      page.getByRole('heading', {
+        name: new RegExp(`Waiting for ${target.name} to accept`, 'i'),
+      }),
+    ).toBeVisible();
+
+    await page
+      .getByRole('button', { name: /cancel request/i })
+      .click();
+
+    // Optimistic state: gate flips to the NONE branch.
+    await expect(
+      page.getByRole('button', { name: /add friend/i }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Server-side: the PENDING row is no longer pending.
+    const row = await prisma.friendRequest.findUnique({
+      where: { id: request.id },
+    });
+    expect(row?.status).not.toBe('PENDING');
+  } finally {
+    await cleanupPair(viewer.id, target.id);
+  }
+});

--- a/tests/e2e/friend-gate.test.ts
+++ b/tests/e2e/friend-gate.test.ts
@@ -357,13 +357,23 @@ test('incoming friend request: gate shows accept/reject copy and Accept creates 
       }),
     ).toBeVisible();
 
+    // The Accept handler is optimistic — it flips the UI before awaiting the
+    // fetch — so we can't read the DB right after the UI transitions or we
+    // race the mutation. Wait for the actual `/accept` response to land
+    // before asserting server state.
+    const acceptResponse = page.waitForResponse(
+      (response) =>
+        /\/api\/friends\/requests\/.+\/accept/.test(response.url()) &&
+        response.request().method() === 'POST',
+    );
     await page
       .getByRole('button', {
         name: new RegExp(`Accept friend request from ${target.name}`, 'i'),
       })
       .click();
+    await acceptResponse;
 
-    // Optimistic state: the button flips to the `FRIENDS` variant.
+    // UI: button flips to the `FRIENDS` variant after reconciliation.
     await expect(
       page.getByRole('button', { name: /^friends$/i }).first(),
     ).toBeVisible();
@@ -397,14 +407,22 @@ test('incoming friend request: Reject cancels the pending request', async ({
     });
     await page.goto(`/users/${target.username}`);
 
+    // Same race concern as the Accept test — wait for the `/reject`
+    // response before touching the DB.
+    const rejectResponse = page.waitForResponse(
+      (response) =>
+        /\/api\/friends\/requests\/.+\/reject/.test(response.url()) &&
+        response.request().method() === 'POST',
+    );
     await page
       .getByRole('button', {
         name: new RegExp(`Reject friend request from ${target.name}`, 'i'),
       })
       .click();
+    await rejectResponse;
 
-    // Optimistic state: after reject the gate flips back to NONE, which
-    // shows the "Send friend request" / "Add Friend" variant again.
+    // UI: after reject the gate flips back to NONE, which shows the
+    // "Send friend request" / "Add Friend" variant again.
     await expect(
       page.getByRole('button', { name: /add friend/i }),
     ).toBeVisible({ timeout: 10_000 });
@@ -450,11 +468,19 @@ test('outgoing friend request: gate shows waiting copy and Cancel returns to NON
       }),
     ).toBeVisible();
 
+    // Cancel hits /api/friends/requests/:id/cancel. Wait for the response
+    // before reading the DB so we don't race the mutation.
+    const cancelResponse = page.waitForResponse(
+      (response) =>
+        /\/api\/friends\/requests\/.+\/cancel/.test(response.url()) &&
+        response.request().method() === 'POST',
+    );
     await page
       .getByRole('button', { name: /cancel request/i })
       .click();
+    await cancelResponse;
 
-    // Optimistic state: gate flips to the NONE branch.
+    // UI: gate flips to the NONE branch.
     await expect(
       page.getByRole('button', { name: /add friend/i }),
     ).toBeVisible({ timeout: 10_000 });


### PR DESCRIPTION
## Summary

Final phase of the profile revamp: closes the e2e coverage gaps left from earlier phases. No app code changes — this is test-only.

## What was missing

- **Phase 1** introduced state-aware copy on the `FriendGateCard` with three branches (`NONE` / `PENDING_INCOMING` / `PENDING_OUTGOING`), but only the `NONE` branch had e2e coverage. Accept/Reject/Cancel wiring was only tested indirectly through the friends list.
- **Phase 2** wired up the 2FA disable sub-route + double-check gate, but the flow was never exercised end-to-end.

## Tests added

**`tests/e2e/2fa.test.ts`** — new `Users can disable 2FA after enabling it`

Drives the full disable flow in one go:
1. Enable 2FA (same path as the existing enable test)
2. Click the Disable 2FA link on the landing page
3. Follow the `requireRecentVerification` bounce — the route is protected by a freshness check, so the browser lands on `/verify?type=2fa&...&redirectTo=...` first. Re-enter the TOTP code.
4. On the disable page, exercise the `useDoubleCheck` gate: first click flips the label to "Are you sure?", second click submits.
5. Assert the toast redirect back to the 2FA landing page shows the "not enabled" copy AND the `Verification` row for `type: '2fa'` is gone from the DB.

**`tests/e2e/friend-gate.test.ts`** — three new state-branch tests plus a shared helper

Added `seedPendingRequest({ direction })` and `cleanupPair` so the three new tests stay compact:

- `incoming friend request: gate shows accept/reject copy and Accept creates a friendship`
  Seeds a `target → viewer` `PENDING` request. Verifies the "{name} wants to be friends" heading renders, the Accept / Reject aria-labels are present, clicks Accept, asserts the optimistic button flip to the `FRIENDS` variant AND a `Friendship` row exists in the DB for the pair.

- `incoming friend request: Reject cancels the pending request`
  Same seed, clicks Reject instead. Asserts the gate optimistically falls back to the `NONE` branch (Add Friend button reappears), the `FriendRequest` row is no longer `PENDING`, and no `Friendship` was created.

- `outgoing friend request: gate shows waiting copy and Cancel returns to NONE`
  Seeds a `viewer → target` `PENDING` request. Verifies the "Waiting for {name} to accept" heading, clicks Cancel request, asserts the `NONE` state returns and the request row is no longer `PENDING`.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (82 pre-existing warnings, unchanged)
- [x] `npm test -- --run` — 554/554 passing (unit suite unchanged; phase is e2e-only)
- [x] `npx playwright test tests/e2e/2fa.test.ts tests/e2e/friend-gate.test.ts --workers=1` — 9/9 passing (2 2FA + 7 friend-gate)

## Out of scope

- **Public profile preview for EVERYONE** — the `birthdayVisibility: 'EVERYONE'` branch still doesn't have a user-visible surface because non-friends hit the gate card. Separate future scope.
- **Address field** — still punted pending pool/group visibility rule design.

With this merged, the profile revamp (Phases 1–4) is done 🎉