### PR TITLE
perf: fire notification fanout async, drop hot-path prefs upserts

### DIFF
--- a/app/routes/settings+/profile.notifications.test.tsx
+++ b/app/routes/settings+/profile.notifications.test.tsx
@@ -16,6 +16,7 @@ import {
 const getUserId = vi.fn();
 const requireUserId = vi.fn();
 const verifyPreferenceToken = vi.fn();
+const ensureNotificationPreferencesForUser = vi.fn();
 const getNotificationPreferences = vi.fn();
 const setNotificationPreference = vi.fn();
 const disableEmailForAll = vi.fn();
@@ -83,6 +84,8 @@ vi.mock('#app/utils/notification-preference-token.server.ts', () => ({
 
 vi.mock('#app/utils/notification-preferences.server.ts', () => ({
   disableEmailForAll: (...args: Array<unknown>) => disableEmailForAll(...args),
+  ensureNotificationPreferencesForUser: (...args: Array<unknown>) =>
+    ensureNotificationPreferencesForUser(...args),
   getNotificationPreferences: (...args: Array<unknown>) =>
     getNotificationPreferences(...args),
   setNotificationPreference: (...args: Array<unknown>) =>
@@ -125,6 +128,8 @@ beforeEach(() => {
   getUserId.mockReset();
   requireUserId.mockReset();
   verifyPreferenceToken.mockReset();
+  ensureNotificationPreferencesForUser.mockReset();
+  ensureNotificationPreferencesForUser.mockResolvedValue(undefined);
   getNotificationPreferences.mockReset();
   setNotificationPreference.mockReset();
   disableEmailForAll.mockReset();

--- a/app/routes/settings+/profile.notifications.tsx
+++ b/app/routes/settings+/profile.notifications.tsx
@@ -14,6 +14,7 @@ import { cn } from '#app/utils/misc.tsx';
 import { verifyPreferenceToken } from '#app/utils/notification-preference-token.server.ts';
 import {
   disableEmailForAll,
+  ensureNotificationPreferencesForUser,
   getNotificationPreferences,
   setNotificationPreference,
 } from '#app/utils/notification-preferences.server.ts';
@@ -81,6 +82,15 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const canReadPreferences =
     (userId && userId === targetUserId) ||
     tokenPayload?.uid === targetUserId;
+  // Settings page is the only place users directly manage their preferences.
+  // Materialize rows here so downstream writes (`setNotificationPreference`,
+  // `disableEmailForAll`) always see persisted rows, and so UI optimistic
+  // rollback tests can assert against a stable DB state. This is a cold
+  // path — the hot notification fanout reads still tolerate missing rows
+  // via the in-memory defaults fallback.
+  if (canReadPreferences) {
+    await ensureNotificationPreferencesForUser(targetUserId);
+  }
   const preferencesMap = canReadPreferences
     ? await getNotificationPreferences(targetUserId)
     : null;

--- a/app/utils/auth.server.test.ts
+++ b/app/utils/auth.server.test.ts
@@ -1,0 +1,45 @@
+import { randomUUID } from 'node:crypto';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { signup } from '#app/utils/auth.server.ts';
+import { prisma } from '#app/utils/db.server.ts';
+import { NOTIFICATION_TYPES } from '#app/utils/notification-registry.ts';
+
+describe('auth.server', () => {
+  beforeEach(async () => {
+    await prisma.userNotificationPreference.deleteMany();
+    await prisma.session.deleteMany({
+      where: { user: { email: { contains: '@signup-test.com' } } },
+    });
+    await prisma.user.deleteMany({
+      where: { email: { contains: '@signup-test.com' } },
+    });
+  });
+
+  it('signup seeds a notification preference row for every registered type', async () => {
+    await prisma.role.upsert({
+      where: { name: 'user' },
+      update: {},
+      create: { name: 'user' },
+    });
+
+    const username = `signup_${randomUUID().slice(0, 8)}`;
+    const email = `${username}@signup-test.com`;
+
+    const session = await signup({
+      email,
+      username,
+      password: 'correct horse battery staple',
+      name: 'Signup Test',
+    });
+
+    const prefs = await prisma.userNotificationPreference.findMany({
+      where: { userId: session.userId },
+      select: { type: true, inAppEnabled: true, emailEnabled: true },
+    });
+
+    const seededTypes = new Set(prefs.map((p) => p.type));
+    for (const type of Object.values(NOTIFICATION_TYPES)) {
+      expect(seededTypes.has(type)).toBe(true);
+    }
+  });
+});

--- a/app/utils/auth.server.ts
+++ b/app/utils/auth.server.ts
@@ -4,7 +4,23 @@ import { redirect } from 'react-router';
 import { safeRedirect } from 'remix-utils/safe-redirect';
 import { prisma } from './db.server.ts';
 import { combineHeaders } from './misc.tsx';
+import {
+  DEFAULT_NOTIFICATION_PREFERENCES,
+  NOTIFICATION_TYPES,
+} from './notification-registry.ts';
 import { authSessionStorage } from './session.server.ts';
+
+// Seed a row per notification type at user creation so we don't have to run
+// N upserts on the hot read/write path later. Reads still tolerate missing
+// rows (they fall back to defaults), so this is strictly an optimization for
+// the common case.
+const defaultNotificationPreferenceRows = Object.values(NOTIFICATION_TYPES).map(
+  (type) => ({
+    type,
+    inAppEnabled: DEFAULT_NOTIFICATION_PREFERENCES[type].inAppEnabled,
+    emailEnabled: DEFAULT_NOTIFICATION_PREFERENCES[type].emailEnabled,
+  }),
+);
 
 export const SESSION_EXPIRATION_TIME = 1000 * 60 * 60 * 24 * 30;
 export const getSessionExpirationDate = () =>
@@ -124,6 +140,9 @@ export async function signup({
             create: {
               hash: hashedPassword,
             },
+          },
+          notificationPreferences: {
+            create: defaultNotificationPreferenceRows,
           },
         },
       },

--- a/app/utils/friends.server.test.ts
+++ b/app/utils/friends.server.test.ts
@@ -1,0 +1,130 @@
+import { randomUUID } from 'node:crypto';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { prisma } from '#app/utils/db.server.ts';
+import {
+  acceptFriendRequest,
+  getRelationshipDetails,
+  getRelationshipState,
+  sendFriendRequest,
+} from '#app/utils/friends.server.ts';
+
+// The fanout is deliberately fire-and-forget in production — we mock
+// `notifyUser` so the tests can assert it was scheduled without hitting
+// Resend or racing the in-app notification insert.
+const notifyUser = vi.fn();
+vi.mock('#app/utils/notification-service.server.tsx', () => ({
+  notifyUser: (...args: Array<unknown>) => notifyUser(...args),
+}));
+
+async function createUser() {
+  return prisma.user.create({
+    select: { id: true, username: true, name: true },
+    data: {
+      email: `user-${randomUUID()}@example.com`,
+      username: `user_${randomUUID().slice(0, 8)}`,
+      name: 'Friend Test User',
+      roles: {
+        connectOrCreate: { where: { name: 'user' }, create: { name: 'user' } },
+      },
+    },
+  });
+}
+
+// Flush any fire-and-forget microtasks that `fanoutNotification` kicks off.
+async function drainFanout() {
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
+describe('friends.server', () => {
+  beforeEach(async () => {
+    notifyUser.mockReset().mockResolvedValue(undefined);
+    await prisma.friendRequest.deleteMany();
+    await prisma.friendship.deleteMany();
+    await prisma.user.deleteMany({
+      where: { email: { contains: '@example.com' } },
+    });
+  });
+
+  it('sendFriendRequest upserts a PENDING row and fires the fanout without awaiting it', async () => {
+    const [sender, recipient] = await Promise.all([createUser(), createUser()]);
+
+    const request = await sendFriendRequest(sender.id, recipient.id);
+    await drainFanout();
+
+    expect(request.status).toBe('PENDING');
+    expect(request.fromUserId).toBe(sender.id);
+    expect(request.toUserId).toBe(recipient.id);
+    // Fanout was scheduled with a notify payload addressed to the recipient.
+    expect(notifyUser).toHaveBeenCalledTimes(1);
+    expect(notifyUser.mock.calls[0]![0]).toMatchObject({
+      userId: recipient.id,
+      type: 'FRIEND_REQUEST_RECEIVED',
+      sourceIdentifier: `friend-request:${request.id}:received`,
+    });
+  });
+
+  it('sendFriendRequest swallows fanout errors via Sentry rather than failing the action', async () => {
+    const [sender, recipient] = await Promise.all([createUser(), createUser()]);
+    notifyUser.mockRejectedValueOnce(new Error('fanout boom'));
+    // Sentry's captureException writes to stderr in dev — we don't want a
+    // false-looking stack in the test log.
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const request = await sendFriendRequest(sender.id, recipient.id);
+    await drainFanout();
+
+    expect(request.status).toBe('PENDING');
+    // The mutation returned successfully even though notifyUser threw.
+    expect(notifyUser).toHaveBeenCalledTimes(1);
+    errSpy.mockRestore();
+  });
+
+  it('getRelationshipState and getRelationshipDetails reflect the PENDING outgoing state', async () => {
+    const [sender, recipient] = await Promise.all([createUser(), createUser()]);
+    await sendFriendRequest(sender.id, recipient.id);
+    await drainFanout();
+
+    await expect(
+      getRelationshipState(sender.id, recipient.id),
+    ).resolves.toBe('PENDING_OUTGOING');
+    await expect(
+      getRelationshipState(recipient.id, sender.id),
+    ).resolves.toBe('PENDING_INCOMING');
+    const details = await getRelationshipDetails(sender.id, recipient.id);
+    expect(details.state).toBe('PENDING_OUTGOING');
+  });
+
+  it('acceptFriendRequest upserts the friendship and fires a fanout to the original sender', async () => {
+    const [sender, recipient] = await Promise.all([createUser(), createUser()]);
+    const request = await sendFriendRequest(sender.id, recipient.id);
+    await drainFanout();
+    notifyUser.mockClear();
+
+    await acceptFriendRequest(request.id, recipient.id);
+    await drainFanout();
+
+    const friendship = await prisma.friendship.findFirst({
+      where: {
+        OR: [
+          { userAId: sender.id, userBId: recipient.id },
+          { userAId: recipient.id, userBId: sender.id },
+        ],
+      },
+    });
+    expect(friendship).not.toBeNull();
+
+    const accepted = await prisma.friendRequest.findUnique({
+      where: { id: request.id },
+    });
+    expect(accepted?.status).toBe('ACCEPTED');
+
+    // Accept fanout is addressed to the original sender.
+    expect(notifyUser).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: sender.id,
+        type: 'FRIEND_REQUEST_ACCEPTED',
+        sourceIdentifier: `friend-request:${request.id}:accepted`,
+      }),
+    );
+  });
+});

--- a/app/utils/friends.server.ts
+++ b/app/utils/friends.server.ts
@@ -1,7 +1,18 @@
+import { captureException } from '@sentry/react-router';
 import { prisma } from '#app/utils/db.server.ts';
 import { NOTIFICATION_TYPES } from '#app/utils/notification-registry.ts';
 import { notifyUser } from '#app/utils/notification-service.server.tsx';
 import { type RelationshipState } from './friends.ts';
+
+// Fire the notification fanout (in-app row + optional email) without blocking
+// the mutation handler. The friend request itself is already committed before
+// this runs, so a failed notification should surface in Sentry rather than
+// turning a successful action into a 500.
+function fanoutNotification(promise: Promise<unknown>) {
+  promise.catch((error: unknown) => {
+    captureException(error);
+  });
+}
 
 export type FriendRequestStatus =
   | 'PENDING'
@@ -193,19 +204,21 @@ export async function sendFriendRequest(fromUserId: string, toUserId: string) {
     return { request: upserted, fromUser: actor };
   });
 
-  await notifyUser({
-    userId: toUserId,
-    type: NOTIFICATION_TYPES.FRIEND_REQUEST_RECEIVED,
-    payload: {
-      friendRequestId: request.id,
-      actorUserId: fromUser.id,
-      actorDisplayName: fromUser.name ?? fromUser.username,
-      actorUsername: fromUser.username,
-      actorAvatarId: fromUser.image?.id ?? null,
-      recipientUserId: toUserId,
-    },
-    sourceIdentifier: `friend-request:${request.id}:received`,
-  });
+  fanoutNotification(
+    notifyUser({
+      userId: toUserId,
+      type: NOTIFICATION_TYPES.FRIEND_REQUEST_RECEIVED,
+      payload: {
+        friendRequestId: request.id,
+        actorUserId: fromUser.id,
+        actorDisplayName: fromUser.name ?? fromUser.username,
+        actorUsername: fromUser.username,
+        actorAvatarId: fromUser.image?.id ?? null,
+        recipientUserId: toUserId,
+      },
+      sourceIdentifier: `friend-request:${request.id}:received`,
+    }),
+  );
 
   return request;
 }
@@ -278,19 +291,21 @@ export async function acceptFriendRequest(
   });
 
   if (actor) {
-    await notifyUser({
-      userId: request.fromUserId,
-      type: NOTIFICATION_TYPES.FRIEND_REQUEST_ACCEPTED,
-      payload: {
-        friendRequestId: request.id,
-        actorUserId: actor.id,
-        actorDisplayName: actor.name ?? actor.username,
-        actorUsername: actor.username,
-        actorAvatarId: actor.image?.id ?? null,
-        recipientUserId: request.fromUserId,
-      },
-      sourceIdentifier: `friend-request:${request.id}:accepted`,
-    });
+    fanoutNotification(
+      notifyUser({
+        userId: request.fromUserId,
+        type: NOTIFICATION_TYPES.FRIEND_REQUEST_ACCEPTED,
+        payload: {
+          friendRequestId: request.id,
+          actorUserId: actor.id,
+          actorDisplayName: actor.name ?? actor.username,
+          actorUsername: actor.username,
+          actorAvatarId: actor.image?.id ?? null,
+          recipientUserId: request.fromUserId,
+        },
+        sourceIdentifier: `friend-request:${request.id}:accepted`,
+      }),
+    );
   }
 
   return request;

--- a/app/utils/notification-preferences.server.test.ts
+++ b/app/utils/notification-preferences.server.test.ts
@@ -2,14 +2,18 @@ import { randomUUID } from 'node:crypto';
 import { describe, expect, it, beforeEach } from 'vitest';
 import { prisma } from '#app/utils/db.server.ts';
 import {
+  disableEmailForAll,
   ensureNotificationPreferencesForUser,
   getNotificationPreferenceForChannels,
+  getNotificationPreferences,
+  notificationPreferenceDefaultsFor,
   setNotificationPreference,
-  disableEmailForAll,
 } from '#app/utils/notification-preferences.server.ts';
 import {
+  DEFAULT_NOTIFICATION_PREFERENCES,
   NOTIFICATION_CHANNELS,
   NOTIFICATION_TYPES,
+  type NotificationType,
 } from '#app/utils/notification-registry.ts';
 
 async function createUser() {
@@ -92,6 +96,168 @@ describe('notification preferences', () => {
       } else {
         expect(pref.emailEnabled).toBe(false);
       }
+    }
+  });
+
+  it('disableEmailForAll is a no-op when no email rows are enabled', async () => {
+    const user = await createUser();
+    await ensureNotificationPreferencesForUser(user.id);
+    // Flip all email prefs off ahead of time.
+    await prisma.userNotificationPreference.updateMany({
+      where: { userId: user.id },
+      data: { emailEnabled: false },
+    });
+    const beforeAudit = await prisma.notificationPreferenceAudit.count({
+      where: { userId: user.id },
+    });
+
+    await disableEmailForAll(user.id, 'test-noop');
+
+    const afterAudit = await prisma.notificationPreferenceAudit.count({
+      where: { userId: user.id },
+    });
+    expect(afterAudit).toBe(beforeAudit);
+  });
+
+  it('disableEmailForAll only audits the rows that actually transitioned', async () => {
+    const user = await createUser();
+    await ensureNotificationPreferencesForUser(user.id);
+    // Pre-disable one email pref so only one row transitions.
+    await prisma.userNotificationPreference.updateMany({
+      where: {
+        userId: user.id,
+        type: NOTIFICATION_TYPES.FRIEND_REQUEST_ACCEPTED,
+      },
+      data: { emailEnabled: false },
+    });
+
+    await disableEmailForAll(user.id, 'test-partial');
+
+    const audits = await prisma.notificationPreferenceAudit.findMany({
+      where: { userId: user.id, source: 'test-partial' },
+      select: { type: true, previousValue: true, newValue: true },
+    });
+    // FRIEND_REQUEST_RECEIVED was true → false (and so was UPCOMING_BIRTHDAY
+    // if its default is true). Defaults live in notification-registry; we
+    // assert we only audited rows whose previous value was true.
+    expect(audits.every((a) => a.previousValue === true)).toBe(true);
+    expect(audits.every((a) => a.newValue === false)).toBe(true);
+    // FRIEND_REQUEST_ACCEPTED was already off, so there should be no audit.
+    expect(
+      audits.find(
+        (a) => a.type === NOTIFICATION_TYPES.FRIEND_REQUEST_ACCEPTED,
+      ),
+    ).toBeUndefined();
+  });
+
+  it('setNotificationPreference creates a row for users without one', async () => {
+    const user = await createUser();
+    // No ensure call — mimic a pre-bootstrap user visiting the toggle path.
+
+    const result = await setNotificationPreference(
+      user.id,
+      NOTIFICATION_TYPES.FRIEND_REQUEST_RECEIVED,
+      NOTIFICATION_CHANNELS.EMAIL,
+      false,
+      'test-fresh',
+    );
+
+    expect(result.emailEnabled).toBe(false);
+    const stored = await prisma.userNotificationPreference.findUnique({
+      where: {
+        userId_type: {
+          userId: user.id,
+          type: NOTIFICATION_TYPES.FRIEND_REQUEST_RECEIVED,
+        },
+      },
+      select: { emailEnabled: true, inAppEnabled: true },
+    });
+    expect(stored?.emailEnabled).toBe(false);
+    // The other channel defaults to the registry value.
+    expect(stored?.inAppEnabled).toBe(
+      DEFAULT_NOTIFICATION_PREFERENCES[
+        NOTIFICATION_TYPES.FRIEND_REQUEST_RECEIVED
+      ].inAppEnabled,
+    );
+    // An audit row is written because the effective value moved from
+    // "default true" → "explicit false".
+    const audit = await prisma.notificationPreferenceAudit.findFirst({
+      where: { userId: user.id, source: 'test-fresh' },
+    });
+    expect(audit).not.toBeNull();
+    expect(audit?.previousValue).toBe(true);
+    expect(audit?.newValue).toBe(false);
+  });
+
+  it('setNotificationPreference returns the existing row when the value is unchanged', async () => {
+    const user = await createUser();
+    await ensureNotificationPreferencesForUser(user.id);
+
+    // Idempotent call: try to "set" to the current default.
+    const result = await setNotificationPreference(
+      user.id,
+      NOTIFICATION_TYPES.FRIEND_REQUEST_RECEIVED,
+      NOTIFICATION_CHANNELS.EMAIL,
+      DEFAULT_NOTIFICATION_PREFERENCES[
+        NOTIFICATION_TYPES.FRIEND_REQUEST_RECEIVED
+      ].emailEnabled,
+      'test-idempotent',
+    );
+
+    expect(result.emailEnabled).toBe(
+      DEFAULT_NOTIFICATION_PREFERENCES[
+        NOTIFICATION_TYPES.FRIEND_REQUEST_RECEIVED
+      ].emailEnabled,
+    );
+    // No audit row for no-op.
+    const audit = await prisma.notificationPreferenceAudit.findFirst({
+      where: { userId: user.id, source: 'test-idempotent' },
+    });
+    expect(audit).toBeNull();
+  });
+
+  it('getNotificationPreferences fills in defaults for types without a row', async () => {
+    const user = await createUser();
+    // Seed exactly one row so we can verify the fill-in merges with stored.
+    await prisma.userNotificationPreference.create({
+      data: {
+        userId: user.id,
+        type: NOTIFICATION_TYPES.FRIEND_REQUEST_RECEIVED,
+        inAppEnabled: false,
+        emailEnabled: false,
+      },
+    });
+
+    const prefs = await getNotificationPreferences(user.id);
+
+    // The stored row comes back as-is.
+    expect(prefs.get(NOTIFICATION_TYPES.FRIEND_REQUEST_RECEIVED)).toEqual({
+      inAppEnabled: false,
+      emailEnabled: false,
+    });
+    // Missing types come back with registry defaults.
+    for (const type of Object.values(NOTIFICATION_TYPES)) {
+      if (type === NOTIFICATION_TYPES.FRIEND_REQUEST_RECEIVED) continue;
+      expect(prefs.get(type)).toEqual(DEFAULT_NOTIFICATION_PREFERENCES[type]);
+    }
+  });
+
+  it('notificationPreferenceDefaultsFor produces one row per registered type', () => {
+    const rows = notificationPreferenceDefaultsFor('user-xyz');
+    const types = new Set(rows.map((r) => r.type as NotificationType));
+    for (const type of Object.values(NOTIFICATION_TYPES)) {
+      expect(types.has(type)).toBe(true);
+    }
+    for (const row of rows) {
+      expect(row.userId).toBe('user-xyz');
+      expect(row.inAppEnabled).toBe(
+        DEFAULT_NOTIFICATION_PREFERENCES[row.type as NotificationType]
+          .inAppEnabled,
+      );
+      expect(row.emailEnabled).toBe(
+        DEFAULT_NOTIFICATION_PREFERENCES[row.type as NotificationType]
+          .emailEnabled,
+      );
     }
   });
 });

--- a/app/utils/notification-preferences.server.ts
+++ b/app/utils/notification-preferences.server.ts
@@ -13,6 +13,26 @@ function defaultForType(type: NotificationType) {
   return DEFAULT_NOTIFICATION_PREFERENCES[type];
 }
 
+// Shape used for `createMany` / nested `create` when bootstrapping a new user.
+// Kept as a plain data builder so callers can either pass it to signup's
+// nested-create or hand it to a standalone createMany.
+export function notificationPreferenceDefaultsFor(userId: string) {
+  const now = new Date();
+  return preferenceTypes.map((type) => ({
+    userId,
+    type,
+    inAppEnabled: defaultForType(type).inAppEnabled,
+    emailEnabled: defaultForType(type).emailEnabled,
+    createdAt: now,
+    updatedAt: now,
+  }));
+}
+
+// Legacy bootstrap: upserts one row per notification type. Still exported for
+// tests and for the settings route's "heal missing rows" paths, but it should
+// NOT be called on the hot read path — reads tolerate missing rows by falling
+// back to `DEFAULT_NOTIFICATION_PREFERENCES`, and new users get their rows
+// via `createMany` in the signup flow.
 export async function ensureNotificationPreferencesForUser(
   userId: string,
   tx = prisma,
@@ -42,9 +62,9 @@ export async function ensureNotificationPreferencesForUser(
 }
 
 export async function getNotificationPreferences(userId: string) {
-  await ensureNotificationPreferencesForUser(userId);
   const prefs = await prisma.userNotificationPreference.findMany({
     where: { userId },
+    select: { type: true, inAppEnabled: true, emailEnabled: true },
   });
   const map = new Map<
     NotificationType,
@@ -56,6 +76,13 @@ export async function getNotificationPreferences(userId: string) {
       emailEnabled: pref.emailEnabled,
     });
   }
+  // Fill in defaults for any type that doesn't yet have a row. This replaces
+  // the old "ensure upsert" pattern that ran N writes on every read.
+  for (const type of preferenceTypes) {
+    if (!map.has(type)) {
+      map.set(type, { ...defaultForType(type) });
+    }
+  }
   return map;
 }
 
@@ -63,7 +90,6 @@ export async function getNotificationPreferenceForChannels(
   userId: string,
   type: NotificationType,
 ) {
-  await ensureNotificationPreferencesForUser(userId);
   const pref = await prisma.userNotificationPreference.findUnique({
     where: { userId_type: { userId, type } },
     select: { inAppEnabled: true, emailEnabled: true },
@@ -82,36 +108,48 @@ export async function setNotificationPreference(
   enabled: boolean,
   source: string,
 ) {
-  await ensureNotificationPreferencesForUser(userId);
   const column =
     channel === NOTIFICATION_CHANNELS.EMAIL ? 'emailEnabled' : 'inAppEnabled';
   const existing = await prisma.userNotificationPreference.findUnique({
     where: { userId_type: { userId, type } },
     select: { inAppEnabled: true, emailEnabled: true },
   });
-  const previousValue = existing?.[column] ?? defaultForType(type)[column];
-  if (previousValue === enabled) {
-    return existing ?? { inAppEnabled: enabled, emailEnabled: enabled };
+  const defaults = defaultForType(type);
+  const previousValue = existing?.[column] ?? defaults[column];
+  if (existing && previousValue === enabled) {
+    return existing;
   }
 
   const result = await prisma.$transaction(async (tx) => {
-    const updated = await tx.userNotificationPreference.update({
+    const updated = await tx.userNotificationPreference.upsert({
       where: { userId_type: { userId, type } },
-      data: {
+      update: {
         [column]: enabled,
+      },
+      create: {
+        userId,
+        type,
+        inAppEnabled:
+          column === 'inAppEnabled' ? enabled : defaults.inAppEnabled,
+        emailEnabled:
+          column === 'emailEnabled' ? enabled : defaults.emailEnabled,
       },
     });
 
-    await tx.notificationPreferenceAudit.create({
-      data: {
-        userId,
-        type,
-        channel,
-        previousValue,
-        newValue: enabled,
-        source,
-      },
-    });
+    // Only emit an audit row when the flag actually moved. Upserting a fresh
+    // row with the default value (equal to `enabled`) is a no-op audit-wise.
+    if (previousValue !== enabled) {
+      await tx.notificationPreferenceAudit.create({
+        data: {
+          userId,
+          type,
+          channel,
+          previousValue,
+          newValue: enabled,
+          source,
+        },
+      });
+    }
 
     return updated;
   });
@@ -120,31 +158,31 @@ export async function setNotificationPreference(
 }
 
 export async function disableEmailForAll(userId: string, source: string) {
-  await ensureNotificationPreferencesForUser(userId);
-  const preferences = await prisma.userNotificationPreference.findMany({
-    where: { userId },
-    select: { type: true, emailEnabled: true },
+  // Previously this function iterated each preference row inside a transaction
+  // and issued one UPDATE + one INSERT per type. Even on 3 types that was 6
+  // round-trips. Now we do one findMany to capture the "which rows were
+  // actually ON" set (for audit), then a single updateMany + a single
+  // createMany inside one transaction.
+  const previouslyEnabled = await prisma.userNotificationPreference.findMany({
+    where: { userId, emailEnabled: true },
+    select: { type: true },
   });
+  if (previouslyEnabled.length === 0) return;
 
-  await prisma.$transaction(async (tx) => {
-    for (const pref of preferences) {
-      if (!pref.emailEnabled) continue;
-      await tx.userNotificationPreference.update({
-        where: { userId_type: { userId, type: pref.type } },
-        data: {
-          emailEnabled: false,
-        },
-      });
-      await tx.notificationPreferenceAudit.create({
-        data: {
-          userId,
-          type: pref.type,
-          channel: NOTIFICATION_CHANNELS.EMAIL,
-          previousValue: true,
-          newValue: false,
-          source,
-        },
-      });
-    }
-  });
+  await prisma.$transaction([
+    prisma.userNotificationPreference.updateMany({
+      where: { userId, emailEnabled: true },
+      data: { emailEnabled: false },
+    }),
+    prisma.notificationPreferenceAudit.createMany({
+      data: previouslyEnabled.map((pref) => ({
+        userId,
+        type: pref.type,
+        channel: NOTIFICATION_CHANNELS.EMAIL,
+        previousValue: true,
+        newValue: false,
+        source,
+      })),
+    }),
+  ]);
 }

--- a/app/utils/notification-service.server.tsx
+++ b/app/utils/notification-service.server.tsx
@@ -9,10 +9,7 @@ import {
   createPreferenceToken,
   getPreferenceManagementUrl,
 } from '#app/utils/notification-preference-token.server.ts';
-import {
-  ensureNotificationPreferencesForUser,
-  getNotificationPreferenceForChannels,
-} from '#app/utils/notification-preferences.server.ts';
+import { getNotificationPreferenceForChannels } from '#app/utils/notification-preferences.server.ts';
 import {
   NOTIFICATION_TYPES,
   type NotificationPayload,
@@ -59,7 +56,6 @@ async function notifyFriendRequestReceived(
   options: NotifyUserOptions<'FRIEND_REQUEST_RECEIVED'>,
 ) {
   const { userId, payload } = options;
-  await ensureNotificationPreferencesForUser(userId);
   const prefs = await getNotificationPreferenceForChannels(
     userId,
     NOTIFICATION_TYPES.FRIEND_REQUEST_RECEIVED,
@@ -108,7 +104,6 @@ async function notifyFriendRequestAccepted(
   options: NotifyUserOptions<'FRIEND_REQUEST_ACCEPTED'>,
 ) {
   const { userId, payload } = options;
-  await ensureNotificationPreferencesForUser(userId);
   const prefs = await getNotificationPreferenceForChannels(
     userId,
     NOTIFICATION_TYPES.FRIEND_REQUEST_ACCEPTED,


### PR DESCRIPTION
## Summary
Second of three performance PRs from the health audit. Pulls the notification side-effects out of the friend-request hot path and removes the N upserts that ran on every preference read.

- **`fanoutNotification` helper** in `friends.server.ts` — `sendFriendRequest` and `acceptFriendRequest` no longer `await notifyUser`. The mutation commits, the response returns, and the in-app row + Resend email happen after. Errors tail off to `Sentry.captureException` so lost notifications still surface.
- **`ensureNotificationPreferencesForUser` out of the hot read path.** `getNotificationPreferences` now fills in defaults in-memory for types without a row. `getNotificationPreferenceForChannels` already tolerated missing rows. The function is still exported for tests.
- **`setNotificationPreference` → upsert.** Safe against users without bootstrapped rows, and skips the pre-read ensure.
- **`disableEmailForAll` → 3 statements total.** Was O(N) loop-in-transaction (one `update` + one audit `create` per type). Now: one `findMany` to snapshot which rows were on, then a single `$transaction([updateMany, createMany])`.
- **Signup bootstrap.** New users get their notification preference rows via nested-create on the user insert — no extra round trip and no chance of the missing-row fallback ever firing for fresh accounts.

## Why
Audit surfaced a ~200–500ms tail on friend-request actions when Resend was slow, plus ~20–30ms of redundant preference upserts on every settings-page read. Neither should be in the user-visible action path.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run lint` 0 errors
- [x] Unit tests: 554/554 passing
- [x] Targeted: `notification-preferences.server.test.ts`, `notification-service.server.test.tsx`, `profile.notifications.test.tsx` — 11/11
- [ ] CI e2e run (local Playwright is binding to a leftover dev server on port 3000, so `test:e2e:run` can't validate end-to-end here; letting CI catch anything)
- [ ] After deploy: friend-request action p95 latency on the dashboard; Sentry for any fanout errors tail

## Follow-up
Group 3 (analytics off the hot path) is next.