### PR TITLE
docs(claude): capture async side-effects + notification-prefs patterns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,9 +143,28 @@ Uses Conform + Zod for validation with honeypot spam protection.
 ### Analytics
 
 - Client: `track(name, properties)` from `analytics.client.ts`
-- Server: `logEvent(name, requestId, sessionId)` from `analytics.server.ts`
+- Server: `queueLogEvent(...)` from `analytics.server.ts` is the default for action/loader hot paths — it pre-generates the `eventId` synchronously, fires `logEvent` without awaiting, and tails errors to `captureException`. Callers can echo the returned `eventId` back to the client immediately.
+- Use `logEvent` (awaited) only when you genuinely need the persisted row before returning — e.g. `api.analytics` fanning out from a `sendBeacon`.
+- On `eventId` conflict, server writes are canonical: `logEvent` upgrades a `source: 'client'` row in place when the incoming write is `source: 'server'`, so the richer server payload always wins the client-echo race. See `recoverFromEventIdConflict`.
 - Event names in `ANALYTIC_EVENT_NAMES` constant
 - Admin dashboard at `/admin/analytics`
+
+### Side effects off the action response
+
+Mutation handlers should return after committing the primary change; anything the user doesn't need to block on runs afterwards.
+
+- **Pattern**: pre-generate any IDs the client needs, fire the async work without awaiting, catch rejections into `Sentry.captureException`.
+- **Reference implementations**: `queueLogEvent` in `analytics.server.ts`, `fanoutNotification` in `friends.server.ts` (wraps `notifyUser` so in-app rows + Resend emails don't block friend-request actions).
+- The mutation is already committed by the time fanout runs, so a fanout failure must surface in Sentry — it must never convert a successful action into a 500.
+
+### Notification preferences
+
+Hot/cold path split — reads tolerate missing rows, writes don't.
+
+- **Cold path (settings loader)**: `app/routes/settings+/profile.notifications.tsx` calls `ensureNotificationPreferencesForUser` to materialize a row per `NOTIFICATION_TYPES`. This is the only place that upserts on read, and the e2e rollback tests rely on the rows existing afterwards.
+- **Hot path (friend-request fanout)**: `getNotificationPreferences` / `getNotificationPreferenceForChannels` fall back to `DEFAULT_NOTIFICATION_PREFERENCES` when rows are missing — no upsert in the fanout.
+- **Signup**: `auth.server.ts` seeds one row per type via nested-create so new users never hit the fallback.
+- `disableEmailForAll` collapses to one `findMany` + one transactional `updateMany` + audit `createMany` (not an O(N) loop).
 
 ## Environment Variables
 


### PR DESCRIPTION
Folds the conventions that came out of the health-audit PRs (#355-357) into CLAUDE.md's Key Patterns section so future agents don't reinvent them.

- Analytics: document `queueLogEvent` as the default for hot paths, when to still await `logEvent` (api.analytics sendBeacon), and the "server wins" conflict-recovery contract.
- Side effects off the action response: pre-generate IDs, fire without awaiting, tail errors to Sentry. Points to `queueLogEvent` and `fanoutNotification` as reference implementations.
- Notification preferences: settings loader is the only hot-materialize path, friend-request fanout tolerates missing rows via defaults, signup seeds rows via nested-create, `disableEmailForAll` uses updateMany + createMany instead of looping.

<!-- Summary: Put your summary here -->

## Test Plan

<!-- What steps need to be taken to verify this works as expected? -->

## Checklist

- [ ] Tests updated
- [ ] Docs updated

## Screenshots

<!-- If what you're changing is within the app, please show before/after.
You can provide a video as well if that makes more sense -->
