### PR TITLE
feat(admin): phase 1 — overview, ops cleanup, workflow instrumentation

### DIFF
--- a/app/components/admin-ui.test.tsx
+++ b/app/components/admin-ui.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { EmptyRow, SectionCard, SummaryCard } from './admin-ui.tsx';
+
+describe('SummaryCard', () => {
+  it('renders label and numeric value formatted with commas', () => {
+    render(<SummaryCard label="Users" value={1234} />);
+    expect(screen.getByText('Users')).toBeInTheDocument();
+    expect(screen.getByText('1,234')).toBeInTheDocument();
+  });
+
+  it('renders string values as-is', () => {
+    render(<SummaryCard label="Size" value="343.6 KB" />);
+    expect(screen.getByText('343.6 KB')).toBeInTheDocument();
+  });
+
+  it('renders delta and accent lines when provided', () => {
+    render(
+      <SummaryCard
+        label="Active pools"
+        value={3}
+        delta="+1 this week"
+        accent="key metric"
+      />,
+    );
+    expect(screen.getByText('+1 this week')).toBeInTheDocument();
+    expect(screen.getByText('key metric')).toBeInTheDocument();
+  });
+
+  it('applies the warn tone class', () => {
+    const { container } = render(
+      <SummaryCard label="Stuck" value={2} tone="warn" />,
+    );
+    const card = container.querySelector('[class*="amber"]');
+    expect(card).not.toBeNull();
+  });
+
+  it('applies the danger tone class', () => {
+    const { container } = render(
+      <SummaryCard label="Errors" value={5} tone="danger" />,
+    );
+    const card = container.querySelector('[class*="destructive"]');
+    expect(card).not.toBeNull();
+  });
+
+  it('omits delta and accent when not provided', () => {
+    render(<SummaryCard label="Users" value={10} />);
+    // Only the value and the label should be in the card — no extra lines.
+    expect(screen.getByText('Users')).toBeInTheDocument();
+    expect(screen.getByText('10')).toBeInTheDocument();
+  });
+});
+
+describe('SectionCard', () => {
+  it('renders title, description, action, and children', () => {
+    render(
+      <SectionCard
+        title="Pools needing attention"
+        description="Flagged based on status + age."
+        action={<button type="button">View all</button>}
+      >
+        <p>Nothing stuck.</p>
+      </SectionCard>,
+    );
+    expect(
+      screen.getByRole('heading', { name: 'Pools needing attention' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Flagged based on status + age.'),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'View all' })).toBeInTheDocument();
+    expect(screen.getByText('Nothing stuck.')).toBeInTheDocument();
+  });
+
+  it('renders without description or action', () => {
+    render(
+      <SectionCard title="Simple card">
+        <p>Body only.</p>
+      </SectionCard>,
+    );
+    expect(
+      screen.getByRole('heading', { name: 'Simple card' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Body only.')).toBeInTheDocument();
+  });
+});
+
+describe('EmptyRow', () => {
+  it('renders its children inside a dashed container', () => {
+    const { container } = render(<EmptyRow>Nothing here yet.</EmptyRow>);
+    expect(screen.getByText('Nothing here yet.')).toBeInTheDocument();
+    // The dashed border class should be present somewhere on the wrapper.
+    expect(container.querySelector('[class*="dashed"]')).not.toBeNull();
+  });
+});

--- a/app/components/admin-ui.tsx
+++ b/app/components/admin-ui.tsx
@@ -1,0 +1,81 @@
+import { type ReactNode } from 'react';
+import { Card } from '#app/components/ui/card.tsx';
+import { cn } from '#app/utils/misc.tsx';
+
+export const SummaryCard = ({
+  label,
+  value,
+  delta,
+  accent,
+  tone = 'default',
+}: {
+  label: string;
+  value: string | number;
+  delta?: string;
+  accent?: string;
+  tone?: 'default' | 'warn' | 'danger';
+}) => {
+  const toneClass =
+    tone === 'danger'
+      ? 'border-destructive/40 bg-destructive/5'
+      : tone === 'warn'
+        ? 'border-amber-400/40 bg-amber-50/60 dark:bg-amber-950/20'
+        : 'border-border/60 bg-gradient-to-br from-card to-card/70';
+
+  return (
+    <Card
+      className={cn(
+        'flex flex-col gap-1.5 p-4 shadow-sm',
+        toneClass,
+      )}
+    >
+      <span className="text-sm font-medium text-muted-foreground">{label}</span>
+      <span className="text-3xl font-semibold tabular-nums tracking-tight">
+        {typeof value === 'number' ? value.toLocaleString() : value}
+      </span>
+      {delta ? (
+        <span className="text-xs font-medium text-muted-foreground">
+          {delta}
+        </span>
+      ) : null}
+      {accent ? (
+        <span className="text-xs font-medium uppercase text-muted-foreground">
+          {accent}
+        </span>
+      ) : null}
+    </Card>
+  );
+};
+
+export const SectionCard = ({
+  title,
+  description,
+  action,
+  children,
+  className,
+}: {
+  title: string;
+  description?: string;
+  action?: ReactNode;
+  children: ReactNode;
+  className?: string;
+}) => (
+  <Card className={cn('border-border/60 bg-card p-4 shadow-sm', className)}>
+    <div className="mb-3 flex items-start justify-between gap-3">
+      <div>
+        <h2 className="text-lg font-semibold leading-tight">{title}</h2>
+        {description ? (
+          <p className="text-sm text-muted-foreground">{description}</p>
+        ) : null}
+      </div>
+      {action ? <div className="shrink-0">{action}</div> : null}
+    </div>
+    {children}
+  </Card>
+);
+
+export const EmptyRow = ({ children }: { children: ReactNode }) => (
+  <div className="rounded-md border border-dashed border-border/60 bg-muted/20 p-4 text-center text-sm text-muted-foreground">
+    {children}
+  </div>
+);

--- a/app/components/admin-ui.tsx
+++ b/app/components/admin-ui.tsx
@@ -15,12 +15,12 @@ export const SummaryCard = ({
   accent?: string;
   tone?: 'default' | 'warn' | 'danger';
 }) => {
-  const toneClass =
-    tone === 'danger'
-      ? 'border-destructive/40 bg-destructive/5'
-      : tone === 'warn'
-        ? 'border-amber-400/40 bg-amber-50/60 dark:bg-amber-950/20'
-        : 'border-border/60 bg-gradient-to-br from-card to-card/70';
+  const TONE_CLASSES: Record<'default' | 'warn' | 'danger', string> = {
+    danger: 'border-destructive/40 bg-destructive/5',
+    warn: 'border-amber-400/40 bg-amber-50/60 dark:bg-amber-950/20',
+    default: 'border-border/60 bg-gradient-to-br from-card to-card/70',
+  };
+  const toneClass = TONE_CLASSES[tone];
 
   return (
     <Card

--- a/app/routes/admin+/_layout.test.tsx
+++ b/app/routes/admin+/_layout.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('#app/utils/permissions.server.ts', () => ({
+  requireUserWithRole: vi.fn(),
+}));
+
+vi.mock('#app/utils/db.server.ts', () => ({
+  prisma: {},
+}));
+
+import AdminLayout from './_layout.tsx';
+
+describe('admin layout', () => {
+  it('renders the admin header and all six nav tabs', () => {
+    render(
+      <MemoryRouter initialEntries={['/admin']}>
+        <AdminLayout />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('Admin')).toBeInTheDocument();
+    expect(screen.getByText('Internal operator surface')).toBeInTheDocument();
+
+    // Back-to-home link
+    expect(screen.getByRole('link', { name: /Home/i })).toHaveAttribute(
+      'href',
+      '/',
+    );
+
+    // Six tabs
+    for (const label of [
+      'Overview',
+      'Users',
+      'Pools',
+      'Ops',
+      'Analytics',
+      'Cache',
+    ]) {
+      expect(
+        screen.getByRole('link', { name: label }),
+      ).toBeInTheDocument();
+    }
+  });
+
+  it('wires the Overview tab to /admin with end matching', () => {
+    render(
+      <MemoryRouter initialEntries={['/admin']}>
+        <AdminLayout />
+      </MemoryRouter>,
+    );
+    const overviewTab = screen.getByRole('link', { name: 'Overview' });
+    expect(overviewTab).toHaveAttribute('href', '/admin');
+  });
+
+  it('wires subsequent tabs to their /admin/* paths', () => {
+    render(
+      <MemoryRouter initialEntries={['/admin']}>
+        <AdminLayout />
+      </MemoryRouter>,
+    );
+    expect(screen.getByRole('link', { name: 'Users' })).toHaveAttribute(
+      'href',
+      '/admin/users',
+    );
+    expect(screen.getByRole('link', { name: 'Pools' })).toHaveAttribute(
+      'href',
+      '/admin/pools',
+    );
+    expect(screen.getByRole('link', { name: 'Ops' })).toHaveAttribute(
+      'href',
+      '/admin/ops',
+    );
+    expect(screen.getByRole('link', { name: 'Analytics' })).toHaveAttribute(
+      'href',
+      '/admin/analytics',
+    );
+    expect(screen.getByRole('link', { name: 'Cache' })).toHaveAttribute(
+      'href',
+      '/admin/cache',
+    );
+  });
+});

--- a/app/routes/admin+/_layout.tsx
+++ b/app/routes/admin+/_layout.tsx
@@ -1,0 +1,97 @@
+import { LuShieldCheck } from 'react-icons/lu';
+import {
+  Link,
+  NavLink,
+  Outlet,
+  type LoaderFunctionArgs,
+} from 'react-router';
+import { GeneralErrorBoundary } from '#app/components/error-boundary.tsx';
+import { Button } from '#app/components/ui/button.tsx';
+import { Icon } from '#app/components/ui/icon.tsx';
+import { Stack } from '#app/components/ui-kit/stack.tsx';
+import { cn } from '#app/utils/misc.tsx';
+import { requireUserWithRole } from '#app/utils/permissions.server.ts';
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  await requireUserWithRole(request, 'admin');
+  return {};
+}
+
+type Tab = { to: string; label: string; end?: boolean };
+
+const TABS: ReadonlyArray<Tab> = [
+  { to: '/admin', label: 'Overview', end: true },
+  { to: '/admin/users', label: 'Users' },
+  { to: '/admin/pools', label: 'Pools' },
+  { to: '/admin/ops', label: 'Ops' },
+  { to: '/admin/analytics', label: 'Analytics' },
+  { to: '/admin/cache', label: 'Cache' },
+];
+
+const AdminLayout = () => {
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="w-full border-b bg-surface backdrop-blur">
+        <div className="mx-auto max-w-6xl px-3 py-3 sm:px-6">
+          <div className="flex items-center justify-between gap-3">
+            <div className="flex items-center gap-3">
+              <Button asChild variant="ghost" size="sm" className="px-2">
+                <Link to="/">
+                  <Icon name="arrow-left" className="mr-1" /> Home
+                </Link>
+              </Button>
+              <div className="flex items-center gap-3">
+                <LuShieldCheck size={24} className="text-primary" />
+                <div className="leading-tight">
+                  <div className="text-md font-extrabold sm:text-xl">
+                    Admin
+                  </div>
+                  <div className="text-sm text-muted-foreground">
+                    Internal operator surface
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <main className="min-h-0 flex-1 overflow-y-auto">
+        <div className="mx-auto max-w-6xl p-3 sm:p-6">
+          <Stack gap={6}>
+            <TabBar />
+            <Outlet />
+          </Stack>
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default AdminLayout;
+
+const TabBar = () => {
+  return (
+    <div className="grid w-full grid-cols-3 rounded-2xl bg-muted p-1 sm:grid-cols-6">
+      {TABS.map((tab) => (
+        <NavLink
+          key={tab.to}
+          to={tab.to}
+          end={tab.end}
+          className={({ isActive }) =>
+            cn(
+              'px-4 py-1.5 text-center text-sm font-medium text-muted-foreground',
+              'rounded-xl transition-colors',
+              isActive && 'bg-background text-foreground shadow',
+            )
+          }
+        >
+          {tab.label}
+        </NavLink>
+      ))}
+    </div>
+  );
+};
+
+export const ErrorBoundary = () => {
+  return <GeneralErrorBoundary />;
+};

--- a/app/routes/admin+/analytics.test.ts
+++ b/app/routes/admin+/analytics.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, afterEach } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { loader } from '#app/routes/admin+/analytics.tsx';
 import { logEvent } from '#app/utils/analytics.server.ts';
 import { prisma } from '#app/utils/db.server.ts';
@@ -17,16 +17,8 @@ const buildRequest = (cookie?: string) =>
     headers: cookie ? { cookie } : undefined,
   });
 
-const originalEmails = process.env.ANALYTICS_ADMIN_EMAILS;
-const originalIds = process.env.ANALYTICS_ADMIN_USER_IDS;
-
-afterEach(() => {
-  process.env.ANALYTICS_ADMIN_EMAILS = originalEmails;
-  process.env.ANALYTICS_ADMIN_USER_IDS = originalIds;
-});
-
 describe('/admin/analytics loader', () => {
-  it('rejects users outside the allowlist', async () => {
+  it('rejects users without the admin role', async () => {
     const user = await prisma.user.create({ data: createUser() });
     const session = await prisma.session.create({
       data: {
@@ -47,11 +39,19 @@ describe('/admin/analytics loader', () => {
     ).rejects.toMatchObject({ init: { status: 403 } });
   });
 
-  it('returns analytics metrics for allowlisted admins', async () => {
-    const adminData = createUser();
-    const admin = await prisma.user.create({ data: adminData });
+  it('returns analytics metrics for users with the admin role', async () => {
+    await prisma.role.upsert({
+      where: { name: 'admin' },
+      update: {},
+      create: { name: 'admin', description: 'Admin role' },
+    });
+    const admin = await prisma.user.create({
+      data: {
+        ...createUser(),
+        roles: { connect: { name: 'admin' } },
+      },
+    });
     const otherUser = await prisma.user.create({ data: createUser() });
-    process.env.ANALYTICS_ADMIN_EMAILS = admin.email;
 
     const session = await prisma.session.create({
       data: {

--- a/app/routes/admin+/analytics.tsx
+++ b/app/routes/admin+/analytics.tsx
@@ -1,60 +1,14 @@
-import { invariantResponse } from '@epic-web/invariant';
-import { data, type LoaderFunctionArgs, useLoaderData  } from 'react-router';
+import { type LoaderFunctionArgs, useLoaderData } from 'react-router';
 import { GeneralErrorBoundary } from '#app/components/error-boundary.tsx';
 import { Card } from '#app/components/ui/card.tsx';
 import {
   type AnalyticsCounts,
   getAnalyticsCounts,
 } from '#app/utils/analytics.server.ts';
-import { requireUserId } from '#app/utils/auth.server.ts';
-import { prisma } from '#app/utils/db.server.ts';
-function parseAllowlist(value?: string | null) {
-  return (value ?? '')
-    .split(',')
-    .map((entry) => entry.trim().toLowerCase())
-    .filter(Boolean);
-}
-async function requireAnalyticsAdmin(request: Request) {
-  const userId = await requireUserId(request);
-  const allowlistedIds = parseAllowlist(process.env.ANALYTICS_ADMIN_USER_IDS);
-  const allowlistedEmails = parseAllowlist(process.env.ANALYTICS_ADMIN_EMAILS);
-  const user = await prisma.user.findUnique({
-    select: {
-      id: true,
-      email: true,
-      roles: {
-        select: {
-          name: true,
-        },
-      },
-    },
-    where: {
-      id: userId,
-    },
-  });
-  invariantResponse(user, 'User not found', {
-    status: 404,
-  });
-  const isAllowed =
-    allowlistedIds.includes(user.id) ||
-    (user.email
-      ? allowlistedEmails.includes(user.email.toLowerCase())
-      : false) ||
-    user.roles.some((role) => role.name === 'admin');
-  if (!isAllowed) {
-    throw data(
-      {
-        error: 'Unauthorized',
-      },
-      {
-        status: 403,
-      },
-    );
-  }
-  return user.id;
-}
+import { requireUserWithRole } from '#app/utils/permissions.server.ts';
+
 export async function loader({ request }: LoaderFunctionArgs) {
-  await requireAnalyticsAdmin(request);
+  await requireUserWithRole(request, 'admin');
   const analytics = await getAnalyticsCounts();
   return {
     analytics,
@@ -190,7 +144,7 @@ const EventTable = ({
 const AnalyticsRoute = () => {
   const { analytics } = useLoaderData<typeof loader>();
   return (
-    <div className="container space-y-8 py-8">
+    <div className="space-y-8">
       <div className="space-y-1">
         <h1 className="text-h1">Analytics</h1>
         <p className="text-muted-foreground">

--- a/app/routes/admin+/cache.tsx
+++ b/app/routes/admin+/cache.tsx
@@ -100,7 +100,7 @@ const CacheAdminRoute = () => {
     Promise.resolve(submit(form)).catch(() => {});
   }, 400);
   return (
-    <div className="container">
+    <div className="space-y-4">
       <h1 className="text-h1">Cache Admin</h1>
       <Spacer size="2xs" />
       <Form

--- a/app/routes/admin+/index.dom.test.tsx
+++ b/app/routes/admin+/index.dom.test.tsx
@@ -1,0 +1,372 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import * as ReactRouter from 'react-router';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type OverviewCounts = {
+  users: { total: number; last24h: number; last7d: number; last30d: number };
+  pools: {
+    total: number;
+    byStatus: Record<string, number>;
+    stuck: number;
+    active: number;
+  };
+  wishlist: {
+    items: number;
+    active: number;
+    archived: number;
+    purchases: number;
+  };
+  friendships: { total: number; pendingRequestsOverThreshold: number };
+  notifications: { unread24h: number };
+};
+
+type StuckPool = {
+  id: string;
+  title: string;
+  status: 'OPEN' | 'VOTING' | 'DECIDED' | 'PURCHASED' | 'DELIVERED' | 'CANCELLED';
+  eventDate: Date | null;
+  updatedAt: Date;
+  reason: 'open_overdue' | 'voting_stalled' | 'decided_stalled';
+  organizer: { id: string; username: string; name: string | null };
+  contributorCount: number;
+};
+
+type CleanupPreviewCounts = {
+  expiredVerifications: number;
+  expiredSessions: number;
+  stalePendingFriendRequests: number;
+  staleRejectedFriendRequests: number;
+  revokedOrExpiredGroupInvitations: number;
+  expiredGroupBans: number;
+};
+
+type RecentActivityRow = {
+  kind: 'user' | 'pool' | 'wishlist_item' | 'friendship';
+  id: string;
+  actor: { id: string; username: string; name: string | null } | null;
+  subject: string;
+  timestamp: Date;
+};
+
+const loaderDataSnapshot: {
+  overview: OverviewCounts;
+  stuckPools: StuckPool[];
+  cleanup: CleanupPreviewCounts;
+  activity: RecentActivityRow[];
+} = {
+  overview: {
+    users: { total: 0, last24h: 0, last7d: 0, last30d: 0 },
+    pools: {
+      total: 0,
+      byStatus: {
+        OPEN: 0,
+        VOTING: 0,
+        DECIDED: 0,
+        PURCHASED: 0,
+        DELIVERED: 0,
+        CANCELLED: 0,
+      },
+      stuck: 0,
+      active: 0,
+    },
+    wishlist: { items: 0, active: 0, archived: 0, purchases: 0 },
+    friendships: { total: 0, pendingRequestsOverThreshold: 0 },
+    notifications: { unread24h: 0 },
+  },
+  stuckPools: [],
+  cleanup: {
+    expiredVerifications: 0,
+    expiredSessions: 0,
+    stalePendingFriendRequests: 0,
+    staleRejectedFriendRequests: 0,
+    revokedOrExpiredGroupInvitations: 0,
+    expiredGroupBans: 0,
+  },
+  activity: [],
+};
+
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual<typeof ReactRouter>('react-router');
+  return {
+    ...actual,
+    useLoaderData: () => loaderDataSnapshot,
+  };
+});
+
+vi.mock('#app/utils/permissions.server.ts', () => ({
+  requireUserWithRole: vi.fn(),
+}));
+
+vi.mock('#app/utils/admin.server.ts', () => ({
+  getOverviewCounts: vi.fn(),
+  getStuckPools: vi.fn(),
+  getCleanupPreviewCounts: vi.fn(),
+  getRecentActivity: vi.fn(),
+}));
+
+import AdminIndexRoute from './index.tsx';
+
+const renderOverview = () =>
+  render(
+    <MemoryRouter initialEntries={['/admin']}>
+      <AdminIndexRoute />
+    </MemoryRouter>,
+  );
+
+const setOverview = (partial: {
+  overview?: Partial<OverviewCounts>;
+  stuckPools?: StuckPool[];
+  cleanup?: Partial<CleanupPreviewCounts>;
+  activity?: RecentActivityRow[];
+}) => {
+  if (partial.overview) {
+    loaderDataSnapshot.overview = {
+      ...loaderDataSnapshot.overview,
+      ...partial.overview,
+    };
+  }
+  if (partial.stuckPools) loaderDataSnapshot.stuckPools = partial.stuckPools;
+  if (partial.cleanup) {
+    loaderDataSnapshot.cleanup = {
+      ...loaderDataSnapshot.cleanup,
+      ...partial.cleanup,
+    };
+  }
+  if (partial.activity) loaderDataSnapshot.activity = partial.activity;
+};
+
+beforeEach(() => {
+  // Reset to fully-zero state before each test.
+  loaderDataSnapshot.overview = {
+    users: { total: 0, last24h: 0, last7d: 0, last30d: 0 },
+    pools: {
+      total: 0,
+      byStatus: {
+        OPEN: 0,
+        VOTING: 0,
+        DECIDED: 0,
+        PURCHASED: 0,
+        DELIVERED: 0,
+        CANCELLED: 0,
+      },
+      stuck: 0,
+      active: 0,
+    },
+    wishlist: { items: 0, active: 0, archived: 0, purchases: 0 },
+    friendships: { total: 0, pendingRequestsOverThreshold: 0 },
+    notifications: { unread24h: 0 },
+  };
+  loaderDataSnapshot.stuckPools = [];
+  loaderDataSnapshot.cleanup = {
+    expiredVerifications: 0,
+    expiredSessions: 0,
+    stalePendingFriendRequests: 0,
+    staleRejectedFriendRequests: 0,
+    revokedOrExpiredGroupInvitations: 0,
+    expiredGroupBans: 0,
+  };
+  loaderDataSnapshot.activity = [];
+});
+
+describe('admin overview page — empty state', () => {
+  it('renders all empty-state rows when every list is empty', () => {
+    renderOverview();
+
+    // Headings
+    expect(
+      screen.getByRole('heading', { name: 'Overview' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Pools needing attention' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Cleanup queue' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Recent activity (last 48h)' }),
+    ).toBeInTheDocument();
+
+    // Empty messages
+    expect(
+      screen.getByText(/No stuck pools. Nothing to do here./),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Nothing to clean up./)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Nothing in the last 48 hours./),
+    ).toBeInTheDocument();
+  });
+
+  it('renders metric labels even when values are zero', () => {
+    renderOverview();
+    for (const label of [
+      'Users',
+      'Active pools',
+      'Wishlist items',
+      'Friendships',
+      'Stuck pools',
+      'Wishlist purchases',
+      'Unread notifications (24h)',
+    ]) {
+      expect(screen.getByText(label)).toBeInTheDocument();
+    }
+  });
+});
+
+describe('admin overview page — populated state', () => {
+  it('renders metric values, stuck pool rows, cleanup items, and recent activity', () => {
+    setOverview({
+      overview: {
+        users: { total: 42, last24h: 2, last7d: 5, last30d: 12 },
+        pools: {
+          total: 10,
+          byStatus: {
+            OPEN: 3,
+            VOTING: 1,
+            DECIDED: 2,
+            PURCHASED: 0,
+            DELIVERED: 4,
+            CANCELLED: 0,
+          },
+          stuck: 2,
+          active: 6,
+        },
+        wishlist: { items: 80, active: 70, archived: 10, purchases: 15 },
+        friendships: { total: 30, pendingRequestsOverThreshold: 1 },
+        notifications: { unread24h: 7 },
+      },
+      stuckPools: [
+        {
+          id: 'pool-1',
+          title: 'Marco Birthday',
+          status: 'OPEN',
+          eventDate: new Date('2026-04-01'),
+          updatedAt: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000),
+          reason: 'open_overdue',
+          organizer: { id: 'u1', username: 'wade', name: 'Wade Wilson' },
+          contributorCount: 3,
+        },
+        {
+          id: 'pool-2',
+          title: 'Ana Farewell',
+          status: 'VOTING',
+          eventDate: null,
+          updatedAt: new Date(Date.now() - 10 * 24 * 60 * 60 * 1000),
+          reason: 'voting_stalled',
+          organizer: { id: 'u2', username: 'marco', name: 'Marco' },
+          contributorCount: 5,
+        },
+      ],
+      cleanup: {
+        expiredVerifications: 3,
+        expiredSessions: 4,
+        stalePendingFriendRequests: 1,
+        staleRejectedFriendRequests: 0,
+        revokedOrExpiredGroupInvitations: 2,
+        expiredGroupBans: 0,
+      },
+      activity: [
+        {
+          kind: 'user',
+          id: 'u99',
+          actor: { id: 'u99', username: 'newbie', name: 'Newbie Name' },
+          subject: 'signed up',
+          timestamp: new Date(Date.now() - 60 * 60 * 1000),
+        },
+        {
+          kind: 'pool',
+          id: 'p99',
+          actor: { id: 'u1', username: 'wade', name: 'Wade Wilson' },
+          subject: 'created pool "Launch party"',
+          timestamp: new Date(Date.now() - 2 * 60 * 60 * 1000),
+        },
+        {
+          kind: 'friendship',
+          id: 'f99',
+          actor: { id: 'u3', username: 'zoe', name: null },
+          subject: 'became friends with hana',
+          timestamp: new Date(Date.now() - 3 * 60 * 60 * 1000),
+        },
+      ],
+    });
+
+    renderOverview();
+
+    // Metric values — use getAllByText since numbers may appear multiple times
+    // (e.g. "2" as stuck-pool count and also as contributor count badge).
+    expect(screen.getAllByText('42').length).toBeGreaterThan(0); // users total
+    expect(screen.getAllByText('6').length).toBeGreaterThan(0); // active pools
+    expect(screen.getAllByText('80').length).toBeGreaterThan(0); // wishlist items
+    expect(screen.getAllByText('15').length).toBeGreaterThan(0); // purchases
+    expect(screen.getAllByText('7').length).toBeGreaterThan(0); // unread notifs
+    // Cleanup total: 3+4+1+0+2+0 = 10
+    expect(screen.getAllByText('10').length).toBeGreaterThan(0);
+
+    // Stuck pool rows
+    expect(screen.getByText('Marco Birthday')).toBeInTheDocument();
+    expect(screen.getByText('Ana Farewell')).toBeInTheDocument();
+    expect(
+      screen.getByText(/Event date past, still OPEN/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/VOTING with no votes >7d/),
+    ).toBeInTheDocument();
+
+    // Cleanup rows (only non-zero ones render)
+    expect(screen.getByText('Expired verification rows')).toBeInTheDocument();
+    expect(screen.getByText('Expired sessions')).toBeInTheDocument();
+    expect(
+      screen.getByText('Stale pending friend requests (>30d)'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Revoked or expired group invitations'),
+    ).toBeInTheDocument();
+    // Zero-value rows should NOT be rendered
+    expect(
+      screen.queryByText('Stale rejected friend requests (>90d)'),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('Expired group bans (ready to lift)'),
+    ).not.toBeInTheDocument();
+
+    // Activity feed
+    expect(screen.getByText('signed up')).toBeInTheDocument();
+    expect(
+      screen.getByText('created pool "Launch party"'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('became friends with hana'),
+    ).toBeInTheDocument();
+  });
+
+  it('links stuck pool rows to their drill-down routes', () => {
+    setOverview({
+      stuckPools: [
+        {
+          id: 'pool-xyz',
+          title: 'Something stuck',
+          status: 'DECIDED',
+          eventDate: null,
+          updatedAt: new Date(),
+          reason: 'decided_stalled',
+          organizer: { id: 'u1', username: 'wade', name: null },
+          contributorCount: 1,
+        },
+      ],
+    });
+
+    renderOverview();
+
+    const link = screen.getByRole('link', { name: /Something stuck/ });
+    expect(link).toHaveAttribute('href', '/admin/pools/pool-xyz');
+  });
+
+  it('links the alert callout to the stuck-pools filter', () => {
+    renderOverview();
+    const viewAll = screen.getByRole('link', { name: /View all/ });
+    expect(viewAll).toHaveAttribute('href', '/admin/pools?status=stuck');
+  });
+});

--- a/app/routes/admin+/index.test.ts
+++ b/app/routes/admin+/index.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import { loader } from '#app/routes/admin+/index.tsx';
+import { prisma } from '#app/utils/db.server.ts';
+import { POOL_STATUS } from '#app/utils/pool-constants.ts';
+import { createUser } from '#tests/db-utils.ts';
+import {
+  getRouteResultData,
+  getRouteResultStatus,
+  toLoaderArgs,
+} from '#tests/route-module-test-utils.ts';
+import { getSessionCookieHeader } from '#tests/utils.ts';
+
+const DAY_MS = 1000 * 60 * 60 * 24;
+
+const buildRequest = (cookie?: string) =>
+  new Request('http://localhost/admin', {
+    headers: cookie ? { cookie } : undefined,
+  });
+
+async function seedAdminSession() {
+  await prisma.role.upsert({
+    where: { name: 'admin' },
+    update: {},
+    create: { name: 'admin', description: 'Admin role' },
+  });
+  const admin = await prisma.user.create({
+    data: { ...createUser(), roles: { connect: { name: 'admin' } } },
+    select: { id: true },
+  });
+  const session = await prisma.session.create({
+    data: { userId: admin.id, expirationDate: new Date(Date.now() + DAY_MS) },
+  });
+  const cookie = await getSessionCookieHeader(session);
+  return { admin, cookie };
+}
+
+describe('/admin (overview) loader', () => {
+  it('rejects users without the admin role', async () => {
+    const user = await prisma.user.create({ data: createUser() });
+    const session = await prisma.session.create({
+      data: { userId: user.id, expirationDate: new Date(Date.now() + DAY_MS) },
+    });
+    const cookie = await getSessionCookieHeader(session);
+
+    await expect(
+      loader(
+        toLoaderArgs({
+          request: buildRequest(cookie),
+          params: {},
+          context: {} as any,
+        }),
+      ),
+    ).rejects.toMatchObject({ init: { status: 403 } });
+  });
+
+  it('returns overview + stuck pools + cleanup preview + activity for admin', async () => {
+    const { admin, cookie } = await seedAdminSession();
+
+    // Create a stuck OPEN pool so the stuck list has one row.
+    await prisma.pool.create({
+      data: {
+        title: 'Overdue pool',
+        organizerId: admin.id,
+        status: POOL_STATUS.OPEN,
+        eventDate: new Date(Date.now() - 3 * DAY_MS),
+        contributors: { create: { userId: admin.id } },
+      },
+    });
+    await prisma.wishlistItem.create({
+      data: {
+        ownerId: admin.id,
+        title: 'Hat',
+        sortOrder: 0,
+        type: 'text',
+        status: 'ACTIVE',
+      },
+    });
+
+    const result = await loader(
+      toLoaderArgs({
+        request: buildRequest(cookie),
+        params: {},
+        context: {} as any,
+      }),
+    );
+    expect(getRouteResultStatus(result)).toBe(200);
+    const data = await getRouteResultData<{
+      overview: { users: { total: number }; pools: { stuck: number } };
+      stuckPools: Array<{ title: string; reason: string }>;
+      cleanup: { expiredVerifications: number };
+      activity: Array<unknown>;
+    }>(result);
+
+    expect(data.overview.users.total).toBeGreaterThanOrEqual(1);
+    expect(data.overview.pools.stuck).toBe(1);
+    expect(data.stuckPools).toHaveLength(1);
+    expect(data.stuckPools[0]?.reason).toBe('open_overdue');
+    expect(data.cleanup.expiredVerifications).toBe(0);
+    expect(Array.isArray(data.activity)).toBe(true);
+  });
+});

--- a/app/routes/admin+/index.tsx
+++ b/app/routes/admin+/index.tsx
@@ -1,59 +1,294 @@
-import { LuActivity, LuDatabase } from 'react-icons/lu';
-import { type LoaderFunctionArgs, Link  } from 'react-router';
+import {
+  LuActivity,
+  LuClock,
+  LuSparkles,
+  LuTriangleAlert,
+} from 'react-icons/lu';
+import {
+  Link,
+  type LoaderFunctionArgs,
+  useLoaderData,
+} from 'react-router';
+import { SectionCard, SummaryCard, EmptyRow } from '#app/components/admin-ui.tsx';
 import { GeneralErrorBoundary } from '#app/components/error-boundary.tsx';
-import { Spacer } from '#app/components/spacer.tsx';
-import { Card } from '#app/components/ui/card.tsx';
+import {
+  getCleanupPreviewCounts,
+  getOverviewCounts,
+  getRecentActivity,
+  getStuckPools,
+} from '#app/utils/admin.server.ts';
 import { requireUserWithRole } from '#app/utils/permissions.server.ts';
+import { POOL_STATUS_LABELS } from '#app/utils/pool-constants.ts';
+
 export async function loader({ request }: LoaderFunctionArgs) {
   await requireUserWithRole(request, 'admin');
-  return {};
+
+  const [overview, stuckPools, cleanup, activity] = await Promise.all([
+    getOverviewCounts(),
+    getStuckPools(5),
+    getCleanupPreviewCounts(),
+    getRecentActivity(15),
+  ]);
+
+  return { overview, stuckPools, cleanup, activity };
 }
+
+const STUCK_REASON_LABEL: Record<
+  'open_overdue' | 'voting_stalled' | 'decided_stalled',
+  string
+> = {
+  open_overdue: 'Event date past, still OPEN',
+  voting_stalled: 'VOTING with no votes >7d',
+  decided_stalled: 'DECIDED >14d without progress',
+};
+
+const formatRelative = (date: Date | string) => {
+  const d = typeof date === 'string' ? new Date(date) : date;
+  const diffMs = Date.now() - d.getTime();
+  const minutes = Math.round(diffMs / 60000);
+  if (minutes < 1) return 'just now';
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.round(hours / 24);
+  return `${days}d ago`;
+};
+
 const AdminIndexRoute = () => {
+  const { overview, stuckPools, cleanup, activity } =
+    useLoaderData<typeof loader>();
+
+  const totalCleanup =
+    cleanup.expiredVerifications +
+    cleanup.expiredSessions +
+    cleanup.stalePendingFriendRequests +
+    cleanup.staleRejectedFriendRequests +
+    cleanup.revokedOrExpiredGroupInvitations +
+    cleanup.expiredGroupBans;
+
   return (
-    <div className="container space-y-6 py-8">
+    <div className="space-y-6">
       <div className="space-y-1">
-        <h1 className="text-h1">Admin</h1>
-        <p className="text-muted-foreground">Quick links to internal tools.</p>
+        <h1 className="text-h1">Overview</h1>
+        <p className="text-muted-foreground">
+          At-a-glance product health — all figures are direct queries against
+          the domain tables, cached 60s.
+        </p>
       </div>
 
-      <div className="grid gap-4 md:grid-cols-2">
-        <Link to="/admin/analytics">
-          <Card className="flex h-full flex-col gap-3 border-border/70 bg-card p-4 transition hover:translate-y-[-2px] hover:border-foreground/20 hover:shadow-md">
-            <div className="flex items-center gap-3">
-              <span className="flex size-9 items-center justify-center rounded-lg bg-primary/10 text-primary">
-                <LuActivity className="h-4 w-4" aria-hidden />
-              </span>
-              <div>
-                <p className="text-base font-semibold">Analytics</p>
-                <p className="text-sm text-muted-foreground">
-                  DAU/WAU/MAU, event counts, and daily active trends.
-                </p>
-              </div>
-            </div>
-          </Card>
-        </Link>
+      {/* --- primary metrics --- */}
+      <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <SummaryCard
+          label="Users"
+          value={overview.users.total}
+          delta={`+${overview.users.last7d} this week · +${overview.users.last24h} today`}
+        />
+        <SummaryCard
+          label="Active pools"
+          value={overview.pools.active}
+          delta={`${overview.pools.total} total · ${overview.pools.byStatus.DELIVERED} delivered`}
+          tone={overview.pools.stuck > 0 ? 'warn' : 'default'}
+        />
+        <SummaryCard
+          label="Wishlist items"
+          value={overview.wishlist.items}
+          delta={`${overview.wishlist.active} active · ${overview.wishlist.archived} archived`}
+        />
+        <SummaryCard
+          label="Friendships"
+          value={overview.friendships.total}
+          delta={
+            overview.friendships.pendingRequestsOverThreshold > 0
+              ? `${overview.friendships.pendingRequestsOverThreshold} pending request(s) >7d`
+              : 'all requests fresh'
+          }
+        />
+      </section>
 
-        <Link to="/admin/cache">
-          <Card className="flex h-full flex-col gap-3 border-border/70 bg-card p-4 transition hover:translate-y-[-2px] hover:border-foreground/20 hover:shadow-md">
-            <div className="flex items-center gap-3">
-              <span className="flex size-9 items-center justify-center rounded-lg bg-primary/10 text-primary">
-                <LuDatabase className="h-4 w-4" aria-hidden />
-              </span>
-              <div>
-                <p className="text-base font-semibold">Cache</p>
-                <p className="text-sm text-muted-foreground">
-                  Inspect and clear LRU + SQLite cache entries.
-                </p>
-              </div>
-            </div>
-          </Card>
-        </Link>
-      </div>
-      <Spacer size="xl" />
+      {/* --- secondary metrics --- */}
+      <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <SummaryCard
+          label="Stuck pools"
+          value={overview.pools.stuck}
+          tone={overview.pools.stuck > 0 ? 'danger' : 'default'}
+          delta={
+            overview.pools.stuck > 0
+              ? 'needs attention'
+              : 'nothing stuck'
+          }
+        />
+        <SummaryCard
+          label="Wishlist purchases"
+          value={overview.wishlist.purchases}
+        />
+        <SummaryCard
+          label="Unread notifications (24h)"
+          value={overview.notifications.unread24h}
+        />
+        <SummaryCard
+          label="Cleanup queue"
+          value={totalCleanup}
+          tone={totalCleanup > 0 ? 'warn' : 'default'}
+          delta={totalCleanup > 0 ? 'review on Ops tab' : 'nothing expired'}
+        />
+      </section>
+
+      {/* --- alerts + cleanup side-by-side --- */}
+      <section className="grid gap-4 lg:grid-cols-2">
+        <SectionCard
+          title="Pools needing attention"
+          description="Automatically flagged based on status + age."
+          action={
+            <Link
+              to="/admin/pools?status=stuck"
+              className="text-sm font-medium text-primary hover:underline"
+            >
+              View all →
+            </Link>
+          }
+        >
+          {stuckPools.length === 0 ? (
+            <EmptyRow>
+              <LuTriangleAlert className="mr-1 inline h-4 w-4" />
+              No stuck pools. Nothing to do here.
+            </EmptyRow>
+          ) : (
+            <ul className="divide-y divide-border/60">
+              {stuckPools.map((pool) => (
+                <li key={pool.id} className="py-2">
+                  <Link
+                    to={`/admin/pools/${pool.id}`}
+                    className="group flex items-start justify-between gap-2"
+                  >
+                    <div className="min-w-0">
+                      <div className="truncate text-sm font-medium group-hover:underline">
+                        {pool.title}
+                      </div>
+                      <div className="text-xs text-muted-foreground">
+                        {POOL_STATUS_LABELS[pool.status]} ·{' '}
+                        {STUCK_REASON_LABEL[pool.reason]} · organizer{' '}
+                        {pool.organizer.username}
+                      </div>
+                    </div>
+                    <span className="shrink-0 text-xs text-muted-foreground">
+                      {formatRelative(pool.updatedAt)}
+                    </span>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          )}
+        </SectionCard>
+
+        <SectionCard
+          title="Cleanup queue"
+          description="One-click purges on the Ops tab."
+          action={
+            <Link
+              to="/admin/ops"
+              className="text-sm font-medium text-primary hover:underline"
+            >
+              Open Ops →
+            </Link>
+          }
+        >
+          {totalCleanup === 0 ? (
+            <EmptyRow>
+              <LuSparkles className="mr-1 inline h-4 w-4" />
+              Nothing to clean up.
+            </EmptyRow>
+          ) : (
+            <ul className="divide-y divide-border/60 text-sm">
+              <CleanupRow
+                label="Expired verification rows"
+                count={cleanup.expiredVerifications}
+              />
+              <CleanupRow
+                label="Expired sessions"
+                count={cleanup.expiredSessions}
+              />
+              <CleanupRow
+                label="Stale pending friend requests (>30d)"
+                count={cleanup.stalePendingFriendRequests}
+              />
+              <CleanupRow
+                label="Stale rejected friend requests (>90d)"
+                count={cleanup.staleRejectedFriendRequests}
+              />
+              <CleanupRow
+                label="Revoked or expired group invitations"
+                count={cleanup.revokedOrExpiredGroupInvitations}
+              />
+              <CleanupRow
+                label="Expired group bans (ready to lift)"
+                count={cleanup.expiredGroupBans}
+              />
+            </ul>
+          )}
+        </SectionCard>
+      </section>
+
+      {/* --- recent activity --- */}
+      <SectionCard
+        title="Recent activity (last 48h)"
+        description="Union of new users, pools, wishlist items, and friendships."
+      >
+        {activity.length === 0 ? (
+          <EmptyRow>
+            <LuClock className="mr-1 inline h-4 w-4" />
+            Nothing in the last 48 hours.
+          </EmptyRow>
+        ) : (
+          <ul className="divide-y divide-border/60">
+            {activity.map((row) => (
+              <li
+                key={`${row.kind}-${row.id}`}
+                className="flex items-start justify-between gap-2 py-2 text-sm"
+              >
+                <div className="min-w-0">
+                  <span className="mr-2 inline-flex items-center rounded-md bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+                    <LuActivity className="mr-1 h-3 w-3" />
+                    {row.kind.replace('_', ' ')}
+                  </span>
+                  <span className="font-medium">
+                    {row.actor?.name ?? row.actor?.username ?? 'unknown'}
+                  </span>{' '}
+                  <span className="text-muted-foreground">{row.subject}</span>
+                </div>
+                <span className="shrink-0 text-xs text-muted-foreground">
+                  {formatRelative(row.timestamp)}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </SectionCard>
+
+      <p className="text-xs text-muted-foreground">
+        Wishlist disk usage and LiteFS instance info live on the{' '}
+        <Link to="/admin/ops" className="underline hover:text-foreground">
+          Ops
+        </Link>{' '}
+        tab.
+      </p>
     </div>
   );
 };
+
+const CleanupRow = ({ label, count }: { label: string; count: number }) => {
+  if (count === 0) return null;
+  return (
+    <li className="flex items-center justify-between py-1.5">
+      <span>{label}</span>
+      <span className="rounded-md bg-muted px-2 py-0.5 text-xs font-semibold tabular-nums">
+        {count.toLocaleString()}
+      </span>
+    </li>
+  );
+};
+
 export default AdminIndexRoute;
+
 export const ErrorBoundary = () => {
   return <GeneralErrorBoundary />;
 };

--- a/app/routes/admin+/ops.dom.test.tsx
+++ b/app/routes/admin+/ops.dom.test.tsx
@@ -1,0 +1,284 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import * as ReactRouter from 'react-router';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type CleanupPreviewCounts = {
+  expiredVerifications: number;
+  expiredSessions: number;
+  stalePendingFriendRequests: number;
+  staleRejectedFriendRequests: number;
+  revokedOrExpiredGroupInvitations: number;
+  expiredGroupBans: number;
+};
+
+type DiskUsageCounts = {
+  wishlistItemTotal: number;
+  wishlistItemsWithImage: number;
+  wishlistImageBytes: number;
+};
+
+const loaderDataSnapshot: {
+  cleanup: CleanupPreviewCounts;
+  disk: DiskUsageCounts;
+  instances: Record<string, string>;
+  instanceInfo: { currentInstance: string; primaryInstance: string };
+} = {
+  cleanup: {
+    expiredVerifications: 0,
+    expiredSessions: 0,
+    stalePendingFriendRequests: 0,
+    staleRejectedFriendRequests: 0,
+    revokedOrExpiredGroupInvitations: 0,
+    expiredGroupBans: 0,
+  },
+  disk: {
+    wishlistItemTotal: 0,
+    wishlistItemsWithImage: 0,
+    wishlistImageBytes: 0,
+  },
+  instances: {},
+  instanceInfo: { currentInstance: 'local', primaryInstance: 'local' },
+};
+
+const actionDataSnapshot: {
+  value: { ok: false; message: string } | null;
+} = { value: null };
+
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual<typeof ReactRouter>('react-router');
+  return {
+    ...actual,
+    useLoaderData: () => loaderDataSnapshot,
+    useActionData: () => actionDataSnapshot.value,
+    // Form uses useSubmit internally, which requires a data router.
+    // In render tests we just want a plain <form> so the hidden
+    // <input name="intent"> fields and buttons are queryable.
+    Form: ({
+      children,
+      method,
+      className,
+    }: {
+      children?: React.ReactNode;
+      method?: string;
+      className?: string;
+    }) => (
+      <form method={method} className={className}>
+        {children}
+      </form>
+    ),
+  };
+});
+
+vi.mock('#app/utils/permissions.server.ts', () => ({
+  requireUserWithRole: vi.fn(),
+}));
+
+vi.mock('#app/utils/admin.server.ts', () => ({
+  getCleanupPreviewCounts: vi.fn(),
+  getDiskUsageCounts: vi.fn(),
+  purgeExpiredVerifications: vi.fn(),
+  purgeExpiredSessions: vi.fn(),
+  purgeStaleFriendRequests: vi.fn(),
+  purgeDeadGroupInvitations: vi.fn(),
+  expireGroupBans: vi.fn(),
+}));
+
+vi.mock('#app/utils/litefs.server.ts', () => ({
+  getAllInstances: vi.fn(),
+  getInstanceInfo: vi.fn(),
+}));
+
+import OpsRoute from './ops.tsx';
+
+const renderOps = () =>
+  render(
+    <MemoryRouter initialEntries={['/admin/ops']}>
+      <OpsRoute />
+    </MemoryRouter>,
+  );
+
+beforeEach(() => {
+  loaderDataSnapshot.cleanup = {
+    expiredVerifications: 0,
+    expiredSessions: 0,
+    stalePendingFriendRequests: 0,
+    staleRejectedFriendRequests: 0,
+    revokedOrExpiredGroupInvitations: 0,
+    expiredGroupBans: 0,
+  };
+  loaderDataSnapshot.disk = {
+    wishlistItemTotal: 0,
+    wishlistItemsWithImage: 0,
+    wishlistImageBytes: 0,
+  };
+  loaderDataSnapshot.instances = {};
+  loaderDataSnapshot.instanceInfo = {
+    currentInstance: 'local',
+    primaryInstance: 'local',
+  };
+  actionDataSnapshot.value = null;
+});
+
+describe('admin ops page — cleanup jobs', () => {
+  it('renders all five cleanup job cards with their titles and descriptions', () => {
+    renderOps();
+
+    expect(
+      screen.getByRole('heading', { name: 'Ops' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Cleanup queue' }),
+    ).toBeInTheDocument();
+
+    // Each job card has a title
+    expect(
+      screen.getByRole('heading', { name: 'Expired verifications' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Expired sessions' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Stale friend requests' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Dead group invitations' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Expired group bans' }),
+    ).toBeInTheDocument();
+  });
+
+  it('disables cleanup buttons when counts are zero', () => {
+    renderOps();
+    const buttons = screen.getAllByRole('button', { name: 'Nothing to do' });
+    expect(buttons).toHaveLength(5);
+    for (const btn of buttons) {
+      expect(btn).toBeDisabled();
+    }
+  });
+
+  it('enables buttons and shows the action verb + count when counts are non-zero', () => {
+    loaderDataSnapshot.cleanup = {
+      expiredVerifications: 3,
+      expiredSessions: 7,
+      stalePendingFriendRequests: 2,
+      staleRejectedFriendRequests: 1,
+      revokedOrExpiredGroupInvitations: 4,
+      expiredGroupBans: 5,
+    };
+    renderOps();
+
+    // verifications (3) + friend requests (2+1=3) → two "Delete 3" buttons
+    expect(screen.getAllByRole('button', { name: 'Delete 3' })).toHaveLength(2);
+    expect(
+      screen.getByRole('button', { name: 'Delete 7' }),
+    ).toBeEnabled();
+    expect(
+      screen.getByRole('button', { name: 'Delete 4' }),
+    ).toBeEnabled();
+    // Expire 5 — group bans (verb = "Lift", count = 5)
+    expect(screen.getByRole('button', { name: 'Lift 5' })).toBeEnabled();
+    // None of the cleanup buttons should be the disabled "Nothing to do" one
+    expect(
+      screen.queryByRole('button', { name: 'Nothing to do' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('surfaces each cleanup intent via a hidden form field', () => {
+    const { container } = renderOps();
+    const intents = Array.from(
+      container.querySelectorAll('input[name="intent"]'),
+    ).map((el) => el.getAttribute('value'));
+    expect(intents).toEqual(
+      expect.arrayContaining([
+        'purge_verifications',
+        'purge_sessions',
+        'purge_friend_requests',
+        'purge_group_invitations',
+        'expire_group_bans',
+      ]),
+    );
+    expect(intents).toHaveLength(5);
+  });
+});
+
+describe('admin ops page — disk usage', () => {
+  it('renders the disk usage summary cards', () => {
+    loaderDataSnapshot.disk = {
+      wishlistItemTotal: 64,
+      wishlistItemsWithImage: 16,
+      wishlistImageBytes: 351883,
+    };
+    renderOps();
+
+    expect(
+      screen.getByRole('heading', { name: 'Disk usage' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Wishlist items')).toBeInTheDocument();
+    expect(screen.getByText('64')).toBeInTheDocument();
+    expect(screen.getByText(/16 with inline image/)).toBeInTheDocument();
+    // 351883 bytes → 343.6 KB
+    expect(screen.getByText('343.6 KB')).toBeInTheDocument();
+    // Average = 351883 / 16 ≈ 21.5 KB
+    expect(screen.getByText('21.5 KB')).toBeInTheDocument();
+  });
+
+  it('renders an em-dash when no items have inline images', () => {
+    renderOps();
+    expect(screen.getByText('—')).toBeInTheDocument();
+  });
+});
+
+describe('admin ops page — instance panel', () => {
+  it('renders the LiteFS instances with current + primary tags', () => {
+    loaderDataSnapshot.instances = {
+      'inst-a': 'ord',
+      'inst-b': 'fra',
+    };
+    loaderDataSnapshot.instanceInfo = {
+      currentInstance: 'inst-a',
+      primaryInstance: 'inst-a',
+    };
+    renderOps();
+
+    expect(
+      screen.getByRole('heading', { name: 'LiteFS instances' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/inst-a/)).toBeInTheDocument();
+    expect(screen.getByText(/inst-b/)).toBeInTheDocument();
+    expect(screen.getByText('current')).toBeInTheDocument();
+    expect(screen.getByText('primary')).toBeInTheDocument();
+  });
+
+  it('falls back to a single-instance message when no instances exist', () => {
+    renderOps();
+    expect(
+      screen.getByText(/Single-instance mode/),
+    ).toBeInTheDocument();
+  });
+});
+
+describe('admin ops page — cache inspector link', () => {
+  it('links to /admin/cache', () => {
+    renderOps();
+    const link = screen.getByRole('link', { name: /Open/ });
+    expect(link).toHaveAttribute('href', '/admin/cache');
+  });
+});
+
+describe('admin ops page — action error banner', () => {
+  it('renders the error banner when the action returns ok: false', () => {
+    actionDataSnapshot.value = {
+      ok: false,
+      message: 'Cleanup failed: something went wrong.',
+    };
+    renderOps();
+    expect(
+      screen.getByText('Cleanup failed: something went wrong.'),
+    ).toBeInTheDocument();
+  });
+});

--- a/app/routes/admin+/ops.test.ts
+++ b/app/routes/admin+/ops.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from 'vitest';
+import { action, loader } from '#app/routes/admin+/ops.tsx';
+import { prisma } from '#app/utils/db.server.ts';
+import { createUser } from '#tests/db-utils.ts';
+import {
+  getRouteResultData,
+  getRouteResultStatus,
+  toActionArgs,
+  toLoaderArgs,
+} from '#tests/route-module-test-utils.ts';
+import { getSessionCookieHeader } from '#tests/utils.ts';
+
+const DAY_MS = 1000 * 60 * 60 * 24;
+
+async function seedAdminSession() {
+  await prisma.role.upsert({
+    where: { name: 'admin' },
+    update: {},
+    create: { name: 'admin', description: 'Admin role' },
+  });
+  const admin = await prisma.user.create({
+    data: { ...createUser(), roles: { connect: { name: 'admin' } } },
+    select: { id: true },
+  });
+  const session = await prisma.session.create({
+    data: { userId: admin.id, expirationDate: new Date(Date.now() + DAY_MS) },
+  });
+  const cookie = await getSessionCookieHeader(session);
+  return { admin, cookie };
+}
+
+describe('/admin/ops loader', () => {
+  it('rejects non-admin users', async () => {
+    const user = await prisma.user.create({ data: createUser() });
+    const session = await prisma.session.create({
+      data: { userId: user.id, expirationDate: new Date(Date.now() + DAY_MS) },
+    });
+    const cookie = await getSessionCookieHeader(session);
+    const request = new Request('http://localhost/admin/ops', {
+      headers: { cookie },
+    });
+
+    await expect(
+      loader(toLoaderArgs({ request, params: {}, context: {} as any })),
+    ).rejects.toMatchObject({ init: { status: 403 } });
+  });
+
+  it('returns cleanup preview + disk usage for admin', async () => {
+    const { cookie } = await seedAdminSession();
+    const request = new Request('http://localhost/admin/ops', {
+      headers: { cookie },
+    });
+
+    const result = await loader(
+      toLoaderArgs({ request, params: {}, context: {} as any }),
+    );
+    expect(getRouteResultStatus(result)).toBe(200);
+    const data = await getRouteResultData<{
+      cleanup: { expiredVerifications: number };
+      disk: { wishlistItemTotal: number };
+    }>(result);
+    expect(typeof data.cleanup.expiredVerifications).toBe('number');
+    expect(typeof data.disk.wishlistItemTotal).toBe('number');
+  });
+});
+
+describe('/admin/ops action', () => {
+  it('rejects invalid intents', async () => {
+    const { cookie } = await seedAdminSession();
+    const formData = new FormData();
+    formData.append('intent', 'bogus');
+    const request = new Request('http://localhost/admin/ops', {
+      method: 'POST',
+      headers: { cookie },
+      body: formData,
+    });
+
+    // invariantResponse throws a Response directly (not a react-router
+    // data() envelope), so assert on the Response status.
+    try {
+      await action(toActionArgs({ request, params: {}, context: {} as any }));
+      throw new Error('expected action to throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(Response);
+      expect((err as Response).status).toBe(400);
+    }
+  });
+
+  it('purges expired verifications and redirects', async () => {
+    const { cookie } = await seedAdminSession();
+    await prisma.verification.create({
+      data: {
+        type: '2fa',
+        target: 'expired-target',
+        secret: 'abc',
+        algorithm: 'SHA1',
+        digits: 6,
+        period: 30,
+        charSet: '0123456789',
+        expiresAt: new Date(Date.now() - DAY_MS),
+      },
+    });
+
+    const formData = new FormData();
+    formData.append('intent', 'purge_verifications');
+    const request = new Request('http://localhost/admin/ops', {
+      method: 'POST',
+      headers: { cookie },
+      body: formData,
+    });
+
+    const result = await action(
+      toActionArgs({ request, params: {}, context: {} as any }),
+    );
+    expect(result instanceof Response).toBe(true);
+    if (result instanceof Response) {
+      expect(result.status).toBe(302);
+      expect(result.headers.get('location')).toContain(
+        '/admin/ops?just=purge_verifications&n=1',
+      );
+    }
+
+    const remaining = await prisma.verification.count({
+      where: { target: 'expired-target' },
+    });
+    expect(remaining).toBe(0);
+  });
+
+  it('expires group bans', async () => {
+    const { cookie } = await seedAdminSession();
+    const user = await prisma.user.create({ data: createUser() });
+    const group = await prisma.giftGroup.create({
+      data: { name: 'Bans', description: null },
+    });
+    await prisma.usersInGiftGroups.create({
+      data: {
+        userId: user.id,
+        giftGroupId: group.id,
+        bannedUntil: new Date(Date.now() - DAY_MS),
+      },
+    });
+
+    const formData = new FormData();
+    formData.append('intent', 'expire_group_bans');
+    const request = new Request('http://localhost/admin/ops', {
+      method: 'POST',
+      headers: { cookie },
+      body: formData,
+    });
+
+    const result = await action(
+      toActionArgs({ request, params: {}, context: {} as any }),
+    );
+    expect(result instanceof Response).toBe(true);
+
+    const row = await prisma.usersInGiftGroups.findUniqueOrThrow({
+      where: {
+        userId_giftGroupId: { userId: user.id, giftGroupId: group.id },
+      },
+    });
+    expect(row.bannedUntil).toBeNull();
+  });
+});

--- a/app/routes/admin+/ops.tsx
+++ b/app/routes/admin+/ops.tsx
@@ -6,6 +6,7 @@ import {
   redirect,
   useActionData,
   useLoaderData,
+  useSearchParams,
   type ActionFunctionArgs,
   type LoaderFunctionArgs,
 } from 'react-router';
@@ -189,10 +190,13 @@ const OpsRoute = () => {
       ? actionData.message
       : null;
 
-  const url =
-    typeof window !== 'undefined' ? new URL(window.location.href) : null;
-  const justIntent = url?.searchParams.get('just') as Intent | null;
-  const justCount = Number(url?.searchParams.get('n') ?? 0);
+  const [searchParams] = useSearchParams();
+  const justIntentParam = searchParams.get('just');
+  const justIntent =
+    justIntentParam && INTENTS.has(justIntentParam)
+      ? (justIntentParam as Intent)
+      : null;
+  const justCount = Number(searchParams.get('n') ?? 0);
 
   return (
     <div className="space-y-6">
@@ -209,7 +213,7 @@ const OpsRoute = () => {
           {actionError}
         </div>
       ) : null}
-      {justIntent && INTENTS.has(justIntent) ? (
+      {justIntent ? (
         <div className="rounded-md border border-emerald-400/50 bg-emerald-50/60 p-3 text-sm text-emerald-900 dark:bg-emerald-950/20 dark:text-emerald-200">
           {INTENT_LABEL[justIntent]}: {justCount}{' '}
           {justCount === 1 ? 'row' : 'rows'}{' '}
@@ -336,6 +340,15 @@ const CleanupJobCard = ({
   const total = primary + secondary;
   const isEmpty = total === 0;
 
+  let buttonLabel: string;
+  if (isEmpty) {
+    buttonLabel = 'Nothing to do';
+  } else if (dc.doubleCheck) {
+    buttonLabel = 'Click again to confirm';
+  } else {
+    buttonLabel = `${job.verb} ${total.toLocaleString()}`;
+  }
+
   return (
     <div className="rounded-xl border border-border/60 bg-card p-4 shadow-sm">
       <div className="flex items-start justify-between gap-3">
@@ -364,11 +377,7 @@ const CleanupJobCard = ({
           disabled={isEmpty}
           {...dc.getButtonProps({ type: 'submit' })}
         >
-          {isEmpty
-            ? 'Nothing to do'
-            : dc.doubleCheck
-              ? 'Click again to confirm'
-              : `${job.verb} ${total.toLocaleString()}`}
+          {buttonLabel}
         </Button>
       </Form>
     </div>

--- a/app/routes/admin+/ops.tsx
+++ b/app/routes/admin+/ops.tsx
@@ -1,0 +1,382 @@
+import { invariantResponse } from '@epic-web/invariant';
+import { LuDatabase, LuHardDrive } from 'react-icons/lu';
+import {
+  Form,
+  Link,
+  redirect,
+  useActionData,
+  useLoaderData,
+  type ActionFunctionArgs,
+  type LoaderFunctionArgs,
+} from 'react-router';
+import { EmptyRow, SectionCard, SummaryCard } from '#app/components/admin-ui.tsx';
+import { GeneralErrorBoundary } from '#app/components/error-boundary.tsx';
+import { Button } from '#app/components/ui/button.tsx';
+import {
+  expireGroupBans,
+  getCleanupPreviewCounts,
+  getDiskUsageCounts,
+  purgeDeadGroupInvitations,
+  purgeExpiredSessions,
+  purgeExpiredVerifications,
+  purgeStaleFriendRequests,
+  type CleanupPreviewCounts,
+} from '#app/utils/admin.server.ts';
+import { getAllInstances, getInstanceInfo } from '#app/utils/litefs.server.ts';
+import { useDoubleCheck } from '#app/utils/misc.tsx';
+import { requireUserWithRole } from '#app/utils/permissions.server.ts';
+
+type Intent =
+  | 'purge_verifications'
+  | 'purge_sessions'
+  | 'purge_friend_requests'
+  | 'purge_group_invitations'
+  | 'expire_group_bans';
+
+const INTENTS: ReadonlySet<string> = new Set<Intent>([
+  'purge_verifications',
+  'purge_sessions',
+  'purge_friend_requests',
+  'purge_group_invitations',
+  'expire_group_bans',
+]);
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  await requireUserWithRole(request, 'admin');
+
+  const [cleanup, disk, instances, instanceInfo] = await Promise.all([
+    getCleanupPreviewCounts(),
+    getDiskUsageCounts(),
+    getAllInstances(),
+    getInstanceInfo(),
+  ]);
+
+  return { cleanup, disk, instances, instanceInfo };
+}
+
+type ActionResult =
+  | { ok: true; intent: Intent; changed: number }
+  | { ok: false; message: string };
+
+export async function action({
+  request,
+}: ActionFunctionArgs): Promise<ActionResult | Response> {
+  await requireUserWithRole(request, 'admin');
+
+  const formData = await request.formData();
+  const intent = formData.get('intent');
+  invariantResponse(
+    typeof intent === 'string' && INTENTS.has(intent),
+    'Invalid intent',
+    { status: 400 },
+  );
+
+  try {
+    let changed = 0;
+    switch (intent as Intent) {
+      case 'purge_verifications': {
+        const result = await purgeExpiredVerifications();
+        changed = result.deleted;
+        break;
+      }
+      case 'purge_sessions': {
+        const result = await purgeExpiredSessions();
+        changed = result.deleted;
+        break;
+      }
+      case 'purge_friend_requests': {
+        const result = await purgeStaleFriendRequests();
+        changed = result.deleted;
+        break;
+      }
+      case 'purge_group_invitations': {
+        const result = await purgeDeadGroupInvitations();
+        changed = result.deleted;
+        break;
+      }
+      case 'expire_group_bans': {
+        const result = await expireGroupBans();
+        changed = result.updated;
+        break;
+      }
+    }
+    // LiteFS replica forwarding note: the write above was forwarded to the
+    // primary (if we're on a replica). The loader revalidation below reads
+    // the local replica, which may briefly lag — the loader hits lruCache
+    // anyway, so the next page render will show the post-purge count after
+    // invalidateCleanupPreviewCache() runs in the helper.
+    return redirect(`/admin/ops?just=${intent}&n=${changed}`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Cleanup failed';
+    return { ok: false, message };
+  }
+}
+
+const formatBytes = (bytes: number) => {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 * 1024 * 1024)
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+};
+
+const INTENT_LABEL: Record<Intent, string> = {
+  purge_verifications: 'Expired verification rows',
+  purge_sessions: 'Expired sessions',
+  purge_friend_requests: 'Stale friend requests',
+  purge_group_invitations: 'Dead group invitations',
+  expire_group_bans: 'Expired group bans',
+};
+
+type CleanupJobConfig = {
+  intent: Intent;
+  title: string;
+  description: string;
+  countKey: keyof CleanupPreviewCounts;
+  secondaryCountKey?: keyof CleanupPreviewCounts;
+  verb: 'Delete' | 'Lift';
+};
+
+const JOBS: ReadonlyArray<CleanupJobConfig> = [
+  {
+    intent: 'purge_verifications',
+    title: 'Expired verifications',
+    description:
+      '2FA setup / password reset / email change OTPs past their expiry.',
+    countKey: 'expiredVerifications',
+    verb: 'Delete',
+  },
+  {
+    intent: 'purge_sessions',
+    title: 'Expired sessions',
+    description:
+      'Session rows whose expiration has passed. Prisma does not auto-expire.',
+    countKey: 'expiredSessions',
+    verb: 'Delete',
+  },
+  {
+    intent: 'purge_friend_requests',
+    title: 'Stale friend requests',
+    description:
+      'PENDING older than 30 days or REJECTED older than 90 days.',
+    countKey: 'stalePendingFriendRequests',
+    secondaryCountKey: 'staleRejectedFriendRequests',
+    verb: 'Delete',
+  },
+  {
+    intent: 'purge_group_invitations',
+    title: 'Dead group invitations',
+    description:
+      'Revoked or expired invite links with zero uses. Used links stay for history.',
+    countKey: 'revokedOrExpiredGroupInvitations',
+    verb: 'Delete',
+  },
+  {
+    intent: 'expire_group_bans',
+    title: 'Expired group bans',
+    description: 'Lift group bans whose bannedUntil is already in the past.',
+    countKey: 'expiredGroupBans',
+    verb: 'Lift',
+  },
+];
+
+const OpsRoute = () => {
+  const { cleanup, disk, instances, instanceInfo } =
+    useLoaderData<typeof loader>();
+  const actionData = useActionData<typeof action>();
+  const actionError =
+    actionData && 'ok' in actionData && !actionData.ok
+      ? actionData.message
+      : null;
+
+  const url =
+    typeof window !== 'undefined' ? new URL(window.location.href) : null;
+  const justIntent = url?.searchParams.get('just') as Intent | null;
+  const justCount = Number(url?.searchParams.get('n') ?? 0);
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-1">
+        <h1 className="text-h1">Ops</h1>
+        <p className="text-muted-foreground">
+          Cleanup jobs, disk usage, and LiteFS instance info. All purges are
+          idempotent — running them twice is safe.
+        </p>
+      </div>
+
+      {actionError ? (
+        <div className="rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
+          {actionError}
+        </div>
+      ) : null}
+      {justIntent && INTENTS.has(justIntent) ? (
+        <div className="rounded-md border border-emerald-400/50 bg-emerald-50/60 p-3 text-sm text-emerald-900 dark:bg-emerald-950/20 dark:text-emerald-200">
+          {INTENT_LABEL[justIntent]}: {justCount}{' '}
+          {justCount === 1 ? 'row' : 'rows'}{' '}
+          {justIntent === 'expire_group_bans' ? 'lifted' : 'deleted'}.
+        </div>
+      ) : null}
+
+      {/* --- cleanup jobs --- */}
+      <section className="space-y-4">
+        <h2 className="text-h2">Cleanup queue</h2>
+        <div className="grid gap-4 md:grid-cols-2">
+          {JOBS.map((job) => (
+            <CleanupJobCard key={job.intent} job={job} cleanup={cleanup} />
+          ))}
+        </div>
+      </section>
+
+      {/* --- disk usage --- */}
+      <section className="space-y-4">
+        <h2 className="text-h2">Disk usage</h2>
+        <div className="grid gap-4 md:grid-cols-3">
+          <SummaryCard
+            label="Wishlist items"
+            value={disk.wishlistItemTotal}
+            delta={`${disk.wishlistItemsWithImage} with inline image`}
+          />
+          <SummaryCard
+            label="Wishlist image bytes"
+            value={formatBytes(disk.wishlistImageBytes)}
+            tone={
+              disk.wishlistImageBytes > 500 * 1024 * 1024 ? 'warn' : 'default'
+            }
+            delta="WishlistItem.image is inlined in SQLite"
+          />
+          <SummaryCard
+            label="Average image size"
+            value={
+              disk.wishlistItemsWithImage > 0
+                ? formatBytes(
+                    disk.wishlistImageBytes / disk.wishlistItemsWithImage,
+                  )
+                : '—'
+            }
+          />
+        </div>
+      </section>
+
+      {/* --- instance info --- */}
+      <section className="grid gap-4 lg:grid-cols-2">
+        <SectionCard
+          title="LiteFS instances"
+          description="Current instance routing. Writes forward to the primary."
+        >
+          {Object.entries(instances).length === 0 ? (
+            <EmptyRow>Single-instance mode.</EmptyRow>
+          ) : (
+            <ul className="divide-y divide-border/60 text-sm">
+              {Object.entries(instances).map(([inst, region]) => {
+                const isCurrent = inst === instanceInfo.currentInstance;
+                const isPrimary = inst === instanceInfo.primaryInstance;
+                return (
+                  <li
+                    key={inst}
+                    className="flex items-center justify-between py-1.5"
+                  >
+                    <span className="font-mono">
+                      {inst} <span className="text-muted-foreground">({region})</span>
+                    </span>
+                    <span className="flex gap-1 text-xs">
+                      {isCurrent ? (
+                        <span className="rounded-md bg-primary/10 px-2 py-0.5 font-semibold text-primary">
+                          current
+                        </span>
+                      ) : null}
+                      {isPrimary ? (
+                        <span className="rounded-md bg-emerald-500/10 px-2 py-0.5 font-semibold text-emerald-700 dark:text-emerald-300">
+                          primary
+                        </span>
+                      ) : null}
+                    </span>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </SectionCard>
+
+        <SectionCard
+          title="Cache inspector"
+          description="Search / delete LRU + SQLite cache entries."
+          action={
+            <Link
+              to="/admin/cache"
+              className="text-sm font-medium text-primary hover:underline"
+            >
+              Open →
+            </Link>
+          }
+        >
+          <div className="flex items-center gap-3 rounded-md border border-border/60 bg-muted/20 p-3 text-sm text-muted-foreground">
+            <LuDatabase className="h-5 w-5 shrink-0" />
+            <p>
+              The cache inspector is still at <code>/admin/cache</code>. It
+              shows the SQLite-backed cache (LiteFS-replicated) and the
+              in-memory LRU cache (instance-local).
+            </p>
+          </div>
+        </SectionCard>
+      </section>
+    </div>
+  );
+};
+
+const CleanupJobCard = ({
+  job,
+  cleanup,
+}: {
+  job: CleanupJobConfig;
+  cleanup: CleanupPreviewCounts;
+}) => {
+  const dc = useDoubleCheck();
+  const primary = cleanup[job.countKey];
+  const secondary = job.secondaryCountKey ? cleanup[job.secondaryCountKey] : 0;
+  const total = primary + secondary;
+  const isEmpty = total === 0;
+
+  return (
+    <div className="rounded-xl border border-border/60 bg-card p-4 shadow-sm">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <LuHardDrive className="h-4 w-4 text-muted-foreground" />
+            <h3 className="text-base font-semibold">{job.title}</h3>
+          </div>
+          <p className="mt-1 text-sm text-muted-foreground">{job.description}</p>
+        </div>
+        <span
+          className={
+            isEmpty
+              ? 'rounded-md bg-muted px-2 py-0.5 text-xs font-semibold tabular-nums text-muted-foreground'
+              : 'rounded-md bg-amber-500/10 px-2 py-0.5 text-xs font-semibold tabular-nums text-amber-700 dark:text-amber-300'
+          }
+        >
+          {total.toLocaleString()}
+        </span>
+      </div>
+      <Form method="POST" className="mt-3">
+        <input type="hidden" name="intent" value={job.intent} />
+        <Button
+          variant={isEmpty ? 'secondary' : 'default'}
+          size="sm"
+          disabled={isEmpty}
+          {...dc.getButtonProps({ type: 'submit' })}
+        >
+          {isEmpty
+            ? 'Nothing to do'
+            : dc.doubleCheck
+              ? 'Click again to confirm'
+              : `${job.verb} ${total.toLocaleString()}`}
+        </Button>
+      </Form>
+    </div>
+  );
+};
+
+export default OpsRoute;
+
+export const ErrorBoundary = () => {
+  return <GeneralErrorBoundary />;
+};

--- a/app/routes/wishlist+/purchase.ts
+++ b/app/routes/wishlist+/purchase.ts
@@ -1,6 +1,7 @@
 import { parseWithZod } from '@conform-to/zod';
 import { data, type ActionFunctionArgs } from 'react-router';
 import { z } from 'zod';
+import { queueLogEvent } from '#app/utils/analytics.server.ts';
 import { requireUserId } from '#app/utils/auth.server.ts';
 import { prisma } from '#app/utils/db.server.ts';
 import { usersShareWishlistAccess } from '#app/utils/wishlist.server.ts';
@@ -134,6 +135,15 @@ export async function action({ request }: ActionFunctionArgs) {
       },
       update: {
         purchasedById: userId,
+      },
+    });
+    queueLogEvent({
+      name: 'wishlist_purchase_recorded',
+      userId,
+      source: 'server',
+      properties: {
+        wishlistItemId,
+        ownerId: wishlistItem.ownerId,
       },
     });
     return {

--- a/app/utils/admin.server.test.ts
+++ b/app/utils/admin.server.test.ts
@@ -274,12 +274,13 @@ describe('cleanup preview + purges', () => {
     ]);
     await prisma.friendRequest.createMany({
       data: [
-        // stale PENDING
+        // stale PENDING — both createdAt AND updatedAt past the cutoff
         {
           fromUserId: a.id,
           toUserId: b.id,
           status: 'PENDING',
           createdAt: daysAgo(45),
+          updatedAt: daysAgo(45),
         },
         // fresh PENDING — must survive
         {
@@ -287,6 +288,7 @@ describe('cleanup preview + purges', () => {
           toUserId: d.id,
           status: 'PENDING',
           createdAt: daysAgo(5),
+          updatedAt: daysAgo(5),
         },
         // stale REJECTED
         {
@@ -294,6 +296,7 @@ describe('cleanup preview + purges', () => {
           toUserId: f.id,
           status: 'REJECTED',
           createdAt: daysAgo(120),
+          updatedAt: daysAgo(120),
         },
       ],
     });
@@ -309,6 +312,34 @@ describe('cleanup preview + purges', () => {
       select: { status: true },
     });
     expect(remaining).toEqual([{ status: 'PENDING' }]);
+  });
+
+  it('stale friend requests: preserves rows that were re-opened recently even if createdAt is old', async () => {
+    // Regression: sendFriendRequest upserts existing rows and flips
+    // status back to PENDING. A row that was first created 100 days ago
+    // but reopened TODAY has a stale createdAt but a fresh updatedAt.
+    // The purge must key on updatedAt, not createdAt.
+    const [a, b] = await Promise.all([
+      prisma.user.create({ data: createUser() }),
+      prisma.user.create({ data: createUser() }),
+    ]);
+    await prisma.friendRequest.create({
+      data: {
+        fromUserId: a.id,
+        toUserId: b.id,
+        status: 'PENDING',
+        createdAt: daysAgo(100),
+        // updatedAt defaults to now() via @updatedAt
+      },
+    });
+
+    const preview = await getCleanupPreviewCounts();
+    expect(preview.stalePendingFriendRequests).toBe(0);
+
+    const result = await purgeStaleFriendRequests();
+    expect(result.deleted).toBe(0);
+
+    expect(await prisma.friendRequest.count()).toBe(1);
   });
 
   it('dead group invitations: only deletes unused revoked/expired rows', async () => {

--- a/app/utils/admin.server.test.ts
+++ b/app/utils/admin.server.test.ts
@@ -1,0 +1,454 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  expireGroupBans,
+  getCleanupPreviewCounts,
+  getDiskUsageCounts,
+  getOverviewCounts,
+  getRecentActivity,
+  getStuckPools,
+  purgeDeadGroupInvitations,
+  purgeExpiredSessions,
+  purgeExpiredVerifications,
+  purgeStaleFriendRequests,
+} from '#app/utils/admin.server.ts';
+import { lruCache } from '#app/utils/cache.server.ts';
+import { prisma } from '#app/utils/db.server.ts';
+import { POOL_STATUS } from '#app/utils/pool-constants.ts';
+import { createUser } from '#tests/db-utils.ts';
+
+const DAY_MS = 1000 * 60 * 60 * 24;
+const daysAgo = (n: number) => new Date(Date.now() - n * DAY_MS);
+
+// Every admin helper is cached in lruCache with 60s TTL. We purge the keys
+// between tests so each `it` block sees a cold cache.
+beforeEach(() => {
+  const keys = [
+    'admin:overview:counts:v1',
+    'admin:overview:cleanup-preview:v1',
+    'admin:ops:disk-usage:v1',
+  ];
+  for (const key of keys) lruCache.delete(key);
+  for (let n = 1; n <= 20; n++)
+    lruCache.delete(`admin:overview:stuck-pools:v1:${n}`);
+});
+
+async function seedAdmin() {
+  await prisma.role.upsert({
+    where: { name: 'admin' },
+    update: {},
+    create: { name: 'admin', description: 'Admin role' },
+  });
+  return prisma.user.create({
+    data: {
+      ...createUser(),
+      roles: { connect: { name: 'admin' } },
+    },
+    select: { id: true },
+  });
+}
+
+describe('getOverviewCounts', () => {
+  it('returns zeros against an empty database', async () => {
+    const counts = await getOverviewCounts();
+    expect(counts.users.total).toBe(0);
+    expect(counts.pools.total).toBe(0);
+    expect(counts.pools.stuck).toBe(0);
+    expect(counts.pools.active).toBe(0);
+    expect(counts.wishlist.items).toBe(0);
+    expect(counts.friendships.total).toBe(0);
+  });
+
+  it('counts users by window', async () => {
+    await prisma.user.create({ data: createUser() });
+    await prisma.user.create({
+      data: { ...createUser(), createdAt: daysAgo(10) },
+    });
+    await prisma.user.create({
+      data: { ...createUser(), createdAt: daysAgo(45) },
+    });
+
+    const counts = await getOverviewCounts();
+    expect(counts.users.total).toBe(3);
+    expect(counts.users.last24h).toBe(1);
+    expect(counts.users.last7d).toBe(1);
+    expect(counts.users.last30d).toBe(2);
+  });
+
+  it('detects stuck OPEN pools (event date past)', async () => {
+    const user = await prisma.user.create({ data: createUser() });
+    await prisma.pool.create({
+      data: {
+        title: 'Overdue pool',
+        organizerId: user.id,
+        status: POOL_STATUS.OPEN,
+        eventDate: daysAgo(2),
+      },
+    });
+
+    const counts = await getOverviewCounts();
+    expect(counts.pools.stuck).toBe(1);
+    expect(counts.pools.byStatus.OPEN).toBe(1);
+  });
+
+  it('detects stuck VOTING pools (no votes, stale updatedAt)', async () => {
+    const user = await prisma.user.create({ data: createUser() });
+    await prisma.pool.create({
+      data: {
+        title: 'Stale vote',
+        organizerId: user.id,
+        status: POOL_STATUS.VOTING,
+        updatedAt: daysAgo(10),
+      },
+    });
+
+    const counts = await getOverviewCounts();
+    expect(counts.pools.stuck).toBe(1);
+  });
+
+  it('does not flag VOTING pools that have votes even if old', async () => {
+    const user = await prisma.user.create({ data: createUser() });
+    const pool = await prisma.pool.create({
+      data: {
+        title: 'Voting but active',
+        organizerId: user.id,
+        status: POOL_STATUS.VOTING,
+        updatedAt: daysAgo(10),
+        contributors: { create: { userId: user.id } },
+      },
+    });
+    const idea = await prisma.giftIdea.create({
+      data: { poolId: pool.id, proposedById: user.id, name: 'something' },
+    });
+    await prisma.ideaVote.create({
+      data: { poolId: pool.id, ideaId: idea.id, voterId: user.id },
+    });
+
+    const counts = await getOverviewCounts();
+    expect(counts.pools.stuck).toBe(0);
+  });
+
+  it('counts wishlist items split by status', async () => {
+    const user = await prisma.user.create({ data: createUser() });
+    await prisma.wishlistItem.createMany({
+      data: [
+        {
+          ownerId: user.id,
+          title: 'a',
+          sortOrder: 0,
+          type: 'text',
+          status: 'ACTIVE',
+        },
+        {
+          ownerId: user.id,
+          title: 'b',
+          sortOrder: 1,
+          type: 'text',
+          status: 'ARCHIVED',
+        },
+      ],
+    });
+
+    const counts = await getOverviewCounts();
+    expect(counts.wishlist.items).toBe(2);
+    expect(counts.wishlist.active).toBe(1);
+    expect(counts.wishlist.archived).toBe(1);
+  });
+});
+
+describe('getStuckPools', () => {
+  it('returns a classified stuck-pool list', async () => {
+    const user = await prisma.user.create({ data: createUser() });
+    const overdue = await prisma.pool.create({
+      data: {
+        title: 'Overdue birthday',
+        organizerId: user.id,
+        status: POOL_STATUS.OPEN,
+        eventDate: daysAgo(3),
+        contributors: { create: { userId: user.id } },
+      },
+      select: { id: true },
+    });
+    await prisma.pool.create({
+      data: {
+        title: 'Decided long ago',
+        organizerId: user.id,
+        status: POOL_STATUS.DECIDED,
+        updatedAt: daysAgo(20),
+        contributors: { create: { userId: user.id } },
+      },
+    });
+
+    const stuck = await getStuckPools(10);
+    expect(stuck).toHaveLength(2);
+    const byReason = Object.fromEntries(stuck.map((p) => [p.reason, p]));
+    expect(byReason.open_overdue?.id).toBe(overdue.id);
+    expect(byReason.open_overdue?.contributorCount).toBe(1);
+    expect(byReason.decided_stalled).toBeDefined();
+  });
+
+  it('returns an empty array when nothing is stuck', async () => {
+    const user = await prisma.user.create({ data: createUser() });
+    await prisma.pool.create({
+      data: {
+        title: 'Fresh pool',
+        organizerId: user.id,
+        status: POOL_STATUS.OPEN,
+        eventDate: new Date(Date.now() + 7 * DAY_MS),
+      },
+    });
+    expect(await getStuckPools(10)).toEqual([]);
+  });
+});
+
+describe('cleanup preview + purges', () => {
+  it('expired verifications: preview matches purge, and purge is idempotent', async () => {
+    await prisma.verification.create({
+      data: {
+        type: '2fa',
+        target: 'expired-user',
+        secret: 'abc',
+        algorithm: 'SHA1',
+        digits: 6,
+        period: 30,
+        charSet: '0123456789',
+        expiresAt: daysAgo(1),
+      },
+    });
+    await prisma.verification.create({
+      data: {
+        type: '2fa',
+        target: 'valid-user',
+        secret: 'def',
+        algorithm: 'SHA1',
+        digits: 6,
+        period: 30,
+        charSet: '0123456789',
+        expiresAt: new Date(Date.now() + DAY_MS),
+      },
+    });
+
+    const preview = await getCleanupPreviewCounts();
+    expect(preview.expiredVerifications).toBe(1);
+
+    const first = await purgeExpiredVerifications();
+    expect(first.deleted).toBe(1);
+
+    const second = await purgeExpiredVerifications();
+    expect(second.deleted).toBe(0);
+
+    // The valid row is untouched.
+    const remaining = await prisma.verification.count();
+    expect(remaining).toBe(1);
+  });
+
+  it('expired sessions: preview matches purge', async () => {
+    const user = await prisma.user.create({ data: createUser() });
+    await prisma.session.create({
+      data: { userId: user.id, expirationDate: daysAgo(1) },
+    });
+    await prisma.session.create({
+      data: {
+        userId: user.id,
+        expirationDate: new Date(Date.now() + DAY_MS),
+      },
+    });
+
+    const preview = await getCleanupPreviewCounts();
+    expect(preview.expiredSessions).toBe(1);
+
+    const result = await purgeExpiredSessions();
+    expect(result.deleted).toBe(1);
+
+    const second = await purgeExpiredSessions();
+    expect(second.deleted).toBe(0);
+  });
+
+  it('stale friend requests: deletes PENDING >30d and REJECTED >90d together', async () => {
+    const [a, b, c, d, e, f] = await Promise.all([
+      prisma.user.create({ data: createUser() }),
+      prisma.user.create({ data: createUser() }),
+      prisma.user.create({ data: createUser() }),
+      prisma.user.create({ data: createUser() }),
+      prisma.user.create({ data: createUser() }),
+      prisma.user.create({ data: createUser() }),
+    ]);
+    await prisma.friendRequest.createMany({
+      data: [
+        // stale PENDING
+        {
+          fromUserId: a.id,
+          toUserId: b.id,
+          status: 'PENDING',
+          createdAt: daysAgo(45),
+        },
+        // fresh PENDING — must survive
+        {
+          fromUserId: c.id,
+          toUserId: d.id,
+          status: 'PENDING',
+          createdAt: daysAgo(5),
+        },
+        // stale REJECTED
+        {
+          fromUserId: e.id,
+          toUserId: f.id,
+          status: 'REJECTED',
+          createdAt: daysAgo(120),
+        },
+      ],
+    });
+
+    const preview = await getCleanupPreviewCounts();
+    expect(preview.stalePendingFriendRequests).toBe(1);
+    expect(preview.staleRejectedFriendRequests).toBe(1);
+
+    const result = await purgeStaleFriendRequests();
+    expect(result.deleted).toBe(2);
+
+    const remaining = await prisma.friendRequest.findMany({
+      select: { status: true },
+    });
+    expect(remaining).toEqual([{ status: 'PENDING' }]);
+  });
+
+  it('dead group invitations: only deletes unused revoked/expired rows', async () => {
+    const admin = await seedAdmin();
+    const group = await prisma.giftGroup.create({
+      data: { name: 'Test', description: null },
+    });
+    await prisma.groupInvitation.createMany({
+      data: [
+        {
+          code: 'rev1',
+          createdById: admin.id,
+          giftGroupId: group.id,
+          expiresAt: new Date(Date.now() + DAY_MS),
+          revokedAt: daysAgo(1),
+          usedCount: 0,
+        },
+        {
+          code: 'exp1',
+          createdById: admin.id,
+          giftGroupId: group.id,
+          expiresAt: daysAgo(1),
+          usedCount: 0,
+        },
+        // used-then-revoked: should stay for history
+        {
+          code: 'hist',
+          createdById: admin.id,
+          giftGroupId: group.id,
+          expiresAt: daysAgo(1),
+          revokedAt: daysAgo(1),
+          usedCount: 3,
+        },
+        // live invite
+        {
+          code: 'live',
+          createdById: admin.id,
+          giftGroupId: group.id,
+          expiresAt: new Date(Date.now() + DAY_MS),
+          usedCount: 0,
+        },
+      ],
+    });
+
+    const preview = await getCleanupPreviewCounts();
+    expect(preview.revokedOrExpiredGroupInvitations).toBe(2);
+
+    const result = await purgeDeadGroupInvitations();
+    expect(result.deleted).toBe(2);
+
+    const remaining = await prisma.groupInvitation.findMany({
+      select: { code: true },
+      orderBy: { code: 'asc' },
+    });
+    expect(remaining.map((r) => r.code)).toEqual(['hist', 'live']);
+  });
+
+  it('expire group bans: lifts past-due bans and is idempotent', async () => {
+    const user = await prisma.user.create({ data: createUser() });
+    const group = await prisma.giftGroup.create({
+      data: { name: 'Bans', description: null },
+    });
+    await prisma.usersInGiftGroups.create({
+      data: {
+        userId: user.id,
+        giftGroupId: group.id,
+        bannedUntil: daysAgo(1),
+      },
+    });
+
+    const preview = await getCleanupPreviewCounts();
+    expect(preview.expiredGroupBans).toBe(1);
+
+    const first = await expireGroupBans();
+    expect(first.updated).toBe(1);
+
+    const second = await expireGroupBans();
+    expect(second.updated).toBe(0);
+
+    const row = await prisma.usersInGiftGroups.findUniqueOrThrow({
+      where: { userId_giftGroupId: { userId: user.id, giftGroupId: group.id } },
+    });
+    expect(row.bannedUntil).toBeNull();
+  });
+});
+
+describe('getRecentActivity', () => {
+  it('unions recent users, pools, wishlist items, and friendships, newest first', async () => {
+    const alice = await prisma.user.create({ data: createUser() });
+    const bob = await prisma.user.create({ data: createUser() });
+    await prisma.pool.create({
+      data: {
+        title: 'Birthday bash',
+        organizerId: alice.id,
+      },
+    });
+    await prisma.wishlistItem.create({
+      data: {
+        ownerId: alice.id,
+        title: 'Hat',
+        sortOrder: 0,
+        type: 'text',
+      },
+    });
+    await prisma.friendship.create({
+      data: { userAId: alice.id, userBId: bob.id },
+    });
+
+    const rows = await getRecentActivity(15);
+    const kinds = rows.map((r) => r.kind).sort();
+    expect(kinds).toEqual(['friendship', 'pool', 'user', 'user', 'wishlist_item']);
+  });
+});
+
+describe('getDiskUsageCounts', () => {
+  it('reports item counts and total image bytes', async () => {
+    const user = await prisma.user.create({ data: createUser() });
+    await prisma.wishlistItem.create({
+      data: {
+        ownerId: user.id,
+        title: 'No image',
+        sortOrder: 0,
+        type: 'text',
+      },
+    });
+    await prisma.wishlistItem.create({
+      data: {
+        ownerId: user.id,
+        title: 'With image',
+        sortOrder: 1,
+        type: 'text',
+        image: Buffer.from('x'.repeat(1024)),
+        hasImage: true,
+        imageSource: 'UPLOAD',
+      },
+    });
+
+    const disk = await getDiskUsageCounts();
+    expect(disk.wishlistItemTotal).toBe(2);
+    expect(disk.wishlistItemsWithImage).toBe(1);
+    expect(disk.wishlistImageBytes).toBe(1024);
+  });
+});

--- a/app/utils/admin.server.ts
+++ b/app/utils/admin.server.ts
@@ -114,10 +114,13 @@ export async function getOverviewCounts(): Promise<OverviewCounts> {
         prisma.wishlistItem.count({ where: { status: 'ARCHIVED' } }),
         prisma.wishlistPurchase.count(),
         prisma.friendship.count(),
+        // `updatedAt`, not `createdAt`: sendFriendRequest upserts an
+        // existing row and flips status back to PENDING, so an old row
+        // can become newly active today. Staleness tracks inactivity.
         prisma.friendRequest.count({
           where: {
             status: 'PENDING',
-            createdAt: { lt: pendingFriendRequestCutoff },
+            updatedAt: { lt: pendingFriendRequestCutoff },
           },
         }),
         prisma.notification.count({
@@ -314,16 +317,20 @@ export async function getCleanupPreviewCounts(): Promise<CleanupPreviewCounts> {
         prisma.session.count({
           where: { expirationDate: { lt: now } },
         }),
+        // `updatedAt`, not `createdAt`: sendFriendRequest upserts
+        // existing rows and flips status back to PENDING, so a
+        // newly-active row could have a stale createdAt. Staleness
+        // means "no activity in N days", not "row is N days old".
         prisma.friendRequest.count({
           where: {
             status: 'PENDING',
-            createdAt: { lt: staleFriendReqCutoff },
+            updatedAt: { lt: staleFriendReqCutoff },
           },
         }),
         prisma.friendRequest.count({
           where: {
             status: 'REJECTED',
-            createdAt: { lt: rejectedRetentionCutoff },
+            updatedAt: { lt: rejectedRetentionCutoff },
           },
         }),
         prisma.groupInvitation.count({
@@ -512,17 +519,22 @@ export async function purgeExpiredSessions(): Promise<{ deleted: number }> {
 }
 
 export async function purgeStaleFriendRequests(): Promise<{ deleted: number }> {
-  // Delete PENDING older than 30d + REJECTED older than 90d in one shot.
+  // Delete PENDING > 30d + REJECTED > 90d in one shot, keyed on
+  // `updatedAt` rather than `createdAt`. sendFriendRequest upserts
+  // existing rows via Prisma and flips status back to PENDING — that
+  // bumps updatedAt but preserves createdAt. A `createdAt < 30d` filter
+  // would wrongly purge rows that were reopened today but first
+  // created a long time ago. Staleness tracks inactivity.
   const { count } = await prisma.friendRequest.deleteMany({
     where: {
       OR: [
         {
           status: 'PENDING',
-          createdAt: { lt: daysAgo(STALE_FRIEND_REQUEST_DAYS) },
+          updatedAt: { lt: daysAgo(STALE_FRIEND_REQUEST_DAYS) },
         },
         {
           status: 'REJECTED',
-          createdAt: { lt: daysAgo(REJECTED_FRIEND_REQUEST_RETENTION_DAYS) },
+          updatedAt: { lt: daysAgo(REJECTED_FRIEND_REQUEST_RETENTION_DAYS) },
         },
       ],
     },

--- a/app/utils/admin.server.ts
+++ b/app/utils/admin.server.ts
@@ -1,0 +1,555 @@
+import { cachified, lruCache } from './cache.server.ts';
+import { prisma } from './db.server.ts';
+import { POOL_STATUS, type PoolStatus } from './pool-constants.ts';
+
+const SIXTY_SECONDS = 60 * 1000;
+const FIVE_MINUTES = 5 * 60 * 1000;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const daysAgo = (days: number) => new Date(Date.now() - days * DAY_MS);
+const hoursAgo = (hours: number) => new Date(Date.now() - hours * 60 * 60 * 1000);
+
+const STALE_FRIEND_REQUEST_DAYS = 30;
+const REJECTED_FRIEND_REQUEST_RETENTION_DAYS = 90;
+const STUCK_VOTING_DAYS = 7;
+const STUCK_DECIDED_DAYS = 14;
+const PENDING_FRIEND_REQUEST_ALERT_DAYS = 7;
+
+// ---------------------------------------------------------------------------
+// Overview aggregates — cached 60s in lruCache (instance-local, not SQLite
+// cache). Short TTL + instance-local avoids LiteFS replication lag on the
+// "purge → preview count" interaction on the Ops page.
+// ---------------------------------------------------------------------------
+
+export type OverviewCounts = {
+  users: {
+    total: number;
+    last24h: number;
+    last7d: number;
+    last30d: number;
+  };
+  pools: {
+    total: number;
+    byStatus: Record<PoolStatus, number>;
+    stuck: number;
+    active: number;
+  };
+  wishlist: {
+    items: number;
+    active: number;
+    archived: number;
+    purchases: number;
+  };
+  friendships: {
+    total: number;
+    pendingRequestsOverThreshold: number;
+  };
+  notifications: {
+    unread24h: number;
+  };
+};
+
+export async function getOverviewCounts(): Promise<OverviewCounts> {
+  return cachified({
+    key: 'admin:overview:counts:v1',
+    cache: lruCache,
+    ttl: SIXTY_SECONDS,
+    getFreshValue: async () => {
+      const now = new Date();
+      const oneDay = new Date(now.getTime() - DAY_MS);
+      const sevenDays = new Date(now.getTime() - 7 * DAY_MS);
+      const thirtyDays = new Date(now.getTime() - 30 * DAY_MS);
+      const stuckVotingCutoff = new Date(
+        now.getTime() - STUCK_VOTING_DAYS * DAY_MS,
+      );
+      const stuckDecidedCutoff = new Date(
+        now.getTime() - STUCK_DECIDED_DAYS * DAY_MS,
+      );
+      const pendingFriendRequestCutoff = new Date(
+        now.getTime() - PENDING_FRIEND_REQUEST_ALERT_DAYS * DAY_MS,
+      );
+
+      const [
+        totalUsers,
+        usersLast24h,
+        usersLast7d,
+        usersLast30d,
+        totalPools,
+        poolStatusGroups,
+        stuckOpenPools,
+        stuckVotingPools,
+        stuckDecidedPools,
+        totalWishlistItems,
+        activeWishlistItems,
+        archivedWishlistItems,
+        totalPurchases,
+        totalFriendships,
+        pendingFriendRequestsAlert,
+        unreadNotifications24h,
+      ] = await Promise.all([
+        prisma.user.count(),
+        prisma.user.count({ where: { createdAt: { gte: oneDay } } }),
+        prisma.user.count({ where: { createdAt: { gte: sevenDays } } }),
+        prisma.user.count({ where: { createdAt: { gte: thirtyDays } } }),
+        prisma.pool.count(),
+        prisma.pool.groupBy({ by: ['status'], _count: { _all: true } }),
+        prisma.pool.count({
+          where: { status: POOL_STATUS.OPEN, eventDate: { lt: now } },
+        }),
+        prisma.pool.count({
+          where: {
+            status: POOL_STATUS.VOTING,
+            updatedAt: { lt: stuckVotingCutoff },
+            votes: { none: {} },
+          },
+        }),
+        prisma.pool.count({
+          where: {
+            status: POOL_STATUS.DECIDED,
+            updatedAt: { lt: stuckDecidedCutoff },
+          },
+        }),
+        prisma.wishlistItem.count(),
+        prisma.wishlistItem.count({ where: { status: 'ACTIVE' } }),
+        prisma.wishlistItem.count({ where: { status: 'ARCHIVED' } }),
+        prisma.wishlistPurchase.count(),
+        prisma.friendship.count(),
+        prisma.friendRequest.count({
+          where: {
+            status: 'PENDING',
+            createdAt: { lt: pendingFriendRequestCutoff },
+          },
+        }),
+        prisma.notification.count({
+          where: {
+            status: 'UNREAD',
+            createdAt: { gte: oneDay },
+          },
+        }),
+      ]);
+
+      const byStatus: Record<PoolStatus, number> = {
+        OPEN: 0,
+        VOTING: 0,
+        DECIDED: 0,
+        PURCHASED: 0,
+        DELIVERED: 0,
+        CANCELLED: 0,
+      };
+      for (const row of poolStatusGroups) {
+        const status = row.status as PoolStatus;
+        if (status in byStatus) {
+          byStatus[status] = row._count._all;
+        }
+      }
+
+      const activePools =
+        byStatus.OPEN + byStatus.VOTING + byStatus.DECIDED + byStatus.PURCHASED;
+      const stuck = stuckOpenPools + stuckVotingPools + stuckDecidedPools;
+
+      return {
+        users: {
+          total: totalUsers,
+          last24h: usersLast24h,
+          last7d: usersLast7d,
+          last30d: usersLast30d,
+        },
+        pools: {
+          total: totalPools,
+          byStatus,
+          stuck,
+          active: activePools,
+        },
+        wishlist: {
+          items: totalWishlistItems,
+          active: activeWishlistItems,
+          archived: archivedWishlistItems,
+          purchases: totalPurchases,
+        },
+        friendships: {
+          total: totalFriendships,
+          pendingRequestsOverThreshold: pendingFriendRequestsAlert,
+        },
+        notifications: {
+          unread24h: unreadNotifications24h,
+        },
+      };
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Stuck pools — the alert list on the overview + the default tab in Phase 3.
+// A pool is "stuck" if it meets one of these conditions:
+//   - OPEN with eventDate already past
+//   - VOTING for >7 days with zero votes cast
+//   - DECIDED for >14 days (never advanced to PURCHASED)
+// ---------------------------------------------------------------------------
+
+export type StuckPool = {
+  id: string;
+  title: string;
+  status: PoolStatus;
+  eventDate: Date | null;
+  updatedAt: Date;
+  reason: 'open_overdue' | 'voting_stalled' | 'decided_stalled';
+  organizer: {
+    id: string;
+    username: string;
+    name: string | null;
+  };
+  contributorCount: number;
+};
+
+export async function getStuckPools(limit = 10): Promise<StuckPool[]> {
+  return cachified({
+    key: `admin:overview:stuck-pools:v1:${limit}`,
+    cache: lruCache,
+    ttl: SIXTY_SECONDS,
+    getFreshValue: async () => {
+      const now = new Date();
+      const stuckVotingCutoff = new Date(
+        now.getTime() - STUCK_VOTING_DAYS * DAY_MS,
+      );
+      const stuckDecidedCutoff = new Date(
+        now.getTime() - STUCK_DECIDED_DAYS * DAY_MS,
+      );
+
+      const pools = await prisma.pool.findMany({
+        where: {
+          OR: [
+            {
+              status: POOL_STATUS.OPEN,
+              eventDate: { lt: now },
+            },
+            {
+              status: POOL_STATUS.VOTING,
+              updatedAt: { lt: stuckVotingCutoff },
+              votes: { none: {} },
+            },
+            {
+              status: POOL_STATUS.DECIDED,
+              updatedAt: { lt: stuckDecidedCutoff },
+            },
+          ],
+        },
+        orderBy: { updatedAt: 'asc' },
+        take: limit,
+        select: {
+          id: true,
+          title: true,
+          status: true,
+          eventDate: true,
+          updatedAt: true,
+          organizer: {
+            select: { id: true, username: true, name: true },
+          },
+          _count: { select: { contributors: true } },
+        },
+      });
+
+      return pools.map((pool) => {
+        const status = pool.status as PoolStatus;
+        const reason: StuckPool['reason'] =
+          status === POOL_STATUS.OPEN
+            ? 'open_overdue'
+            : status === POOL_STATUS.VOTING
+              ? 'voting_stalled'
+              : 'decided_stalled';
+        return {
+          id: pool.id,
+          title: pool.title,
+          status,
+          eventDate: pool.eventDate,
+          updatedAt: pool.updatedAt,
+          reason,
+          organizer: pool.organizer,
+          contributorCount: pool._count.contributors,
+        };
+      });
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Cleanup preview counts — each count is a single cheap COUNT query.
+// Cached 60s via lruCache. After a purge, we invalidate the cache key so the
+// next request shows zero immediately (see purge helpers below).
+// ---------------------------------------------------------------------------
+
+export type CleanupPreviewCounts = {
+  expiredVerifications: number;
+  expiredSessions: number;
+  stalePendingFriendRequests: number;
+  staleRejectedFriendRequests: number;
+  revokedOrExpiredGroupInvitations: number;
+  expiredGroupBans: number;
+};
+
+const CLEANUP_PREVIEW_KEY = 'admin:overview:cleanup-preview:v1';
+
+export async function getCleanupPreviewCounts(): Promise<CleanupPreviewCounts> {
+  return cachified({
+    key: CLEANUP_PREVIEW_KEY,
+    cache: lruCache,
+    ttl: SIXTY_SECONDS,
+    getFreshValue: async () => {
+      const now = new Date();
+      const staleFriendReqCutoff = daysAgo(STALE_FRIEND_REQUEST_DAYS);
+      const rejectedRetentionCutoff = daysAgo(
+        REJECTED_FRIEND_REQUEST_RETENTION_DAYS,
+      );
+
+      const [
+        expiredVerifications,
+        expiredSessions,
+        stalePendingFriendRequests,
+        staleRejectedFriendRequests,
+        revokedOrExpiredGroupInvitations,
+        expiredGroupBans,
+      ] = await Promise.all([
+        prisma.verification.count({
+          where: { expiresAt: { lt: now } },
+        }),
+        prisma.session.count({
+          where: { expirationDate: { lt: now } },
+        }),
+        prisma.friendRequest.count({
+          where: {
+            status: 'PENDING',
+            createdAt: { lt: staleFriendReqCutoff },
+          },
+        }),
+        prisma.friendRequest.count({
+          where: {
+            status: 'REJECTED',
+            createdAt: { lt: rejectedRetentionCutoff },
+          },
+        }),
+        prisma.groupInvitation.count({
+          where: {
+            usedCount: 0,
+            OR: [{ revokedAt: { not: null } }, { expiresAt: { lt: now } }],
+          },
+        }),
+        prisma.usersInGiftGroups.count({
+          where: { bannedUntil: { lt: now, not: null } },
+        }),
+      ]);
+
+      return {
+        expiredVerifications,
+        expiredSessions,
+        stalePendingFriendRequests,
+        staleRejectedFriendRequests,
+        revokedOrExpiredGroupInvitations,
+        expiredGroupBans,
+      };
+    },
+  });
+}
+
+function invalidateCleanupPreviewCache() {
+  lruCache.delete(CLEANUP_PREVIEW_KEY);
+  lruCache.delete('admin:overview:counts:v1');
+}
+
+// ---------------------------------------------------------------------------
+// Recent activity feed — union of four table createdAts over the last 48h.
+// Not cached — hits the same tables the overview counts hit, and it's cheap
+// at current scale. Promote to lruCache if this grows.
+// ---------------------------------------------------------------------------
+
+export type RecentActivityRow = {
+  kind: 'user' | 'pool' | 'wishlist_item' | 'friendship';
+  id: string;
+  actor: { id: string; username: string; name: string | null } | null;
+  subject: string;
+  timestamp: Date;
+};
+
+export async function getRecentActivity(
+  limit = 15,
+): Promise<RecentActivityRow[]> {
+  const since = hoursAgo(48);
+
+  const [users, pools, wishlistItems, friendships] = await Promise.all([
+    prisma.user.findMany({
+      where: { createdAt: { gte: since } },
+      orderBy: { createdAt: 'desc' },
+      take: limit,
+      select: { id: true, username: true, name: true, createdAt: true },
+    }),
+    prisma.pool.findMany({
+      where: { createdAt: { gte: since } },
+      orderBy: { createdAt: 'desc' },
+      take: limit,
+      select: {
+        id: true,
+        title: true,
+        createdAt: true,
+        organizer: { select: { id: true, username: true, name: true } },
+      },
+    }),
+    prisma.wishlistItem.findMany({
+      where: { createdAt: { gte: since } },
+      orderBy: { createdAt: 'desc' },
+      take: limit,
+      select: {
+        id: true,
+        title: true,
+        createdAt: true,
+        owner: { select: { id: true, username: true, name: true } },
+      },
+    }),
+    prisma.friendship.findMany({
+      where: { createdAt: { gte: since } },
+      orderBy: { createdAt: 'desc' },
+      take: limit,
+      select: {
+        id: true,
+        createdAt: true,
+        userA: { select: { id: true, username: true, name: true } },
+        userB: { select: { id: true, username: true, name: true } },
+      },
+    }),
+  ]);
+
+  const rows: RecentActivityRow[] = [
+    ...users.map<RecentActivityRow>((user) => ({
+      kind: 'user',
+      id: user.id,
+      actor: { id: user.id, username: user.username, name: user.name },
+      subject: 'signed up',
+      timestamp: user.createdAt,
+    })),
+    ...pools.map<RecentActivityRow>((pool) => ({
+      kind: 'pool',
+      id: pool.id,
+      actor: pool.organizer,
+      subject: `created pool "${pool.title}"`,
+      timestamp: pool.createdAt,
+    })),
+    ...wishlistItems.map<RecentActivityRow>((item) => ({
+      kind: 'wishlist_item',
+      id: item.id,
+      actor: item.owner,
+      subject: `added "${item.title}"`,
+      timestamp: item.createdAt,
+    })),
+    ...friendships.map<RecentActivityRow>((f) => ({
+      kind: 'friendship',
+      id: f.id,
+      actor: f.userA,
+      subject: `became friends with ${f.userB.username}`,
+      timestamp: f.createdAt,
+    })),
+  ];
+
+  rows.sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime());
+  return rows.slice(0, limit);
+}
+
+// ---------------------------------------------------------------------------
+// Disk usage — only called from the Ops page. Full-table scan with LENGTH()
+// on a BLOB column, so cached 5 minutes and NOT surfaced on the overview.
+// ---------------------------------------------------------------------------
+
+export type DiskUsageCounts = {
+  wishlistItemTotal: number;
+  wishlistItemsWithImage: number;
+  wishlistImageBytes: number;
+};
+
+export async function getDiskUsageCounts(): Promise<DiskUsageCounts> {
+  return cachified({
+    key: 'admin:ops:disk-usage:v1',
+    cache: lruCache,
+    ttl: FIVE_MINUTES,
+    getFreshValue: async () => {
+      const rows = await prisma.$queryRaw<
+        Array<{ total: bigint; withImage: bigint; imageBytes: bigint | null }>
+      >`
+        SELECT
+          COUNT(*) AS total,
+          SUM(CASE WHEN image IS NOT NULL THEN 1 ELSE 0 END) AS withImage,
+          COALESCE(SUM(LENGTH(image)), 0) AS imageBytes
+        FROM WishlistItem
+      `;
+      const row = rows[0];
+      return {
+        wishlistItemTotal: Number(row?.total ?? 0),
+        wishlistItemsWithImage: Number(row?.withImage ?? 0),
+        wishlistImageBytes: Number(row?.imageBytes ?? 0),
+      };
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Cleanup helpers — each is idempotent. All are single-statement deleteMany
+// or updateMany so LiteFS replica forwarding is a straight round-trip.
+// Every helper invalidates the cleanup-preview cache key on success so the
+// next loader call shows the post-purge state immediately.
+// ---------------------------------------------------------------------------
+
+export async function purgeExpiredVerifications(): Promise<{
+  deleted: number;
+}> {
+  const { count } = await prisma.verification.deleteMany({
+    where: { expiresAt: { lt: new Date() } },
+  });
+  invalidateCleanupPreviewCache();
+  return { deleted: count };
+}
+
+export async function purgeExpiredSessions(): Promise<{ deleted: number }> {
+  const { count } = await prisma.session.deleteMany({
+    where: { expirationDate: { lt: new Date() } },
+  });
+  invalidateCleanupPreviewCache();
+  return { deleted: count };
+}
+
+export async function purgeStaleFriendRequests(): Promise<{ deleted: number }> {
+  // Delete PENDING older than 30d + REJECTED older than 90d in one shot.
+  const { count } = await prisma.friendRequest.deleteMany({
+    where: {
+      OR: [
+        {
+          status: 'PENDING',
+          createdAt: { lt: daysAgo(STALE_FRIEND_REQUEST_DAYS) },
+        },
+        {
+          status: 'REJECTED',
+          createdAt: { lt: daysAgo(REJECTED_FRIEND_REQUEST_RETENTION_DAYS) },
+        },
+      ],
+    },
+  });
+  invalidateCleanupPreviewCache();
+  return { deleted: count };
+}
+
+export async function purgeDeadGroupInvitations(): Promise<{
+  deleted: number;
+}> {
+  // Only delete unused invites — leave used-then-revoked rows for history.
+  const { count } = await prisma.groupInvitation.deleteMany({
+    where: {
+      usedCount: 0,
+      OR: [{ revokedAt: { not: null } }, { expiresAt: { lt: new Date() } }],
+    },
+  });
+  invalidateCleanupPreviewCache();
+  return { deleted: count };
+}
+
+export async function expireGroupBans(): Promise<{ updated: number }> {
+  const { count } = await prisma.usersInGiftGroups.updateMany({
+    where: { bannedUntil: { lt: new Date(), not: null } },
+    data: { bannedUntil: null },
+  });
+  invalidateCleanupPreviewCache();
+  return { updated: count };
+}

--- a/app/utils/admin.server.ts
+++ b/app/utils/admin.server.ts
@@ -253,12 +253,14 @@ export async function getStuckPools(limit = 10): Promise<StuckPool[]> {
 
       return pools.map((pool) => {
         const status = pool.status as PoolStatus;
-        const reason: StuckPool['reason'] =
-          status === POOL_STATUS.OPEN
-            ? 'open_overdue'
-            : status === POOL_STATUS.VOTING
-              ? 'voting_stalled'
-              : 'decided_stalled';
+        let reason: StuckPool['reason'];
+        if (status === POOL_STATUS.OPEN) {
+          reason = 'open_overdue';
+        } else if (status === POOL_STATUS.VOTING) {
+          reason = 'voting_stalled';
+        } else {
+          reason = 'decided_stalled';
+        }
         return {
           id: pool.id,
           title: pool.title,

--- a/app/utils/analytics.ts
+++ b/app/utils/analytics.ts
@@ -4,6 +4,18 @@ export const ANALYTIC_EVENT_NAMES = [
   'wishlist_viewed',
   'wishlist_item_added',
   'wishlist_item_archived',
+  // Phase 1.5 — gifting workflow instrumentation
+  'pool_created',
+  'pool_contributor_joined',
+  'pool_vote_called',
+  'pool_vote_cast',
+  'pool_decided',
+  'pool_purchased',
+  'pool_delivered',
+  'pool_cancelled',
+  'friend_request_sent',
+  'friend_request_accepted',
+  'wishlist_purchase_recorded',
 ] as const;
 
 export type AnalyticEventName = (typeof ANALYTIC_EVENT_NAMES)[number];
@@ -16,4 +28,16 @@ export const USER_REQUIRED_EVENTS: Set<AnalyticEventName> = new Set([
   'wishlist_item_added',
   'wishlist_item_archived',
   'wishlist_viewed',
+  // Phase 1.5 — every workflow event has a known actor (the acting user).
+  'pool_created',
+  'pool_contributor_joined',
+  'pool_vote_called',
+  'pool_vote_cast',
+  'pool_decided',
+  'pool_purchased',
+  'pool_delivered',
+  'pool_cancelled',
+  'friend_request_sent',
+  'friend_request_accepted',
+  'wishlist_purchase_recorded',
 ]);

--- a/app/utils/env.server.ts
+++ b/app/utils/env.server.ts
@@ -11,8 +11,6 @@ const schema = z.object({
   // If you plan on using Sentry, uncomment this line
   SENTRY_DSN: z.string(),
   NOTIFICATION_TOKEN_SECRET: z.string().optional(),
-  ANALYTICS_ADMIN_EMAILS: z.string().optional(),
-  ANALYTICS_ADMIN_USER_IDS: z.string().optional(),
   // If you plan to use Resend, uncomment this line
   // RESEND_API_KEY: z.string(),
   // If you plan to use GitHub auth, remove the default:

--- a/app/utils/friends.server.ts
+++ b/app/utils/friends.server.ts
@@ -1,4 +1,5 @@
 import { captureException } from '@sentry/react-router';
+import { queueLogEvent } from '#app/utils/analytics.server.ts';
 import { prisma } from '#app/utils/db.server.ts';
 import { NOTIFICATION_TYPES } from '#app/utils/notification-registry.ts';
 import { notifyUser } from '#app/utils/notification-service.server.tsx';
@@ -220,6 +221,14 @@ export async function sendFriendRequest(fromUserId: string, toUserId: string) {
     }),
   );
 
+  // Fired after the transaction closes (see plan §1.10.3).
+  queueLogEvent({
+    name: 'friend_request_sent',
+    userId: fromUserId,
+    source: 'server',
+    properties: { friendRequestId: request.id, toUserId },
+  });
+
   return request;
 }
 
@@ -307,6 +316,17 @@ export async function acceptFriendRequest(
       }),
     );
   }
+
+  // Fired after the transaction closes (see plan §1.10.3).
+  queueLogEvent({
+    name: 'friend_request_accepted',
+    userId: actingUserId,
+    source: 'server',
+    properties: {
+      friendRequestId: request.id,
+      fromUserId: request.fromUserId,
+    },
+  });
 
   return request;
 }

--- a/app/utils/pool.server.ts
+++ b/app/utils/pool.server.ts
@@ -1,5 +1,6 @@
 import { data } from 'react-router'
 import { nanoid } from 'nanoid'
+import { queueLogEvent } from '#app/utils/analytics.server.ts'
 import { prisma } from '#app/utils/db.server.ts'
 import { logPoolActivity } from '#app/utils/pool-activity.server.ts'
 import {
@@ -146,6 +147,19 @@ export async function createPool(input: CreatePoolInput) {
 		payload: { title },
 	})
 
+	queueLogEvent({
+		name: 'pool_created',
+		userId: organizerId,
+		source: 'server',
+		properties: {
+			poolId: pool.id,
+			occasionType,
+			decisionMode,
+			contributorCount: contributorData.length,
+			hasGroup: giftGroupId != null,
+		},
+	})
+
 	return pool
 }
 
@@ -192,6 +206,13 @@ export async function addContributor(
 	await logPoolActivity(poolId, POOL_ACTIVITY_TYPE.CONTRIBUTOR_JOINED, {
 		actorId: userId,
 		payload: { userId },
+	})
+
+	queueLogEvent({
+		name: 'pool_contributor_joined',
+		userId,
+		source: 'server',
+		properties: { poolId },
 	})
 
 	return contributor
@@ -360,6 +381,13 @@ export async function callVote(poolId: string, actorId: string) {
 	})
 
 	await logPoolActivity(poolId, POOL_ACTIVITY_TYPE.VOTE_CALLED, { actorId })
+
+	queueLogEvent({
+		name: 'pool_vote_called',
+		userId: actorId,
+		source: 'server',
+		properties: { poolId },
+	})
 }
 
 // Cast or change a vote. One vote per contributor per pool.
@@ -387,6 +415,13 @@ export async function castVote(
 	await logPoolActivity(poolId, POOL_ACTIVITY_TYPE.VOTE_CAST, {
 		actorId: voterId,
 		payload: { ideaId },
+	})
+
+	queueLogEvent({
+		name: 'pool_vote_cast',
+		userId: voterId,
+		source: 'server',
+		properties: { poolId, ideaId },
 	})
 }
 
@@ -445,6 +480,13 @@ export async function chooseIdea(
 	await logPoolActivity(poolId, POOL_ACTIVITY_TYPE.IDEA_CHOSEN, {
 		actorId,
 		payload: { ideaId, name: idea.name, finalPriceCents: resolvedPrice },
+	})
+
+	queueLogEvent({
+		name: 'pool_decided',
+		userId: actorId,
+		source: 'server',
+		properties: { poolId, ideaId, finalPriceCents: resolvedPrice },
 	})
 }
 
@@ -508,6 +550,13 @@ export async function markPurchased(poolId: string, actorId: string) {
 	})
 
 	await logPoolActivity(poolId, POOL_ACTIVITY_TYPE.MARKED_PURCHASED, { actorId })
+
+	queueLogEvent({
+		name: 'pool_purchased',
+		userId: actorId,
+		source: 'server',
+		properties: { poolId },
+	})
 }
 
 export async function markDelivered(poolId: string, actorId: string) {
@@ -517,6 +566,13 @@ export async function markDelivered(poolId: string, actorId: string) {
 	})
 
 	await logPoolActivity(poolId, POOL_ACTIVITY_TYPE.MARKED_DELIVERED, { actorId })
+
+	queueLogEvent({
+		name: 'pool_delivered',
+		userId: actorId,
+		source: 'server',
+		properties: { poolId },
+	})
 }
 
 export async function cancelPool(poolId: string, actorId: string) {
@@ -526,6 +582,13 @@ export async function cancelPool(poolId: string, actorId: string) {
 	})
 
 	await logPoolActivity(poolId, POOL_ACTIVITY_TYPE.POOL_CANCELLED, { actorId })
+
+	queueLogEvent({
+		name: 'pool_cancelled',
+		userId: actorId,
+		source: 'server',
+		properties: { poolId },
+	})
 }
 
 export async function deletePool(poolId: string, actorId: string) {

--- a/other/migrate-analytics-admins.js
+++ b/other/migrate-analytics-admins.js
@@ -1,0 +1,99 @@
+// One-shot migration: convert the legacy ANALYTICS_ADMIN_USER_IDS /
+// ANALYTICS_ADMIN_EMAILS env allowlists into real `admin` role connections.
+//
+// Run ONCE against prod BEFORE merging the commit that removes the env vars
+// from env.server.ts, otherwise any reviewer who was on the allowlist without
+// an admin role will lose access.
+//
+// Usage (prod):
+//   fly ssh console --app <app>
+//   node other/migrate-analytics-admins.js
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+function parseAllowlist(value) {
+  return (value ?? '')
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+async function main() {
+  const rawIds = parseAllowlist(process.env.ANALYTICS_ADMIN_USER_IDS);
+  const rawEmails = parseAllowlist(process.env.ANALYTICS_ADMIN_EMAILS).map(
+    (email) => email.toLowerCase(),
+  );
+
+  if (rawIds.length === 0 && rawEmails.length === 0) {
+    console.log(
+      'ANALYTICS_ADMIN_USER_IDS / ANALYTICS_ADMIN_EMAILS are empty. Nothing to migrate.',
+    );
+    return;
+  }
+
+  const adminRole = await prisma.role.upsert({
+    where: { name: 'admin' },
+    update: {},
+    create: { name: 'admin', description: 'Admin role' },
+  });
+
+  const users = await prisma.user.findMany({
+    where: {
+      OR: [
+        ...(rawIds.length ? [{ id: { in: rawIds } }] : []),
+        ...(rawEmails.length ? [{ email: { in: rawEmails } }] : []),
+      ],
+    },
+    select: {
+      id: true,
+      email: true,
+      username: true,
+      roles: { select: { name: true } },
+    },
+  });
+
+  if (users.length === 0) {
+    console.warn(
+      'No users matched the allowlists. Check that the env vars still resolve to real accounts.',
+    );
+    return;
+  }
+
+  let granted = 0;
+  let alreadyAdmin = 0;
+
+  for (const user of users) {
+    const hasAdmin = user.roles.some((role) => role.name === adminRole.name);
+    if (hasAdmin) {
+      alreadyAdmin++;
+      console.log(
+        `[skip] ${user.username} (${user.email}) already has admin role.`,
+      );
+      continue;
+    }
+
+    await prisma.user.update({
+      where: { id: user.id },
+      data: { roles: { connect: { name: adminRole.name } } },
+    });
+    granted++;
+    console.log(`[grant] ${user.username} (${user.email}) → admin`);
+  }
+
+  console.log(
+    `\nDone. Granted: ${granted}. Already admin: ${alreadyAdmin}. Matched: ${users.length}.`,
+  );
+  console.log(
+    'It is now safe to deploy the commit that removes the ANALYTICS_ADMIN_* env vars from env.server.ts.',
+  );
+}
+
+main()
+  .catch((error) => {
+    console.error('Migration failed:', error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/other/migrate-analytics-admins.js
+++ b/other/migrate-analytics-admins.js
@@ -89,11 +89,11 @@ async function main() {
   );
 }
 
-main()
-  .catch((error) => {
-    console.error('Migration failed:', error);
-    process.exitCode = 1;
-  })
-  .finally(async () => {
-    await prisma.$disconnect();
-  });
+try {
+  await main();
+} catch (error) {
+  console.error('Migration failed:', error);
+  process.exitCode = 1;
+} finally {
+  await prisma.$disconnect();
+}


### PR DESCRIPTION
## Summary

Phase 1 of the admin rebuild. Turns `/admin` from a two-card link tree into a real operator surface. Everything here is against the **existing schema with zero migrations**.

**What shipped (§1.1–§1.10 of the plan):**

- **Layout** — `admin+/_layout.tsx` wraps all admin routes with a persistent top bar + 6-tab NavLink row (Overview, Users, Pools, Ops, Analytics, Cache). Users/Pools tabs 404 until Phases 2/3 ship.
- **Overview** — `admin+/index.tsx` renders 8 metric cards, a stuck-pool alert list, cleanup queue preview, and 48h activity feed. All queries hit domain tables (`Pool`, `WishlistItem`, `Friendship`, `FriendRequest`, `Verification`, `Session`, `Notification`) — no dependency on the sparse `AnalyticsEvent` stream. Cached 60s in `lruCache` (instance-local) to avoid LiteFS replication lag on the Ops purge UX.
- **Stuck pool detector** — flags `OPEN && eventDate<now`, `VOTING && updatedAt<7d && votes.none()`, and `DECIDED && updatedAt<14d`.
- **Ops page** — five idempotent cleanup jobs (`purgeExpiredVerifications`, `purgeExpiredSessions`, `purgeStaleFriendRequests`, `purgeDeadGroupInvitations`, `expireGroupBans`), each with `useDoubleCheck`. Disk usage card runs `SELECT SUM(LENGTH(image)) FROM WishlistItem` once every 5 minutes. LiteFS instance panel + link to the existing `/admin/cache` inspector.
- **Auth flatten** — `admin+/analytics.tsx` now uses `requireUserWithRole('admin')`. The env-allowlist side door is deleted and `ANALYTICS_ADMIN_USER_IDS` / `_EMAILS` are removed from `env.server.ts`. Confirmed via \`fly secrets list\` that neither var is set in prod, so no migration is needed on deploy. `other/migrate-analytics-admins.js` is committed as a safety net if either var is ever added later.
- **Workflow instrumentation (§1.10)** — 11 new events appended to `ANALYTIC_EVENT_NAMES`: `pool_created`, `pool_contributor_joined`, `pool_vote_called`, `pool_vote_cast`, `pool_decided`, `pool_purchased`, `pool_delivered`, `pool_cancelled`, `friend_request_sent`, `friend_request_accepted`, `wishlist_purchase_recorded`. `queueLogEvent` wired into `pool.server.ts`, `friends.server.ts` (after the `$transaction` closes), and `wishlist+/purchase.ts`. This is the prerequisite for Phase 4's retention grid.
- **Tests** — 24 new tests: `admin.server.test.ts` (15), `admin+/index.test.ts` (2), `admin+/ops.test.ts` (5), updated `admin+/analytics.test.ts` (2). Full unit suite: **598 / 598 passing locally**.

**Cache tier discipline:** short-TTL queries (overview 60s, disk 5m) use `lruCache` (instance-local, in-memory). The SQLite-backed `cache` is reserved for 1h+ aggregates in Phase 4 where cross-instance coherence pays for the replication lag.

**End-to-end verified locally:** `/admin` renders with correct numbers (10 users / 3 active pools / 64 wishlist items / 10 friendships / 0 stuck / 8 purchases / 1 unread / 0 cleanup). `/admin/ops` shows real disk usage. Ran a full pool workflow (`callVote → castVote → chooseIdea → markPurchased → markDelivered`) and confirmed all 5 events landed in `AnalyticsEvent` with correct `userId` and `properties.poolId`.

## Test plan

- [x] `npm run lint` — zero new errors
- [x] `npm run typecheck` — clean
- [x] `npm test -- --run` — 598 / 598 passing
- [x] Local dev server — overview page visually verified, correct numbers rendered
- [x] Instrumentation smoke test — full pool workflow run locally, all 5 events confirmed in AnalyticsEvent
- [ ] `/admin/analytics` still loads after deploy (spot check)
- [ ] `/admin/ops` cleanup buttons work against prod data (all currently show 0 so this is a no-op visual check)

## Rollout notes

- No schema migration.
- No env var changes required (confirmed `ANALYTICS_ADMIN_*` are not set in prod).
- Phase 1.5 instrumentation bundled into this PR — events start collecting immediately on deploy, which gives Phase 4's retention grid real history by the time it ships.