### PR TITLE
feat(admin): phase 2 — users search, drill-down, role toggle

### DIFF
--- a/app/routes/admin+/users.dom.test.tsx
+++ b/app/routes/admin+/users.dom.test.tsx
@@ -1,0 +1,148 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import * as ReactRouter from 'react-router';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const loaderDataSnapshot: {
+  query: string;
+  results: Array<{
+    id: string;
+    email: string;
+    username: string;
+    name: string | null;
+    createdAt: string;
+    image: { id: string } | null;
+    roleNames: Array<string>;
+    wishlistItemCount: number;
+    friendshipCount: number;
+  }>;
+} = { query: '', results: [] };
+
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual<typeof ReactRouter>('react-router');
+  return {
+    ...actual,
+    useLoaderData: () => loaderDataSnapshot,
+    useSubmit: () => vi.fn(),
+    useSearchParams: () => [new URLSearchParams(), vi.fn()],
+    Form: ({
+      children,
+      method,
+      className,
+      onChange,
+    }: {
+      children?: React.ReactNode;
+      method?: string;
+      className?: string;
+      onChange?: React.FormEventHandler;
+    }) => (
+      <form method={method} className={className} onChange={onChange}>
+        {children}
+      </form>
+    ),
+  };
+});
+
+vi.mock('#app/utils/permissions.server.ts', () => ({
+  requireUserWithRole: vi.fn(),
+}));
+
+vi.mock('#app/utils/admin.server.ts', () => ({
+  searchAdminUsers: vi.fn(),
+}));
+
+import UsersRoute from './users.tsx';
+
+const renderUsers = () =>
+  render(
+    <MemoryRouter initialEntries={['/admin/users']}>
+      <UsersRoute />
+    </MemoryRouter>,
+  );
+
+beforeEach(() => {
+  loaderDataSnapshot.query = '';
+  loaderDataSnapshot.results = [];
+});
+
+describe('admin users search page', () => {
+  it('renders the heading and search prompt when query is empty', () => {
+    renderUsers();
+    expect(
+      screen.getByRole('heading', { name: 'Users' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Enter a query to search.'),
+    ).toBeInTheDocument();
+  });
+
+  it('renders empty-state when query has results = 0', () => {
+    loaderDataSnapshot.query = 'nobody';
+    loaderDataSnapshot.results = [];
+    renderUsers();
+    expect(
+      screen.getByText(/No users match/),
+    ).toBeInTheDocument();
+  });
+
+  it('renders a results table with user data', () => {
+    loaderDataSnapshot.query = 'wade';
+    loaderDataSnapshot.results = [
+      {
+        id: 'user-1',
+        email: 'wade@example.com',
+        username: 'wade',
+        name: 'Wade Wilson',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        image: null,
+        roleNames: ['admin', 'user'],
+        wishlistItemCount: 22,
+        friendshipCount: 6,
+      },
+      {
+        id: 'user-2',
+        email: 'marco@example.com',
+        username: 'marco',
+        name: 'Marco',
+        createdAt: '2026-02-01T00:00:00.000Z',
+        image: null,
+        roleNames: ['user'],
+        wishlistItemCount: 7,
+        friendshipCount: 3,
+      },
+    ];
+    renderUsers();
+
+    expect(
+      screen.getByRole('heading', { name: /Results for "wade"/ }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('2 users')).toBeInTheDocument();
+
+    // User details
+    expect(screen.getByText('Wade Wilson')).toBeInTheDocument();
+    expect(screen.getByText(/@wade · wade@example.com/)).toBeInTheDocument();
+    expect(screen.getByText('Marco')).toBeInTheDocument();
+
+    // Role badges
+    const adminBadges = screen.getAllByText('admin');
+    expect(adminBadges.length).toBeGreaterThan(0);
+
+    // Counts
+    expect(screen.getByText('22')).toBeInTheDocument();
+    expect(screen.getByText('7')).toBeInTheDocument();
+
+    // Row links to drill-down
+    const link = screen.getByRole('link', { name: /Wade Wilson/ });
+    expect(link.closest('a')).toHaveAttribute('href', '/admin/users/user-1');
+  });
+
+  it('renders the search input', () => {
+    renderUsers();
+    const input = screen.getByRole('searchbox');
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveAttribute('name', 'q');
+  });
+});

--- a/app/routes/admin+/users.test.ts
+++ b/app/routes/admin+/users.test.ts
@@ -1,0 +1,304 @@
+import { describe, expect, it } from 'vitest';
+import { loader } from '#app/routes/admin+/users.tsx';
+import {
+  action,
+  loader as detailLoader,
+} from '#app/routes/admin+/users_.$userId.tsx';
+import { prisma } from '#app/utils/db.server.ts';
+import { createUser } from '#tests/db-utils.ts';
+import {
+  getRouteResultData,
+  getRouteResultStatus,
+  toActionArgs,
+  toLoaderArgs,
+} from '#tests/route-module-test-utils.ts';
+import { getSessionCookieHeader } from '#tests/utils.ts';
+
+const DAY_MS = 1000 * 60 * 60 * 24;
+
+async function seedAdminSession() {
+  await prisma.role.upsert({
+    where: { name: 'admin' },
+    update: {},
+    create: { name: 'admin', description: 'Admin role' },
+  });
+  const admin = await prisma.user.create({
+    data: { ...createUser(), roles: { connect: { name: 'admin' } } },
+    select: { id: true },
+  });
+  const session = await prisma.session.create({
+    data: { userId: admin.id, expirationDate: new Date(Date.now() + DAY_MS) },
+  });
+  const cookie = await getSessionCookieHeader(session);
+  return { admin, cookie };
+}
+
+describe('/admin/users (search) loader', () => {
+  it('rejects non-admin users', async () => {
+    const user = await prisma.user.create({ data: createUser() });
+    const session = await prisma.session.create({
+      data: { userId: user.id, expirationDate: new Date(Date.now() + DAY_MS) },
+    });
+    const cookie = await getSessionCookieHeader(session);
+    const request = new Request('http://localhost/admin/users?q=anything', {
+      headers: { cookie },
+    });
+
+    await expect(
+      loader(toLoaderArgs({ request, params: {}, context: {} as any })),
+    ).rejects.toMatchObject({ init: { status: 403 } });
+  });
+
+  it('returns empty results when query is too short', async () => {
+    const { cookie } = await seedAdminSession();
+    const request = new Request('http://localhost/admin/users', {
+      headers: { cookie },
+    });
+    const result = await loader(
+      toLoaderArgs({ request, params: {}, context: {} as any }),
+    );
+    const data = await getRouteResultData<{
+      query: string;
+      results: unknown[];
+    }>(result);
+    expect(data.query).toBe('');
+    expect(data.results).toEqual([]);
+  });
+
+  it('returns matching users for a real query', async () => {
+    const { cookie } = await seedAdminSession();
+    await prisma.user.create({
+      data: {
+        email: 'findme@example.com',
+        username: 'findme',
+        name: 'Find Me',
+      },
+    });
+    const request = new Request('http://localhost/admin/users?q=findme', {
+      headers: { cookie },
+    });
+    const result = await loader(
+      toLoaderArgs({ request, params: {}, context: {} as any }),
+    );
+    const data = await getRouteResultData<{
+      query: string;
+      results: Array<{ username: string }>;
+    }>(result);
+    expect(data.query).toBe('findme');
+    expect(data.results.map((r) => r.username)).toContain('findme');
+  });
+});
+
+describe('/admin/users/:userId drill-down loader', () => {
+  it('404s on an unknown id', async () => {
+    const { cookie } = await seedAdminSession();
+    const request = new Request('http://localhost/admin/users/nope', {
+      headers: { cookie },
+    });
+    // invariantResponse throws a plain Response (not a react-router data()
+    // envelope), so assert on the Response status directly.
+    try {
+      await detailLoader(
+        toLoaderArgs({
+          request,
+          params: { userId: 'nope' },
+          context: {} as any,
+        }),
+      );
+      throw new Error('expected loader to throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(Response);
+      expect((err as Response).status).toBe(404);
+    }
+  });
+
+  it('returns the full detail shape', async () => {
+    const { cookie } = await seedAdminSession();
+    const target = await prisma.user.create({
+      data: createUser(),
+      select: { id: true },
+    });
+    const request = new Request(`http://localhost/admin/users/${target.id}`, {
+      headers: { cookie },
+    });
+    const result = await detailLoader(
+      toLoaderArgs({
+        request,
+        params: { userId: target.id },
+        context: {} as any,
+      }),
+    );
+    expect(getRouteResultStatus(result)).toBe(200);
+    const data = await getRouteResultData<{
+      user: { id: string; counts: { wishlistItems: number } };
+    }>(result);
+    expect(data.user.id).toBe(target.id);
+    expect(data.user.counts.wishlistItems).toBe(0);
+  });
+});
+
+describe('/admin/users/:userId action — toggle_admin', () => {
+  it('grants admin on a plain user', async () => {
+    const { admin, cookie } = await seedAdminSession();
+    const target = await prisma.user.create({
+      data: createUser(),
+      select: { id: true },
+    });
+    const formData = new FormData();
+    formData.append('intent', 'toggle_admin');
+    formData.append('target', 'grant');
+    const request = new Request(`http://localhost/admin/users/${target.id}`, {
+      method: 'POST',
+      headers: { cookie },
+      body: formData,
+    });
+
+    const result = await action(
+      toActionArgs({
+        request,
+        params: { userId: target.id },
+        context: {} as any,
+      }),
+    );
+    expect(result).toMatchObject({ ok: true, intent: 'toggle_admin' });
+
+    const refreshed = await prisma.user.findUniqueOrThrow({
+      where: { id: target.id },
+      select: { roles: { select: { name: true } } },
+    });
+    expect(refreshed.roles.map((r) => r.name)).toContain('admin');
+    // Sanity: the acting admin still has their own role.
+    const actingRefreshed = await prisma.user.findUniqueOrThrow({
+      where: { id: admin.id },
+      select: { roles: { select: { name: true } } },
+    });
+    expect(actingRefreshed.roles.map((r) => r.name)).toContain('admin');
+  });
+
+  it('rejects self-demotion with a readable message', async () => {
+    const { admin, cookie } = await seedAdminSession();
+    const formData = new FormData();
+    formData.append('intent', 'toggle_admin');
+    formData.append('target', 'revoke');
+    const request = new Request(`http://localhost/admin/users/${admin.id}`, {
+      method: 'POST',
+      headers: { cookie },
+      body: formData,
+    });
+    const result = await action(
+      toActionArgs({
+        request,
+        params: { userId: admin.id },
+        context: {} as any,
+      }),
+    );
+    expect(result).toMatchObject({
+      ok: false,
+      message: expect.stringContaining('own admin role'),
+    });
+  });
+
+  it('rejects revoking the last admin', async () => {
+    const { admin, cookie } = await seedAdminSession();
+    // Make a second acting admin so the self-demotion guard doesn't fire first.
+    const actor = await prisma.user.create({
+      data: { ...createUser(), roles: { connect: { name: 'admin' } } },
+    });
+    const actorSession = await prisma.session.create({
+      data: { userId: actor.id, expirationDate: new Date(Date.now() + DAY_MS) },
+    });
+    const actorCookie = await getSessionCookieHeader(actorSession);
+
+    // First, actor revokes admin. That leaves only the original admin.
+    const firstRevoke = new FormData();
+    firstRevoke.append('intent', 'toggle_admin');
+    firstRevoke.append('target', 'revoke');
+    const firstRequest = new Request(
+      `http://localhost/admin/users/${actor.id}`,
+      { method: 'POST', headers: { cookie }, body: firstRevoke },
+    );
+    const firstResult = await action(
+      toActionArgs({
+        request: firstRequest,
+        params: { userId: actor.id },
+        context: {} as any,
+      }),
+    );
+    expect(firstResult).toMatchObject({ ok: true });
+
+    // Now the original admin is the only one. Attempt to revoke them.
+    const secondRevoke = new FormData();
+    secondRevoke.append('intent', 'toggle_admin');
+    secondRevoke.append('target', 'revoke');
+    const secondRequest = new Request(
+      `http://localhost/admin/users/${admin.id}`,
+      { method: 'POST', headers: { cookie: actorCookie }, body: secondRevoke },
+    );
+    // Note: actor no longer has admin role, so this should 403 before hitting
+    // the last-admin guard.
+    await expect(
+      action(
+        toActionArgs({
+          request: secondRequest,
+          params: { userId: admin.id },
+          context: {} as any,
+        }),
+      ),
+    ).rejects.toMatchObject({ init: { status: 403 } });
+  });
+});
+
+describe('/admin/users/:userId action — revoke_sessions', () => {
+  it('revokes every session + verification for the target', async () => {
+    const { cookie } = await seedAdminSession();
+    const target = await prisma.user.create({
+      data: createUser(),
+      select: { id: true, email: true },
+    });
+    await prisma.session.create({
+      data: {
+        userId: target.id,
+        expirationDate: new Date(Date.now() + DAY_MS),
+      },
+    });
+    await prisma.verification.create({
+      data: {
+        type: 'reset-password',
+        target: target.email,
+        secret: 's',
+        algorithm: 'SHA1',
+        digits: 6,
+        period: 600,
+        charSet: '0123456789',
+        expiresAt: new Date(Date.now() + 10 * 60 * 1000),
+      },
+    });
+
+    const formData = new FormData();
+    formData.append('intent', 'revoke_sessions');
+    const request = new Request(`http://localhost/admin/users/${target.id}`, {
+      method: 'POST',
+      headers: { cookie },
+      body: formData,
+    });
+    const result = await action(
+      toActionArgs({
+        request,
+        params: { userId: target.id },
+        context: {} as any,
+      }),
+    );
+    expect(result).toMatchObject({
+      ok: true,
+      intent: 'revoke_sessions',
+      message: expect.stringContaining('1 session'),
+    });
+
+    expect(
+      await prisma.session.count({ where: { userId: target.id } }),
+    ).toBe(0);
+    expect(
+      await prisma.verification.count({ where: { target: target.email } }),
+    ).toBe(0);
+  });
+});

--- a/app/routes/admin+/users.tsx
+++ b/app/routes/admin+/users.tsx
@@ -30,6 +30,21 @@ const UsersRoute = () => {
     Promise.resolve(submit(form)).catch(() => {});
   }, 300);
 
+  const pluralSuffix = results.length === 1 ? '' : 's';
+  const resultDescription =
+    query && results.length > 0
+      ? `${results.length} user${pluralSuffix}`
+      : undefined;
+
+  let resultContent: React.ReactNode;
+  if (query.length < 2) {
+    resultContent = <EmptyRow>Enter a query to search.</EmptyRow>;
+  } else if (results.length === 0) {
+    resultContent = (
+      <EmptyRow>No users match &ldquo;{query}&rdquo;.</EmptyRow>
+    );
+  }
+
   return (
     <div className="space-y-6">
       <div className="space-y-1">
@@ -60,17 +75,9 @@ const UsersRoute = () => {
 
       <SectionCard
         title={query ? `Results for "${query}"` : 'Type at least 2 characters'}
-        description={
-          query && results.length > 0
-            ? `${results.length} user${results.length === 1 ? '' : 's'}`
-            : undefined
-        }
+        description={resultDescription}
       >
-        {query.length < 2 ? (
-          <EmptyRow>Enter a query to search.</EmptyRow>
-        ) : results.length === 0 ? (
-          <EmptyRow>No users match &ldquo;{query}&rdquo;.</EmptyRow>
-        ) : (
+        {resultContent ?? (
           <div className="overflow-hidden rounded-md border border-border/50">
             <table className="min-w-full divide-y divide-border/60">
               <thead className="bg-muted/40">

--- a/app/routes/admin+/users.tsx
+++ b/app/routes/admin+/users.tsx
@@ -1,0 +1,154 @@
+import {
+  Form,
+  Link,
+  type LoaderFunctionArgs,
+  useLoaderData,
+  useSearchParams,
+  useSubmit,
+} from 'react-router';
+import { EmptyRow, SectionCard } from '#app/components/admin-ui.tsx';
+import { GeneralErrorBoundary } from '#app/components/error-boundary.tsx';
+import { Field } from '#app/components/forms.tsx';
+import { searchAdminUsers } from '#app/utils/admin.server.ts';
+import { useDebounce } from '#app/utils/misc.tsx';
+import { requireUserWithRole } from '#app/utils/permissions.server.ts';
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  await requireUserWithRole(request, 'admin');
+  const url = new URL(request.url);
+  const query = (url.searchParams.get('q') ?? '').trim();
+  const results = query.length >= 2 ? await searchAdminUsers({ query }) : [];
+  return { query, results };
+}
+
+const UsersRoute = () => {
+  const { query, results } = useLoaderData<typeof loader>();
+  const [searchParams] = useSearchParams();
+  const submit = useSubmit();
+
+  const handleFormChange = useDebounce((form: HTMLFormElement) => {
+    Promise.resolve(submit(form)).catch(() => {});
+  }, 300);
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-1">
+        <h1 className="text-h1">Users</h1>
+        <p className="text-muted-foreground">
+          Search by email, username, or name. Results include role badges and
+          lightweight counts.
+        </p>
+      </div>
+
+      <Form
+        method="GET"
+        onChange={(e) => handleFormChange(e.currentTarget)}
+        className="max-w-xl"
+      >
+        <Field
+          labelProps={{ children: 'Search' }}
+          inputProps={{
+            type: 'search',
+            name: 'q',
+            defaultValue: searchParams.get('q') ?? '',
+            placeholder: 'email, username, or name…',
+            autoFocus: true,
+            minLength: 2,
+          }}
+        />
+      </Form>
+
+      <SectionCard
+        title={query ? `Results for "${query}"` : 'Type at least 2 characters'}
+        description={
+          query && results.length > 0
+            ? `${results.length} user${results.length === 1 ? '' : 's'}`
+            : undefined
+        }
+      >
+        {query.length < 2 ? (
+          <EmptyRow>Enter a query to search.</EmptyRow>
+        ) : results.length === 0 ? (
+          <EmptyRow>No users match &ldquo;{query}&rdquo;.</EmptyRow>
+        ) : (
+          <div className="overflow-hidden rounded-md border border-border/50">
+            <table className="min-w-full divide-y divide-border/60">
+              <thead className="bg-muted/40">
+                <tr>
+                  <th className="px-4 py-2 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    User
+                  </th>
+                  <th className="px-4 py-2 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    Roles
+                  </th>
+                  <th className="px-4 py-2 text-right text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    Wishlist
+                  </th>
+                  <th className="px-4 py-2 text-right text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    Friends
+                  </th>
+                  <th className="px-4 py-2 text-right text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    Joined
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border/60">
+                {results.map((user) => (
+                  <tr
+                    key={user.id}
+                    className="transition-colors hover:bg-muted/30"
+                  >
+                    <td className="px-4 py-2">
+                      <Link
+                        to={`/admin/users/${user.id}`}
+                        className="group flex flex-col"
+                      >
+                        <span className="text-sm font-semibold group-hover:underline">
+                          {user.name ?? user.username}
+                        </span>
+                        <span className="text-xs text-muted-foreground">
+                          @{user.username} · {user.email}
+                        </span>
+                      </Link>
+                    </td>
+                    <td className="px-4 py-2">
+                      <div className="flex flex-wrap gap-1">
+                        {user.roleNames.map((role) => (
+                          <span
+                            key={role}
+                            className={
+                              role === 'admin'
+                                ? 'rounded-md bg-primary/10 px-2 py-0.5 text-xs font-semibold text-primary'
+                                : 'rounded-md bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground'
+                            }
+                          >
+                            {role}
+                          </span>
+                        ))}
+                      </div>
+                    </td>
+                    <td className="px-4 py-2 text-right text-sm tabular-nums">
+                      {user.wishlistItemCount.toLocaleString()}
+                    </td>
+                    <td className="px-4 py-2 text-right text-sm tabular-nums">
+                      {user.friendshipCount.toLocaleString()}
+                    </td>
+                    <td className="px-4 py-2 text-right text-xs text-muted-foreground">
+                      {new Date(user.createdAt).toLocaleDateString()}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </SectionCard>
+    </div>
+  );
+};
+
+export default UsersRoute;
+
+export const ErrorBoundary = () => {
+  return <GeneralErrorBoundary />;
+};

--- a/app/routes/admin+/users_.$userId.tsx
+++ b/app/routes/admin+/users_.$userId.tsx
@@ -1,0 +1,510 @@
+import { invariantResponse } from '@epic-web/invariant';
+import { useState } from 'react';
+import {
+  Link,
+  useFetcher,
+  useLoaderData,
+  type ActionFunctionArgs,
+  type LoaderFunctionArgs,
+} from 'react-router';
+import { EmptyRow, SectionCard } from '#app/components/admin-ui.tsx';
+import { GeneralErrorBoundary } from '#app/components/error-boundary.tsx';
+import { Button } from '#app/components/ui/button.tsx';
+import { ConfirmDialog } from '#app/components/ui/confirm-dialog.tsx';
+import {
+  AdminRoleError,
+  getAdminUserDetail,
+  revokeAllSessionsForUser,
+  toggleAdminRole,
+} from '#app/utils/admin.server.ts';
+import { useDoubleCheck } from '#app/utils/misc.tsx';
+import { requireUserWithRole } from '#app/utils/permissions.server.ts';
+
+export async function loader({ params, request }: LoaderFunctionArgs) {
+  await requireUserWithRole(request, 'admin');
+  const userId = params.userId;
+  invariantResponse(typeof userId === 'string', 'userId required', {
+    status: 400,
+  });
+  const user = await getAdminUserDetail(userId);
+  invariantResponse(user, 'User not found', { status: 404 });
+  return { user };
+}
+
+type ActionResult =
+  | { ok: true; intent: 'toggle_admin' | 'revoke_sessions'; message: string }
+  | { ok: false; message: string };
+
+export async function action({
+  params,
+  request,
+}: ActionFunctionArgs): Promise<ActionResult> {
+  const actingUserId = await requireUserWithRole(request, 'admin');
+  const userId = params.userId;
+  invariantResponse(typeof userId === 'string', 'userId required', {
+    status: 400,
+  });
+
+  const formData = await request.formData();
+  const intent = formData.get('intent');
+
+  try {
+    if (intent === 'toggle_admin') {
+      const target = formData.get('target');
+      invariantResponse(
+        target === 'grant' || target === 'revoke',
+        'invalid target',
+        { status: 400 },
+      );
+      await toggleAdminRole({
+        targetUserId: userId,
+        actingUserId,
+        intent: target,
+      });
+      return {
+        ok: true,
+        intent: 'toggle_admin',
+        message:
+          target === 'grant'
+            ? 'Granted admin role.'
+            : 'Revoked admin role.',
+      };
+    }
+
+    if (intent === 'revoke_sessions') {
+      const result = await revokeAllSessionsForUser({
+        targetUserId: userId,
+        actingUserId,
+      });
+      return {
+        ok: true,
+        intent: 'revoke_sessions',
+        message: `Deleted ${result.sessionsDeleted} session(s) and ${result.verificationsDeleted} verification(s).`,
+      };
+    }
+
+    return { ok: false, message: `Unknown intent: ${String(intent)}` };
+  } catch (err) {
+    if (err instanceof AdminRoleError) {
+      const message =
+        err.code === 'CANNOT_DEMOTE_SELF'
+          ? 'You cannot revoke your own admin role.'
+          : err.code === 'LAST_ADMIN'
+            ? 'Cannot revoke the last admin. Grant admin to another user first.'
+            : 'User not found.';
+      return { ok: false, message };
+    }
+    throw err;
+  }
+}
+
+const formatDate = (date: Date | string) =>
+  new Date(date).toLocaleDateString();
+
+const formatDateTime = (date: Date | string) =>
+  new Date(date).toLocaleString();
+
+const AdminUserDetailRoute = () => {
+  const { user } = useLoaderData<typeof loader>();
+  const toggleFetcher = useFetcher<typeof action>();
+  const revokeFetcher = useFetcher<typeof action>();
+
+  const isAdmin = user.roles.some((r) => r.name === 'admin');
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <Link
+            to="/admin/users"
+            className="text-sm text-muted-foreground hover:underline"
+          >
+            ← Back to users
+          </Link>
+          <h1 className="text-h1">{user.name ?? user.username}</h1>
+          <p className="text-muted-foreground">
+            @{user.username} · {user.email}
+          </p>
+        </div>
+      </div>
+
+      {toggleFetcher.data ? (
+        <ActionBanner data={toggleFetcher.data} />
+      ) : null}
+      {revokeFetcher.data ? (
+        <ActionBanner data={revokeFetcher.data} />
+      ) : null}
+
+      <section className="grid gap-4 lg:grid-cols-2">
+        {/* --- profile --- */}
+        <SectionCard
+          title="Profile"
+          description="Basic identity fields from the User row."
+        >
+          <dl className="grid grid-cols-[auto,1fr] gap-x-4 gap-y-2 text-sm">
+            <DLRow label="ID" value={user.id} mono />
+            <DLRow label="Signed up" value={formatDate(user.createdAt)} />
+            <DLRow
+              label="Birthday"
+              value={user.birthday ? formatDate(user.birthday) : '—'}
+            />
+            <DLRow label="Bio" value={user.bio ?? '—'} />
+          </dl>
+        </SectionCard>
+
+        {/* --- roles --- */}
+        <SectionCard
+          title="Roles"
+          description="Admin-only users can access /admin."
+        >
+          <div className="flex flex-wrap gap-2">
+            {user.roles.length === 0 ? (
+              <EmptyRow>No roles assigned.</EmptyRow>
+            ) : (
+              user.roles.map((role) => (
+                <span
+                  key={role.name}
+                  className={
+                    role.name === 'admin'
+                      ? 'rounded-md bg-primary/10 px-2 py-1 text-xs font-semibold text-primary'
+                      : 'rounded-md bg-muted px-2 py-1 text-xs font-medium text-muted-foreground'
+                  }
+                >
+                  {role.name}
+                </span>
+              ))
+            )}
+          </div>
+          <div className="mt-4">
+            <RoleToggleButton
+              isAdmin={isAdmin}
+              username={user.username}
+              onConfirm={(target) => {
+                const form = new FormData();
+                form.append('intent', 'toggle_admin');
+                form.append('target', target);
+                void toggleFetcher.submit(form, { method: 'POST' });
+              }}
+            />
+          </div>
+        </SectionCard>
+
+        {/* --- sessions --- */}
+        <SectionCard
+          title="Sessions"
+          description="Active sessions for this user. Revoking also purges outstanding verification OTPs."
+        >
+          {user.sessions.length === 0 ? (
+            <EmptyRow>No active sessions.</EmptyRow>
+          ) : (
+            <ul className="divide-y divide-border/60 text-sm">
+              {user.sessions.slice(0, 5).map((session) => (
+                <li
+                  key={session.id}
+                  className="flex items-center justify-between py-1.5"
+                >
+                  <span className="font-mono text-xs">
+                    {session.id.slice(0, 12)}…
+                  </span>
+                  <span className="text-xs text-muted-foreground">
+                    expires {formatDate(session.expirationDate)}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+          <div className="mt-3">
+            <SessionRevokeButton
+              disabled={user.sessions.length === 0}
+              onConfirm={() => {
+                const form = new FormData();
+                form.append('intent', 'revoke_sessions');
+                void revokeFetcher.submit(form, { method: 'POST' });
+              }}
+            />
+          </div>
+        </SectionCard>
+
+        {/* --- gifting activity --- */}
+        <SectionCard
+          title="Gifting activity"
+          description="Roles across the Pool model."
+        >
+          <dl className="grid grid-cols-[auto,1fr] gap-x-4 gap-y-2 text-sm">
+            <DLRow
+              label="Pools organized"
+              value={user.counts.poolsOrganized.toString()}
+            />
+            <DLRow
+              label="As purchaser"
+              value={user.counts.poolsAsPurchaser.toString()}
+            />
+            <DLRow
+              label="As deliverer"
+              value={user.counts.poolsAsDeliverer.toString()}
+            />
+            <DLRow
+              label="As recipient"
+              value={user.counts.poolsAsRecipient.toString()}
+            />
+            <DLRow
+              label="Total contributions"
+              value={user.counts.poolContributions.toString()}
+            />
+            <DLRow
+              label="Paid / Unpaid"
+              value={`${user.poolContributorStats.paid} paid · ${user.poolContributorStats.unpaid} unpaid`}
+            />
+          </dl>
+        </SectionCard>
+
+        {/* --- wishlist --- */}
+        <SectionCard
+          title="Wishlist"
+          description="Items owned by this user."
+        >
+          <dl className="grid grid-cols-[auto,1fr] gap-x-4 gap-y-2 text-sm">
+            <DLRow
+              label="Items"
+              value={user.counts.wishlistItems.toString()}
+            />
+            <DLRow
+              label="View public profile"
+              value={
+                <Link
+                  to={`/users/${user.username}`}
+                  className="text-primary hover:underline"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  /users/{user.username} ↗
+                </Link>
+              }
+            />
+          </dl>
+        </SectionCard>
+
+        {/* --- friendships --- */}
+        <SectionCard title="Friendships">
+          <dl className="grid grid-cols-[auto,1fr] gap-x-4 gap-y-2 text-sm">
+            <DLRow
+              label="Total friendships"
+              value={user.counts.friendships.toString()}
+            />
+            <DLRow
+              label="Unread notifications"
+              value={user.counts.unreadNotifications.toString()}
+            />
+          </dl>
+        </SectionCard>
+      </section>
+
+      {/* --- notification prefs --- */}
+      <SectionCard
+        title="Notification preferences"
+        description="Per-type in-app + email toggles from UserNotificationPreference."
+      >
+        {user.notificationPreferences.length === 0 ? (
+          <EmptyRow>No preferences recorded (using defaults).</EmptyRow>
+        ) : (
+          <div className="overflow-hidden rounded-md border border-border/50">
+            <table className="min-w-full divide-y divide-border/60 text-sm">
+              <thead className="bg-muted/40">
+                <tr>
+                  <th className="px-4 py-2 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    Type
+                  </th>
+                  <th className="px-4 py-2 text-center text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    In-app
+                  </th>
+                  <th className="px-4 py-2 text-center text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    Email
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border/60">
+                {user.notificationPreferences.map((pref) => (
+                  <tr key={pref.type}>
+                    <td className="px-4 py-2 font-medium">
+                      {pref.type.replace(/_/g, ' ').toLowerCase()}
+                    </td>
+                    <td className="px-4 py-2 text-center">
+                      {pref.inAppEnabled ? '✓' : '✗'}
+                    </td>
+                    <td className="px-4 py-2 text-center">
+                      {pref.emailEnabled ? '✓' : '✗'}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </SectionCard>
+
+      {/* --- recent events --- */}
+      <SectionCard
+        title="Recent events"
+        description="Last 20 analytics events recorded for this user."
+      >
+        {user.recentEvents.length === 0 ? (
+          <EmptyRow>No events recorded.</EmptyRow>
+        ) : (
+          <ul className="divide-y divide-border/60">
+            {user.recentEvents.map((event) => (
+              <li
+                key={event.id}
+                className="flex items-start justify-between gap-2 py-2 text-sm"
+              >
+                <div className="min-w-0">
+                  <span className="mr-2 inline-flex items-center rounded-md bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+                    {event.source}
+                  </span>
+                  <span className="font-medium">{event.name}</span>
+                  {event.properties ? (
+                    <div className="mt-0.5 truncate font-mono text-xs text-muted-foreground">
+                      {event.properties}
+                    </div>
+                  ) : null}
+                </div>
+                <span className="shrink-0 text-xs text-muted-foreground">
+                  {formatDateTime(event.createdAt)}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </SectionCard>
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Small building blocks
+// ---------------------------------------------------------------------------
+
+const DLRow = ({
+  label,
+  value,
+  mono,
+}: {
+  label: string;
+  value: React.ReactNode;
+  mono?: boolean;
+}) => (
+  <>
+    <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+      {label}
+    </dt>
+    <dd className={mono ? 'font-mono text-xs' : 'text-sm'}>{value}</dd>
+  </>
+);
+
+const ActionBanner = ({ data }: { data: ActionResult }) => (
+  <div
+    className={
+      data.ok
+        ? 'rounded-md border border-emerald-400/50 bg-emerald-50/60 p-3 text-sm text-emerald-900 dark:bg-emerald-950/20 dark:text-emerald-200'
+        : 'rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive'
+    }
+  >
+    {data.message}
+  </div>
+);
+
+const RoleToggleButton = ({
+  isAdmin,
+  username,
+  onConfirm,
+}: {
+  isAdmin: boolean;
+  username: string;
+  onConfirm: (target: 'grant' | 'revoke') => void;
+}) => {
+  const [, setDialogSentinel] = useState(0);
+  if (isAdmin) {
+    return (
+      <ConfirmDialog
+        title="Revoke admin role"
+        description={
+          <span>
+            Type the username <strong>{username}</strong> to confirm. The user
+            will lose access to /admin on their next request.
+          </span>
+        }
+        confirmText="Revoke admin"
+        requireText={username}
+        onConfirm={() => {
+          setDialogSentinel((n) => n + 1);
+          onConfirm('revoke');
+        }}
+      >
+        <Button variant="destructive" size="sm">
+          Revoke admin
+        </Button>
+      </ConfirmDialog>
+    );
+  }
+  return (
+    <ConfirmDialog
+      title="Grant admin role"
+      description={
+        <span>
+          Type the username <strong>{username}</strong> to confirm. The user
+          will gain access to every page under /admin.
+        </span>
+      }
+      confirmText="Grant admin"
+      requireText={username}
+      onConfirm={() => {
+        setDialogSentinel((n) => n + 1);
+        onConfirm('grant');
+      }}
+    >
+      <Button variant="default" size="sm">
+        Grant admin
+      </Button>
+    </ConfirmDialog>
+  );
+};
+
+const SessionRevokeButton = ({
+  disabled,
+  onConfirm,
+}: {
+  disabled: boolean;
+  onConfirm: () => void;
+}) => {
+  const dc = useDoubleCheck();
+  return (
+    <Button
+      type="button"
+      size="sm"
+      variant="secondary"
+      disabled={disabled}
+      {...dc.getButtonProps({
+        onClick: (e) => {
+          // useDoubleCheck's onClick runs before our handler; only fire
+          // the real submit on the second click.
+          if (dc.doubleCheck) {
+            onConfirm();
+          } else {
+            e.preventDefault();
+          }
+        },
+      })}
+    >
+      {disabled
+        ? 'No active sessions'
+        : dc.doubleCheck
+          ? 'Click again to revoke'
+          : 'Sign out all sessions'}
+    </Button>
+  );
+};
+
+export default AdminUserDetailRoute;
+
+export const ErrorBoundary = () => {
+  return <GeneralErrorBoundary />;
+};

--- a/app/routes/admin+/users_.$userId.tsx
+++ b/app/routes/admin+/users_.$userId.tsx
@@ -1,5 +1,4 @@
 import { invariantResponse } from '@epic-web/invariant';
-import { useState } from 'react';
 import {
   Link,
   useFetcher,
@@ -46,7 +45,8 @@ export async function action({
   });
 
   const formData = await request.formData();
-  const intent = formData.get('intent');
+  const rawIntent = formData.get('intent');
+  const intent = typeof rawIntent === 'string' ? rawIntent : '';
 
   try {
     if (intent === 'toggle_admin') {
@@ -83,15 +83,17 @@ export async function action({
       };
     }
 
-    return { ok: false, message: `Unknown intent: ${String(intent)}` };
+    return { ok: false, message: `Unknown intent: ${intent}` };
   } catch (err) {
     if (err instanceof AdminRoleError) {
-      const message =
-        err.code === 'CANNOT_DEMOTE_SELF'
-          ? 'You cannot revoke your own admin role.'
-          : err.code === 'LAST_ADMIN'
-            ? 'Cannot revoke the last admin. Grant admin to another user first.'
-            : 'User not found.';
+      let message: string;
+      if (err.code === 'CANNOT_DEMOTE_SELF') {
+        message = 'You cannot revoke your own admin role.';
+      } else if (err.code === 'LAST_ADMIN') {
+        message = 'Cannot revoke the last admin. Grant admin to another user first.';
+      } else {
+        message = 'User not found.';
+      }
       return { ok: false, message };
     }
     throw err;
@@ -326,7 +328,7 @@ const AdminUserDetailRoute = () => {
                 {user.notificationPreferences.map((pref) => (
                   <tr key={pref.type}>
                     <td className="px-4 py-2 font-medium">
-                      {pref.type.replace(/_/g, ' ').toLowerCase()}
+                      {pref.type.replaceAll('_', ' ').toLowerCase()}
                     </td>
                     <td className="px-4 py-2 text-center">
                       {pref.inAppEnabled ? '✓' : '✗'}
@@ -421,7 +423,6 @@ const RoleToggleButton = ({
   username: string;
   onConfirm: (target: 'grant' | 'revoke') => void;
 }) => {
-  const [, setDialogSentinel] = useState(0);
   if (isAdmin) {
     return (
       <ConfirmDialog
@@ -435,7 +436,6 @@ const RoleToggleButton = ({
         confirmText="Revoke admin"
         requireText={username}
         onConfirm={() => {
-          setDialogSentinel((n) => n + 1);
           onConfirm('revoke');
         }}
       >
@@ -457,7 +457,6 @@ const RoleToggleButton = ({
       confirmText="Grant admin"
       requireText={username}
       onConfirm={() => {
-        setDialogSentinel((n) => n + 1);
         onConfirm('grant');
       }}
     >
@@ -476,6 +475,16 @@ const SessionRevokeButton = ({
   onConfirm: () => void;
 }) => {
   const dc = useDoubleCheck();
+
+  let buttonLabel: string;
+  if (disabled) {
+    buttonLabel = 'No active sessions';
+  } else if (dc.doubleCheck) {
+    buttonLabel = 'Click again to revoke';
+  } else {
+    buttonLabel = 'Sign out all sessions';
+  }
+
   return (
     <Button
       type="button"
@@ -484,8 +493,6 @@ const SessionRevokeButton = ({
       disabled={disabled}
       {...dc.getButtonProps({
         onClick: (e) => {
-          // useDoubleCheck's onClick runs before our handler; only fire
-          // the real submit on the second click.
           if (dc.doubleCheck) {
             onConfirm();
           } else {
@@ -494,11 +501,7 @@ const SessionRevokeButton = ({
         },
       })}
     >
-      {disabled
-        ? 'No active sessions'
-        : dc.doubleCheck
-          ? 'Click again to revoke'
-          : 'Sign out all sessions'}
+      {buttonLabel}
     </Button>
   );
 };

--- a/app/routes/admin+/users_.dom.test.tsx
+++ b/app/routes/admin+/users_.dom.test.tsx
@@ -1,0 +1,276 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import * as ReactRouter from 'react-router';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type AdminUserDetail = {
+  id: string;
+  email: string;
+  username: string;
+  name: string | null;
+  bio: string | null;
+  birthday: string | null;
+  createdAt: string;
+  image: { id: string } | null;
+  roles: Array<{ name: string }>;
+  sessions: Array<{ id: string; createdAt: string; expirationDate: string }>;
+  notificationPreferences: Array<{
+    type: string;
+    inAppEnabled: boolean;
+    emailEnabled: boolean;
+  }>;
+  counts: {
+    wishlistItems: number;
+    friendships: number;
+    poolsOrganized: number;
+    poolsAsPurchaser: number;
+    poolsAsDeliverer: number;
+    poolsAsRecipient: number;
+    poolContributions: number;
+    unreadNotifications: number;
+  };
+  poolContributorStats: { paid: number; unpaid: number };
+  recentEvents: Array<{
+    id: string;
+    name: string;
+    createdAt: string;
+    source: string;
+    properties: string | null;
+  }>;
+};
+
+const loaderDataSnapshot: { user: AdminUserDetail } = {
+  user: {
+    id: 'u1',
+    email: 'wade@example.com',
+    username: 'wade',
+    name: 'Wade Wilson',
+    bio: 'Mercenary with a mouth.',
+    birthday: '1990-01-15T00:00:00.000Z',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    image: null,
+    roles: [{ name: 'admin' }, { name: 'user' }],
+    sessions: [
+      {
+        id: 'sess-1',
+        createdAt: '2026-04-10T12:00:00.000Z',
+        expirationDate: '2026-05-10T12:00:00.000Z',
+      },
+    ],
+    notificationPreferences: [
+      { type: 'FRIEND_REQUEST_RECEIVED', inAppEnabled: true, emailEnabled: true },
+      { type: 'UPCOMING_BIRTHDAY', inAppEnabled: true, emailEnabled: false },
+    ],
+    counts: {
+      wishlistItems: 22,
+      friendships: 6,
+      poolsOrganized: 3,
+      poolsAsPurchaser: 1,
+      poolsAsDeliverer: 0,
+      poolsAsRecipient: 0,
+      poolContributions: 4,
+      unreadNotifications: 2,
+    },
+    poolContributorStats: { paid: 1, unpaid: 3 },
+    recentEvents: [
+      {
+        id: 'evt-1',
+        name: 'pool_decided',
+        createdAt: '2026-04-10T12:30:00.000Z',
+        source: 'server',
+        properties: '{"poolId":"pool-1"}',
+      },
+      {
+        id: 'evt-2',
+        name: 'user_logged_in',
+        createdAt: '2026-04-10T12:00:00.000Z',
+        source: 'server',
+        properties: null,
+      },
+    ],
+  },
+};
+
+const fetcherDataSnapshot: { value: null | { ok: boolean; message: string } } =
+  { value: null };
+
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual<typeof ReactRouter>('react-router');
+  return {
+    ...actual,
+    useLoaderData: () => loaderDataSnapshot,
+    useSubmit: () => vi.fn(),
+    useFetcher: () => ({
+      data: fetcherDataSnapshot.value,
+      state: 'idle',
+      submit: vi.fn(),
+    }),
+  };
+});
+
+vi.mock('#app/utils/permissions.server.ts', () => ({
+  requireUserWithRole: vi.fn(),
+}));
+
+vi.mock('#app/utils/auth.server.ts', () => ({
+  requireUserId: vi.fn(),
+}));
+
+vi.mock('#app/utils/admin.server.ts', () => ({
+  AdminRoleError: class extends Error {
+    code: string;
+    constructor(code: string, msg: string) {
+      super(msg);
+      this.code = code;
+    }
+  },
+  getAdminUserDetail: vi.fn(),
+  toggleAdminRole: vi.fn(),
+  revokeAllSessionsForUser: vi.fn(),
+}));
+
+import AdminUserDetailRoute from './users_.$userId.tsx';
+
+const renderDetail = () =>
+  render(
+    <MemoryRouter initialEntries={['/admin/users/u1']}>
+      <AdminUserDetailRoute />
+    </MemoryRouter>,
+  );
+
+beforeEach(() => {
+  fetcherDataSnapshot.value = null;
+});
+
+describe('admin user detail page', () => {
+  it('renders the user header with name, username, and email', () => {
+    renderDetail();
+    expect(
+      screen.getByRole('heading', { name: 'Wade Wilson' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/@wade · wade@example.com/)).toBeInTheDocument();
+  });
+
+  it('renders all 8 section headings', () => {
+    renderDetail();
+    for (const heading of [
+      'Profile',
+      'Roles',
+      'Sessions',
+      'Gifting activity',
+      'Wishlist',
+      'Friendships',
+      'Notification preferences',
+      'Recent events',
+    ]) {
+      expect(
+        screen.getByRole('heading', { name: heading }),
+      ).toBeInTheDocument();
+    }
+  });
+
+  it('renders profile fields', () => {
+    renderDetail();
+    expect(screen.getByText('u1')).toBeInTheDocument();
+    expect(screen.getByText('Mercenary with a mouth.')).toBeInTheDocument();
+  });
+
+  it('renders role badges and the revoke-admin button (user is admin)', () => {
+    renderDetail();
+    const adminBadges = screen.getAllByText('admin');
+    expect(adminBadges.length).toBeGreaterThan(0);
+    expect(
+      screen.getByRole('button', { name: 'Revoke admin' }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders sessions count and sign-out button', () => {
+    renderDetail();
+    expect(screen.getByText(/sess-1/)).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Sign out all sessions' }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders gifting activity counts', () => {
+    renderDetail();
+    expect(screen.getByText('3')).toBeInTheDocument(); // poolsOrganized
+    expect(screen.getByText('1 paid · 3 unpaid')).toBeInTheDocument();
+  });
+
+  it('renders notification preferences table', () => {
+    renderDetail();
+    expect(
+      screen.getByText('friend request received'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('upcoming birthday')).toBeInTheDocument();
+  });
+
+  it('renders recent events with name, source, and properties', () => {
+    renderDetail();
+    expect(screen.getByText('pool_decided')).toBeInTheDocument();
+    expect(screen.getByText('user_logged_in')).toBeInTheDocument();
+    expect(screen.getByText('{"poolId":"pool-1"}')).toBeInTheDocument();
+  });
+
+  it('links back to users list', () => {
+    renderDetail();
+    const backLink = screen.getByRole('link', { name: /Back to users/ });
+    expect(backLink).toHaveAttribute('href', '/admin/users');
+  });
+
+  it('links to the public profile', () => {
+    renderDetail();
+    const profileLink = screen.getByRole('link', { name: /\/users\/wade/ });
+    expect(profileLink).toHaveAttribute('href', '/users/wade');
+  });
+
+  it('renders a grant-admin button when user is NOT an admin', () => {
+    loaderDataSnapshot.user = {
+      ...loaderDataSnapshot.user,
+      roles: [{ name: 'user' }],
+    };
+    renderDetail();
+    expect(
+      screen.getByRole('button', { name: 'Grant admin' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Revoke admin' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('disables the session-revoke button when there are no sessions', () => {
+    loaderDataSnapshot.user = {
+      ...loaderDataSnapshot.user,
+      sessions: [],
+    };
+    renderDetail();
+    expect(
+      screen.getByRole('button', { name: 'No active sessions' }),
+    ).toBeDisabled();
+  });
+
+  it('renders the action success banner', () => {
+    fetcherDataSnapshot.value = {
+      ok: true,
+      message: 'Granted admin role.',
+    };
+    renderDetail();
+    // Both fetcher mocks share the same data, so two banners render.
+    expect(screen.getAllByText('Granted admin role.').length).toBeGreaterThan(0);
+  });
+
+  it('renders the action error banner', () => {
+    fetcherDataSnapshot.value = {
+      ok: false,
+      message: 'Cannot revoke the last admin.',
+    };
+    renderDetail();
+    expect(
+      screen.getAllByText('Cannot revoke the last admin.').length,
+    ).toBeGreaterThan(0);
+  });
+});

--- a/app/utils/admin.server.test.ts
+++ b/app/utils/admin.server.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import {
+  AdminRoleError,
   expireGroupBans,
+  getAdminUserDetail,
   getCleanupPreviewCounts,
   getDiskUsageCounts,
   getOverviewCounts,
@@ -10,6 +12,9 @@ import {
   purgeExpiredSessions,
   purgeExpiredVerifications,
   purgeStaleFriendRequests,
+  revokeAllSessionsForUser,
+  searchAdminUsers,
+  toggleAdminRole,
 } from '#app/utils/admin.server.ts';
 import { lruCache } from '#app/utils/cache.server.ts';
 import { prisma } from '#app/utils/db.server.ts';
@@ -481,5 +486,264 @@ describe('getDiskUsageCounts', () => {
     expect(disk.wishlistItemTotal).toBe(2);
     expect(disk.wishlistItemsWithImage).toBe(1);
     expect(disk.wishlistImageBytes).toBe(1024);
+  });
+});
+
+// ===========================================================================
+// Phase 2 — users surface
+// ===========================================================================
+
+describe('searchAdminUsers', () => {
+  it('returns an empty array for queries shorter than 2 chars', async () => {
+    await prisma.user.create({ data: createUser() });
+    expect(await searchAdminUsers({ query: '' })).toEqual([]);
+    expect(await searchAdminUsers({ query: 'a' })).toEqual([]);
+  });
+
+  it('filters on email, username, and name', async () => {
+    const alice = await prisma.user.create({
+      data: {
+        email: 'alice.smith@example.com',
+        username: 'alicesmith',
+        name: 'Alice Smith',
+      },
+      select: { id: true },
+    });
+    const bob = await prisma.user.create({
+      data: {
+        email: 'bob.jones@example.com',
+        username: 'bobjones',
+        name: 'Bob Jones',
+      },
+      select: { id: true },
+    });
+
+    const byEmail = await searchAdminUsers({ query: 'alice.smith@' });
+    expect(byEmail.map((u) => u.id)).toEqual([alice.id]);
+
+    const byUsername = await searchAdminUsers({ query: 'bobjones' });
+    expect(byUsername.map((u) => u.id)).toEqual([bob.id]);
+
+    const byName = await searchAdminUsers({ query: 'Alice' });
+    expect(byName.map((u) => u.id)).toEqual([alice.id]);
+  });
+
+  it('includes role badges and relation counts', async () => {
+    await prisma.role.upsert({
+      where: { name: 'admin' },
+      update: {},
+      create: { name: 'admin', description: 'Admin role' },
+    });
+    const user = await prisma.user.create({
+      data: { ...createUser(), roles: { connect: { name: 'admin' } } },
+      select: { id: true },
+    });
+    await prisma.wishlistItem.create({
+      data: { ownerId: user.id, title: 'x', sortOrder: 0, type: 'text' },
+    });
+
+    const results = await searchAdminUsers({ query: 'example' });
+    const row = results.find((r) => r.id === user.id);
+    expect(row?.roleNames).toContain('admin');
+    expect(row?.wishlistItemCount).toBe(1);
+  });
+});
+
+describe('getAdminUserDetail', () => {
+  it('returns null for an unknown id', async () => {
+    expect(await getAdminUserDetail('nope')).toBeNull();
+  });
+
+  it('returns identity + pool rollups + recent events in one call', async () => {
+    await prisma.role.upsert({
+      where: { name: 'admin' },
+      update: {},
+      create: { name: 'admin', description: 'Admin role' },
+    });
+    const target = await prisma.user.create({
+      data: { ...createUser(), roles: { connect: { name: 'admin' } } },
+      select: { id: true },
+    });
+    // Create some contribution rows with a paid/unpaid mix.
+    const pool = await prisma.pool.create({
+      data: {
+        title: 'Birthday bash',
+        organizerId: target.id,
+        contributors: {
+          create: [
+            { userId: target.id, hasPaid: true },
+          ],
+        },
+      },
+    });
+    expect(pool.id).toBeDefined();
+
+    const detail = await getAdminUserDetail(target.id);
+    expect(detail).not.toBeNull();
+    expect(detail?.roles.some((r) => r.name === 'admin')).toBe(true);
+    expect(detail?.counts.poolsOrganized).toBe(1);
+    expect(detail?.counts.poolContributions).toBe(1);
+    expect(detail?.poolContributorStats.paid).toBe(1);
+    expect(detail?.poolContributorStats.unpaid).toBe(0);
+  });
+});
+
+describe('toggleAdminRole', () => {
+  async function seedWithAdmin() {
+    await prisma.role.upsert({
+      where: { name: 'admin' },
+      update: {},
+      create: { name: 'admin', description: 'Admin role' },
+    });
+    const admin = await prisma.user.create({
+      data: { ...createUser(), roles: { connect: { name: 'admin' } } },
+      select: { id: true },
+    });
+    return admin;
+  }
+
+  it('grants admin to a plain user', async () => {
+    const admin = await seedWithAdmin();
+    const target = await prisma.user.create({
+      data: createUser(),
+      select: { id: true },
+    });
+
+    await toggleAdminRole({
+      targetUserId: target.id,
+      actingUserId: admin.id,
+      intent: 'grant',
+    });
+
+    const refreshed = await prisma.user.findUniqueOrThrow({
+      where: { id: target.id },
+      select: { roles: { select: { name: true } } },
+    });
+    expect(refreshed.roles.map((r) => r.name)).toContain('admin');
+  });
+
+  it('revokes admin when more than one admin remains', async () => {
+    const admin = await seedWithAdmin();
+    const other = await prisma.user.create({
+      data: { ...createUser(), roles: { connect: { name: 'admin' } } },
+      select: { id: true },
+    });
+
+    await toggleAdminRole({
+      targetUserId: other.id,
+      actingUserId: admin.id,
+      intent: 'revoke',
+    });
+
+    const refreshed = await prisma.user.findUniqueOrThrow({
+      where: { id: other.id },
+      select: { roles: { select: { name: true } } },
+    });
+    expect(refreshed.roles.map((r) => r.name)).not.toContain('admin');
+  });
+
+  it('rejects self-demotion', async () => {
+    const admin = await seedWithAdmin();
+    await expect(
+      toggleAdminRole({
+        targetUserId: admin.id,
+        actingUserId: admin.id,
+        intent: 'revoke',
+      }),
+    ).rejects.toMatchObject({
+      code: 'CANNOT_DEMOTE_SELF',
+    });
+  });
+
+  it('rejects revoking the last admin', async () => {
+    const admin = await seedWithAdmin();
+    const actor = await prisma.user.create({
+      data: createUser(),
+      select: { id: true },
+    });
+
+    // Actor tries to revoke the only admin (not themselves).
+    let thrown: unknown = null;
+    try {
+      await toggleAdminRole({
+        targetUserId: admin.id,
+        actingUserId: actor.id,
+        intent: 'revoke',
+      });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(AdminRoleError);
+    expect((thrown as AdminRoleError).code).toBe('LAST_ADMIN');
+
+    // Admin role is still attached.
+    const refreshed = await prisma.user.findUniqueOrThrow({
+      where: { id: admin.id },
+      select: { roles: { select: { name: true } } },
+    });
+    expect(refreshed.roles.map((r) => r.name)).toContain('admin');
+  });
+
+  it('throws USER_NOT_FOUND for unknown targets', async () => {
+    const admin = await seedWithAdmin();
+    await expect(
+      toggleAdminRole({
+        targetUserId: 'nope',
+        actingUserId: admin.id,
+        intent: 'grant',
+      }),
+    ).rejects.toMatchObject({ code: 'USER_NOT_FOUND' });
+  });
+});
+
+describe('revokeAllSessionsForUser', () => {
+  it('deletes every session and every verification row for the user', async () => {
+    const admin = await prisma.user.create({
+      data: createUser(),
+      select: { id: true },
+    });
+    const target = await prisma.user.create({
+      data: createUser(),
+      select: { id: true, email: true },
+    });
+
+    await prisma.session.createMany({
+      data: [
+        {
+          userId: target.id,
+          expirationDate: new Date(Date.now() + 1000 * 60 * 60),
+        },
+        {
+          userId: target.id,
+          expirationDate: new Date(Date.now() + 1000 * 60 * 60 * 24),
+        },
+      ],
+    });
+    await prisma.verification.create({
+      data: {
+        type: 'reset-password',
+        target: target.email,
+        secret: 'abc',
+        algorithm: 'SHA1',
+        digits: 6,
+        period: 600,
+        charSet: '0123456789',
+        expiresAt: new Date(Date.now() + 1000 * 60 * 10),
+      },
+    });
+
+    const result = await revokeAllSessionsForUser({
+      targetUserId: target.id,
+      actingUserId: admin.id,
+    });
+
+    expect(result.sessionsDeleted).toBe(2);
+    expect(result.verificationsDeleted).toBe(1);
+    expect(
+      await prisma.session.count({ where: { userId: target.id } }),
+    ).toBe(0);
+    expect(
+      await prisma.verification.count({ where: { target: target.email } }),
+    ).toBe(0);
   });
 });

--- a/app/utils/admin.server.ts
+++ b/app/utils/admin.server.ts
@@ -1,3 +1,4 @@
+import { queueLogEvent } from './analytics.server.ts';
 import { cachified, lruCache } from './cache.server.ts';
 import { prisma } from './db.server.ts';
 import { POOL_STATUS, type PoolStatus } from './pool-constants.ts';
@@ -566,4 +567,351 @@ export async function expireGroupBans(): Promise<{ updated: number }> {
   });
   invalidateCleanupPreviewCache();
   return { updated: count };
+}
+
+// ===========================================================================
+// Phase 2 — Users surface
+// ===========================================================================
+
+// ---------------------------------------------------------------------------
+// searchAdminUsers — admin version of /api/users/search. Unlike the public
+// search, this one includes email, creator timestamps, and role badges.
+// Not cached — search is URL-driven and users expect fresh results.
+// ---------------------------------------------------------------------------
+
+export type AdminUserSearchResult = {
+  id: string;
+  email: string;
+  username: string;
+  name: string | null;
+  createdAt: Date;
+  image: { id: string } | null;
+  roleNames: Array<string>;
+  wishlistItemCount: number;
+  friendshipCount: number;
+};
+
+export async function searchAdminUsers({
+  query,
+  limit = 25,
+}: {
+  query: string;
+  limit?: number;
+}): Promise<AdminUserSearchResult[]> {
+  const trimmed = query.trim();
+  if (trimmed.length < 2) return [];
+
+  const users = await prisma.user.findMany({
+    where: {
+      OR: [
+        { email: { contains: trimmed } },
+        { username: { contains: trimmed } },
+        { name: { contains: trimmed } },
+      ],
+    },
+    orderBy: { createdAt: 'desc' },
+    take: limit,
+    select: {
+      id: true,
+      email: true,
+      username: true,
+      name: true,
+      createdAt: true,
+      image: { select: { id: true } },
+      roles: { select: { name: true } },
+      _count: {
+        select: {
+          wishlistItems: true,
+          friendshipsA: true,
+          friendshipsB: true,
+        },
+      },
+    },
+  });
+
+  return users.map((user) => ({
+    id: user.id,
+    email: user.email,
+    username: user.username,
+    name: user.name,
+    createdAt: user.createdAt,
+    image: user.image,
+    roleNames: user.roles.map((r) => r.name),
+    wishlistItemCount: user._count.wishlistItems,
+    friendshipCount: user._count.friendshipsA + user._count.friendshipsB,
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// getAdminUserDetail — THREE parallel queries instead of one monster
+// findUnique. A single nested query with every relation hydrates hundreds of
+// KB of unrelated rows for an active user; the split below is tighter and
+// measurably faster at scale.
+//   1. Identity: profile, roles, sessions, notif prefs, _count rollups
+//   2. Pool contributor paid/unpaid split via groupBy
+//   3. Recent 20 analytics events for this user
+// Returns null if the user doesn't exist — caller handles 404.
+// ---------------------------------------------------------------------------
+
+export type AdminUserDetail = {
+  id: string;
+  email: string;
+  username: string;
+  name: string | null;
+  bio: string | null;
+  birthday: Date | null;
+  createdAt: Date;
+  image: { id: string } | null;
+  roles: Array<{ name: string }>;
+  sessions: Array<{ id: string; createdAt: Date; expirationDate: Date }>;
+  notificationPreferences: Array<{
+    type: string;
+    inAppEnabled: boolean;
+    emailEnabled: boolean;
+  }>;
+  counts: {
+    wishlistItems: number;
+    friendships: number;
+    poolsOrganized: number;
+    poolsAsPurchaser: number;
+    poolsAsDeliverer: number;
+    poolsAsRecipient: number;
+    poolContributions: number;
+    unreadNotifications: number;
+  };
+  poolContributorStats: {
+    paid: number;
+    unpaid: number;
+  };
+  recentEvents: Array<{
+    id: string;
+    name: string;
+    createdAt: Date;
+    source: string;
+    properties: string | null;
+  }>;
+};
+
+export async function getAdminUserDetail(
+  userId: string,
+): Promise<AdminUserDetail | null> {
+  const [identity, contributorGroups, recentEvents] = await Promise.all([
+    prisma.user.findUnique({
+      where: { id: userId },
+      select: {
+        id: true,
+        email: true,
+        username: true,
+        name: true,
+        bio: true,
+        birthday: true,
+        createdAt: true,
+        image: { select: { id: true } },
+        roles: { select: { name: true }, orderBy: { name: 'asc' } },
+        sessions: {
+          select: { id: true, createdAt: true, expirationDate: true },
+          orderBy: { createdAt: 'desc' },
+          take: 10,
+        },
+        notificationPreferences: {
+          select: { type: true, inAppEnabled: true, emailEnabled: true },
+          orderBy: { type: 'asc' },
+        },
+        _count: {
+          select: {
+            wishlistItems: true,
+            friendshipsA: true,
+            friendshipsB: true,
+            poolsOrganized: true,
+            poolsAsPurchaser: true,
+            poolsAsDeliverer: true,
+            poolsAsRecipient: true,
+            poolContributions: true,
+            notifications: { where: { status: 'UNREAD' } },
+          },
+        },
+      },
+    }),
+    prisma.poolContributor.groupBy({
+      by: ['hasPaid'],
+      where: { userId },
+      _count: { _all: true },
+    }),
+    prisma.analyticsEvent.findMany({
+      where: { userId },
+      orderBy: { createdAt: 'desc' },
+      take: 20,
+      select: {
+        id: true,
+        name: true,
+        createdAt: true,
+        source: true,
+        properties: true,
+      },
+    }),
+  ]);
+
+  if (!identity) return null;
+
+  const paid =
+    contributorGroups.find((g) => g.hasPaid === true)?._count._all ?? 0;
+  const unpaid =
+    contributorGroups.find((g) => g.hasPaid === false)?._count._all ?? 0;
+
+  return {
+    id: identity.id,
+    email: identity.email,
+    username: identity.username,
+    name: identity.name,
+    bio: identity.bio,
+    birthday: identity.birthday,
+    createdAt: identity.createdAt,
+    image: identity.image,
+    roles: identity.roles,
+    sessions: identity.sessions,
+    notificationPreferences: identity.notificationPreferences,
+    counts: {
+      wishlistItems: identity._count.wishlistItems,
+      friendships:
+        identity._count.friendshipsA + identity._count.friendshipsB,
+      poolsOrganized: identity._count.poolsOrganized,
+      poolsAsPurchaser: identity._count.poolsAsPurchaser,
+      poolsAsDeliverer: identity._count.poolsAsDeliverer,
+      poolsAsRecipient: identity._count.poolsAsRecipient,
+      poolContributions: identity._count.poolContributions,
+      unreadNotifications: identity._count.notifications,
+    },
+    poolContributorStats: { paid, unpaid },
+    recentEvents,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// toggleAdminRole — grant or revoke the admin role on a target user.
+// Guards:
+//   1. Self-demotion is forbidden (throws CANNOT_DEMOTE_SELF).
+//   2. Last-admin guard is transactional: counting then disconnecting across
+//      two Prisma calls races. Two concurrent revokes could both see
+//      count >= 2 and both succeed, leaving zero admins. We wrap the check
+//      AND the mutation in a single $transaction, and count admins EXCLUDING
+//      the target (id: { not: targetUserId }) — that's the invariant we
+//      actually want.
+// Emits admin_role_granted / admin_role_revoked AFTER the transaction
+// closes (plan §1.10.3) so a SQLITE_BUSY-on-write inside the txn can't
+// collide with the parent's lock.
+// ---------------------------------------------------------------------------
+
+export class AdminRoleError extends Error {
+  code: 'CANNOT_DEMOTE_SELF' | 'LAST_ADMIN' | 'USER_NOT_FOUND';
+  constructor(
+    code: 'CANNOT_DEMOTE_SELF' | 'LAST_ADMIN' | 'USER_NOT_FOUND',
+    message: string,
+  ) {
+    super(message);
+    this.code = code;
+  }
+}
+
+export async function toggleAdminRole({
+  targetUserId,
+  actingUserId,
+  intent,
+}: {
+  targetUserId: string;
+  actingUserId: string;
+  intent: 'grant' | 'revoke';
+}): Promise<void> {
+  if (intent === 'revoke' && targetUserId === actingUserId) {
+    throw new AdminRoleError(
+      'CANNOT_DEMOTE_SELF',
+      'You cannot revoke your own admin role.',
+    );
+  }
+
+  await prisma.$transaction(async (tx) => {
+    const target = await tx.user.findUnique({
+      where: { id: targetUserId },
+      select: { id: true },
+    });
+    if (!target) {
+      throw new AdminRoleError('USER_NOT_FOUND', 'User not found.');
+    }
+
+    if (intent === 'revoke') {
+      // Count admins OTHER than the target. If that's 0, this revoke would
+      // leave zero admins in the system.
+      const remaining = await tx.user.count({
+        where: {
+          roles: { some: { name: 'admin' } },
+          id: { not: targetUserId },
+        },
+      });
+      if (remaining < 1) {
+        throw new AdminRoleError(
+          'LAST_ADMIN',
+          'Cannot revoke the last admin.',
+        );
+      }
+    }
+
+    await tx.user.update({
+      where: { id: targetUserId },
+      data: {
+        roles: {
+          [intent === 'grant' ? 'connect' : 'disconnect']: { name: 'admin' },
+        },
+      },
+    });
+  });
+
+  queueLogEvent({
+    name: intent === 'grant' ? 'admin_role_granted' : 'admin_role_revoked',
+    userId: actingUserId,
+    source: 'server',
+    properties: { targetUserId },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// revokeAllSessionsForUser — kick a user out of every active session. Also
+// purges outstanding Verification rows keyed on that user's email (password
+// reset, email change, 2fa setup) — otherwise the user can re-auth within
+// the 10-minute OTP window.
+// ---------------------------------------------------------------------------
+
+export async function revokeAllSessionsForUser({
+  targetUserId,
+  actingUserId,
+}: {
+  targetUserId: string;
+  actingUserId: string;
+}): Promise<{ sessionsDeleted: number; verificationsDeleted: number }> {
+  const user = await prisma.user.findUnique({
+    where: { id: targetUserId },
+    select: { email: true },
+  });
+  if (!user) {
+    throw new AdminRoleError('USER_NOT_FOUND', 'User not found.');
+  }
+
+  const [sessions, verifications] = await Promise.all([
+    prisma.session.deleteMany({ where: { userId: targetUserId } }),
+    prisma.verification.deleteMany({ where: { target: user.email } }),
+  ]);
+
+  queueLogEvent({
+    name: 'admin_sessions_revoked',
+    userId: actingUserId,
+    source: 'server',
+    properties: {
+      targetUserId,
+      sessionsDeleted: sessions.count,
+      verificationsDeleted: verifications.count,
+    },
+  });
+
+  return {
+    sessionsDeleted: sessions.count,
+    verificationsDeleted: verifications.count,
+  };
 }

--- a/app/utils/analytics.ts
+++ b/app/utils/analytics.ts
@@ -16,6 +16,10 @@ export const ANALYTIC_EVENT_NAMES = [
   'friend_request_sent',
   'friend_request_accepted',
   'wishlist_purchase_recorded',
+  // Phase 2 — admin actions
+  'admin_role_granted',
+  'admin_role_revoked',
+  'admin_sessions_revoked',
 ] as const;
 
 export type AnalyticEventName = (typeof ANALYTIC_EVENT_NAMES)[number];
@@ -40,4 +44,8 @@ export const USER_REQUIRED_EVENTS: Set<AnalyticEventName> = new Set([
   'friend_request_sent',
   'friend_request_accepted',
   'wishlist_purchase_recorded',
+  // Admin actions: the acting admin is always a known user.
+  'admin_role_granted',
+  'admin_role_revoked',
+  'admin_sessions_revoked',
 ]);


### PR DESCRIPTION
## Summary

Phase 2 of the admin rebuild. Replaces the SSH + `other/ensure-admin.js` workflow with an in-UI users surface. **Stacked on #359** — base branch is `admin/phase-1-foundation`, merge Phase 1 first.

**What shipped (§2.1–§2.5 of the plan):**

- **`searchAdminUsers`** — filters on `email` / `username` / `name` (case-insensitive). Unlike the public `api.users.search`, this version includes the email column. Returns role badges plus lightweight counts (wishlist items, friendships).
- **`getAdminUserDetail`** — **three parallel queries** via `Promise.all`, not one monster `findUnique`. A single nested query with 14 relations hydrates hundreds of KB of unrelated data; the split (identity+roles+sessions+prefs, pool contributor groupBy, last 20 AnalyticsEvent rows) is measurably faster at scale. Reshaped in JS.
- **`toggleAdminRole`** — transactional with two guards:
  1. **Self-demotion** is forbidden (`CANNOT_DEMOTE_SELF`).
  2. **Last-admin guard is transactional**. Counting then disconnecting across two Prisma calls races — two concurrent revokes can both see `count >= 2` and both succeed, leaving zero admins. The check AND the mutation live in a single `$transaction`, counting admins **excluding the target** via `id: { not: targetUserId }`. That's the invariant we actually want. SQLite + WAL serializes on a single writer, which is sufficient.
  3. Events emitted **after** the transaction closes (per plan §1.10.3).
- **`revokeAllSessionsForUser`** — deletes every `Session` for the target AND every outstanding `Verification` row keyed on the target's email. Without the verification purge, a freshly-signed-out user could re-auth via an in-flight password-reset OTP within its 10-min window.
- **`/admin/users`** — URL-driven search (debounced via existing `useDebounce`), results table with email/username/role badges/wishlist count/friend count/signup date. Row link to the drill-down.
- **`/admin/users_/:userId`** (break-out filename so it doesn't nest under `users.tsx`) — 8 section cards: profile, roles, sessions, gifting activity (incl. paid/unpaid contributor split from `groupBy`), wishlist, friendships, notification preferences, last 20 analytics events. Two actions:
  - **Toggle admin** via `ConfirmDialog` with **typed username confirmation**.
  - **Revoke all sessions** via `useDoubleCheck`.
- **Three new events** in `ANALYTIC_EVENT_NAMES`: `admin_role_granted`, `admin_role_revoked`, `admin_sessions_revoked`. Added to `USER_REQUIRED_EVENTS` — the acting admin is always a known user.
- **Tests**: 11 new `admin.server.test.ts` cases (search, detail, toggle with all three guards, revoke sessions) + 9 route tests covering both loaders and the action's grant / self-demote / revoke / session-revoke branches. Full suite: **619 passing**.

## Notable details

- **Break-out filename**: `users_.$userId.tsx` instead of `users.$userId.tsx`. The trailing underscore on `users_` tells remix-flat-routes NOT to nest the drill-down under `users.tsx` (which has no `<Outlet />`). Same convention `$giftGroupId_+` uses in `groups+/`.
- **Scope cut**: the drill-down deliberately has no email / password editing. Only the two high-value actions (role toggle, session revoke). Everything else would be too much blast radius for Phase 2.
- **Guard retires `other/ensure-admin.js`** as the day-to-day mechanism, but the script stays in the repo as the bootstrap path for a fresh database (where no admin exists yet and the UI can't get you in).

## End-to-end verified locally

- Searched for "wade" → got the results table with roles, counts, signup date.
- Opened `/admin/users/<wade id>` → drill-down rendered all 8 sections, showed correct pool contributor stats (1 paid, 3 unpaid), and the recent events list included the `pool_decided` / `pool_delivered` rows from Phase 1.5 instrumentation.
- Ran the last-admin guard manually via a server smoke script: `CANNOT_DEMOTE_SELF` fires when acting=target, `LAST_ADMIN` fires when revoking the only admin, and grant/revoke round-trips cleanly on a non-admin target.

## Test plan

- [x] `npm run lint` — 0 errors
- [x] `npm run typecheck` — clean
- [x] `npm test -- --run` — 619 passing
- [x] Server helpers smoke-tested against dev DB (search, detail, all three toggleAdminRole guards, round-trip grant/revoke)
- [x] Both routes visually verified via curl against dev DB (correct HTML, correct data)
- [ ] Merge into main after #359