### PR TITLE
feat(admin): phase 3 — pools health board + drill-down + admin cancel

### DIFF
--- a/app/components/admin-ui.tsx
+++ b/app/components/admin-ui.tsx
@@ -79,3 +79,20 @@ export const EmptyRow = ({ children }: { children: ReactNode }) => (
     {children}
   </div>
 );
+
+export const DLRow = ({
+  label,
+  value,
+  mono,
+}: {
+  label: string;
+  value: ReactNode;
+  mono?: boolean;
+}) => (
+  <>
+    <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+      {label}
+    </dt>
+    <dd className={mono ? 'font-mono text-xs' : 'text-sm'}>{value}</dd>
+  </>
+);

--- a/app/routes/admin+/pools.dom.test.tsx
+++ b/app/routes/admin+/pools.dom.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import * as ReactRouter from 'react-router';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const loaderDataSnapshot: {
+  pools: Array<{
+    id: string;
+    title: string;
+    status: string;
+    occasionType: string;
+    eventDate: string | null;
+    updatedAt: string;
+    inviteCode: string | null;
+    organizer: { id: string; username: string; name: string | null };
+    contributorCount: number;
+  }>;
+  total: number;
+  statusParam: string;
+  page: number;
+  pageSize: number;
+} = { pools: [], total: 0, statusParam: 'stuck', page: 1, pageSize: 25 };
+
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual<typeof ReactRouter>('react-router');
+  return {
+    ...actual,
+    useLoaderData: () => loaderDataSnapshot,
+  };
+});
+
+vi.mock('#app/utils/permissions.server.ts', () => ({
+  requireUserWithRole: vi.fn(),
+}));
+
+vi.mock('#app/utils/admin.server.ts', () => ({
+  listAdminPools: vi.fn(),
+}));
+
+import PoolsRoute from './pools.tsx';
+
+const renderPools = () =>
+  render(
+    <MemoryRouter initialEntries={['/admin/pools']}>
+      <PoolsRoute />
+    </MemoryRouter>,
+  );
+
+beforeEach(() => {
+  loaderDataSnapshot.pools = [];
+  loaderDataSnapshot.total = 0;
+  loaderDataSnapshot.statusParam = 'stuck';
+  loaderDataSnapshot.page = 1;
+  loaderDataSnapshot.pageSize = 25;
+});
+
+describe('admin pools list page', () => {
+  it('renders the heading and status tabs', () => {
+    renderPools();
+    expect(screen.getByRole('heading', { name: 'Pools' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Stuck' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'All' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Open' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Delivered' })).toBeInTheDocument();
+  });
+
+  it('shows empty state for stuck pools', () => {
+    renderPools();
+    expect(
+      screen.getByText(/No stuck pools. Everything is moving along./),
+    ).toBeInTheDocument();
+  });
+
+  it('renders pool rows with title, status badge, occasion, and contributor count', () => {
+    loaderDataSnapshot.pools = [
+      {
+        id: 'p1',
+        title: "Marco's Birthday",
+        status: 'OPEN',
+        occasionType: 'BIRTHDAY',
+        eventDate: '2026-03-01T00:00:00.000Z',
+        updatedAt: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString(),
+        inviteCode: null,
+        organizer: { id: 'u1', username: 'wade', name: 'Wade' },
+        contributorCount: 4,
+      },
+    ];
+    loaderDataSnapshot.total = 1;
+    loaderDataSnapshot.statusParam = 'all';
+    renderPools();
+
+    expect(screen.getByText("Marco's Birthday")).toBeInTheDocument();
+    expect(screen.getAllByText('Open').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Birthday').length).toBeGreaterThan(0);
+    expect(screen.getByText('4')).toBeInTheDocument();
+    expect(screen.getByText('overdue')).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: /Marco's Birthday/ }),
+    ).toHaveAttribute('href', '/admin/pools/p1');
+  });
+
+  it('renders pagination when more than one page', () => {
+    loaderDataSnapshot.pools = [
+      {
+        id: 'p1',
+        title: 'Pool 1',
+        status: 'OPEN',
+        occasionType: 'OTHER',
+        eventDate: null,
+        updatedAt: new Date().toISOString(),
+        inviteCode: null,
+        organizer: { id: 'u1', username: 'wade', name: null },
+        contributorCount: 1,
+      },
+    ];
+    loaderDataSnapshot.total = 50;
+    loaderDataSnapshot.page = 1;
+    loaderDataSnapshot.statusParam = 'all';
+    renderPools();
+
+    expect(screen.getByText('Page 1 of 2')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Next/ })).toBeInTheDocument();
+  });
+});

--- a/app/routes/admin+/pools.test.ts
+++ b/app/routes/admin+/pools.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import { loader } from '#app/routes/admin+/pools.tsx';
+import { prisma } from '#app/utils/db.server.ts';
+import { POOL_STATUS } from '#app/utils/pool-constants.ts';
+import { createUser } from '#tests/db-utils.ts';
+import {
+  getRouteResultData,
+  getRouteResultStatus,
+  toLoaderArgs,
+} from '#tests/route-module-test-utils.ts';
+import { getSessionCookieHeader } from '#tests/utils.ts';
+
+const DAY_MS = 1000 * 60 * 60 * 24;
+
+async function seedAdminSession() {
+  await prisma.role.upsert({
+    where: { name: 'admin' },
+    update: {},
+    create: { name: 'admin', description: 'Admin role' },
+  });
+  const admin = await prisma.user.create({
+    data: { ...createUser(), roles: { connect: { name: 'admin' } } },
+    select: { id: true },
+  });
+  const session = await prisma.session.create({
+    data: { userId: admin.id, expirationDate: new Date(Date.now() + DAY_MS) },
+  });
+  const cookie = await getSessionCookieHeader(session);
+  return { admin, cookie };
+}
+
+describe('/admin/pools loader', () => {
+  it('rejects non-admin users', async () => {
+    const user = await prisma.user.create({ data: createUser() });
+    const session = await prisma.session.create({
+      data: { userId: user.id, expirationDate: new Date(Date.now() + DAY_MS) },
+    });
+    const cookie = await getSessionCookieHeader(session);
+    const request = new Request('http://localhost/admin/pools', {
+      headers: { cookie },
+    });
+    await expect(
+      loader(toLoaderArgs({ request, params: {}, context: {} as any })),
+    ).rejects.toMatchObject({ init: { status: 403 } });
+  });
+
+  it('returns stuck pools by default', async () => {
+    const { admin, cookie } = await seedAdminSession();
+    await prisma.pool.create({
+      data: {
+        title: 'Overdue one',
+        organizerId: admin.id,
+        status: POOL_STATUS.OPEN,
+        eventDate: new Date(Date.now() - 3 * DAY_MS),
+      },
+    });
+    const request = new Request('http://localhost/admin/pools', {
+      headers: { cookie },
+    });
+    const result = await loader(
+      toLoaderArgs({ request, params: {}, context: {} as any }),
+    );
+    expect(getRouteResultStatus(result)).toBe(200);
+    const data = await getRouteResultData<{
+      pools: Array<{ title: string }>;
+      statusParam: string;
+    }>(result);
+    expect(data.statusParam).toBe('stuck');
+    expect(data.pools).toHaveLength(1);
+    expect(data.pools[0]?.title).toBe('Overdue one');
+  });
+
+  it('filters by status when ?status=OPEN', async () => {
+    const { admin, cookie } = await seedAdminSession();
+    await prisma.pool.create({
+      data: {
+        title: 'Open pool',
+        organizerId: admin.id,
+        status: POOL_STATUS.OPEN,
+      },
+    });
+    await prisma.pool.create({
+      data: {
+        title: 'Voting pool',
+        organizerId: admin.id,
+        status: POOL_STATUS.VOTING,
+      },
+    });
+    const request = new Request(
+      'http://localhost/admin/pools?status=OPEN',
+      { headers: { cookie } },
+    );
+    const result = await loader(
+      toLoaderArgs({ request, params: {}, context: {} as any }),
+    );
+    const data = await getRouteResultData<{
+      pools: Array<{ title: string; status: string }>;
+      total: number;
+    }>(result);
+    expect(data.total).toBe(1);
+    expect(data.pools[0]?.status).toBe('OPEN');
+  });
+});

--- a/app/routes/admin+/pools.tsx
+++ b/app/routes/admin+/pools.tsx
@@ -1,0 +1,243 @@
+import {
+  Link,
+  NavLink,
+  type LoaderFunctionArgs,
+  useLoaderData,
+  useSearchParams,
+} from 'react-router';
+import { EmptyRow, SectionCard } from '#app/components/admin-ui.tsx';
+import { GeneralErrorBoundary } from '#app/components/error-boundary.tsx';
+import { listAdminPools } from '#app/utils/admin.server.ts';
+import { cn } from '#app/utils/misc.tsx';
+import { requireUserWithRole } from '#app/utils/permissions.server.ts';
+import {
+  POOL_STATUS,
+  POOL_STATUS_LABELS,
+  OCCASION_TYPE_LABELS,
+  type PoolStatus,
+} from '#app/utils/pool-constants.ts';
+
+const STATUS_TABS: Array<{ value: string; label: string }> = [
+  { value: 'stuck', label: 'Stuck' },
+  { value: 'all', label: 'All' },
+  ...Object.values(POOL_STATUS).map((s) => ({
+    value: s,
+    label: POOL_STATUS_LABELS[s],
+  })),
+];
+
+const PAGE_SIZE = 25;
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  await requireUserWithRole(request, 'admin');
+  const url = new URL(request.url);
+  const statusParam = url.searchParams.get('status') ?? 'stuck';
+  const page = Math.max(1, Number(url.searchParams.get('page') ?? 1));
+  const offset = (page - 1) * PAGE_SIZE;
+
+  const stuckOnly = statusParam === 'stuck';
+  const status = stuckOnly
+    ? undefined
+    : (statusParam as PoolStatus | 'all');
+
+  const { pools, total } = await listAdminPools({
+    status,
+    stuckOnly,
+    limit: PAGE_SIZE,
+    offset,
+  });
+
+  return { pools, total, statusParam, page, pageSize: PAGE_SIZE };
+}
+
+const formatRelative = (date: Date | string) => {
+  const d = typeof date === 'string' ? new Date(date) : date;
+  const diffMs = Date.now() - d.getTime();
+  const days = Math.round(diffMs / (1000 * 60 * 60 * 24));
+  if (days < 1) return 'today';
+  if (days === 1) return '1d ago';
+  return `${days}d ago`;
+};
+
+const PoolsRoute = () => {
+  const { pools, total, statusParam, page, pageSize } =
+    useLoaderData<typeof loader>();
+  const [searchParams] = useSearchParams();
+  const totalPages = Math.ceil(total / pageSize);
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-1">
+        <h1 className="text-h1">Pools</h1>
+        <p className="text-muted-foreground">
+          Health board — default view is stuck pools. Filter by status or view
+          all.
+        </p>
+      </div>
+
+      {/* --- status tabs --- */}
+      <div className="flex flex-wrap gap-1.5 rounded-xl bg-muted p-1">
+        {STATUS_TABS.map((tab) => (
+          <NavLink
+            key={tab.value}
+            to={`/admin/pools?status=${tab.value}`}
+            className={cn(
+              'px-3 py-1.5 text-sm font-medium text-muted-foreground',
+              'rounded-lg transition-colors',
+              statusParam === tab.value &&
+                'bg-background text-foreground shadow',
+            )}
+          >
+            {tab.label}
+          </NavLink>
+        ))}
+      </div>
+
+      {/* --- pool table --- */}
+      <SectionCard
+        title={
+          statusParam === 'stuck'
+            ? `Stuck pools (${total})`
+            : `Pools — ${statusParam === 'all' ? 'all' : POOL_STATUS_LABELS[statusParam as PoolStatus] ?? statusParam} (${total})`
+        }
+      >
+        {pools.length === 0 ? (
+          <EmptyRow>
+            {statusParam === 'stuck'
+              ? 'No stuck pools. Everything is moving along.'
+              : 'No pools match this filter.'}
+          </EmptyRow>
+        ) : (
+          <div className="overflow-hidden rounded-md border border-border/50">
+            <table className="min-w-full divide-y divide-border/60">
+              <thead className="bg-muted/40">
+                <tr>
+                  <th className="px-4 py-2 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    Pool
+                  </th>
+                  <th className="px-4 py-2 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    Status
+                  </th>
+                  <th className="px-4 py-2 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    Occasion
+                  </th>
+                  <th className="px-4 py-2 text-right text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    Contributors
+                  </th>
+                  <th className="px-4 py-2 text-right text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    Last activity
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border/60">
+                {pools.map((pool) => {
+                  const isOverdue =
+                    pool.eventDate &&
+                    new Date(pool.eventDate).getTime() < Date.now() &&
+                    pool.status !== 'DELIVERED' &&
+                    pool.status !== 'CANCELLED';
+                  return (
+                    <tr
+                      key={pool.id}
+                      className="transition-colors hover:bg-muted/30"
+                    >
+                      <td className="px-4 py-2">
+                        <Link
+                          to={`/admin/pools/${pool.id}`}
+                          className="group flex flex-col"
+                        >
+                          <span className="text-sm font-semibold group-hover:underline">
+                            {pool.title}
+                          </span>
+                          <span className="text-xs text-muted-foreground">
+                            organizer: {pool.organizer.username}
+                          </span>
+                        </Link>
+                      </td>
+                      <td className="px-4 py-2">
+                        <StatusBadge status={pool.status} />
+                      </td>
+                      <td className="px-4 py-2 text-sm">
+                        {OCCASION_TYPE_LABELS[pool.occasionType as keyof typeof OCCASION_TYPE_LABELS] ?? pool.occasionType}
+                        {isOverdue ? (
+                          <span className="ml-1 text-xs font-semibold text-destructive">
+                            overdue
+                          </span>
+                        ) : null}
+                      </td>
+                      <td className="px-4 py-2 text-right text-sm tabular-nums">
+                        {pool.contributorCount}
+                      </td>
+                      <td className="px-4 py-2 text-right text-xs text-muted-foreground">
+                        {formatRelative(pool.updatedAt)}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {/* pagination */}
+        {totalPages > 1 ? (
+          <div className="mt-4 flex items-center justify-between text-sm">
+            <span className="text-muted-foreground">
+              Page {page} of {totalPages}
+            </span>
+            <div className="flex gap-2">
+              {page > 1 ? (
+                <Link
+                  to={`/admin/pools?status=${statusParam}&page=${page - 1}`}
+                  className="rounded-md bg-muted px-3 py-1 font-medium hover:bg-accent"
+                >
+                  ← Prev
+                </Link>
+              ) : null}
+              {page < totalPages ? (
+                <Link
+                  to={`/admin/pools?status=${statusParam}&page=${page + 1}`}
+                  className="rounded-md bg-muted px-3 py-1 font-medium hover:bg-accent"
+                >
+                  Next →
+                </Link>
+              ) : null}
+            </div>
+          </div>
+        ) : null}
+      </SectionCard>
+    </div>
+  );
+};
+
+const StatusBadge = ({ status }: { status: PoolStatus }) => {
+  const colorMap: Record<PoolStatus, string> = {
+    OPEN: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300',
+    VOTING:
+      'bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300',
+    DECIDED:
+      'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300',
+    PURCHASED:
+      'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300',
+    DELIVERED:
+      'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300',
+    CANCELLED:
+      'bg-gray-100 text-gray-600 dark:bg-gray-800/30 dark:text-gray-400',
+  };
+  return (
+    <span
+      className={cn(
+        'inline-block rounded-md px-2 py-0.5 text-xs font-semibold',
+        colorMap[status],
+      )}
+    >
+      {POOL_STATUS_LABELS[status]}
+    </span>
+  );
+};
+
+export default PoolsRoute;
+
+export const ErrorBoundary = () => {
+  return <GeneralErrorBoundary />;
+};

--- a/app/routes/admin+/pools.tsx
+++ b/app/routes/admin+/pools.tsx
@@ -3,7 +3,6 @@ import {
   NavLink,
   type LoaderFunctionArgs,
   useLoaderData,
-  useSearchParams,
 } from 'react-router';
 import { EmptyRow, SectionCard } from '#app/components/admin-ui.tsx';
 import { GeneralErrorBoundary } from '#app/components/error-boundary.tsx';
@@ -32,7 +31,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
   await requireUserWithRole(request, 'admin');
   const url = new URL(request.url);
   const statusParam = url.searchParams.get('status') ?? 'stuck';
-  const page = Math.max(1, Number(url.searchParams.get('page') ?? 1));
+  const rawPage = Number.parseInt(url.searchParams.get('page') ?? '1', 10);
+  const page = Number.isFinite(rawPage) && rawPage > 0 ? rawPage : 1;
   const offset = (page - 1) * PAGE_SIZE;
 
   const stuckOnly = statusParam === 'stuck';
@@ -62,8 +62,18 @@ const formatRelative = (date: Date | string) => {
 const PoolsRoute = () => {
   const { pools, total, statusParam, page, pageSize } =
     useLoaderData<typeof loader>();
-  const [searchParams] = useSearchParams();
   const totalPages = Math.ceil(total / pageSize);
+
+  let sectionTitle: string;
+  if (statusParam === 'stuck') {
+    sectionTitle = `Stuck pools (${total})`;
+  } else {
+    const statusLabel =
+      statusParam === 'all'
+        ? 'all'
+        : (POOL_STATUS_LABELS[statusParam as PoolStatus] ?? statusParam);
+    sectionTitle = `Pools — ${statusLabel} (${total})`;
+  }
 
   return (
     <div className="space-y-6">
@@ -94,13 +104,7 @@ const PoolsRoute = () => {
       </div>
 
       {/* --- pool table --- */}
-      <SectionCard
-        title={
-          statusParam === 'stuck'
-            ? `Stuck pools (${total})`
-            : `Pools — ${statusParam === 'all' ? 'all' : POOL_STATUS_LABELS[statusParam as PoolStatus] ?? statusParam} (${total})`
-        }
-      >
+      <SectionCard title={sectionTitle}>
         {pools.length === 0 ? (
           <EmptyRow>
             {statusParam === 'stuck'

--- a/app/routes/admin+/pools_.$poolId.tsx
+++ b/app/routes/admin+/pools_.$poolId.tsx
@@ -1,0 +1,331 @@
+import { invariantResponse } from '@epic-web/invariant';
+import {
+  Link,
+  useFetcher,
+  useLoaderData,
+  type ActionFunctionArgs,
+  type LoaderFunctionArgs,
+} from 'react-router';
+import { EmptyRow, SectionCard } from '#app/components/admin-ui.tsx';
+import { GeneralErrorBoundary } from '#app/components/error-boundary.tsx';
+import { Button } from '#app/components/ui/button.tsx';
+import { ConfirmDialog } from '#app/components/ui/confirm-dialog.tsx';
+import { getAdminPoolDetail } from '#app/utils/admin.server.ts';
+import { cn } from '#app/utils/misc.tsx';
+import { requireUserWithRole } from '#app/utils/permissions.server.ts';
+import { logPoolActivity } from '#app/utils/pool-activity.server.ts';
+import {
+  POOL_ACTIVITY_TYPE,
+  POOL_STATUS_LABELS,
+  OCCASION_TYPE_LABELS,
+  type PoolStatus,
+} from '#app/utils/pool-constants.ts';
+import { cancelPool } from '#app/utils/pool.server.ts';
+
+export async function loader({ params, request }: LoaderFunctionArgs) {
+  await requireUserWithRole(request, 'admin');
+  const poolId = params.poolId;
+  invariantResponse(typeof poolId === 'string', 'poolId required', {
+    status: 400,
+  });
+  const pool = await getAdminPoolDetail(poolId);
+  invariantResponse(pool, 'Pool not found', { status: 404 });
+  return { pool };
+}
+
+type ActionResult =
+  | { ok: true; message: string }
+  | { ok: false; message: string };
+
+export async function action({
+  params,
+  request,
+}: ActionFunctionArgs): Promise<ActionResult> {
+  const actingUserId = await requireUserWithRole(request, 'admin');
+  const poolId = params.poolId;
+  invariantResponse(typeof poolId === 'string', 'poolId required', {
+    status: 400,
+  });
+
+  const formData = await request.formData();
+  const intent = formData.get('intent');
+
+  if (intent === 'cancel_pool') {
+    await cancelPool(poolId, actingUserId);
+    await logPoolActivity(poolId, POOL_ACTIVITY_TYPE.POOL_CANCELLED, {
+      actorId: actingUserId,
+      payload: { source: 'admin' },
+    });
+    return { ok: true, message: 'Pool cancelled by admin.' };
+  }
+
+  return { ok: false, message: `Unknown intent: ${typeof intent === 'string' ? intent : ''}` };
+}
+
+const formatDate = (date: Date | string) =>
+  new Date(date).toLocaleDateString();
+
+const formatDateTime = (date: Date | string) =>
+  new Date(date).toLocaleString();
+
+const formatCents = (cents: number | null) =>
+  cents != null ? `$${(cents / 100).toFixed(2)}` : '—';
+
+const PoolDetailRoute = () => {
+  const { pool } = useLoaderData<typeof loader>();
+  const fetcher = useFetcher<typeof action>();
+
+  const isCancellable =
+    pool.status !== 'CANCELLED' && pool.status !== 'DELIVERED';
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <Link
+            to="/admin/pools"
+            className="text-sm text-muted-foreground hover:underline"
+          >
+            ← Back to pools
+          </Link>
+          <h1 className="text-h1">{pool.title}</h1>
+          <p className="text-muted-foreground">
+            {POOL_STATUS_LABELS[pool.status]} ·{' '}
+            {OCCASION_TYPE_LABELS[pool.occasionType as keyof typeof OCCASION_TYPE_LABELS] ?? pool.occasionType}
+            {pool.eventDate
+              ? ` · event ${formatDate(pool.eventDate)}`
+              : null}
+          </p>
+        </div>
+      </div>
+
+      {fetcher.data ? (
+        <div
+          className={
+            fetcher.data.ok
+              ? 'rounded-md border border-emerald-400/50 bg-emerald-50/60 p-3 text-sm text-emerald-900 dark:bg-emerald-950/20 dark:text-emerald-200'
+              : 'rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive'
+          }
+        >
+          {fetcher.data.message}
+        </div>
+      ) : null}
+
+      <section className="grid gap-4 lg:grid-cols-2">
+        {/* --- meta --- */}
+        <SectionCard title="Details">
+          <dl className="grid grid-cols-[auto,1fr] gap-x-4 gap-y-2 text-sm">
+            <DLRow label="ID" value={pool.id} mono />
+            <DLRow label="Created" value={formatDate(pool.createdAt)} />
+            <DLRow label="Decision mode" value={pool.decisionMode} />
+            <DLRow label="Organizer" value={pool.organizer.username} />
+            <DLRow
+              label="Purchaser"
+              value={pool.purchaser?.username ?? '—'}
+            />
+            <DLRow
+              label="Deliverer"
+              value={pool.deliverer?.username ?? '—'}
+            />
+            <DLRow
+              label="Recipient"
+              value={
+                pool.recipientUser?.username ?? pool.recipientName ?? '—'
+              }
+            />
+            <DLRow label="Invite code" value={pool.inviteCode ?? '—'} />
+            <DLRow
+              label="Final price"
+              value={formatCents(pool.finalPriceCents)}
+            />
+            <DLRow
+              label="Chosen idea"
+              value={pool.chosenIdeaId ?? '—'}
+              mono
+            />
+          </dl>
+        </SectionCard>
+
+        {/* --- contributors --- */}
+        <SectionCard
+          title={`Contributors (${pool.contributors.length})`}
+        >
+          {pool.contributors.length === 0 ? (
+            <EmptyRow>No contributors yet.</EmptyRow>
+          ) : (
+            <div className="overflow-hidden rounded-md border border-border/50">
+              <table className="min-w-full divide-y divide-border/60 text-sm">
+                <thead className="bg-muted/40">
+                  <tr>
+                    <th className="px-3 py-1.5 text-left text-xs font-medium uppercase text-muted-foreground">
+                      User
+                    </th>
+                    <th className="px-3 py-1.5 text-right text-xs font-medium uppercase text-muted-foreground">
+                      Budget
+                    </th>
+                    <th className="px-3 py-1.5 text-center text-xs font-medium uppercase text-muted-foreground">
+                      Paid
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-border/60">
+                  {pool.contributors.map((c) => (
+                    <tr key={c.userId}>
+                      <td className="px-3 py-1.5 font-medium">
+                        {c.name ?? c.username}
+                      </td>
+                      <td className="px-3 py-1.5 text-right tabular-nums">
+                        {formatCents(c.contributionCents)}
+                      </td>
+                      <td className="px-3 py-1.5 text-center">
+                        <span
+                          className={cn(
+                            'inline-block rounded px-1.5 py-0.5 text-xs font-semibold',
+                            c.hasPaid
+                              ? 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300'
+                              : 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300',
+                          )}
+                        >
+                          {c.hasPaid ? 'paid' : 'unpaid'}
+                        </span>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </SectionCard>
+
+        {/* --- ideas --- */}
+        <SectionCard title={`Ideas (${pool.ideas.length})`}>
+          {pool.ideas.length === 0 ? (
+            <EmptyRow>No ideas proposed yet.</EmptyRow>
+          ) : (
+            <ul className="divide-y divide-border/60 text-sm">
+              {pool.ideas.map((idea) => (
+                <li
+                  key={idea.id}
+                  className={cn(
+                    'flex items-center justify-between py-2',
+                    idea.id === pool.chosenIdeaId &&
+                      'rounded bg-emerald-50/60 px-2 dark:bg-emerald-950/20',
+                  )}
+                >
+                  <div>
+                    <span className="font-medium">{idea.name}</span>
+                    <span className="ml-2 text-xs text-muted-foreground">
+                      by {idea.proposedBy.username}
+                    </span>
+                    {idea.id === pool.chosenIdeaId ? (
+                      <span className="ml-2 text-xs font-semibold text-emerald-700 dark:text-emerald-300">
+                        chosen
+                      </span>
+                    ) : null}
+                  </div>
+                  <div className="flex items-center gap-3 text-xs text-muted-foreground">
+                    <span>{formatCents(idea.estimatedPriceCents)}</span>
+                    <span>{idea.voteCount} vote{idea.voteCount !== 1 ? 's' : ''}</span>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </SectionCard>
+
+        {/* --- cancel action --- */}
+        <SectionCard
+          title="Admin actions"
+          description="Only pool cancellation is exposed. Other transitions should go through the normal flow."
+        >
+          {isCancellable ? (
+            <ConfirmDialog
+              title="Cancel this pool"
+              description="This will mark the pool as CANCELLED. Contributors will see the status change on their next visit. This action cannot be undone from the admin UI."
+              confirmText="Cancel pool"
+              requireText={pool.title}
+              onConfirm={() => {
+                const form = new FormData();
+                form.append('intent', 'cancel_pool');
+                void fetcher.submit(form, { method: 'POST' });
+              }}
+            >
+              <Button variant="destructive" size="sm">
+                Cancel pool
+              </Button>
+            </ConfirmDialog>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              This pool is{' '}
+              <strong>
+                {POOL_STATUS_LABELS[pool.status as PoolStatus]}
+              </strong>{' '}
+              — no admin actions available.
+            </p>
+          )}
+        </SectionCard>
+      </section>
+
+      {/* --- activity timeline --- */}
+      <SectionCard
+        title={`Activity timeline (${pool.activities.length})`}
+        description="Last 50 PoolActivity rows, newest first."
+      >
+        {pool.activities.length === 0 ? (
+          <EmptyRow>No activity recorded.</EmptyRow>
+        ) : (
+          <ul className="divide-y divide-border/60">
+            {pool.activities.map((activity) => (
+              <li
+                key={activity.id}
+                className="flex items-start justify-between gap-2 py-2 text-sm"
+              >
+                <div className="min-w-0">
+                  <span className="mr-2 inline-flex items-center rounded-md bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+                    {activity.type}
+                  </span>
+                  {activity.actorId ? (
+                    <span className="text-xs text-muted-foreground">
+                      actor: {activity.actorId.slice(0, 12)}…
+                    </span>
+                  ) : null}
+                  {activity.payload ? (
+                    <div className="mt-0.5 truncate font-mono text-xs text-muted-foreground">
+                      {activity.payload}
+                    </div>
+                  ) : null}
+                </div>
+                <span className="shrink-0 text-xs text-muted-foreground">
+                  {formatDateTime(activity.createdAt)}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </SectionCard>
+    </div>
+  );
+};
+
+const DLRow = ({
+  label,
+  value,
+  mono,
+}: {
+  label: string;
+  value: React.ReactNode;
+  mono?: boolean;
+}) => (
+  <>
+    <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+      {label}
+    </dt>
+    <dd className={mono ? 'font-mono text-xs' : 'text-sm'}>{value}</dd>
+  </>
+);
+
+export default PoolDetailRoute;
+
+export const ErrorBoundary = () => {
+  return <GeneralErrorBoundary />;
+};

--- a/app/routes/admin+/pools_.$poolId.tsx
+++ b/app/routes/admin+/pools_.$poolId.tsx
@@ -6,7 +6,7 @@ import {
   type ActionFunctionArgs,
   type LoaderFunctionArgs,
 } from 'react-router';
-import { EmptyRow, SectionCard } from '#app/components/admin-ui.tsx';
+import { DLRow, EmptyRow, SectionCard } from '#app/components/admin-ui.tsx';
 import { GeneralErrorBoundary } from '#app/components/error-boundary.tsx';
 import { Button } from '#app/components/ui/button.tsx';
 import { ConfirmDialog } from '#app/components/ui/confirm-dialog.tsx';
@@ -18,7 +18,6 @@ import {
   POOL_ACTIVITY_TYPE,
   POOL_STATUS_LABELS,
   OCCASION_TYPE_LABELS,
-  type PoolStatus,
 } from '#app/utils/pool-constants.ts';
 import { cancelPool } from '#app/utils/pool.server.ts';
 
@@ -68,8 +67,10 @@ const formatDate = (date: Date | string) =>
 const formatDateTime = (date: Date | string) =>
   new Date(date).toLocaleString();
 
-const formatCents = (cents: number | null) =>
-  cents != null ? `$${(cents / 100).toFixed(2)}` : '—';
+const formatCents = (cents: number | null) => {
+  if (cents == null) return '—';
+  return `$${(cents / 100).toFixed(2)}`;
+};
 
 const PoolDetailRoute = () => {
   const { pool } = useLoaderData<typeof loader>();
@@ -225,7 +226,7 @@ const PoolDetailRoute = () => {
                   </div>
                   <div className="flex items-center gap-3 text-xs text-muted-foreground">
                     <span>{formatCents(idea.estimatedPriceCents)}</span>
-                    <span>{idea.voteCount} vote{idea.voteCount !== 1 ? 's' : ''}</span>
+                    <span>{idea.voteCount} {idea.voteCount === 1 ? 'vote' : 'votes'}</span>
                   </div>
                 </li>
               ))}
@@ -258,7 +259,7 @@ const PoolDetailRoute = () => {
             <p className="text-sm text-muted-foreground">
               This pool is{' '}
               <strong>
-                {POOL_STATUS_LABELS[pool.status as PoolStatus]}
+                {POOL_STATUS_LABELS[pool.status]}
               </strong>{' '}
               — no admin actions available.
             </p>
@@ -306,23 +307,6 @@ const PoolDetailRoute = () => {
     </div>
   );
 };
-
-const DLRow = ({
-  label,
-  value,
-  mono,
-}: {
-  label: string;
-  value: React.ReactNode;
-  mono?: boolean;
-}) => (
-  <>
-    <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-      {label}
-    </dt>
-    <dd className={mono ? 'font-mono text-xs' : 'text-sm'}>{value}</dd>
-  </>
-);
 
 export default PoolDetailRoute;
 

--- a/app/routes/admin+/pools_.dom.test.tsx
+++ b/app/routes/admin+/pools_.dom.test.tsx
@@ -1,0 +1,194 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import * as ReactRouter from 'react-router';
+import { MemoryRouter } from 'react-router';
+import { describe, expect, it, vi } from 'vitest';
+
+const loaderDataSnapshot = {
+  pool: {
+    id: 'pool-1',
+    title: "Marco's Birthday",
+    status: 'OPEN' as const,
+    occasionType: 'BIRTHDAY',
+    eventDate: '2026-05-15T00:00:00.000Z',
+    decisionMode: 'ORGANIZER_PICKS',
+    inviteCode: 'abc123',
+    finalPriceCents: 2500,
+    chosenIdeaId: 'idea-1',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-04-10T00:00:00.000Z',
+    organizer: { id: 'u1', username: 'wade', name: 'Wade Wilson' },
+    purchaser: null,
+    deliverer: null,
+    recipientUser: { id: 'u2', username: 'marco', name: 'Marco' },
+    recipientName: null,
+    contributors: [
+      {
+        userId: 'u1',
+        username: 'wade',
+        name: 'Wade Wilson',
+        contributionCents: 1000,
+        hasPaid: true,
+      },
+      {
+        userId: 'u3',
+        username: 'sofia',
+        name: 'Sofia',
+        contributionCents: null,
+        hasPaid: false,
+      },
+    ],
+    ideas: [
+      {
+        id: 'idea-1',
+        name: 'Nice watch',
+        estimatedPriceCents: 2500,
+        proposedBy: { username: 'wade' },
+        voteCount: 2,
+      },
+      {
+        id: 'idea-2',
+        name: 'Book set',
+        estimatedPriceCents: 1500,
+        proposedBy: { username: 'sofia' },
+        voteCount: 0,
+      },
+    ],
+    activities: [
+      {
+        id: 'act-1',
+        type: 'pool.created',
+        actorId: 'u1',
+        payload: '{"title":"Marco\'s Birthday"}',
+        createdAt: '2026-01-01T00:00:00.000Z',
+      },
+      {
+        id: 'act-2',
+        type: 'idea.proposed',
+        actorId: 'u1',
+        payload: null,
+        createdAt: '2026-01-02T00:00:00.000Z',
+      },
+    ],
+  },
+};
+
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual<typeof ReactRouter>('react-router');
+  return {
+    ...actual,
+    useLoaderData: () => loaderDataSnapshot,
+    useFetcher: () => ({ data: null, state: 'idle', submit: vi.fn() }),
+  };
+});
+
+vi.mock('#app/utils/permissions.server.ts', () => ({
+  requireUserWithRole: vi.fn(),
+}));
+
+vi.mock('#app/utils/admin.server.ts', () => ({
+  getAdminPoolDetail: vi.fn(),
+}));
+
+vi.mock('#app/utils/pool.server.ts', () => ({
+  cancelPool: vi.fn(),
+}));
+
+vi.mock('#app/utils/pool-activity.server.ts', () => ({
+  logPoolActivity: vi.fn(),
+}));
+
+import PoolDetailRoute from './pools_.$poolId.tsx';
+
+const renderDetail = () =>
+  render(
+    <MemoryRouter initialEntries={['/admin/pools/pool-1']}>
+      <PoolDetailRoute />
+    </MemoryRouter>,
+  );
+
+describe('admin pool detail page', () => {
+  it('renders the pool title and status line', () => {
+    renderDetail();
+    expect(
+      screen.getByRole('heading', { name: "Marco's Birthday" }),
+    ).toBeInTheDocument();
+    expect(screen.getAllByText(/Open/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Birthday/).length).toBeGreaterThan(0);
+  });
+
+  it('renders all section headings', () => {
+    renderDetail();
+    for (const heading of [
+      'Details',
+      'Contributors (2)',
+      'Ideas (2)',
+      'Admin actions',
+      'Activity timeline (2)',
+    ]) {
+      expect(
+        screen.getByRole('heading', { name: heading }),
+      ).toBeInTheDocument();
+    }
+  });
+
+  it('renders contributor table with paid/unpaid badges', () => {
+    renderDetail();
+    expect(screen.getByText('Wade Wilson')).toBeInTheDocument();
+    expect(screen.getByText('Sofia')).toBeInTheDocument();
+    expect(screen.getByText('paid')).toBeInTheDocument();
+    expect(screen.getByText('unpaid')).toBeInTheDocument();
+  });
+
+  it('renders ideas with vote counts and chosen highlight', () => {
+    renderDetail();
+    expect(screen.getByText('Nice watch')).toBeInTheDocument();
+    expect(screen.getByText('Book set')).toBeInTheDocument();
+    expect(screen.getByText('chosen')).toBeInTheDocument();
+    expect(screen.getByText('2 votes')).toBeInTheDocument();
+    expect(screen.getByText('0 votes')).toBeInTheDocument();
+  });
+
+  it('renders activity timeline rows', () => {
+    renderDetail();
+    expect(screen.getByText('pool.created')).toBeInTheDocument();
+    expect(screen.getByText('idea.proposed')).toBeInTheDocument();
+  });
+
+  it('renders the cancel button for cancellable pools', () => {
+    renderDetail();
+    expect(
+      screen.getByRole('button', { name: 'Cancel pool' }),
+    ).toBeInTheDocument();
+  });
+
+  it('does NOT render cancel button for delivered pools', () => {
+    loaderDataSnapshot.pool = {
+      ...loaderDataSnapshot.pool,
+      status: 'DELIVERED' as const,
+    };
+    renderDetail();
+    expect(
+      screen.queryByRole('button', { name: 'Cancel pool' }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/no admin actions available/),
+    ).toBeInTheDocument();
+  });
+
+  it('links back to the pools list', () => {
+    renderDetail();
+    const link = screen.getByRole('link', { name: /Back to pools/ });
+    expect(link).toHaveAttribute('href', '/admin/pools');
+  });
+
+  it('renders the detail fields', () => {
+    renderDetail();
+    expect(screen.getByText('pool-1')).toBeInTheDocument();
+    expect(screen.getAllByText('wade').length).toBeGreaterThan(0);
+    expect(screen.getByText('abc123')).toBeInTheDocument();
+    expect(screen.getAllByText('$25.00').length).toBeGreaterThan(0);
+  });
+});

--- a/app/routes/admin+/pools_.dom.test.tsx
+++ b/app/routes/admin+/pools_.dom.test.tsx
@@ -10,7 +10,7 @@ const loaderDataSnapshot = {
   pool: {
     id: 'pool-1',
     title: "Marco's Birthday",
-    status: 'OPEN' as const,
+    status: 'OPEN' as string,
     occasionType: 'BIRTHDAY',
     eventDate: '2026-05-15T00:00:00.000Z',
     decisionMode: 'ORGANIZER_PICKS',

--- a/app/routes/admin+/pools_.test.ts
+++ b/app/routes/admin+/pools_.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from 'vitest';
+import {
+  action,
+  loader as detailLoader,
+} from '#app/routes/admin+/pools_.$poolId.tsx';
+import { prisma } from '#app/utils/db.server.ts';
+import { POOL_STATUS } from '#app/utils/pool-constants.ts';
+import { createUser } from '#tests/db-utils.ts';
+import {
+  getRouteResultData,
+  getRouteResultStatus,
+  toActionArgs,
+  toLoaderArgs,
+} from '#tests/route-module-test-utils.ts';
+import { getSessionCookieHeader } from '#tests/utils.ts';
+
+const DAY_MS = 1000 * 60 * 60 * 24;
+
+async function seedAdminSession() {
+  await prisma.role.upsert({
+    where: { name: 'admin' },
+    update: {},
+    create: { name: 'admin', description: 'Admin role' },
+  });
+  const admin = await prisma.user.create({
+    data: { ...createUser(), roles: { connect: { name: 'admin' } } },
+    select: { id: true },
+  });
+  const session = await prisma.session.create({
+    data: { userId: admin.id, expirationDate: new Date(Date.now() + DAY_MS) },
+  });
+  const cookie = await getSessionCookieHeader(session);
+  return { admin, cookie };
+}
+
+describe('/admin/pools/:poolId loader', () => {
+  it('404s on an unknown pool id', async () => {
+    const { cookie } = await seedAdminSession();
+    const request = new Request('http://localhost/admin/pools/nope', {
+      headers: { cookie },
+    });
+    try {
+      await detailLoader(
+        toLoaderArgs({
+          request,
+          params: { poolId: 'nope' },
+          context: {} as any,
+        }),
+      );
+      throw new Error('expected throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(Response);
+      expect((err as Response).status).toBe(404);
+    }
+  });
+
+  it('returns full pool detail shape', async () => {
+    const { admin, cookie } = await seedAdminSession();
+    const pool = await prisma.pool.create({
+      data: {
+        title: 'Test pool',
+        organizerId: admin.id,
+        status: POOL_STATUS.OPEN,
+        contributors: { create: { userId: admin.id } },
+      },
+      select: { id: true },
+    });
+    const request = new Request(`http://localhost/admin/pools/${pool.id}`, {
+      headers: { cookie },
+    });
+    const result = await detailLoader(
+      toLoaderArgs({
+        request,
+        params: { poolId: pool.id },
+        context: {} as any,
+      }),
+    );
+    expect(getRouteResultStatus(result)).toBe(200);
+    const data = await getRouteResultData<{
+      pool: {
+        id: string;
+        title: string;
+        status: string;
+        contributors: unknown[];
+        ideas: unknown[];
+        activities: unknown[];
+      };
+    }>(result);
+    expect(data.pool.id).toBe(pool.id);
+    expect(data.pool.title).toBe('Test pool');
+    expect(data.pool.contributors).toHaveLength(1);
+    expect(data.pool.ideas).toHaveLength(0);
+    expect(data.pool.activities).toHaveLength(0);
+  });
+});
+
+describe('/admin/pools/:poolId action — cancel_pool', () => {
+  it('cancels the pool and logs a supplemental admin activity', async () => {
+    const { admin, cookie } = await seedAdminSession();
+    const pool = await prisma.pool.create({
+      data: {
+        title: 'Cancelable pool',
+        organizerId: admin.id,
+        status: POOL_STATUS.OPEN,
+      },
+      select: { id: true },
+    });
+
+    const formData = new FormData();
+    formData.append('intent', 'cancel_pool');
+    const request = new Request(`http://localhost/admin/pools/${pool.id}`, {
+      method: 'POST',
+      headers: { cookie },
+      body: formData,
+    });
+    const result = await action(
+      toActionArgs({
+        request,
+        params: { poolId: pool.id },
+        context: {} as any,
+      }),
+    );
+    expect(result).toMatchObject({ ok: true });
+
+    // Pool is now cancelled
+    const refreshed = await prisma.pool.findUniqueOrThrow({
+      where: { id: pool.id },
+      select: { status: true },
+    });
+    expect(refreshed.status).toBe(POOL_STATUS.CANCELLED);
+
+    // Two activity rows: one from cancelPool + one supplemental from admin action
+    const activities = await prisma.poolActivity.findMany({
+      where: { poolId: pool.id },
+      orderBy: { createdAt: 'desc' },
+      select: { type: true, actorId: true, payload: true },
+    });
+    expect(activities.length).toBeGreaterThanOrEqual(2);
+    const adminActivity = activities.find((a) =>
+      a.payload?.includes('"source":"admin"'),
+    );
+    expect(adminActivity).toBeDefined();
+    expect(adminActivity?.actorId).toBe(admin.id);
+  });
+
+  it('returns error for unknown intents', async () => {
+    const { admin, cookie } = await seedAdminSession();
+    const pool = await prisma.pool.create({
+      data: { title: 'Pool', organizerId: admin.id, status: POOL_STATUS.OPEN },
+      select: { id: true },
+    });
+    const formData = new FormData();
+    formData.append('intent', 'bogus');
+    const request = new Request(`http://localhost/admin/pools/${pool.id}`, {
+      method: 'POST',
+      headers: { cookie },
+      body: formData,
+    });
+    const result = await action(
+      toActionArgs({
+        request,
+        params: { poolId: pool.id },
+        context: {} as any,
+      }),
+    );
+    expect(result).toMatchObject({ ok: false });
+  });
+});

--- a/app/routes/admin+/users_.$userId.tsx
+++ b/app/routes/admin+/users_.$userId.tsx
@@ -6,7 +6,7 @@ import {
   type ActionFunctionArgs,
   type LoaderFunctionArgs,
 } from 'react-router';
-import { EmptyRow, SectionCard } from '#app/components/admin-ui.tsx';
+import { DLRow, EmptyRow, SectionCard } from '#app/components/admin-ui.tsx';
 import { GeneralErrorBoundary } from '#app/components/error-boundary.tsx';
 import { Button } from '#app/components/ui/button.tsx';
 import { ConfirmDialog } from '#app/components/ui/confirm-dialog.tsx';
@@ -384,23 +384,6 @@ const AdminUserDetailRoute = () => {
 // ---------------------------------------------------------------------------
 // Small building blocks
 // ---------------------------------------------------------------------------
-
-const DLRow = ({
-  label,
-  value,
-  mono,
-}: {
-  label: string;
-  value: React.ReactNode;
-  mono?: boolean;
-}) => (
-  <>
-    <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-      {label}
-    </dt>
-    <dd className={mono ? 'font-mono text-xs' : 'text-sm'}>{value}</dd>
-  </>
-);
 
 const ActionBanner = ({ data }: { data: ActionResult }) => (
   <div

--- a/app/utils/admin.server.ts
+++ b/app/utils/admin.server.ts
@@ -194,8 +194,10 @@ export type StuckPool = {
   id: string;
   title: string;
   status: PoolStatus;
+  occasionType: string;
   eventDate: Date | null;
   updatedAt: Date;
+  inviteCode: string | null;
   reason: 'open_overdue' | 'voting_stalled' | 'decided_stalled';
   organizer: {
     id: string;
@@ -243,8 +245,10 @@ export async function getStuckPools(limit = 10): Promise<StuckPool[]> {
           id: true,
           title: true,
           status: true,
+          occasionType: true,
           eventDate: true,
           updatedAt: true,
+          inviteCode: true,
           organizer: {
             select: { id: true, username: true, name: true },
           },
@@ -266,8 +270,10 @@ export async function getStuckPools(limit = 10): Promise<StuckPool[]> {
           id: pool.id,
           title: pool.title,
           status,
+          occasionType: pool.occasionType,
           eventDate: pool.eventDate,
           updatedAt: pool.updatedAt,
+          inviteCode: pool.inviteCode,
           reason,
           organizer: pool.organizer,
           contributorCount: pool._count.contributors,
@@ -567,6 +573,214 @@ export async function expireGroupBans(): Promise<{ updated: number }> {
   });
   invalidateCleanupPreviewCache();
   return { updated: count };
+}
+
+// ===========================================================================
+// Phase 3 — Pools surface
+// ===========================================================================
+
+export const adminPoolListSelect = {
+  id: true,
+  title: true,
+  status: true,
+  occasionType: true,
+  eventDate: true,
+  updatedAt: true,
+  inviteCode: true,
+  organizer: { select: { id: true, username: true, name: true } },
+  _count: { select: { contributors: true } },
+} as const;
+
+export type AdminPoolListItem = {
+  id: string;
+  title: string;
+  status: PoolStatus;
+  occasionType: string;
+  eventDate: Date | null;
+  updatedAt: Date;
+  inviteCode: string | null;
+  organizer: { id: string; username: string; name: string | null };
+  contributorCount: number;
+};
+
+export async function listAdminPools({
+  status,
+  stuckOnly,
+  limit = 25,
+  offset = 0,
+}: {
+  status?: PoolStatus | 'all';
+  stuckOnly?: boolean;
+  limit?: number;
+  offset?: number;
+}): Promise<{ pools: AdminPoolListItem[]; total: number }> {
+  if (stuckOnly) {
+    const pools = await getStuckPools(limit);
+    return { pools, total: pools.length };
+  }
+
+  const where = status && status !== 'all' ? { status } : {};
+
+  const [rows, total] = await Promise.all([
+    prisma.pool.findMany({
+      where,
+      orderBy: { updatedAt: 'desc' },
+      take: limit,
+      skip: offset,
+      select: adminPoolListSelect,
+    }),
+    prisma.pool.count({ where }),
+  ]);
+
+  return {
+    pools: rows.map((p) => ({
+      id: p.id,
+      title: p.title,
+      status: p.status as PoolStatus,
+      occasionType: p.occasionType,
+      eventDate: p.eventDate,
+      updatedAt: p.updatedAt,
+      inviteCode: p.inviteCode,
+      organizer: p.organizer,
+      contributorCount: p._count.contributors,
+    })),
+    total,
+  };
+}
+
+export type AdminPoolDetail = {
+  id: string;
+  title: string;
+  status: PoolStatus;
+  occasionType: string;
+  eventDate: Date | null;
+  decisionMode: string;
+  inviteCode: string | null;
+  finalPriceCents: number | null;
+  chosenIdeaId: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+  organizer: { id: string; username: string; name: string | null };
+  purchaser: { id: string; username: string; name: string | null } | null;
+  deliverer: { id: string; username: string; name: string | null } | null;
+  recipientUser: { id: string; username: string; name: string | null } | null;
+  recipientName: string | null;
+  contributors: Array<{
+    userId: string;
+    username: string;
+    name: string | null;
+    contributionCents: number | null;
+    hasPaid: boolean;
+  }>;
+  ideas: Array<{
+    id: string;
+    name: string;
+    estimatedPriceCents: number | null;
+    proposedBy: { username: string };
+    voteCount: number;
+  }>;
+  activities: Array<{
+    id: string;
+    type: string;
+    actorId: string | null;
+    payload: string | null;
+    createdAt: Date;
+  }>;
+};
+
+export async function getAdminPoolDetail(
+  poolId: string,
+): Promise<AdminPoolDetail | null> {
+  const [pool, activities] = await Promise.all([
+    prisma.pool.findUnique({
+      where: { id: poolId },
+      select: {
+        id: true,
+        title: true,
+        status: true,
+        occasionType: true,
+        eventDate: true,
+        decisionMode: true,
+        inviteCode: true,
+        finalPriceCents: true,
+        chosenIdeaId: true,
+        createdAt: true,
+        updatedAt: true,
+        recipientName: true,
+        organizer: { select: { id: true, username: true, name: true } },
+        purchaser: { select: { id: true, username: true, name: true } },
+        deliverer: { select: { id: true, username: true, name: true } },
+        recipientUser: { select: { id: true, username: true, name: true } },
+        contributors: {
+          select: {
+            userId: true,
+            contributionCents: true,
+            hasPaid: true,
+            user: { select: { username: true, name: true } },
+          },
+          orderBy: { joinedAt: 'asc' },
+        },
+        ideas: {
+          orderBy: { createdAt: 'asc' },
+          select: {
+            id: true,
+            name: true,
+            estimatedPriceCents: true,
+            proposedBy: { select: { username: true } },
+            _count: { select: { votes: true } },
+          },
+        },
+      },
+    }),
+    prisma.poolActivity.findMany({
+      where: { poolId },
+      orderBy: { createdAt: 'desc' },
+      take: 50,
+      select: {
+        id: true,
+        type: true,
+        actorId: true,
+        payload: true,
+        createdAt: true,
+      },
+    }),
+  ]);
+
+  if (!pool) return null;
+
+  return {
+    id: pool.id,
+    title: pool.title,
+    status: pool.status as PoolStatus,
+    occasionType: pool.occasionType,
+    eventDate: pool.eventDate,
+    decisionMode: pool.decisionMode,
+    inviteCode: pool.inviteCode,
+    finalPriceCents: pool.finalPriceCents,
+    chosenIdeaId: pool.chosenIdeaId,
+    createdAt: pool.createdAt,
+    updatedAt: pool.updatedAt,
+    organizer: pool.organizer,
+    purchaser: pool.purchaser,
+    deliverer: pool.deliverer,
+    recipientUser: pool.recipientUser,
+    recipientName: pool.recipientName,
+    contributors: pool.contributors.map((c) => ({
+      userId: c.userId,
+      username: c.user.username,
+      name: c.user.name,
+      contributionCents: c.contributionCents,
+      hasPaid: c.hasPaid,
+    })),
+    ideas: pool.ideas.map((i) => ({
+      id: i.id,
+      name: i.name,
+      estimatedPriceCents: i.estimatedPriceCents,
+      proposedBy: i.proposedBy,
+      voteCount: i._count.votes,
+    })),
+    activities,
+  };
 }
 
 // ===========================================================================

--- a/app/utils/admin.server.ts
+++ b/app/utils/admin.server.ts
@@ -615,8 +615,48 @@ export async function listAdminPools({
   offset?: number;
 }): Promise<{ pools: AdminPoolListItem[]; total: number }> {
   if (stuckOnly) {
-    const pools = await getStuckPools(limit);
-    return { pools, total: pools.length };
+    const now = new Date();
+    const stuckVotingCutoff = new Date(
+      now.getTime() - STUCK_VOTING_DAYS * DAY_MS,
+    );
+    const stuckDecidedCutoff = new Date(
+      now.getTime() - STUCK_DECIDED_DAYS * DAY_MS,
+    );
+    const stuckWhere = {
+      OR: [
+        { status: POOL_STATUS.OPEN, eventDate: { lt: now } },
+        {
+          status: POOL_STATUS.VOTING,
+          updatedAt: { lt: stuckVotingCutoff },
+          votes: { none: {} },
+        },
+        { status: POOL_STATUS.DECIDED, updatedAt: { lt: stuckDecidedCutoff } },
+      ],
+    };
+    const [rows, total] = await Promise.all([
+      prisma.pool.findMany({
+        where: stuckWhere,
+        orderBy: { updatedAt: 'asc' },
+        take: limit,
+        skip: offset,
+        select: adminPoolListSelect,
+      }),
+      prisma.pool.count({ where: stuckWhere }),
+    ]);
+    return {
+      pools: rows.map((p) => ({
+        id: p.id,
+        title: p.title,
+        status: p.status as PoolStatus,
+        occasionType: p.occasionType,
+        eventDate: p.eventDate,
+        updatedAt: p.updatedAt,
+        inviteCode: p.inviteCode,
+        organizer: p.organizer,
+        contributorCount: p._count.contributors,
+      })),
+      total,
+    };
   }
 
   const where = status && status !== 'all' ? { status } : {};


### PR DESCRIPTION
## Summary

Phase 3 of the admin rebuild. The core product failure mode — stuck pools that nobody notices — now has full admin visibility. Stacked on #360 (Phase 2).

**What shipped (§3.1–§3.4):**

- **`/admin/pools`** — health board with status tabs (Stuck default, All, then one per status). Pool table shows title, status badge (color-coded), occasion type, "overdue" callout when eventDate is past, organizer, contributor count, and last-activity age. Pagination via `?page=`. Stuck mode reuses the `getStuckPools` detector from Phase 1.
- **`/admin/pools/:poolId`** — full state drill-down: detail card (IDs, organizer, purchaser, deliverer, recipient, invite code, final price, chosen idea), contributors table with paid/unpaid badges, ideas list with vote counts + "chosen" highlight, and a 50-row activity timeline. **Admin cancel action** via `ConfirmDialog` with typed pool title — calls `cancelPool` then `logPoolActivity` with `{ source: 'admin' }` so the timeline distinguishes admin-forced from organizer-initiated cancellations. Cancel button hidden for DELIVERED/CANCELLED pools.
- **`adminPoolListSelect`** — lean select for the list view (no full contributor/idea arrays). `poolSelect` reserved for the detail page as per the plan.
- **`listAdminPools`** — paginated, with status filter + `stuckOnly` mode.
- **`getAdminPoolDetail`** — two parallel queries (pool + activities), shaped for the drill-down.

**Tests (20 new):**
- `pools.test.ts`: loader auth, stuck-default, status-filter (3)
- `pools_.test.ts`: detail 404, full shape, cancel action + activity payload, unknown intent (4)
- `pools.dom.test.tsx`: render tests — tabs, empty state, populated table with overdue + pagination (4)
- `pools_.dom.test.tsx`: render tests — all sections, contributor badges, ideas/chosen, activity rows, cancel visibility, delivered no-action, back link, detail fields (9)

**Full suite: 684 passing. 0 lint errors.**

## Test plan

- [x] `npm run lint` — 0 errors
- [x] `npm run typecheck` — clean
- [x] `npm test -- --run` — 684 passing
- [x] Dev server smoke: `/admin/pools` shows 0 stuck, `?status=all` lists all 4 seed pools, drill-down renders 4 contributors + 3 ideas + 5 activity rows
- [ ] Merge #360 first, then rebase this branch onto main and merge