### PR TITLE
feat(admin): phase 4 — analytics upgrade with funnel, retention, opt-outs

### DIFF
--- a/app/routes/admin+/analytics.dom.test.tsx
+++ b/app/routes/admin+/analytics.dom.test.tsx
@@ -1,0 +1,152 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import * as ReactRouter from 'react-router';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const loaderDataSnapshot = {
+  analytics: {
+    totalUsers: 42,
+    dau: 5,
+    wau: 12,
+    mau: 30,
+    dailyActive: [
+      { date: '2026-03-12', count: 3 },
+      { date: '2026-03-13', count: 5 },
+    ],
+    eventsLast7Days: [
+      { name: 'user_logged_in', count: 20 },
+      { name: 'wishlist_viewed', count: 8 },
+    ],
+    eventsLast30Days: [
+      { name: 'user_logged_in', count: 60 },
+      { name: 'pool_created', count: 3 },
+    ],
+  },
+  funnel: [
+    { step: 'Signed up', count: 10, percent: 100 },
+    { step: 'Added first wishlist item', count: 8, percent: 80 },
+    { step: 'Made first friend', count: 7, percent: 70 },
+    { step: 'Contributed to a pool', count: 4, percent: 40 },
+    { step: 'Received a delivered gift', count: 0, percent: 0 },
+  ],
+  retention: [
+    {
+      cohortWeek: '2026-W14',
+      cohortSize: 10,
+      weeks: [
+        { weekOffset: 0, retainedUsers: 10, retainedPercent: 100 },
+        { weekOffset: 1, retainedUsers: 5, retainedPercent: 50 },
+      ],
+    },
+  ],
+  optOutMatrix: [
+    { type: 'FRIEND_REQUEST_RECEIVED', inAppOptOutPercent: 0, emailOptOutPercent: 0, total: 10 },
+    { type: 'UPCOMING_BIRTHDAY', inAppOptOutPercent: 0, emailOptOutPercent: 100, total: 10 },
+  ],
+};
+
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual<typeof ReactRouter>('react-router');
+  return {
+    ...actual,
+    useLoaderData: () => loaderDataSnapshot,
+  };
+});
+
+vi.mock('#app/utils/permissions.server.ts', () => ({
+  requireUserWithRole: vi.fn(),
+}));
+
+vi.mock('#app/utils/analytics.server.ts', () => ({
+  getAnalyticsCounts: vi.fn(),
+}));
+
+vi.mock('#app/utils/admin.server.ts', () => ({
+  getActivationFunnel: vi.fn(),
+  getWeeklyRetention: vi.fn(),
+  getNotificationOptOutMatrix: vi.fn(),
+}));
+
+import AnalyticsRoute from './analytics.tsx';
+
+const renderAnalytics = () =>
+  render(
+    <MemoryRouter initialEntries={['/admin/analytics']}>
+      <AnalyticsRoute />
+    </MemoryRouter>,
+  );
+
+describe('admin analytics page', () => {
+  it('renders the page heading', () => {
+    renderAnalytics();
+    expect(
+      screen.getByRole('heading', { name: 'Analytics' }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders DAU/WAU/MAU summary cards', () => {
+    renderAnalytics();
+    expect(screen.getByText('Total users')).toBeInTheDocument();
+    expect(screen.getByText('42')).toBeInTheDocument();
+    expect(screen.getByText('DAU (24h)')).toBeInTheDocument();
+    expect(screen.getByText('WAU (7d)')).toBeInTheDocument();
+    expect(screen.getByText('MAU (30d)')).toBeInTheDocument();
+  });
+
+  it('renders the daily active chart', () => {
+    renderAnalytics();
+    expect(
+      screen.getByRole('heading', { name: 'Daily active users' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Peak: 5')).toBeInTheDocument();
+  });
+
+  it('renders the activation funnel', () => {
+    renderAnalytics();
+    expect(
+      screen.getByRole('heading', { name: 'Activation funnel' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Signed up')).toBeInTheDocument();
+    expect(screen.getByText('Added first wishlist item')).toBeInTheDocument();
+    expect(screen.getByText('Made first friend')).toBeInTheDocument();
+    expect(screen.getByText('Contributed to a pool')).toBeInTheDocument();
+    expect(screen.getByText('Received a delivered gift')).toBeInTheDocument();
+    expect(screen.getByText(/8 \(80%\)/)).toBeInTheDocument();
+    expect(screen.getByText(/4 \(40%\)/)).toBeInTheDocument();
+  });
+
+  it('renders the retention cohort grid', () => {
+    renderAnalytics();
+    expect(
+      screen.getByRole('heading', { name: 'Weekly retention' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('2026-W14')).toBeInTheDocument();
+    expect(screen.getAllByText('100%').length).toBeGreaterThan(0);
+    expect(screen.getByText('50%')).toBeInTheDocument();
+  });
+
+  it('renders the notification opt-out matrix', () => {
+    renderAnalytics();
+    expect(
+      screen.getByRole('heading', { name: 'Notification opt-outs' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('friend request received'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('upcoming birthday')).toBeInTheDocument();
+  });
+
+  it('renders event tables', () => {
+    renderAnalytics();
+    expect(
+      screen.getByRole('heading', { name: 'Events (last 7 days)' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Events (last 30 days)' }),
+    ).toBeInTheDocument();
+    expect(screen.getAllByText('user logged in').length).toBeGreaterThan(0);
+  });
+});

--- a/app/routes/admin+/analytics.tsx
+++ b/app/routes/admin+/analytics.tsx
@@ -1,38 +1,42 @@
 import { type LoaderFunctionArgs, useLoaderData } from 'react-router';
+import {
+  EmptyRow,
+  SectionCard,
+  SummaryCard,
+} from '#app/components/admin-ui.tsx';
 import { GeneralErrorBoundary } from '#app/components/error-boundary.tsx';
 import { Card } from '#app/components/ui/card.tsx';
 import {
   type AnalyticsCounts,
   getAnalyticsCounts,
 } from '#app/utils/analytics.server.ts';
+import {
+  type FunnelStep,
+  type NotificationOptOutRow,
+  type RetentionCohort,
+  getActivationFunnel,
+  getNotificationOptOutMatrix,
+  getWeeklyRetention,
+} from '#app/utils/admin.server.ts';
+import { cn } from '#app/utils/misc.tsx';
 import { requireUserWithRole } from '#app/utils/permissions.server.ts';
 
 export async function loader({ request }: LoaderFunctionArgs) {
   await requireUserWithRole(request, 'admin');
-  const analytics = await getAnalyticsCounts();
-  return {
-    analytics,
-  };
+
+  const now = new Date();
+  const thirtyDaysAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+
+  const [analytics, funnel, retention, optOutMatrix] = await Promise.all([
+    getAnalyticsCounts(),
+    getActivationFunnel({ cohortStart: thirtyDaysAgo, cohortEnd: now }),
+    getWeeklyRetention(8),
+    getNotificationOptOutMatrix(),
+  ]);
+
+  return { analytics, funnel, retention, optOutMatrix };
 }
-const SummaryCard = ({
-  label,
-  value,
-  accent,
-}: {
-  label: string;
-  value: string;
-  accent?: string;
-}) => (
-  <Card className="flex flex-col gap-2 border-border/60 bg-gradient-to-br from-card to-card/70 p-4 shadow-sm">
-    <span className="text-sm font-medium text-muted-foreground">{label}</span>
-    <span className="text-3xl font-semibold tracking-tight">{value}</span>
-    {accent ? (
-      <span className="text-xs font-medium uppercase text-muted-foreground">
-        {accent}
-      </span>
-    ) : null}
-  </Card>
-);
+
 const LineChart = ({
   data,
   height = 200,
@@ -99,15 +103,13 @@ const LineChart = ({
     </div>
   );
 };
+
 const EventTable = ({
   title,
   rows,
 }: {
   title: string;
-  rows: Array<{
-    name: string;
-    count: number;
-  }>;
+  rows: Array<{ name: string; count: number }>;
 }) => (
   <Card className="border-border/70 bg-card p-4 shadow-sm">
     <div className="mb-3 flex items-center justify-between">
@@ -141,27 +143,32 @@ const EventTable = ({
     </div>
   </Card>
 );
+
 const AnalyticsRoute = () => {
-  const { analytics } = useLoaderData<typeof loader>();
+  const { analytics, funnel, retention, optOutMatrix } =
+    useLoaderData<typeof loader>();
   return (
     <div className="space-y-8">
       <div className="space-y-1">
         <h1 className="text-h1">Analytics</h1>
         <p className="text-muted-foreground">
-          Internal usage metrics sourced from in-app events.
+          Usage metrics, activation funnel, retention, and notification
+          opt-outs.
         </p>
       </div>
 
+      {/* --- DAU/WAU/MAU --- */}
       <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
         <SummaryCard
           label="Total users"
-          value={analytics.totalUsers.toLocaleString()}
+          value={analytics.totalUsers}
         />
-        <SummaryCard label="DAU (24h)" value={analytics.dau.toLocaleString()} />
-        <SummaryCard label="WAU (7d)" value={analytics.wau.toLocaleString()} />
-        <SummaryCard label="MAU (30d)" value={analytics.mau.toLocaleString()} />
+        <SummaryCard label="DAU (24h)" value={analytics.dau} />
+        <SummaryCard label="WAU (7d)" value={analytics.wau} />
+        <SummaryCard label="MAU (30d)" value={analytics.mau} />
       </section>
 
+      {/* --- daily active line chart --- */}
       <Card className="space-y-3 border-border/70 bg-card p-4 shadow-sm">
         <div className="flex items-center justify-between">
           <div>
@@ -175,6 +182,39 @@ const AnalyticsRoute = () => {
         <LineChart data={analytics.dailyActive} />
       </Card>
 
+      {/* --- activation funnel --- */}
+      <SectionCard
+        title="Activation funnel"
+        description="Last 30-day cohort. Steps: signup → wishlist → friend → pool contribution → delivered gift."
+      >
+        <FunnelViz steps={funnel} />
+      </SectionCard>
+
+      {/* --- retention cohort grid --- */}
+      <SectionCard
+        title="Weekly retention"
+        description="Cohort by signup week. Retention = user has a Session.createdAt in that week."
+      >
+        {retention.length === 0 ? (
+          <EmptyRow>Not enough data for retention yet.</EmptyRow>
+        ) : (
+          <RetentionGrid cohorts={retention} />
+        )}
+      </SectionCard>
+
+      {/* --- notification opt-outs --- */}
+      <SectionCard
+        title="Notification opt-outs"
+        description="Per-type in-app + email opt-out percentages across all users."
+      >
+        {optOutMatrix.length === 0 ? (
+          <EmptyRow>No notification preferences recorded yet.</EmptyRow>
+        ) : (
+          <OptOutTable rows={optOutMatrix} />
+        )}
+      </SectionCard>
+
+      {/* --- event tables (existing) --- */}
       <section className="grid gap-4 lg:grid-cols-2">
         <EventTable
           title="Events (last 7 days)"
@@ -188,7 +228,133 @@ const AnalyticsRoute = () => {
     </div>
   );
 };
+
+// ---------------------------------------------------------------------------
+// Funnel visualization — horizontal bar chart
+// ---------------------------------------------------------------------------
+
+const FunnelViz = ({ steps }: { steps: FunnelStep[] }) => {
+  if (steps.length === 0 || steps[0]?.count === 0) {
+    return <EmptyRow>No users in this cohort yet.</EmptyRow>;
+  }
+  return (
+    <div className="space-y-2">
+      {steps.map((step) => (
+        <div key={step.step} className="flex items-center gap-3">
+          <div className="w-48 shrink-0 text-sm">{step.step}</div>
+          <div className="relative h-7 flex-1 overflow-hidden rounded-md bg-muted/40">
+            <div
+              className="absolute inset-y-0 left-0 rounded-md bg-primary/20"
+              style={{ width: `${step.percent}%` }}
+            />
+            <span className="absolute inset-0 flex items-center px-2 text-xs font-semibold tabular-nums">
+              {step.count.toLocaleString()} ({step.percent}%)
+            </span>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Retention heatmap grid
+// ---------------------------------------------------------------------------
+
+const RetentionGrid = ({ cohorts }: { cohorts: RetentionCohort[] }) => (
+  <div className="overflow-x-auto">
+    <table className="min-w-full text-xs">
+      <thead>
+        <tr>
+          <th className="px-2 py-1 text-left font-medium text-muted-foreground">
+            Cohort
+          </th>
+          <th className="px-2 py-1 text-center font-medium text-muted-foreground">
+            Size
+          </th>
+          {cohorts[0]?.weeks.map((week) => (
+            <th
+              key={`w${week.weekOffset}`}
+              className="px-2 py-1 text-center font-medium text-muted-foreground"
+            >
+              W{week.weekOffset}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {cohorts.map((cohort) => (
+          <tr key={cohort.cohortWeek}>
+            <td className="px-2 py-1 font-mono">{cohort.cohortWeek}</td>
+            <td className="px-2 py-1 text-center tabular-nums">
+              {cohort.cohortSize}
+            </td>
+            {cohort.weeks.map((week) => (
+              <td
+                key={week.weekOffset}
+                className={cn(
+                  'px-2 py-1 text-center tabular-nums',
+                  week.retainedPercent > 0 && 'font-semibold',
+                )}
+                style={{
+                  backgroundColor: `hsl(var(--primary) / ${Math.min(week.retainedPercent / 100, 1) * 0.4})`,
+                }}
+              >
+                {week.retainedPercent}%
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </div>
+);
+
+// ---------------------------------------------------------------------------
+// Opt-out table
+// ---------------------------------------------------------------------------
+
+const OptOutTable = ({ rows }: { rows: NotificationOptOutRow[] }) => (
+  <div className="overflow-hidden rounded-md border border-border/50">
+    <table className="min-w-full divide-y divide-border/60 text-sm">
+      <thead className="bg-muted/40">
+        <tr>
+          <th className="px-4 py-2 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Notification type
+          </th>
+          <th className="px-4 py-2 text-center text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            In-app opt-out
+          </th>
+          <th className="px-4 py-2 text-center text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Email opt-out
+          </th>
+          <th className="px-4 py-2 text-right text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Users
+          </th>
+        </tr>
+      </thead>
+      <tbody className="divide-y divide-border/60">
+        {rows.map((row) => (
+          <tr key={row.type}>
+            <td className="px-4 py-2 font-medium">
+              {row.type.replaceAll('_', ' ').toLowerCase()}
+            </td>
+            <td className="px-4 py-2 text-center tabular-nums">
+              {row.inAppOptOutPercent}%
+            </td>
+            <td className="px-4 py-2 text-center tabular-nums">
+              {row.emailOptOutPercent}%
+            </td>
+            <td className="px-4 py-2 text-right tabular-nums">{row.total}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </div>
+);
+
 export default AnalyticsRoute;
+
 export const ErrorBoundary = () => {
   return <GeneralErrorBoundary />;
 };

--- a/app/utils/admin.server.ts
+++ b/app/utils/admin.server.ts
@@ -1,5 +1,5 @@
 import { queueLogEvent } from './analytics.server.ts';
-import { cachified, lruCache } from './cache.server.ts';
+import { cache, cachified, lruCache } from './cache.server.ts';
 import { prisma } from './db.server.ts';
 import { POOL_STATUS, type PoolStatus } from './pool-constants.ts';
 
@@ -1168,4 +1168,276 @@ export async function revokeAllSessionsForUser({
     sessionsDeleted: sessions.count,
     verificationsDeleted: verifications.count,
   };
+}
+
+// ===========================================================================
+// Phase 4 — Analytics aggregates
+// ===========================================================================
+
+const ONE_HOUR = 60 * 60 * 1000;
+
+// ---------------------------------------------------------------------------
+// Activation funnel — built from domain tables, no dependency on events.
+// Cached 1h in the SQLite-backed cache (cross-instance coherent via LiteFS).
+// ---------------------------------------------------------------------------
+
+export type FunnelStep = {
+  step: string;
+  count: number;
+  percent: number;
+};
+
+export async function getActivationFunnel({
+  cohortStart,
+  cohortEnd,
+}: {
+  cohortStart: Date;
+  cohortEnd: Date;
+}): Promise<FunnelStep[]> {
+  const key = `admin:funnel:v1:${cohortStart.toISOString().slice(0, 10)}:${cohortEnd.toISOString().slice(0, 10)}`;
+  return cachified({
+    key,
+    cache,
+    ttl: ONE_HOUR,
+    getFreshValue: async () => {
+      const cohortUsers = await prisma.user.findMany({
+        where: { createdAt: { gte: cohortStart, lte: cohortEnd } },
+        select: { id: true },
+      });
+
+      const userIds = cohortUsers.map((u) => u.id);
+      const total = userIds.length;
+      if (total === 0) {
+        return [
+          { step: 'Signed up', count: 0, percent: 100 },
+          { step: 'Added first wishlist item', count: 0, percent: 0 },
+          { step: 'Made first friend', count: 0, percent: 0 },
+          { step: 'Contributed to a pool', count: 0, percent: 0 },
+          { step: 'Received a delivered gift', count: 0, percent: 0 },
+        ];
+      }
+
+      const [withWishlist, withFriend, withContribution, withDelivered] =
+        await Promise.all([
+          prisma.wishlistItem.findMany({
+            where: { ownerId: { in: userIds } },
+            select: { ownerId: true },
+            distinct: ['ownerId'],
+          }),
+          prisma.friendship.findMany({
+            where: {
+              OR: [
+                { userAId: { in: userIds } },
+                { userBId: { in: userIds } },
+              ],
+            },
+            select: { userAId: true, userBId: true },
+          }),
+          prisma.poolContributor.findMany({
+            where: { userId: { in: userIds } },
+            select: { userId: true },
+            distinct: ['userId'],
+          }),
+          prisma.pool.findMany({
+            where: {
+              recipientUserId: { in: userIds },
+              status: POOL_STATUS.DELIVERED,
+            },
+            select: { recipientUserId: true },
+            distinct: ['recipientUserId'],
+          }),
+        ]);
+
+      const friendUserIds = new Set<string>();
+      for (const f of withFriend) {
+        if (userIds.includes(f.userAId)) friendUserIds.add(f.userAId);
+        if (userIds.includes(f.userBId)) friendUserIds.add(f.userBId);
+      }
+
+      const pct = (n: number) => Math.round((n / total) * 100);
+
+      const wishlistCount = withWishlist.length;
+      const friendCount = friendUserIds.size;
+      const contribCount = withContribution.length;
+      const deliveredCount = withDelivered.length;
+
+      return [
+        { step: 'Signed up', count: total, percent: 100 },
+        {
+          step: 'Added first wishlist item',
+          count: wishlistCount,
+          percent: pct(wishlistCount),
+        },
+        {
+          step: 'Made first friend',
+          count: friendCount,
+          percent: pct(friendCount),
+        },
+        {
+          step: 'Contributed to a pool',
+          count: contribCount,
+          percent: pct(contribCount),
+        },
+        {
+          step: 'Received a delivered gift',
+          count: deliveredCount,
+          percent: pct(deliveredCount),
+        },
+      ];
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Weekly retention cohort grid — uses Session.createdAt as the retention
+// signal. Works against today's data without depending on analytics events.
+// Cached 1h in SQLite cache.
+// ---------------------------------------------------------------------------
+
+export type RetentionCohort = {
+  cohortWeek: string;
+  cohortSize: number;
+  weeks: Array<{
+    weekOffset: number;
+    retainedUsers: number;
+    retainedPercent: number;
+  }>;
+};
+
+export async function getWeeklyRetention(
+  weeks = 8,
+): Promise<RetentionCohort[]> {
+  const key = `admin:retention:v1:${weeks}`;
+  return cachified({
+    key,
+    cache,
+    ttl: ONE_HOUR,
+    getFreshValue: async () => {
+      const rows = await prisma.$queryRaw<
+        Array<{
+          cohort_week: string;
+          cohort_size: bigint;
+          week_offset: bigint;
+          retained: bigint;
+        }>
+      >`
+        WITH cohorts AS (
+          SELECT
+            id AS user_id,
+            strftime('%Y-W%W', createdAt / 1000, 'unixepoch') AS cohort_week
+          FROM User
+          WHERE createdAt >= ${Date.now() - weeks * 7 * DAY_MS}
+        ),
+        cohort_sizes AS (
+          SELECT cohort_week, COUNT(*) AS cohort_size
+          FROM cohorts
+          GROUP BY cohort_week
+        ),
+        sessions_by_week AS (
+          SELECT
+            c.user_id,
+            c.cohort_week,
+            CAST((s.createdAt - c_user.createdAt) / ${7 * DAY_MS} AS INTEGER) AS week_offset
+          FROM cohorts c
+          JOIN Session s ON s.userId = c.user_id
+          JOIN User c_user ON c_user.id = c.user_id
+          WHERE s.createdAt >= c_user.createdAt
+        )
+        SELECT
+          cs.cohort_week,
+          cs.cohort_size,
+          sw.week_offset,
+          COUNT(DISTINCT sw.user_id) AS retained
+        FROM cohort_sizes cs
+        LEFT JOIN sessions_by_week sw ON sw.cohort_week = cs.cohort_week
+        WHERE sw.week_offset IS NOT NULL AND sw.week_offset >= 0 AND sw.week_offset < ${weeks}
+        GROUP BY cs.cohort_week, cs.cohort_size, sw.week_offset
+        ORDER BY cs.cohort_week, sw.week_offset
+      `;
+
+      const cohortMap = new Map<
+        string,
+        { cohortSize: number; weeks: Map<number, number> }
+      >();
+
+      for (const row of rows) {
+        const key = row.cohort_week;
+        if (!cohortMap.has(key)) {
+          cohortMap.set(key, {
+            cohortSize: Number(row.cohort_size),
+            weeks: new Map(),
+          });
+        }
+        cohortMap
+          .get(key)!
+          .weeks.set(Number(row.week_offset), Number(row.retained));
+      }
+
+      const result: RetentionCohort[] = [];
+      for (const [cohortWeek, data] of cohortMap) {
+        result.push({
+          cohortWeek,
+          cohortSize: data.cohortSize,
+          weeks: Array.from({ length: weeks }, (_, i) => {
+            const retained = data.weeks.get(i) ?? 0;
+            return {
+              weekOffset: i,
+              retainedUsers: retained,
+              retainedPercent:
+                data.cohortSize > 0
+                  ? Math.round((retained / data.cohortSize) * 100)
+                  : 0,
+            };
+          }),
+        });
+      }
+
+      return result;
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Notification opt-out matrix — how many users have opted out per type/channel.
+// Not cached (fast single query, always fresh).
+// ---------------------------------------------------------------------------
+
+export type NotificationOptOutRow = {
+  type: string;
+  inAppOptOutPercent: number;
+  emailOptOutPercent: number;
+  total: number;
+};
+
+export async function getNotificationOptOutMatrix(): Promise<
+  NotificationOptOutRow[]
+> {
+  const rows = await prisma.$queryRaw<
+    Array<{
+      type: string;
+      inApp_off: bigint | null;
+      email_off: bigint | null;
+      total: bigint;
+    }>
+  >`
+    SELECT
+      type,
+      SUM(CASE WHEN inAppEnabled = 0 THEN 1 ELSE 0 END) AS inApp_off,
+      SUM(CASE WHEN emailEnabled = 0 THEN 1 ELSE 0 END) AS email_off,
+      COUNT(*) AS total
+    FROM UserNotificationPreference
+    GROUP BY type
+  `;
+
+  return rows.map((row) => {
+    const total = Number(row.total);
+    const inAppOff = Number(row.inApp_off ?? 0);
+    const emailOff = Number(row.email_off ?? 0);
+    return {
+      type: row.type,
+      inAppOptOutPercent: total > 0 ? Math.round((inAppOff / total) * 100) : 0,
+      emailOptOutPercent: total > 0 ? Math.round((emailOff / total) * 100) : 0,
+      total,
+    };
+  });
 }


### PR DESCRIPTION
## Summary

Final phase of the admin rebuild. Upgrades `/admin/analytics` from a DAU/WAU/MAU + event-count page into a real product-learning surface. Stacked on #361 (Phase 3).

**New sections on the analytics page:**

1. **Activation funnel** — 5-step horizontal bar chart built from domain tables (User → WishlistItem → Friendship → PoolContributor → Pool.DELIVERED). Zero dependency on AnalyticsEvent. Default cohort: last 30 days. Cached 1h in SQLite cache.

2. **Weekly retention cohort grid** — heatmap-style table with `td` background opacity mapped to retention percent. Uses `Session.createdAt` as the signal (not AnalyticsEvent), so it works with today's data. Raw SQL for the cohort × week-offset aggregation. Cached 1h.

3. **Notification opt-out matrix** — per-type in-app + email opt-out percentages from `UserNotificationPreference`. Directly product-useful: tells you which notifications users are disabling. Not cached (fast single query).

**Kept from the original page:** DAU/WAU/MAU summary cards, daily-active SVG line chart, event count tables (7d + 30d). The old inline `SummaryCard` was replaced by the shared `admin-ui.tsx` one.

**Tests (7 new render tests):** heading, DAU/WAU/MAU cards, daily-active chart, funnel steps with percentages, retention grid with cohort data, opt-out matrix, event tables. Plus 2 existing loader tests. Full suite: **691 passing**.

**Smoke-tested against dev DB:**
- Funnel: 10 → 8 → 7 → 4 → 0 (signup → wishlist → friend → pool → delivered)
- Retention: 1 cohort (W14, n=10), 10% W0
- Opt-outs: UPCOMING_BIRTHDAY at 100% email opt-out (matches seed)

## Test plan

- [x] `npm run lint` — 0 errors
- [x] `npm run typecheck` — clean
- [x] `npm test -- --run` — 691 passing
- [x] Helpers smoke-tested against dev DB
- [ ] Merge #361 first, then rebase onto main and merge