### PR TITLE
feat: legal pages, global footer, about & support pages

### DIFF
--- a/app/components/site-footer.test.tsx
+++ b/app/components/site-footer.test.tsx
@@ -1,0 +1,37 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { describe, expect, it } from 'vitest';
+import { SiteFooter } from './site-footer.tsx';
+
+describe('SiteFooter', () => {
+  it('renders legal and support links with correct hrefs', () => {
+    render(
+      <MemoryRouter>
+        <SiteFooter />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole('link', { name: 'About' })).toHaveAttribute(
+      'href',
+      '/about',
+    );
+    expect(screen.getByRole('link', { name: 'Contact' })).toHaveAttribute(
+      'href',
+      '/support',
+    );
+    expect(screen.getByRole('link', { name: 'Privacy' })).toHaveAttribute(
+      'href',
+      '/privacy',
+    );
+    expect(screen.getByRole('link', { name: 'Terms' })).toHaveAttribute(
+      'href',
+      '/tos',
+    );
+    expect(
+      screen.getByRole('link', { name: /buy me a coffee/i }),
+    ).toHaveAttribute('href', 'https://buymeacoffee.com/twoplustwoone');
+  });
+});

--- a/app/components/site-footer.tsx
+++ b/app/components/site-footer.tsx
@@ -1,0 +1,46 @@
+import { LuCoffee } from 'react-icons/lu';
+import { Link } from 'react-router';
+
+export const SiteFooter = () => {
+  return (
+    <footer className="border-t border-border/40 mt-auto">
+      <div className="container py-6 md:py-8">
+        <nav aria-label="Footer">
+          <ul className="flex flex-wrap items-center justify-center gap-6 text-sm text-muted-foreground md:gap-8">
+            <li>
+              <Link to="/about" className="hover:text-foreground hover:underline">
+                About
+              </Link>
+            </li>
+            <li>
+              <Link to="/support" className="hover:text-foreground hover:underline">
+                Contact
+              </Link>
+            </li>
+            <li>
+              <Link to="/privacy" className="hover:text-foreground hover:underline">
+                Privacy
+              </Link>
+            </li>
+            <li>
+              <Link to="/tos" className="hover:text-foreground hover:underline">
+                Terms
+              </Link>
+            </li>
+            <li>
+              <a
+                href="https://buymeacoffee.com/twoplustwoone"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 hover:text-foreground hover:underline"
+              >
+                <LuCoffee className="h-3.5 w-3.5" aria-hidden />
+                Buy me a coffee
+              </a>
+            </li>
+          </ul>
+        </nav>
+      </div>
+    </footer>
+  );
+};

--- a/app/root.test.tsx
+++ b/app/root.test.tsx
@@ -52,6 +52,10 @@ vi.mock('./components/nav/bottom/bottom-nav.tsx', () => ({
   BottomNav: () => <div>bottom nav</div>,
 }));
 
+vi.mock('./components/site-footer.tsx', () => ({
+  SiteFooter: () => <div>site footer</div>,
+}));
+
 vi.mock('./components/nav/top-bar.tsx', () => ({
   TopBar: () => <div>top bar</div>,
 }));

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -31,15 +31,16 @@ import { z } from 'zod';
 import appleTouchIconAssetUrl from './assets/favicons/apple-touch-icon.png';
 import faviconAssetUrl from './assets/favicons/favicon.svg';
 import { GeneralErrorBoundary } from './components/error-boundary.tsx';
+import { FriendsRouteSkeleton } from './components/friends/friends-route-skeleton.tsx';
 import { BottomNav } from './components/nav/bottom/bottom-nav.tsx';
 import { TopBar } from './components/nav/top-bar.tsx';
 import { NotificationsProvider } from './components/notifications/notifications-context.tsx';
 import { EpicProgress } from './components/progress-bar.tsx';
 import { PwaInstallBanner } from './components/pwa-install-banner.tsx';
+import { SiteFooter } from './components/site-footer.tsx';
 import { useToast } from './components/toaster.tsx';
 import { href as iconsHref } from './components/ui/icon.tsx';
 import { EpicToaster } from './components/ui/sonner.tsx';
-import { FriendsRouteSkeleton } from './components/friends/friends-route-skeleton.tsx';
 import { WishlistRouteSkeleton } from './components/wishlist/wishlist-route-skeleton.tsx';
 import { usePwaInstallPrompt } from './hooks/use-pwa-install-prompt.ts';
 import nunitoStyleSheet from './styles/nunito-font.css?url';
@@ -430,7 +431,10 @@ const App = () => {
               className="min-h-0 flex-1 overflow-y-auto bg-gradient-to-br from-background to-background-muted pb-bottom-nav sm:pb-0"
               data-testid="app-scroll-area"
             >
-              {routeContent}
+              <div className="flex min-h-full flex-col">
+                <div className="flex-1">{routeContent}</div>
+                <SiteFooter />
+              </div>
             </div>
 
             <Footer />

--- a/app/routes/_auth+/onboarding.tsx
+++ b/app/routes/_auth+/onboarding.tsx
@@ -12,9 +12,10 @@ import {
   type ActionFunctionArgs,
   type MetaFunction,
   Form,
+  Link,
   useActionData,
   useLoaderData,
-  useSearchParams
+  useSearchParams,
 } from 'react-router';
 import { HoneypotInputs } from 'remix-utils/honeypot/react';
 import { safeRedirect } from 'remix-utils/safe-redirect';
@@ -260,8 +261,26 @@ const OnboardingRoute = () => {
           <CheckboxField
             labelProps={{
               htmlFor: fields.agreeToTermsOfServiceAndPrivacyPolicy.id,
-              children:
-                'Do you agree to our Terms of Service and Privacy Policy?',
+              children: (
+                <>
+                  I agree to the{' '}
+                  <Link
+                    to="/tos"
+                    target="_blank"
+                    className="underline hover:text-foreground"
+                  >
+                    Terms of Service
+                  </Link>{' '}
+                  and{' '}
+                  <Link
+                    to="/privacy"
+                    target="_blank"
+                    className="underline hover:text-foreground"
+                  >
+                    Privacy Policy
+                  </Link>
+                </>
+              ),
             }}
             buttonProps={getInputProps(
               fields.agreeToTermsOfServiceAndPrivacyPolicy,

--- a/app/routes/_auth+/signup.tsx
+++ b/app/routes/_auth+/signup.tsx
@@ -10,7 +10,10 @@ import {
   data,
   redirect,
   type ActionFunctionArgs,
-  type MetaFunction, Form, useActionData 
+  type MetaFunction,
+  Form,
+  Link,
+  useActionData,
 } from 'react-router';
 import { HoneypotInputs } from 'remix-utils/honeypot/react';
 import { z } from 'zod';
@@ -150,6 +153,17 @@ const SignupRoute = () => {
           >
             Submit
           </StatusButton>
+          <p className="mt-4 text-center text-body-xs text-muted-foreground">
+            By signing up, you agree to our{' '}
+            <Link to="/tos" className="underline hover:text-foreground">
+              Terms of Service
+            </Link>{' '}
+            and{' '}
+            <Link to="/privacy" className="underline hover:text-foreground">
+              Privacy Policy
+            </Link>
+            .
+          </p>
         </Form>
       </div>
     </div>

--- a/app/routes/_marketing+/about.test.tsx
+++ b/app/routes/_marketing+/about.test.tsx
@@ -1,0 +1,31 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { describe, expect, it } from 'vitest';
+import AboutRoute from './about.tsx';
+
+describe('AboutRoute', () => {
+  it('renders the page with values and a Buy Me a Coffee link', () => {
+    render(
+      <MemoryRouter>
+        <AboutRoute />
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.getByRole('heading', { level: 1, name: /about giftpool/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('People first')).toBeInTheDocument();
+    expect(screen.getByText('No fees, no ads')).toBeInTheDocument();
+    expect(screen.getByText('Privacy by default')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /get in touch/i })).toHaveAttribute(
+      'href',
+      '/support',
+    );
+    expect(
+      screen.getByRole('link', { name: /buy me a coffee/i }),
+    ).toHaveAttribute('href', 'https://buymeacoffee.com/twoplustwoone');
+  });
+});

--- a/app/routes/_marketing+/about.tsx
+++ b/app/routes/_marketing+/about.tsx
@@ -1,5 +1,137 @@
+import {
+  LuCoffee,
+  LuDollarSign,
+  LuGift,
+  LuShield,
+  LuUsers,
+} from 'react-icons/lu';
+import { Link, type MetaFunction } from 'react-router';
+import { Card, CardContent } from '#app/components/ui/card.tsx';
+import { cn } from '#app/utils/misc.tsx';
+
+export const meta: MetaFunction = () => [{ title: 'About | GiftPool' }];
+
+const values = [
+  {
+    icon: <LuUsers className="h-5 w-5" aria-hidden />,
+    color: 'text-blue-500',
+    title: 'People first',
+    blurb:
+      'Gifting is about the people, not the platform. We stay out of the way so you can focus on the people you care about.',
+  },
+  {
+    icon: <LuDollarSign className="h-5 w-5" aria-hidden />,
+    color: 'text-green-500',
+    title: 'No fees, no ads',
+    blurb:
+      'GiftPool is free. We don\u2019t take a cut, run ads, or sell your data. Your gift budget goes where it should.',
+  },
+  {
+    icon: <LuShield className="h-5 w-5" aria-hidden />,
+    color: 'text-yellow-500',
+    title: 'Privacy by default',
+    blurb:
+      'We collect only what we need to run the service. No third-party trackers, no analytics platforms watching you.',
+  },
+];
+
 const AboutRoute = () => {
-  return <div>About page</div>;
+  return (
+    <div className="container max-w-3xl pb-32 pt-20">
+      <section className="text-center">
+        <h1 className="text-h1">
+          About GiftPool{' '}
+          <LuGift className="inline h-8 w-8 text-primary" aria-hidden />
+        </h1>
+        <p className="mx-auto mt-4 max-w-xl text-body-md leading-relaxed text-muted-foreground">
+          GiftPool makes group gifting simple. Create wishlists, coordinate with
+          friends, pool contributions, and make sure nobody gets a duplicate
+          toaster.
+        </p>
+      </section>
+
+      <section className="mt-16">
+        <h2 className="text-center text-xl font-semibold tracking-tight md:text-2xl">
+          Why we built this
+        </h2>
+        <p className="mx-auto mt-4 max-w-xl text-center text-body-md leading-relaxed text-muted-foreground">
+          Every birthday, holiday, and celebration came with the same chaos:
+          scattered group chats, spreadsheets nobody updated, and duplicate
+          gifts. GiftPool exists so you can skip the coordination headache and
+          get straight to the good part.
+        </p>
+      </section>
+
+      <section className="mt-16">
+        <h2 className="text-center text-xl font-semibold tracking-tight md:text-2xl">
+          What we care about
+        </h2>
+        <div className="mt-6 grid grid-cols-1 gap-4 md:grid-cols-3">
+          {values.map((v) => (
+            <Card key={v.title} padding="lg" className="h-full">
+              <CardContent>
+                <div className="flex flex-col items-center gap-3">
+                  <div
+                    className={cn(
+                      'flex h-12 w-12 items-center justify-center rounded-full bg-accent',
+                      v.color,
+                    )}
+                  >
+                    {v.icon}
+                  </div>
+                  <h3 className="text-center text-base font-bold md:text-lg">
+                    {v.title}
+                  </h3>
+                  <p className="text-center text-sm text-muted-foreground md:text-base">
+                    {v.blurb}
+                  </p>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </section>
+
+      <section className="mt-16 text-center">
+        <h2 className="text-xl font-semibold tracking-tight md:text-2xl">
+          Have a question?
+        </h2>
+        <p className="mt-3 text-body-md text-muted-foreground">
+          We&apos;d love to hear from you.{' '}
+          <Link
+            to="/support"
+            className="font-medium text-foreground underline hover:no-underline"
+          >
+            Get in touch
+          </Link>
+          .
+        </p>
+      </section>
+
+      <section className="mt-16 rounded-xl border border-border/60 bg-card px-6 py-8 text-center">
+        <LuCoffee
+          className="mx-auto h-8 w-8 text-yellow-600 dark:text-yellow-500"
+          aria-hidden
+        />
+        <h2 className="mt-3 text-lg font-semibold tracking-tight">
+          Support the project
+        </h2>
+        <p className="mx-auto mt-2 max-w-md text-sm leading-relaxed text-muted-foreground">
+          GiftPool is a passion project and will always be free. If it&apos;s
+          made your life a little easier, a coffee goes a long way.
+        </p>
+        <a
+          href="https://buymeacoffee.com/twoplustwoone"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-4 inline-flex items-center gap-2 rounded-lg bg-yellow-500 px-5 py-2.5 text-sm font-semibold text-neutral-900 shadow-sm transition-colors hover:bg-yellow-400"
+        >
+          <LuCoffee className="h-4 w-4" aria-hidden />
+          Buy me a coffee
+        </a>
+      </section>
+    </div>
+  );
 };
 
 export default AboutRoute;

--- a/app/routes/_marketing+/privacy.test.tsx
+++ b/app/routes/_marketing+/privacy.test.tsx
@@ -1,0 +1,20 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import PrivacyRoute from './privacy.tsx';
+
+describe('PrivacyRoute', () => {
+  it('renders the policy with key sections', () => {
+    render(<PrivacyRoute />);
+
+    expect(
+      screen.getByRole('heading', { level: 1, name: /privacy policy/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/information we collect/i)).toBeInTheDocument();
+    expect(screen.getByText(/third-party services/i)).toBeInTheDocument();
+    expect(screen.getByText(/cookies and sessions/i)).toBeInTheDocument();
+    expect(screen.getByText(/data retention/i)).toBeInTheDocument();
+  });
+});

--- a/app/routes/_marketing+/privacy.tsx
+++ b/app/routes/_marketing+/privacy.tsx
@@ -191,8 +191,7 @@ const PrivacyRoute = () => {
             handled, please reach out through our{' '}
             <a href="/support" className="underline hover:text-foreground">
               support page
-            </a>
-            .
+            </a>{'.'}
           </p>
         </section>
       </div>

--- a/app/routes/_marketing+/privacy.tsx
+++ b/app/routes/_marketing+/privacy.tsx
@@ -1,5 +1,203 @@
+import { type MetaFunction } from 'react-router';
+
+export const meta: MetaFunction = () => [
+  { title: 'Privacy Policy | GiftPool' },
+];
+
 const PrivacyRoute = () => {
-  return <div>Privacy</div>;
+  return (
+    <div className="container max-w-3xl pb-32 pt-20">
+      <h1 className="text-h1">Privacy Policy</h1>
+      <p className="mt-2 text-body-sm text-muted-foreground">
+        Last updated: April 11, 2026
+      </p>
+
+      <div className="mt-10 space-y-8 text-body-md leading-relaxed text-muted-foreground">
+        <section>
+          <h2 className="text-h5 text-foreground">1. Information We Collect</h2>
+
+          <h3 className="mt-4 text-body-md font-semibold text-foreground">
+            Account information
+          </h3>
+          <p className="mt-1">
+            When you create an account, we collect your email address, username,
+            display name, and password (stored in hashed form). You may
+            optionally provide a birthday, mailing address, bio, and profile
+            photo.
+          </p>
+
+          <h3 className="mt-4 text-body-md font-semibold text-foreground">
+            Content you create
+          </h3>
+          <p className="mt-1">
+            This includes wishlist items (names, descriptions, links, images),
+            gift pool participation, group memberships, and friend connections.
+          </p>
+
+          <h3 className="mt-4 text-body-md font-semibold text-foreground">
+            Usage data
+          </h3>
+          <p className="mt-1">
+            We collect analytics events about how you use GiftPool, such as
+            feature usage and navigation patterns. This data is associated with
+            your account and stored in our database. We do not use third-party
+            analytics or advertising trackers.
+          </p>
+
+          <h3 className="mt-4 text-body-md font-semibold text-foreground">
+            Technical data
+          </h3>
+          <p className="mt-1">
+            We automatically collect request IDs and session identifiers for
+            operational purposes.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-h5 text-foreground">
+            2. How We Use Your Information
+          </h2>
+          <p className="mt-2">We use your information to:</p>
+          <ul className="mt-2 list-inside list-disc space-y-1">
+            <li>Operate and maintain the GiftPool service</li>
+            <li>
+              Send you transactional emails (account verification, friend
+              requests, gift pool notifications)
+            </li>
+            <li>
+              Display your profile and wishlist to users you have connected with
+            </li>
+            <li>Improve the service based on usage patterns</li>
+            <li>Detect and prevent abuse or security issues</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2 className="text-h5 text-foreground">3. Third-Party Services</h2>
+          <p className="mt-2">We share limited data with the following:</p>
+          <ul className="mt-2 list-inside list-disc space-y-2">
+            <li>
+              <strong className="text-foreground">Resend</strong> — our email
+              delivery provider. Your email address is shared when we send
+              transactional emails (e.g., verification codes, friend request
+              notifications).
+            </li>
+            <li>
+              <strong className="text-foreground">Sentry</strong> — our error
+              monitoring service. When errors occur, technical data (request IDs,
+              session IDs, and error details) may be sent to Sentry for
+              debugging. This may incidentally include your user ID.
+            </li>
+            <li>
+              <strong className="text-foreground">GitHub</strong> — if you
+              choose to sign in with GitHub, we receive your email address and
+              profile information from GitHub&apos;s OAuth service.
+            </li>
+          </ul>
+          <p className="mt-2">
+            We do not sell your data. We do not share your information with
+            advertisers.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-h5 text-foreground">4. Cookies and Sessions</h2>
+          <p className="mt-2">
+            GiftPool uses a single session cookie (<code>en_session</code>) to
+            keep you logged in. This cookie is HTTP-only (not accessible to
+            JavaScript), uses secure transmission in production, and expires
+            after 30 days by default. If you select &quot;remember me&quot;
+            during login, the cookie persists for the full session duration. We
+            do not use advertising or third-party tracking cookies.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-h5 text-foreground">5. Data Storage</h2>
+          <p className="mt-2">
+            Your data is stored in a SQLite database hosted on Fly.io
+            infrastructure. Passwords are hashed using bcrypt before storage. We
+            take reasonable measures to protect your data, but no method of
+            electronic storage is 100% secure.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-h5 text-foreground">
+            6. Your Choices and Controls
+          </h2>
+          <ul className="mt-2 list-inside list-disc space-y-1">
+            <li>
+              <strong className="text-foreground">
+                Notification preferences
+              </strong>{' '}
+              — you can control which notifications you receive (in-app and
+              email) from your account settings.
+            </li>
+            <li>
+              <strong className="text-foreground">Birthday visibility</strong> —
+              you can choose who can see your birthday: friends, everyone, or
+              nobody.
+            </li>
+            <li>
+              <strong className="text-foreground">Profile information</strong> —
+              you can update or remove your optional profile details at any time
+              in your settings.
+            </li>
+            <li>
+              <strong className="text-foreground">Account deletion</strong> —
+              you can delete your account through your account settings. This
+              removes your profile, wishlists, and associated data.
+            </li>
+          </ul>
+        </section>
+
+        <section>
+          <h2 className="text-h5 text-foreground">7. Data Retention</h2>
+          <p className="mt-2">
+            We retain your account data for as long as your account is active.
+            Expired sessions and stale verification tokens are periodically
+            cleaned up. If you delete your account, your personal data is
+            removed from our active database.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-h5 text-foreground">8. Children&apos;s Privacy</h2>
+          <p className="mt-2">
+            GiftPool is not intended for children under 13. We do not knowingly
+            collect personal information from children under 13. If you believe a
+            child under 13 has created an account, please contact us so we can
+            remove it.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-h5 text-foreground">
+            9. Changes to This Policy
+          </h2>
+          <p className="mt-2">
+            We may update this privacy policy from time to time. If we make
+            material changes, we will notify you through the service or by email.
+            The &quot;last updated&quot; date at the top indicates when this
+            policy was last revised.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-h5 text-foreground">10. Contact</h2>
+          <p className="mt-2">
+            If you have questions about this privacy policy or how your data is
+            handled, please reach out through our{' '}
+            <a href="/support" className="underline hover:text-foreground">
+              support page
+            </a>
+            .
+          </p>
+        </section>
+      </div>
+    </div>
+  );
 };
 
 export default PrivacyRoute;

--- a/app/routes/_marketing+/support.test.tsx
+++ b/app/routes/_marketing+/support.test.tsx
@@ -1,0 +1,38 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import SupportRoute from './support.tsx';
+
+describe('SupportRoute', () => {
+  it('renders contact channels and the FAQ', () => {
+    render(<SupportRoute />);
+
+    expect(
+      screen.getByRole('heading', { level: 1, name: /support/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { level: 2, name: /email us/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { level: 2, name: /report a bug/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { level: 2, name: /suggest a feature/i }),
+    ).toBeInTheDocument();
+
+    const emailLink = screen.getByRole('link', {
+      name: 'support@giftpool.app',
+    });
+    expect(emailLink).toHaveAttribute('href', 'mailto:support@giftpool.app');
+
+    expect(
+      screen.getByText(/frequently asked questions/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/is giftpool free\?/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/can i delete my account\?/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/app/routes/_marketing+/support.tsx
+++ b/app/routes/_marketing+/support.tsx
@@ -1,5 +1,127 @@
+import { LuBug, LuLightbulb, LuMail, LuMessageCircle } from 'react-icons/lu';
+import { type MetaFunction } from 'react-router';
+import { Card, CardContent } from '#app/components/ui/card.tsx';
+import { cn } from '#app/utils/misc.tsx';
+
+export const meta: MetaFunction = () => [{ title: 'Support | GiftPool' }];
+
+const channels = [
+  {
+    icon: <LuMail className="h-5 w-5" aria-hidden />,
+    color: 'text-primary',
+    title: 'Email us',
+    description: 'For account issues, questions, or anything else.',
+    action: 'support@giftpool.app',
+    href: 'mailto:support@giftpool.app',
+  },
+  {
+    icon: <LuBug className="h-5 w-5" aria-hidden />,
+    color: 'text-yellow-500',
+    title: 'Report a bug',
+    description:
+      'Something broken? Let us know and we\u2019ll get it sorted.',
+    action: 'File a report',
+    href: 'mailto:support@giftpool.app?subject=Bug%20Report',
+  },
+  {
+    icon: <LuLightbulb className="h-5 w-5" aria-hidden />,
+    color: 'text-green-500',
+    title: 'Suggest a feature',
+    description: 'Got an idea that would make GiftPool better? We\u2019re all ears.',
+    action: 'Send a suggestion',
+    href: 'mailto:support@giftpool.app?subject=Feature%20Suggestion',
+  },
+];
+
+const faqs = [
+  {
+    q: 'Is GiftPool free?',
+    a: 'Yes, completely. No fees, no premium tiers, no ads.',
+  },
+  {
+    q: 'How do gift pools work?',
+    a: 'One person creates a pool for a recipient, invites contributors, and the group votes on what to get. Once decided, someone purchases and delivers the gift.',
+  },
+  {
+    q: 'Does GiftPool handle payments?',
+    a: 'No. GiftPool coordinates who\u2019s contributing what, but actual money transfers happen directly between people however they prefer (Venmo, cash, etc.).',
+  },
+  {
+    q: 'Can I delete my account?',
+    a: 'Yes. Head to Settings and you\u2019ll find the option to delete your account and all associated data.',
+  },
+  {
+    q: 'Who can see my wishlist?',
+    a: 'By default, only your friends on GiftPool. You can also create a public share link for anyone.',
+  },
+];
+
 const SupportRoute = () => {
-  return <div>Support</div>;
+  return (
+    <div className="container max-w-3xl pb-32 pt-20">
+      <section className="text-center">
+        <h1 className="text-h1">
+          Support{' '}
+          <LuMessageCircle
+            className="inline h-8 w-8 text-primary"
+            aria-hidden
+          />
+        </h1>
+        <p className="mx-auto mt-4 max-w-xl text-body-md leading-relaxed text-muted-foreground">
+          Need help or have feedback? Here&apos;s how to reach us.
+        </p>
+      </section>
+
+      <section className="mt-12">
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+          {channels.map((c) => (
+            <Card key={c.title} padding="lg" className="h-full">
+              <CardContent>
+                <div className="flex flex-col items-center gap-3 text-center">
+                  <div
+                    className={cn(
+                      'flex h-12 w-12 items-center justify-center rounded-full bg-accent',
+                      c.color,
+                    )}
+                  >
+                    {c.icon}
+                  </div>
+                  <h2 className="text-base font-bold md:text-lg">{c.title}</h2>
+                  <p className="text-sm text-muted-foreground">
+                    {c.description}
+                  </p>
+                  <a
+                    href={c.href}
+                    className="mt-1 text-sm font-medium text-foreground underline hover:no-underline"
+                  >
+                    {c.action}
+                  </a>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </section>
+
+      <section className="mt-16">
+        <h2 className="text-center text-xl font-semibold tracking-tight md:text-2xl">
+          Frequently asked questions
+        </h2>
+        <dl className="mt-6 divide-y divide-border">
+          {faqs.map((faq) => (
+            <div key={faq.q} className="py-5">
+              <dt className="text-body-md font-semibold text-foreground">
+                {faq.q}
+              </dt>
+              <dd className="mt-2 text-body-md leading-relaxed text-muted-foreground">
+                {faq.a}
+              </dd>
+            </div>
+          ))}
+        </dl>
+      </section>
+    </div>
+  );
 };
 
 export default SupportRoute;

--- a/app/routes/_marketing+/tos.test.tsx
+++ b/app/routes/_marketing+/tos.test.tsx
@@ -1,0 +1,22 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import TermsOfServiceRoute from './tos.tsx';
+
+describe('TermsOfServiceRoute', () => {
+  it('renders the terms with key sections', () => {
+    render(<TermsOfServiceRoute />);
+
+    expect(
+      screen.getByRole('heading', { level: 1, name: /terms of service/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/acceptance of terms/i)).toBeInTheDocument();
+    expect(screen.getByText(/acceptable use/i)).toBeInTheDocument();
+    expect(screen.getByText(/gift coordination/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/limitation of liability/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/app/routes/_marketing+/tos.tsx
+++ b/app/routes/_marketing+/tos.tsx
@@ -1,5 +1,155 @@
+import { type MetaFunction } from 'react-router';
+
+export const meta: MetaFunction = () => [
+  { title: 'Terms of Service | GiftPool' },
+];
+
 const TermsOfServiceRoute = () => {
-  return <div>Terms of service</div>;
+  return (
+    <div className="container max-w-3xl pb-32 pt-20">
+      <h1 className="text-h1">Terms of Service</h1>
+      <p className="mt-2 text-body-sm text-muted-foreground">
+        Last updated: April 11, 2026
+      </p>
+
+      <div className="mt-10 space-y-8 text-body-md leading-relaxed text-muted-foreground">
+        <section>
+          <h2 className="text-h5 text-foreground">1. Acceptance of Terms</h2>
+          <p className="mt-2">
+            By creating an account or using GiftPool, you agree to these Terms
+            of Service and our{' '}
+            <a href="/privacy" className="underline hover:text-foreground">
+              Privacy Policy
+            </a>
+            . If you do not agree, please do not use the service.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-h5 text-foreground">
+            2. Description of Service
+          </h2>
+          <p className="mt-2">
+            GiftPool is a web application that lets users create wishlists,
+            coordinate gift-giving within groups, and manage gift pools with
+            friends. The service is provided free of charge.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-h5 text-foreground">3. Your Account</h2>
+          <p className="mt-2">
+            You are responsible for maintaining the security of your account
+            credentials. You must provide accurate information when creating your
+            account. You may not use another person&apos;s account without
+            permission. You must be at least 13 years old to use GiftPool.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-h5 text-foreground">4. Acceptable Use</h2>
+          <p className="mt-2">You agree not to:</p>
+          <ul className="mt-2 list-inside list-disc space-y-1">
+            <li>Use the service for any unlawful purpose</li>
+            <li>Harass, abuse, or harm other users</li>
+            <li>
+              Attempt to gain unauthorized access to the service or other
+              accounts
+            </li>
+            <li>
+              Upload malicious content, spam, or content that infringes on
+              others&apos; rights
+            </li>
+            <li>
+              Interfere with or disrupt the service or its infrastructure
+            </li>
+            <li>Scrape, crawl, or otherwise collect data from the service</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2 className="text-h5 text-foreground">5. Your Content</h2>
+          <p className="mt-2">
+            You retain ownership of the content you create on GiftPool,
+            including wishlist items, profile information, and messages. By
+            posting content, you grant GiftPool a limited license to store,
+            display, and transmit that content as necessary to operate the
+            service. You may delete your content at any time.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-h5 text-foreground">6. Gift Coordination</h2>
+          <p className="mt-2">
+            GiftPool facilitates communication and coordination between users
+            for gift-giving purposes. GiftPool is not a party to any gift
+            transactions and is not responsible for the purchase, delivery, or
+            quality of any gifts. Any financial contributions or purchases
+            related to gift pools are made directly between users and are not
+            processed through GiftPool.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-h5 text-foreground">
+            7. Disclaimer of Warranties
+          </h2>
+          <p className="mt-2">
+            GiftPool is provided &quot;as is&quot; and &quot;as available&quot;
+            without warranties of any kind, whether express or implied. We do
+            not guarantee that the service will be uninterrupted, secure, or
+            error-free. We make no warranties regarding the accuracy or
+            reliability of any content on the service.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-h5 text-foreground">
+            8. Limitation of Liability
+          </h2>
+          <p className="mt-2">
+            To the maximum extent permitted by law, GiftPool and its operators
+            shall not be liable for any indirect, incidental, special,
+            consequential, or punitive damages, or any loss of profits or
+            revenue, whether incurred directly or indirectly, or any loss of
+            data, use, or goodwill arising out of your use of the service.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-h5 text-foreground">9. Account Termination</h2>
+          <p className="mt-2">
+            We may suspend or terminate your account at our discretion if you
+            violate these terms. You may delete your account at any time through
+            your account settings. Upon termination, your right to use the
+            service ceases immediately.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-h5 text-foreground">10. Changes to Terms</h2>
+          <p className="mt-2">
+            We may update these terms from time to time. If we make material
+            changes, we will notify you through the service or by email. Your
+            continued use of GiftPool after changes take effect constitutes
+            acceptance of the updated terms.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-h5 text-foreground">11. Contact</h2>
+          <p className="mt-2">
+            If you have questions about these terms, please reach out through
+            our{' '}
+            <a href="/support" className="underline hover:text-foreground">
+              support page
+            </a>
+            .
+          </p>
+        </section>
+      </div>
+    </div>
+  );
 };
 
 export default TermsOfServiceRoute;

--- a/app/routes/_marketing+/tos.tsx
+++ b/app/routes/_marketing+/tos.tsx
@@ -21,7 +21,7 @@ const TermsOfServiceRoute = () => {
             <a href="/privacy" className="underline hover:text-foreground">
               Privacy Policy
             </a>
-            . If you do not agree, please do not use the service.
+            {'. '}If you do not agree, please do not use the service.
           </p>
         </section>
 
@@ -143,8 +143,7 @@ const TermsOfServiceRoute = () => {
             our{' '}
             <a href="/support" className="underline hover:text-foreground">
               support page
-            </a>
-            .
+            </a>{'.'}
           </p>
         </section>
       </div>

--- a/app/routes/index.test.tsx
+++ b/app/routes/index.test.tsx
@@ -353,9 +353,6 @@ describe('app/routes/index.tsx', () => {
     ).toBeInTheDocument();
     expect(screen.getByText(HOME_COPY.hero.visualAlt)).toBeInTheDocument();
     expect(screen.getByText(HOME_COPY.features[0].title)).toBeInTheDocument();
-    expect(
-      screen.getByRole('link', { name: HOME_COPY.footer.about }),
-    ).toHaveAttribute('href', '/about');
 
     await userEvent.click(
       screen.getByRole('link', { name: HOME_COPY.hero.primaryCta }),

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -1,7 +1,6 @@
 import { type LoaderFunctionArgs, type MetaFunction, useLoaderData, useSearchParams  } from 'react-router';
 import { HOME_COPY } from '#app/components/home/home-copy';
 import { HomeFeatures } from '#app/components/home/HomeFeatures';
-import { HomeFooterLite } from '#app/components/home/HomeFooterLite';
 import { HomeHero } from '#app/components/home/HomeHero';
 import { HomeLoggedIn } from '#app/components/home/HomeLoggedIn';
 import { useHomeBackgroundPrefetch } from '#app/hooks/use-background-route-prefetch.ts';
@@ -119,7 +118,6 @@ const Index = () => {
         onSecondaryClick={() => track('home.cta.start_group')}
       />
       <HomeFeatures />
-      <HomeFooterLite />
     </main>
   );
 };


### PR DESCRIPTION
## Summary
- **Terms of Service & Privacy Policy**: Replace stub pages with full legal content covering liability, data practices, third-party services (Resend, Sentry, GitHub OAuth), cookies, and user controls.
- **Auth consent**: Add passive consent line on signup page and update onboarding checkbox with actual links to ToS and Privacy Policy.
- **Global site footer**: New `SiteFooter` component in the root layout with links to About, Contact, Privacy, Terms, and Buy Me a Coffee. Removes the duplicate `HomeFooterLite` from the home page.
- **About page**: Mission, values (people first, no fees, privacy by default), and a Buy Me a Coffee section.
- **Support page**: Three contact channels (email, bug report, feature suggestion) and a 5-question FAQ.

## Test plan
- [ ] Visit `/tos` and `/privacy` — verify full content renders with proper heading hierarchy
- [ ] Visit `/signup` — verify "By signing up, you agree to..." line appears below submit button with working links
- [ ] Start onboarding flow — verify checkbox label has clickable links that open `/tos` and `/privacy` in new tabs
- [ ] Visit any page — verify global footer appears at the bottom with all 5 links (About, Contact, Privacy, Terms, Buy me a coffee)
- [ ] Visit `/` logged out — verify only one footer (no duplicate from old HomeFooterLite)
- [ ] Visit `/about` — verify values cards, "Support the project" section, and Buy Me a Coffee button linking to `buymeacoffee.com/twoplustwoone`
- [ ] Visit `/support` — verify contact cards with mailto links and FAQ section
- [ ] Check mobile layout — footer links wrap cleanly, bottom nav doesn't overlap