### PR TITLE
feat(wishlist): wishlist item types — Phase 1

### DIFF
--- a/app/components/wishlist/wishlist-category-card.tsx
+++ b/app/components/wishlist/wishlist-category-card.tsx
@@ -278,7 +278,7 @@ function CategoryItemsGrid({
           wishlistItem={item}
           isOwner={isOwner}
           categories={optimisticCategories}
-          disableClaims={isPublicView}
+          disableClaims={isPublicView || item.type === 'wishlist'}
           isReorderMode={false}
           dragState={dragState}
           onStatusChange={onStatusChange}

--- a/app/components/wishlist/wishlist-item.test.tsx
+++ b/app/components/wishlist/wishlist-item.test.tsx
@@ -5,7 +5,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { WishlistItem } from './wishlist-item';
+import { WishlistItem, parseDisplayUrl } from './wishlist-item';
 
 const mockOpenView = vi.fn();
 const mockOpenEdit = vi.fn();
@@ -359,5 +359,230 @@ describe('WishlistItem', () => {
     // inside the row button itself, so assert on the Card ancestor rather
     // than on the row button specifically.
     expect(screen.getByText('Claimed')).toBeInTheDocument();
+  });
+});
+
+describe('parseDisplayUrl', () => {
+  it('returns host and href for a valid https URL', () => {
+    const result = parseDisplayUrl('https://www.amazon.com/hz/wishlist/ls/abc');
+    expect(result).toEqual({
+      host: 'amazon.com',
+      href: 'https://www.amazon.com/hz/wishlist/ls/abc',
+    });
+  });
+
+  it('returns null for a javascript: URL', () => {
+    expect(parseDisplayUrl('javascript:alert(1)')).toBeNull();
+  });
+
+  it('returns null for a data: URL', () => {
+    expect(parseDisplayUrl('data:text/html,<script>alert(1)</script>')).toBeNull();
+  });
+
+  it('returns null for a malformed string', () => {
+    expect(parseDisplayUrl('not a url at all')).toBeNull();
+  });
+
+  it('strips www from the host', () => {
+    const result = parseDisplayUrl('https://www.example.com/path');
+    expect(result?.host).toBe('example.com');
+  });
+});
+
+describe('WishlistItem — list link type', () => {
+  beforeEach(() => {
+    mockUser = { id: 'friend-id', roles: [] };
+  });
+
+  it('renders a "List link" badge for wishlist-type items', () => {
+    render(
+      <WishlistItem
+        categories={[]}
+        wishlistItem={{
+          id: 'item-1',
+          title: 'My Amazon Wishlist',
+          note: null,
+          url: 'https://www.amazon.com/hz/wishlist/ls/abc',
+          type: 'wishlist',
+          categoryId: null,
+          ownerId: 'owner-id',
+          updatedAt: new Date(),
+          status: 'ACTIVE',
+        }}
+      />,
+    );
+
+    expect(screen.getByText('List link')).toBeInTheDocument();
+  });
+
+  it('does not render a "List link" badge for gift-idea items', () => {
+    render(
+      <WishlistItem
+        categories={[]}
+        wishlistItem={{
+          id: 'item-1',
+          title: 'A Gift Idea',
+          note: null,
+          url: null,
+          type: 'text',
+          categoryId: null,
+          ownerId: 'owner-id',
+          updatedAt: new Date(),
+          status: 'ACTIVE',
+        }}
+      />,
+    );
+
+    expect(screen.queryByText('List link')).not.toBeInTheDocument();
+  });
+
+  it('renders a Visit link for non-owners viewing a list link with a valid URL', () => {
+    render(
+      <WishlistItem
+        categories={[]}
+        disableClaims
+        wishlistItem={{
+          id: 'item-1',
+          title: 'My Amazon Wishlist',
+          note: null,
+          url: 'https://www.amazon.com/hz/wishlist/ls/abc',
+          type: 'wishlist',
+          categoryId: null,
+          ownerId: 'owner-id',
+          updatedAt: new Date(),
+          status: 'ACTIVE',
+        }}
+      />,
+    );
+
+    const visitLink = screen.getByRole('link', { name: /visit/i });
+    expect(visitLink).toBeInTheDocument();
+    expect(visitLink).toHaveAttribute(
+      'href',
+      'https://www.amazon.com/hz/wishlist/ls/abc',
+    );
+    expect(visitLink).toHaveAttribute('target', '_blank');
+    expect(visitLink).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('does not render a Visit link when the stored URL has a non-http(s) scheme', () => {
+    render(
+      <WishlistItem
+        categories={[]}
+        disableClaims
+        wishlistItem={{
+          id: 'item-1',
+          title: 'Suspicious List',
+          note: null,
+          url: 'javascript:alert(1)',
+          type: 'wishlist',
+          categoryId: null,
+          ownerId: 'owner-id',
+          updatedAt: new Date(),
+          status: 'ACTIVE',
+        }}
+      />,
+    );
+
+    expect(screen.queryByRole('link', { name: /visit/i })).not.toBeInTheDocument();
+  });
+
+  it('does not render a Visit link when the list link has no URL', () => {
+    render(
+      <WishlistItem
+        categories={[]}
+        disableClaims
+        wishlistItem={{
+          id: 'item-1',
+          title: 'Unnamed List',
+          note: null,
+          url: null,
+          type: 'wishlist',
+          categoryId: null,
+          ownerId: 'owner-id',
+          updatedAt: new Date(),
+          status: 'ACTIVE',
+        }}
+      />,
+    );
+
+    expect(screen.queryByRole('link', { name: /visit/i })).not.toBeInTheDocument();
+  });
+});
+
+describe('WishlistItem — owner ⋮ menu type-change', () => {
+  beforeEach(() => {
+    mockOpenView.mockClear();
+    mockOpenEdit.mockClear();
+    mockUser = { id: 'owner-id', roles: [] };
+  });
+
+  it('opens the editor when "Mark as list link" is clicked and the item has no URL', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <WishlistItem
+        isOwner
+        categories={[]}
+        wishlistItem={{
+          id: 'item-1',
+          title: 'Gift with no URL',
+          note: null,
+          url: null,
+          type: 'text',
+          categoryId: null,
+          ownerId: 'owner-id',
+          updatedAt: new Date(),
+          status: 'ACTIVE',
+        }}
+      />,
+    );
+
+    const actionsButton = screen.getAllByRole('button', {
+      name: /item actions for gift with no url/i,
+    })[0];
+    if (!actionsButton) throw new Error('Expected actions button');
+
+    await user.click(actionsButton);
+    await user.click(
+      await screen.findByRole('menuitem', { name: /mark as list link/i }),
+    );
+
+    expect(mockOpenEdit).toHaveBeenCalledOnce();
+  });
+
+  it('does not open the editor when "Mark as list link" is clicked and the item already has a URL', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <WishlistItem
+        isOwner
+        categories={[]}
+        wishlistItem={{
+          id: 'item-1',
+          title: 'Gift with URL',
+          note: null,
+          url: 'https://www.amazon.com/dp/B001',
+          type: 'text',
+          categoryId: null,
+          ownerId: 'owner-id',
+          updatedAt: new Date(),
+          status: 'ACTIVE',
+        }}
+      />,
+    );
+
+    const actionsButton = screen.getAllByRole('button', {
+      name: /item actions for gift with url/i,
+    })[0];
+    if (!actionsButton) throw new Error('Expected actions button');
+
+    await user.click(actionsButton);
+    await user.click(
+      await screen.findByRole('menuitem', { name: /mark as list link/i }),
+    );
+
+    // When a URL is already set the quick-convert path is taken, not the editor
+    expect(mockOpenEdit).not.toHaveBeenCalled();
   });
 });

--- a/app/components/wishlist/wishlist-item.tsx
+++ b/app/components/wishlist/wishlist-item.tsx
@@ -6,6 +6,7 @@ import {
   LuExternalLink,
   LuGift,
   LuImage,
+  LuLayoutList,
   LuLock,
   LuPencil,
   LuTrash,
@@ -309,7 +310,7 @@ function useWishlistImageController({
         imageFetcher.submit(formData, {
           method: 'post',
           encType: 'multipart/form-data',
-          action: '/wishlist',
+          action: '/wishlist?index',
         }),
       ).catch(() => {});
     },
@@ -443,14 +444,17 @@ function WishlistNonOwnerExtras({
   );
 }
 
-// Right-slot control for the non-owner row. Swaps between four states:
-// public-view (no claims), already-claimed-by-someone-else (with an info
-// popover explaining why), you-claimed-it, or free-to-claim.
+// Right-slot control for the non-owner row. Swaps between states:
+// list-link (visit external list), public-view (no claims),
+// already-claimed-by-someone-else (with an info popover explaining why),
+// you-claimed-it, or free-to-claim.
 function NonOwnerClaimSlot({
   allowClaims,
   handlePurchaseToggle,
   isClaimInfoOpen,
   isClaimed,
+  isListLink,
+  itemUrl,
   isPurchasePending,
   isPurchasedByMe,
   isPurchasedBySomeoneElse,
@@ -467,7 +471,34 @@ function NonOwnerClaimSlot({
   | 'isPurchasedBySomeoneElse'
   | 'onClaimInfoOpenChange'
   | 'purchaseButtonAriaLabel'
->) {
+> & {
+  isListLink?: boolean;
+  itemUrl?: string | null;
+}) {
+  // List link — show "Visit list" external link instead of claim affordance.
+  if (!allowClaims && isListLink) {
+    if (itemUrl) {
+      return (
+        <a
+          href={itemUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={(event) => event.stopPropagation()}
+          className="pointer-events-auto flex flex-shrink-0 items-center gap-1 rounded-full border border-border px-2.5 py-1 text-[11px] font-medium text-muted-foreground transition-colors hover:border-foreground/30 hover:text-foreground"
+        >
+          Visit
+          <LuExternalLink className="h-3 w-3" aria-hidden />
+        </a>
+      );
+    }
+    return (
+      <LuChevronRight
+        className="h-5 w-5 flex-shrink-0 text-muted-foreground"
+        aria-hidden
+      />
+    );
+  }
+
   // Public view (signed out on a shared link) — no claim affordance, just
   // show a chevron so the row looks tap-able, or an "Already claimed" badge.
   if (!allowClaims) {
@@ -596,6 +627,8 @@ function WishlistNonOwnerTrigger({
   imageErrored: boolean;
   onImageError: (event?: React.SyntheticEvent) => void;
 }) {
+  const isListLink = wishlistItem.type === 'wishlist';
+
   return (
     <WishlistItemCardShell
       ariaLabel={wishlistItem.title}
@@ -611,6 +644,7 @@ function WishlistNonOwnerTrigger({
       displayImageSrc={displayImageSrc}
       hasImage={wishlistItem.hasImage ?? false}
       imageErrored={imageErrored}
+      isListLink={isListLink}
       note={wishlistItem.note ?? null}
       onImageError={onImageError}
       onOpen={onOpen}
@@ -620,6 +654,8 @@ function WishlistNonOwnerTrigger({
           handlePurchaseToggle={handlePurchaseToggle}
           isClaimInfoOpen={isClaimInfoOpen}
           isClaimed={isClaimed}
+          isListLink={isListLink}
+          itemUrl={wishlistItem.url ?? null}
           isPurchasePending={isPurchasePending}
           isPurchasedByMe={isPurchasedByMe}
           isPurchasedBySomeoneElse={isPurchasedBySomeoneElse}
@@ -697,6 +733,7 @@ type WishlistItemThumbnailProps = Readonly<{
   displayImageSrc: string | null;
   hasImage: boolean;
   imageErrored: boolean;
+  isListLink?: boolean;
   onImageError: (event?: React.SyntheticEvent) => void;
   title: string;
 }>;
@@ -709,6 +746,7 @@ export function WishlistItemThumbnail({
   displayImageSrc,
   hasImage,
   imageErrored,
+  isListLink,
   onImageError,
   title,
 }: WishlistItemThumbnailProps) {
@@ -728,7 +766,7 @@ export function WishlistItemThumbnail({
     );
   }
 
-  const PlaceholderIcon = hasImage && imageErrored ? LuImage : LuGift;
+  const PlaceholderIcon = hasImage && imageErrored ? LuImage : isListLink ? LuLayoutList : LuGift;
 
   return (
     <div
@@ -751,6 +789,7 @@ type WishlistItemCardShellProps = Readonly<{
   displayImageSrc: string | null;
   hasImage: boolean;
   imageErrored: boolean;
+  isListLink?: boolean;
   note: string | null;
   onImageError: (event?: React.SyntheticEvent) => void;
   onOpen: () => void;
@@ -779,6 +818,7 @@ function WishlistItemCardShell({
   displayImageSrc,
   hasImage,
   imageErrored,
+  isListLink,
   note,
   onImageError,
   onOpen,
@@ -811,6 +851,7 @@ function WishlistItemCardShell({
           displayImageSrc={displayImageSrc}
           hasImage={hasImage}
           imageErrored={imageErrored}
+          isListLink={isListLink}
           onImageError={onImageError}
           title={title}
         />
@@ -829,6 +870,12 @@ function WishlistItemCardShell({
             >
               {note}
             </Text>
+          ) : null}
+          {isListLink ? (
+            <span className="pointer-events-none inline-flex items-center gap-1 rounded-full bg-blue-50 px-2 py-0.5 text-[10px] font-medium text-blue-600 ring-1 ring-inset ring-blue-100 dark:bg-blue-950/40 dark:text-blue-400 dark:ring-blue-900">
+              <LuLayoutList className="h-3 w-3" aria-hidden />
+              List link
+            </span>
           ) : null}
           {url ? <WishlistItemUrlChip url={url} /> : null}
         </div>
@@ -863,6 +910,8 @@ function WishlistOwnerRow({
   onOpen,
   wishlistItem,
 }: WishlistOwnerRowProps) {
+  const isListLink = wishlistItem.type === 'wishlist';
+
   return (
     <WishlistItemCardShell
       ariaLabel={ariaLabel}
@@ -877,6 +926,7 @@ function WishlistOwnerRow({
       displayImageSrc={displayImageSrc}
       hasImage={wishlistItem.hasImage ?? false}
       imageErrored={imageErrored}
+      isListLink={isListLink}
       note={wishlistItem.note ?? null}
       onImageError={onImageError}
       onOpen={onOpen}
@@ -926,6 +976,30 @@ export const WishlistItem = ({
   });
   const [isClaimInfoOpen, setIsClaimInfoOpen] = React.useState(false);
   const [deleteOpen, setDeleteOpen] = React.useState(false);
+  const typeChangeFetcher = useFetcher();
+
+  const handleTypeChange = React.useCallback(
+    (newType: 'text' | 'wishlist') => {
+      const formData = new FormData();
+      formData.set('intent', 'save');
+      formData.set('id', wishlistItem.id);
+      formData.set('title', wishlistItem.title);
+      formData.set('type', newType);
+      if (wishlistItem.url) formData.set('url', wishlistItem.url);
+      if (wishlistItem.note) formData.set('note', wishlistItem.note);
+      if (wishlistItem.categoryId) formData.set('categoryId', wishlistItem.categoryId);
+      formData.set('imageAction', 'none');
+      formData.set('clientMutationId', createClientMutationId());
+      Promise.resolve(
+        typeChangeFetcher.submit(formData, {
+          method: 'post',
+          encType: 'multipart/form-data',
+          action: '/wishlist?index',
+        }),
+      ).catch(() => {});
+    },
+    [typeChangeFetcher, wishlistItem],
+  );
 
   // The purchase-related copy below is used by WishlistNonOwnerExtras, which
   // renders INSIDE the item-editor modal (not on the row itself). The row
@@ -1055,6 +1129,7 @@ export const WishlistItem = ({
     );
   }
 
+  const isListLink = wishlistItem.type === 'wishlist';
   const actionMenu = !isReorderMode ? (
     <WishlistRowActionsMenu label={`Item actions for ${wishlistItem.title}`}>
       <WishlistRowActionsItem
@@ -1064,6 +1139,12 @@ export const WishlistItem = ({
       >
         <LuPencil className="h-4 w-4 text-muted-foreground" aria-hidden />
         Edit item
+      </WishlistRowActionsItem>
+      <WishlistRowActionsItem
+        onSelect={() => handleTypeChange(isListLink ? 'text' : 'wishlist')}
+      >
+        <LuLayoutList className="h-4 w-4 text-muted-foreground" aria-hidden />
+        {isListLink ? 'Mark as gift idea' : 'Mark as list link'}
       </WishlistRowActionsItem>
       {onStatusChange ? (
         <WishlistRowActionsItem

--- a/app/components/wishlist/wishlist-item.tsx
+++ b/app/components/wishlist/wishlist-item.tsx
@@ -767,7 +767,8 @@ export function WishlistItemThumbnail({
     );
   }
 
-  const PlaceholderIcon = hasImage && imageErrored ? LuImage : isListLink ? LuLayoutList : LuGift;
+  let PlaceholderIcon = isListLink ? LuLayoutList : LuGift;
+  if (hasImage && imageErrored) PlaceholderIcon = LuImage;
 
   return (
     <div

--- a/app/components/wishlist/wishlist-item.tsx
+++ b/app/components/wishlist/wishlist-item.tsx
@@ -477,10 +477,11 @@ function NonOwnerClaimSlot({
 }) {
   // List link — show "Visit list" external link instead of claim affordance.
   if (!allowClaims && isListLink) {
-    if (itemUrl) {
+    const safeUrl = itemUrl ? parseDisplayUrl(itemUrl) : null;
+    if (safeUrl) {
       return (
         <a
-          href={itemUrl}
+          href={safeUrl.href}
           target="_blank"
           rel="noopener noreferrer"
           onClick={(event) => event.stopPropagation()}
@@ -1141,7 +1142,15 @@ export const WishlistItem = ({
         Edit item
       </WishlistRowActionsItem>
       <WishlistRowActionsItem
-        onSelect={() => handleTypeChange(isListLink ? 'text' : 'wishlist')}
+        onSelect={() => {
+          if (!isListLink && !wishlistItem.url) {
+            // No URL on this item — open the editor so the user can add one
+            // before converting (a URL is required for list links).
+            editorRef.current?.openEdit();
+          } else {
+            handleTypeChange(isListLink ? 'text' : 'wishlist');
+          }
+        }}
       >
         <LuLayoutList className="h-4 w-4 text-muted-foreground" aria-hidden />
         {isListLink ? 'Mark as gift idea' : 'Mark as list link'}

--- a/app/routes/wishlist+/__wishlist-item-editor.schema.test.ts
+++ b/app/routes/wishlist+/__wishlist-item-editor.schema.test.ts
@@ -1,0 +1,53 @@
+/**
+ * @vitest-environment node
+ *
+ * Schema-level tests for WishlistItemSchema.
+ * Uses the node environment so that z.string().url() has an unmodified
+ * URL constructor (the jsdom test file stubs URL.createObjectURL which
+ * can break Zod's URL validation).
+ */
+import { describe, expect, it } from 'vitest';
+import { WishlistItemSchema } from './__wishlist-item-editor';
+
+function parse(fields: Record<string, unknown>) {
+  return WishlistItemSchema.safeParse({
+    title: 'Test item',
+    imageAction: 'none',
+    type: 'text',
+    ...fields,
+  });
+}
+
+describe('WishlistItemSchema — URL required for list links', () => {
+  it('fails when type is wishlist and URL is absent', () => {
+    const result = parse({ type: 'wishlist' });
+    expect(result.success).toBe(false);
+    const urlErrors = result.error?.flatten().fieldErrors.url;
+    expect(urlErrors).toContain('A URL is required for list links');
+  });
+
+  it('fails when type is wishlist and URL is undefined (mirrors Conform coercion of empty string)', () => {
+    const result = parse({ type: 'wishlist', url: undefined });
+    expect(result.success).toBe(false);
+    const urlErrors = result.error?.flatten().fieldErrors.url;
+    expect(urlErrors).toContain('A URL is required for list links');
+  });
+
+  it('passes when type is wishlist and a valid URL is supplied', () => {
+    const result = parse({
+      type: 'wishlist',
+      url: 'https://www.amazon.com/hz/wishlist/ls/abc',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('passes when type is text and no URL is supplied', () => {
+    const result = parse({ type: 'text' });
+    expect(result.success).toBe(true);
+  });
+
+  it('passes when type is link and no URL is supplied', () => {
+    const result = parse({ type: 'link' });
+    expect(result.success).toBe(true);
+  });
+});

--- a/app/routes/wishlist+/__wishlist-item-editor.server.test.ts
+++ b/app/routes/wishlist+/__wishlist-item-editor.server.test.ts
@@ -315,4 +315,32 @@ describe('app/routes/wishlist+/__wishlist-item-editor.server.tsx', () => {
     });
     expect(queueLogEvent).not.toHaveBeenCalled();
   });
+
+  it('returns a result key (not a spread) when list-link URL validation fails', async () => {
+    const { cookie } = await createOwnerWithSession();
+
+    const formData = new FormData();
+    formData.set('intent', 'save');
+    formData.set('title', 'My Amazon Wishlist');
+    formData.set('type', 'wishlist');
+    // Intentionally omit url — server validation should reject this
+    formData.set('clientMutationId', 'client-val-1');
+    formData.set('imageAction', 'none');
+
+    const response = await action(
+      toActionArgs({
+        context,
+        params: {},
+        request: createEditorRequest({ cookie, formData, requestId: 'request-4' }),
+      }),
+    );
+
+    expect(getRouteResultStatus(response)).toBe(400);
+    const data = await getRouteResultData<Record<string, unknown>>(response);
+    // The error payload must be nested under `result`, not spread at the top
+    // level — useForm's lastResult expects `actionData.result`.
+    expect(data).toHaveProperty('result');
+    expect(data).not.toHaveProperty('status'); // would be present if spread
+    expect((data.result as any)?.error?.url).toBeDefined();
+  });
 });

--- a/app/routes/wishlist+/__wishlist-item-editor.server.tsx
+++ b/app/routes/wishlist+/__wishlist-item-editor.server.tsx
@@ -381,7 +381,7 @@ export async function action({ request }: ActionFunctionArgs) {
   if (submission.status !== 'success') {
     return rrData(
       {
-        ...submission.reply(),
+        result: submission.reply(),
         clientMutationId,
       },
       {

--- a/app/routes/wishlist+/__wishlist-item-editor.test.tsx
+++ b/app/routes/wishlist+/__wishlist-item-editor.test.tsx
@@ -234,3 +234,4 @@ describe('WishlistItemEditor image reset', () => {
     ).toBeInTheDocument();
   });
 });
+

--- a/app/routes/wishlist+/__wishlist-item-editor.tsx
+++ b/app/routes/wishlist+/__wishlist-item-editor.tsx
@@ -110,6 +110,76 @@ export const WishlistItemSchema = z
     }
   });
 
+type WishlistItemType = 'text' | 'link' | 'wishlist';
+
+function EditorTypeSelector({
+  isListLinkType,
+  resetImageChanges,
+  setItemType,
+}: {
+  isListLinkType: boolean;
+  resetImageChanges: () => void;
+  setItemType: React.Dispatch<React.SetStateAction<WishlistItemType>>;
+}) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <span className="text-sm font-medium">What are you adding?</span>
+      <div className="flex rounded-lg bg-muted p-1">
+        <button
+          type="button"
+          onClick={() => setItemType('text')}
+          className={cn(
+            'flex flex-1 items-center justify-center gap-1.5 rounded-md px-3 py-2 text-sm font-medium transition-all',
+            isListLinkType
+              ? 'text-muted-foreground hover:text-foreground'
+              : 'bg-background text-foreground shadow-sm',
+          )}
+        >
+          <LuGift className="h-3.5 w-3.5" aria-hidden />
+          Gift idea
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            setItemType('wishlist');
+            resetImageChanges();
+          }}
+          className={cn(
+            'flex flex-1 items-center justify-center gap-1.5 rounded-md px-3 py-2 text-sm font-medium transition-all',
+            isListLinkType
+              ? 'bg-background text-foreground shadow-sm'
+              : 'text-muted-foreground hover:text-foreground',
+          )}
+        >
+          <LuListChecks className="h-3.5 w-3.5" aria-hidden />
+          List link
+        </button>
+      </div>
+      {isListLinkType ? (
+        <p className="text-xs text-muted-foreground">
+          Links to an external collection (Amazon wishlist, Steam list, etc.). Friends can browse
+          it — list links can&apos;t be claimed.
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+function getEditorFieldConfig(isListLink: boolean) {
+  return {
+    titleLabel: isListLink ? 'List name' : 'Title',
+    titlePlaceholder: isListLink ? 'My Amazon Wishlist' : 'Title for your item',
+    urlLabel: isListLink ? 'List URL' : 'Link',
+    urlPlaceholder: isListLink
+      ? 'https://www.amazon.com/hz/wishlist/…'
+      : 'https://amazon.com/',
+    noteLabel: isListLink ? 'Note for friends' : 'Note',
+    notePlaceholder: isListLink
+      ? 'e.g. Anything in the kitchen section works for me'
+      : 'Any details to help friends pick the right one',
+  };
+}
+
 const getSafePreviewSrc = (value: string | null) => {
   if (!value) return null;
   if (value.startsWith('/')) return value;
@@ -1045,7 +1115,7 @@ function EditorFormSection({
   isImageLoading: boolean;
   isPending: boolean;
   isListLinkType: boolean;
-  itemType: 'text' | 'link' | 'wishlist';
+  itemType: WishlistItemType;
   mode: EditorMode;
   prepareImageActionForSave: () => void;
   previewSrc: string | null;
@@ -1061,11 +1131,12 @@ function EditorFormSection({
   setImageUrlValue: React.Dispatch<React.SetStateAction<string>>;
   setImageWarning: React.Dispatch<React.SetStateAction<string | null>>;
   setIsImageLoading: React.Dispatch<React.SetStateAction<boolean>>;
-  setItemType: React.Dispatch<React.SetStateAction<'text' | 'link' | 'wishlist'>>;
+  setItemType: React.Dispatch<React.SetStateAction<WishlistItemType>>;
   showImageError: boolean;
   wishlistItem?: EditorProps['wishlistItem'];
 }>) {
   const { onSubmit: conformOnSubmit, ...conformFormProps } = getFormProps(form);
+  const fieldConfig = getEditorFieldConfig(isListLinkType);
   return (
     <Form
       method="POST"
@@ -1088,47 +1159,16 @@ function EditorFormSection({
       {wishlistItem?.id ? (
         <input type="hidden" name="id" value={wishlistItem.id} />
       ) : null}
-      <div className="flex flex-col gap-1.5">
-        <span className="text-sm font-medium">What are you adding?</span>
-        <div className="flex rounded-lg bg-muted p-1">
-          <button
-            type="button"
-            onClick={() => setItemType('text')}
-            className={cn(
-              'flex flex-1 items-center justify-center gap-1.5 rounded-md px-3 py-2 text-sm font-medium transition-all',
-              !isListLinkType
-                ? 'bg-background text-foreground shadow-sm'
-                : 'text-muted-foreground hover:text-foreground',
-            )}
-          >
-            <LuGift className="h-3.5 w-3.5" aria-hidden />
-            Gift idea
-          </button>
-          <button
-            type="button"
-            onClick={() => setItemType('wishlist')}
-            className={cn(
-              'flex flex-1 items-center justify-center gap-1.5 rounded-md px-3 py-2 text-sm font-medium transition-all',
-              isListLinkType
-                ? 'bg-background text-foreground shadow-sm'
-                : 'text-muted-foreground hover:text-foreground',
-            )}
-          >
-            <LuListChecks className="h-3.5 w-3.5" aria-hidden />
-            List link
-          </button>
-        </div>
-        {isListLinkType ? (
-          <p className="text-xs text-muted-foreground">
-            Links to an external collection (Amazon wishlist, Steam list, etc.). Friends can browse it — list links can&apos;t be claimed.
-          </p>
-        ) : null}
-      </div>
+      <EditorTypeSelector
+        isListLinkType={isListLinkType}
+        resetImageChanges={resetImageChanges}
+        setItemType={setItemType}
+      />
       <Field
         className="w-full"
-        labelProps={{ children: isListLinkType ? 'List name' : 'Title' }}
+        labelProps={{ children: fieldConfig.titleLabel }}
         inputProps={{
-          placeholder: isListLinkType ? 'My Amazon Wishlist' : 'Title for your item',
+          placeholder: fieldConfig.titlePlaceholder,
           autoFocus: true,
           ...getInputProps(fields.title, {
             type: 'text',
@@ -1139,11 +1179,9 @@ function EditorFormSection({
       />
       <Field
         className="w-full"
-        labelProps={{ children: isListLinkType ? 'List URL' : 'Link' }}
+        labelProps={{ children: fieldConfig.urlLabel }}
         inputProps={{
-          placeholder: isListLinkType
-            ? 'https://www.amazon.com/hz/wishlist/…'
-            : 'https://amazon.com/',
+          placeholder: fieldConfig.urlPlaceholder,
           ...getInputProps(fields.url, {
             type: 'url',
             ariaAttributes: true,
@@ -1154,11 +1192,9 @@ function EditorFormSection({
       />
       <TextareaField
         className="w-full"
-        labelProps={{ children: isListLinkType ? 'Note for friends' : 'Description' }}
+        labelProps={{ children: fieldConfig.noteLabel }}
         textareaProps={{
-          placeholder: isListLinkType
-            ? 'e.g. Anything in the kitchen section works for me'
-            : 'Describe the item...',
+          placeholder: fieldConfig.notePlaceholder,
           rows: 3,
           ...getInputProps(fields.note, {
             type: 'text',
@@ -1641,8 +1677,8 @@ export const WishlistItemEditor = React.forwardRef<
 
     const formId = React.useId();
     const isDesktop = useIsDesktop();
-    const [itemType, setItemType] = React.useState<'text' | 'link' | 'wishlist'>(
-      (wishlistItem?.type as 'text' | 'link' | 'wishlist' | undefined) ?? 'text',
+    const [itemType, setItemType] = React.useState<WishlistItemType>(
+      (wishlistItem?.type as WishlistItemType | undefined) ?? 'text',
     );
     const isListLinkType = itemType === 'wishlist';
     const [form, fields] = useForm<z.input<typeof WishlistItemSchema>>({

--- a/app/routes/wishlist+/__wishlist-item-editor.tsx
+++ b/app/routes/wishlist+/__wishlist-item-editor.tsx
@@ -173,10 +173,10 @@ function getEditorFieldConfig(isListLink: boolean) {
     urlPlaceholder: isListLink
       ? 'https://www.amazon.com/hz/wishlist/…'
       : 'https://amazon.com/',
-    noteLabel: isListLink ? 'Note for friends' : 'Note',
+    noteLabel: isListLink ? 'Note for friends' : 'Description',
     notePlaceholder: isListLink
       ? 'e.g. Anything in the kitchen section works for me'
-      : 'Any details to help friends pick the right one',
+      : 'Describe the item...',
   };
 }
 

--- a/app/routes/wishlist+/__wishlist-item-editor.tsx
+++ b/app/routes/wishlist+/__wishlist-item-editor.tsx
@@ -11,6 +11,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   LuArchive,
   LuExternalLink,
+  LuGift,
   LuImage,
   LuListChecks,
   LuLoader,
@@ -50,7 +51,7 @@ import { StatusButton } from '#app/components/ui/status-button.tsx';
 import { Flex, Text } from '#app/components/ui-kit';
 import { track } from '#app/utils/analytics.client.ts';
 import { createClientMutationId } from '#app/utils/client-mutation-id.ts';
-import { getWishlistItemImgSrc, useIsPending } from '#app/utils/misc.tsx';
+import { cn, getWishlistItemImgSrc, useIsPending } from '#app/utils/misc.tsx';
 import { useOptionalRequestInfo } from '#app/utils/request-info.ts';
 import { type Toast } from '#app/utils/toast.server.ts';
 import { type WishlistItemImageSource } from '#app/utils/wishlist-images.server.ts';
@@ -87,17 +88,27 @@ const useIsDesktop = () => {
   return isDesktop;
 };
 
-export const WishlistItemSchema = z.object({
-  id: z.string().optional(),
-  categoryId: z.string().nullable().optional(),
-  title: z.string().min(valueMinLength).max(valueMaxLength),
-  note: z.string().optional(),
-  url: z.string().url().optional(),
-  type: z.enum(['text', 'link', 'wishlist']).default('text'),
-  imageAction: ImageActionSchema,
-  imageUrl: z.string().url().optional(),
-  imageFile: z.instanceof(File).optional(),
-});
+export const WishlistItemSchema = z
+  .object({
+    id: z.string().optional(),
+    categoryId: z.string().nullable().optional(),
+    title: z.string().min(valueMinLength).max(valueMaxLength),
+    note: z.string().optional(),
+    url: z.string().url().optional(),
+    type: z.enum(['text', 'link', 'wishlist']).default('text'),
+    imageAction: ImageActionSchema,
+    imageUrl: z.string().url().optional(),
+    imageFile: z.instanceof(File).optional(),
+  })
+  .superRefine((data, ctx) => {
+    if (data.type === 'wishlist' && !data.url?.trim()) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['url'],
+        message: 'A URL is required for list links',
+      });
+    }
+  });
 
 const getSafePreviewSrc = (value: string | null) => {
   if (!value) return null;
@@ -147,12 +158,13 @@ type EditorProps = {
 type WishlistItemEditorActionData =
   | {
       result: SubmissionResult<z.infer<typeof WishlistItemSchema>>;
-      intent: 'save' | 'save-add-another';
-      toast: Toast | null;
+      intent?: 'save' | 'save-add-another';
+      toast?: Toast | null;
       imageError?: string | null;
       imageAction?: z.infer<typeof ImageActionSchema>;
       analyticsEventId?: string | null;
       requestId?: string;
+      clientMutationId?: string | null;
     }
   | undefined;
 
@@ -1001,9 +1013,12 @@ function EditorFormSection({
   setImageUrlValue,
   setImageWarning,
   setIsImageLoading,
+  setItemType,
   showImageError,
   imageError,
   imageWarning,
+  isListLinkType,
+  itemType,
   wishlistItem,
   attachClientMutationId,
   applyUrlPreview,
@@ -1029,6 +1044,8 @@ function EditorFormSection({
   imageWarning: string | null;
   isImageLoading: boolean;
   isPending: boolean;
+  isListLinkType: boolean;
+  itemType: 'text' | 'link' | 'wishlist';
   mode: EditorMode;
   prepareImageActionForSave: () => void;
   previewSrc: string | null;
@@ -1044,35 +1061,74 @@ function EditorFormSection({
   setImageUrlValue: React.Dispatch<React.SetStateAction<string>>;
   setImageWarning: React.Dispatch<React.SetStateAction<string | null>>;
   setIsImageLoading: React.Dispatch<React.SetStateAction<boolean>>;
+  setItemType: React.Dispatch<React.SetStateAction<'text' | 'link' | 'wishlist'>>;
   showImageError: boolean;
   wishlistItem?: EditorProps['wishlistItem'];
 }>) {
+  const { onSubmit: conformOnSubmit, ...conformFormProps } = getFormProps(form);
   return (
     <Form
       method="POST"
-      {...getFormProps(form)}
+      {...conformFormProps}
       className="flex flex-col gap-4"
       encType="multipart/form-data"
       ref={formRef as React.RefObject<HTMLFormElement>}
-      onSubmit={attachClientMutationId}
+      onSubmit={(event) => {
+        conformOnSubmit?.(event);
+        if (!event.defaultPrevented) {
+          attachClientMutationId(event);
+        }
+      }}
     >
       <input type="hidden" name="clientMutationId" value="" />
+      <input type="hidden" name="type" value={itemType} />
       {mode === 'create' ? (
         <button type="submit" name="intent" value="save-add-another" className="hidden" />
       ) : null}
       {wishlistItem?.id ? (
-        <>
-          <input type="hidden" name="id" value={wishlistItem.id} />
-          {wishlistItem?.type ? (
-            <input type="hidden" name="type" value={wishlistItem.type} />
-          ) : null}
-        </>
+        <input type="hidden" name="id" value={wishlistItem.id} />
       ) : null}
+      <div className="flex flex-col gap-1.5">
+        <span className="text-sm font-medium">What are you adding?</span>
+        <div className="flex rounded-lg bg-muted p-1">
+          <button
+            type="button"
+            onClick={() => setItemType('text')}
+            className={cn(
+              'flex flex-1 items-center justify-center gap-1.5 rounded-md px-3 py-2 text-sm font-medium transition-all',
+              !isListLinkType
+                ? 'bg-background text-foreground shadow-sm'
+                : 'text-muted-foreground hover:text-foreground',
+            )}
+          >
+            <LuGift className="h-3.5 w-3.5" aria-hidden />
+            Gift idea
+          </button>
+          <button
+            type="button"
+            onClick={() => setItemType('wishlist')}
+            className={cn(
+              'flex flex-1 items-center justify-center gap-1.5 rounded-md px-3 py-2 text-sm font-medium transition-all',
+              isListLinkType
+                ? 'bg-background text-foreground shadow-sm'
+                : 'text-muted-foreground hover:text-foreground',
+            )}
+          >
+            <LuListChecks className="h-3.5 w-3.5" aria-hidden />
+            List link
+          </button>
+        </div>
+        {isListLinkType ? (
+          <p className="text-xs text-muted-foreground">
+            Links to an external collection (Amazon wishlist, Steam list, etc.). Friends can browse it — list links can&apos;t be claimed.
+          </p>
+        ) : null}
+      </div>
       <Field
         className="w-full"
-        labelProps={{ children: 'Title' }}
+        labelProps={{ children: isListLinkType ? 'List name' : 'Title' }}
         inputProps={{
-          placeholder: 'Title for your item',
+          placeholder: isListLinkType ? 'My Amazon Wishlist' : 'Title for your item',
           autoFocus: true,
           ...getInputProps(fields.title, {
             type: 'text',
@@ -1083,21 +1139,26 @@ function EditorFormSection({
       />
       <Field
         className="w-full"
-        labelProps={{ children: 'Link' }}
+        labelProps={{ children: isListLinkType ? 'List URL' : 'Link' }}
         inputProps={{
-          placeholder: 'https://amazon.com/',
+          placeholder: isListLinkType
+            ? 'https://www.amazon.com/hz/wishlist/…'
+            : 'https://amazon.com/',
           ...getInputProps(fields.url, {
             type: 'url',
             ariaAttributes: true,
           }),
+          required: isListLinkType,
         }}
         errors={fields.url.errors}
       />
       <TextareaField
         className="w-full"
-        labelProps={{ children: 'Description' }}
+        labelProps={{ children: isListLinkType ? 'Note for friends' : 'Description' }}
         textareaProps={{
-          placeholder: 'Describe the item...',
+          placeholder: isListLinkType
+            ? 'e.g. Anything in the kitchen section works for me'
+            : 'Describe the item...',
           rows: 3,
           ...getInputProps(fields.note, {
             type: 'text',
@@ -1580,6 +1641,10 @@ export const WishlistItemEditor = React.forwardRef<
 
     const formId = React.useId();
     const isDesktop = useIsDesktop();
+    const [itemType, setItemType] = React.useState<'text' | 'link' | 'wishlist'>(
+      (wishlistItem?.type as 'text' | 'link' | 'wishlist' | undefined) ?? 'text',
+    );
+    const isListLinkType = itemType === 'wishlist';
     const [form, fields] = useForm<z.input<typeof WishlistItemSchema>>({
       id: formId,
       constraint: getZodConstraint(WishlistItemSchema),
@@ -1633,9 +1698,7 @@ export const WishlistItemEditor = React.forwardRef<
       normalizeEditorFieldValue(
         (fields.categoryId.value ?? fields.categoryId.defaultValue ?? '') as string,
       ) !== normalizeEditorFieldValue(initialValues.categoryId) ||
-      normalizeEditorFieldValue(
-        fields.type.value ?? fields.type.defaultValue ?? initialValues.type,
-      ) !== normalizeEditorFieldValue(initialValues.type);
+      itemType !== normalizeEditorFieldValue(initialValues.type);
     const hasImageChanges =
       imageController.hasPendingImageChange ||
       imageController.imageActionState === 'remove' ||
@@ -1714,6 +1777,8 @@ export const WishlistItemEditor = React.forwardRef<
                 imageWarning={imageController.imageWarning}
                 isImageLoading={imageController.isImageLoading}
                 isPending={isPending}
+                isListLinkType={isListLinkType}
+                itemType={itemType}
                 mode={mode}
                 prepareImageActionForSave={imageController.prepareImageActionForSave}
                 previewSrc={imageController.previewSrc}
@@ -1727,6 +1792,7 @@ export const WishlistItemEditor = React.forwardRef<
                 setImageUrlValue={imageController.setImageUrlValue}
                 setImageWarning={imageController.setImageWarning}
                 setIsImageLoading={imageController.setIsImageLoading}
+                setItemType={setItemType}
                 showImageError={imageController.showImageError}
                 wishlistItem={wishlistItem}
               />

--- a/app/routes/wishlist+/__wishlist-item-editor.tsx
+++ b/app/routes/wishlist+/__wishlist-item-editor.tsx
@@ -116,11 +116,11 @@ function EditorTypeSelector({
   isListLinkType,
   resetImageChanges,
   setItemType,
-}: {
+}: Readonly<{
   isListLinkType: boolean;
   resetImageChanges: () => void;
   setItemType: React.Dispatch<React.SetStateAction<WishlistItemType>>;
-}) {
+}>) {
   return (
     <div className="flex flex-col gap-1.5">
       <span className="text-sm font-medium">What are you adding?</span>


### PR DESCRIPTION
## Summary

Introduces a two-type model for wishlist items: **Gift idea** (existing behaviour, stored as `'text'`) and **List link** (external collection like an Amazon wishlist or Steam list, stored as `'wishlist'`).

- **Editor form** — segmented control (Gift idea / List link) at top of form, adaptive URL placeholder per type, URL required validation (client-side superRefine blocks submit; server validates as defence-in-depth)
- **Item cards** — "List link" badge in both owner and non-owner views; "Visit list →" CTA replaces the claim button in non-owner view
- **⋮ menu** — quick-convert actions ("Mark as list link" / "Mark as gift idea") using a type-only fetcher mutation
- **Claim gating** — `disableClaims` wired to `item.type === 'wishlist'` in WishlistCategoryCard; list-link items can't be claimed
- **Bug fixes** — composed Conform's `onSubmit` with `attachClientMutationId` (previously the latter overwrote Conform's handler, silently skipping client-side validation); fixed server error response to use `result` key expected by `useForm`'s `lastResult`; corrected fetcher action URLs to `/wishlist?index`

No DB migration needed — the `type` field already exists; all existing rows default to `'text'`.

## Test plan

- [ ] Add a Gift idea item (no URL) — saves normally, no badge
- [ ] Add a List link item with no URL — client-side error "A URL is required for list links" shown immediately, no network request
- [ ] Add a List link item with a valid URL — saves, "List link" badge appears
- [ ] Non-owner view of a list-link item — shows "Visit list →" CTA, no claim button
- [ ] ⋮ menu on a gift-idea item — "Mark as list link" converts it; badge appears
- [ ] ⋮ menu on a claimed item — type-convert option is absent (edit dialog instead)
- [ ] 701 unit tests pass, typecheck clean