### PR TITLE
feat(wishlist): wishlist item types — Phase 2

### DIFF
--- a/app/routes/wishlist+/__wishlist-item-editor.schema.test.ts
+++ b/app/routes/wishlist+/__wishlist-item-editor.schema.test.ts
@@ -7,7 +7,7 @@
  * can break Zod's URL validation).
  */
 import { describe, expect, it } from 'vitest';
-import { WishlistItemSchema } from './__wishlist-item-editor';
+import { WishlistItemSchema, looksLikeWishlistUrl } from './__wishlist-item-editor';
 
 function parse(fields: Record<string, unknown>) {
   return WishlistItemSchema.safeParse({
@@ -17,6 +17,58 @@ function parse(fields: Record<string, unknown>) {
     ...fields,
   });
 }
+
+describe('looksLikeWishlistUrl', () => {
+  it('returns true for an Amazon wishlist URL', () => {
+    expect(
+      looksLikeWishlistUrl('https://www.amazon.com/hz/wishlist/ls/ABC123'),
+    ).toBe(true);
+  });
+
+  it('returns true for an Amazon registry URL', () => {
+    expect(
+      looksLikeWishlistUrl(
+        'https://www.amazon.com/gp/registry/wishlist/ABC123',
+      ),
+    ).toBe(true);
+  });
+
+  it('returns true for a Steam wishlist URL', () => {
+    expect(
+      looksLikeWishlistUrl(
+        'https://store.steampowered.com/wishlist/id/username/',
+      ),
+    ).toBe(true);
+  });
+
+  it('returns true for a Babylist registry URL', () => {
+    expect(
+      looksLikeWishlistUrl('https://www.babylist.com/list/my-registry'),
+    ).toBe(true);
+  });
+
+  it('returns false for a regular Amazon product page', () => {
+    expect(
+      looksLikeWishlistUrl('https://www.amazon.com/dp/B001234567'),
+    ).toBe(false);
+  });
+
+  it('returns false for an arbitrary https URL', () => {
+    expect(looksLikeWishlistUrl('https://example.com/some/path')).toBe(false);
+  });
+
+  it('returns false for a javascript: URL', () => {
+    expect(looksLikeWishlistUrl('javascript:alert(1)')).toBe(false);
+  });
+
+  it('returns false for an empty string', () => {
+    expect(looksLikeWishlistUrl('')).toBe(false);
+  });
+
+  it('returns false for a malformed URL', () => {
+    expect(looksLikeWishlistUrl('not a url')).toBe(false);
+  });
+});
 
 describe('WishlistItemSchema — URL required for list links', () => {
   it('fails when type is wishlist and URL is absent', () => {

--- a/app/routes/wishlist+/__wishlist-item-editor.test.tsx
+++ b/app/routes/wishlist+/__wishlist-item-editor.test.tsx
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -23,6 +23,10 @@ beforeAll(() => {
 vi.mock('#app/components/toaster.tsx', () => ({
   useToast: () => {},
 }));
+
+// Capture the real URL class before any beforeEach can stub it. Tests that
+// need looksLikeWishlistUrl to work (which uses new URL()) must restore this.
+const NativeURL = URL;
 
 vi.mock('react-router', async () => {
   const actual = await vi.importActual('react-router');
@@ -125,6 +129,146 @@ describe('WishlistItemEditor status section', () => {
     expect(
       screen.getByText('Restoring will add this item back to your wishlist.'),
     ).toBeInTheDocument();
+  });
+});
+
+describe('WishlistItemEditor — Phase 2: list link behaviour', () => {
+  beforeEach(() => {
+    // Restore the real URL constructor so looksLikeWishlistUrl (which calls
+    // new URL()) works correctly inside these tests. The outer beforeEach
+    // replaces URL with a plain object that has no constructor.
+    vi.stubGlobal('URL', NativeURL);
+  });
+
+  it('hides the image section when type is switched to list link', async () => {
+    const user = userEvent.setup();
+    render(
+      <WishlistItemEditor
+        wishlistItem={{ ...baseItem, status: 'ACTIVE' }}
+        canEdit
+        initialMode="edit"
+        trigger={<button type="button">Open</button>}
+      />,
+    );
+
+    await user.click(screen.getByText('Open'));
+
+    // Image section visible initially (gift idea)
+    expect(screen.getByLabelText('Image')).toBeInTheDocument();
+
+    // Switch to List link
+    await user.click(screen.getByRole('button', { name: /list link/i }));
+
+    // Image section container should have the Tailwind 'hidden' class
+    // (jsdom doesn't compute CSS so we check the class directly)
+    const imageSection = screen.getByLabelText('Image').closest('.space-y-3');
+    expect(imageSection).toHaveClass('hidden');
+  });
+
+  it('shows "Description" label in gift-idea mode', async () => {
+    const user = userEvent.setup();
+    render(
+      <WishlistItemEditor
+        wishlistItem={{ ...baseItem, type: 'text', status: 'ACTIVE' }}
+        canEdit
+        initialMode="edit"
+        trigger={<button type="button">Open</button>}
+      />,
+    );
+
+    await user.click(screen.getByText('Open'));
+
+    expect(screen.getByRole('textbox', { name: /description/i })).toBeInTheDocument();
+  });
+
+  it('shows "Note for friends" label in list-link mode', async () => {
+    const user = userEvent.setup();
+    render(
+      <WishlistItemEditor
+        wishlistItem={{ ...baseItem, type: 'wishlist', status: 'ACTIVE', url: 'https://www.amazon.com/hz/wishlist/ls/abc' }}
+        canEdit
+        initialMode="edit"
+        trigger={<button type="button">Open</button>}
+      />,
+    );
+
+    await user.click(screen.getByText('Open'));
+
+    expect(screen.getByRole('textbox', { name: /note for friends/i })).toBeInTheDocument();
+  });
+
+  it('shows the list-link suggestion when a wishlist URL is entered', async () => {
+    const user = userEvent.setup();
+    render(
+      <WishlistItemEditor
+        wishlistItem={{ ...baseItem, type: 'text', status: 'ACTIVE' }}
+        canEdit
+        initialMode="edit"
+        trigger={<button type="button">Open</button>}
+      />,
+    );
+
+    await user.click(screen.getByText('Open'));
+
+    const urlInput = screen.getByRole('textbox', { name: /link/i });
+    await user.clear(urlInput);
+    await user.type(urlInput, 'https://www.amazon.com/hz/wishlist/ls/ABC123');
+
+    expect(
+      screen.getByText(/looks like an external wishlist/i),
+    ).toBeInTheDocument();
+  });
+
+  it('dismisses the suggestion when the X button is clicked', async () => {
+    const user = userEvent.setup();
+    render(
+      <WishlistItemEditor
+        wishlistItem={{ ...baseItem, type: 'text', status: 'ACTIVE' }}
+        canEdit
+        initialMode="edit"
+        trigger={<button type="button">Open</button>}
+      />,
+    );
+
+    await user.click(screen.getByText('Open'));
+
+    const urlInput = screen.getByRole('textbox', { name: /link/i });
+    await user.clear(urlInput);
+    await user.type(urlInput, 'https://www.amazon.com/hz/wishlist/ls/ABC123');
+
+    await user.click(screen.getByRole('button', { name: /dismiss suggestion/i }));
+
+    expect(
+      screen.queryByText(/looks like an external wishlist/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it('switches to list link when the suggestion is accepted', async () => {
+    const user = userEvent.setup();
+    render(
+      <WishlistItemEditor
+        wishlistItem={{ ...baseItem, type: 'text', status: 'ACTIVE' }}
+        canEdit
+        initialMode="edit"
+        trigger={<button type="button">Open</button>}
+      />,
+    );
+
+    await user.click(screen.getByText('Open'));
+
+    const urlInput = screen.getByRole('textbox', { name: /link/i });
+    await user.clear(urlInput);
+    await user.type(urlInput, 'https://www.amazon.com/hz/wishlist/ls/ABC123');
+
+    // Click the "List link" button inside the suggestion banner (not the segment control)
+    const suggestionBanner = screen.getByText(/looks like an external wishlist/i).closest('div');
+    await user.click(within(suggestionBanner!).getByRole('button', { name: /list link/i }));
+
+    // After accepting, the suggestion should disappear and label should flip
+    expect(
+      screen.queryByText(/looks like an external wishlist/i),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole('textbox', { name: /note for friends/i })).toBeInTheDocument();
   });
 });
 

--- a/app/routes/wishlist+/__wishlist-item-editor.tsx
+++ b/app/routes/wishlist+/__wishlist-item-editor.tsx
@@ -202,6 +202,57 @@ function EditorTypeSelector({
   );
 }
 
+function UrlFieldWithSuggestion({
+  errors,
+  inputProps,
+  labelText,
+  onAcceptSuggestion,
+  onDismissSuggestion,
+  showSuggestion,
+}: Readonly<{
+  errors: string[] | undefined;
+  inputProps: React.ComponentProps<'input'>;
+  labelText: string;
+  onAcceptSuggestion: () => void;
+  onDismissSuggestion: () => void;
+  showSuggestion: boolean;
+}>) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <Field
+        className="w-full"
+        labelProps={{ children: labelText }}
+        inputProps={inputProps}
+        errors={errors}
+      />
+      {showSuggestion ? (
+        <div className="flex items-start gap-2 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-xs text-blue-800 dark:border-blue-800 dark:bg-blue-950/40 dark:text-blue-300">
+          <LuInfo className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden />
+          <span className="flex-1">
+            Looks like an external wishlist. Switch to{' '}
+            <button
+              type="button"
+              className="font-medium underline underline-offset-2 hover:no-underline"
+              onClick={onAcceptSuggestion}
+            >
+              List link
+            </button>
+            {'?'}
+          </span>
+          <button
+            type="button"
+            aria-label="Dismiss suggestion"
+            className="shrink-0 opacity-60 hover:opacity-100"
+            onClick={onDismissSuggestion}
+          >
+            <LuX className="h-3.5 w-3.5" aria-hidden />
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
 function getEditorFieldConfig(isListLink: boolean) {
   return {
     titleLabel: isListLink ? 'List name' : 'Title',
@@ -1220,49 +1271,25 @@ function EditorFormSection({
         }}
         errors={fields.title.errors}
       />
-      <div className="flex flex-col gap-1.5">
-        <Field
-          className="w-full"
-          labelProps={{ children: fieldConfig.urlLabel }}
-          inputProps={{
-            placeholder: fieldConfig.urlPlaceholder,
-            ...getInputProps(fields.url, {
-              type: 'url',
-              ariaAttributes: true,
-            }),
-            required: isListLinkType,
-          }}
-          errors={fields.url.errors}
-        />
-        {showListLinkSuggestion ? (
-          <div className="flex items-start gap-2 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-xs text-blue-800 dark:border-blue-800 dark:bg-blue-950/40 dark:text-blue-300">
-            <LuInfo className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden />
-            <span className="flex-1">
-              Looks like an external wishlist. Switch to{' '}
-              <button
-                type="button"
-                className="font-medium underline underline-offset-2 hover:no-underline"
-                onClick={() => {
-                  setItemType('wishlist');
-                  resetImageChanges();
-                  setListLinkSuggestionDismissed(true);
-                }}
-              >
-                List link
-              </button>
-              ?
-            </span>
-            <button
-              type="button"
-              aria-label="Dismiss suggestion"
-              className="shrink-0 opacity-60 hover:opacity-100"
-              onClick={() => setListLinkSuggestionDismissed(true)}
-            >
-              <LuX className="h-3.5 w-3.5" aria-hidden />
-            </button>
-          </div>
-        ) : null}
-      </div>
+      <UrlFieldWithSuggestion
+        errors={fields.url.errors}
+        inputProps={{
+          placeholder: fieldConfig.urlPlaceholder,
+          ...getInputProps(fields.url, {
+            type: 'url',
+            ariaAttributes: true,
+          }),
+          required: isListLinkType,
+        }}
+        labelText={fieldConfig.urlLabel}
+        onAcceptSuggestion={() => {
+          setItemType('wishlist');
+          resetImageChanges();
+          setListLinkSuggestionDismissed(true);
+        }}
+        onDismissSuggestion={() => setListLinkSuggestionDismissed(true)}
+        showSuggestion={showListLinkSuggestion}
+      />
       <TextareaField
         className="w-full"
         labelProps={{ children: fieldConfig.noteLabel }}

--- a/app/routes/wishlist+/__wishlist-item-editor.tsx
+++ b/app/routes/wishlist+/__wishlist-item-editor.tsx
@@ -14,6 +14,7 @@ import {
   LuGift,
   LuImage,
   LuListChecks,
+  LuInfo,
   LuLoader,
   LuPlus,
   LuUpload,
@@ -62,6 +63,42 @@ const valueMinLength = 1;
 const valueMaxLength = 255;
 const MAX_UPLOAD_BYTES = 10 * 1024 * 1024;
 const SAFE_IMAGE_PROTOCOLS = new Set(['http:', 'https:']);
+
+/**
+ * High-confidence URL patterns that indicate an external wishlist/registry,
+ * not a single product page. Used for the "Looks like a list — switch to
+ * List link?" inline suggestion. False-positive rate must be near zero,
+ * so we only match known wishlist paths, not generic e-commerce domains.
+ */
+const WISHLIST_URL_PATTERNS: RegExp[] = [
+  // Amazon wishlist — /hz/wishlist/ls/<id> or /gp/registry/wishlist/<id>
+  /amazon\.[a-z.]+\/hz\/wishlist\/ls\//i,
+  /amazon\.[a-z.]+\/gp\/registry\/wishlist\//i,
+  // Steam wishlist — store.steampowered.com/wishlist/id/<id>/ or /profiles/<id>/wishlist
+  /store\.steampowered\.com\/wishlist\//i,
+  // MyRegistry.com
+  /myregistry\.com\/giftlist\//i,
+  // The Knot registry
+  /theknot\.com\/registry\//i,
+  // Babylist registry
+  /babylist\.com\/list\//i,
+  // Target registry
+  /target\.com\/gift-registry\//i,
+  // Zola registry
+  /zola\.com\/registry\//i,
+];
+
+export function looksLikeWishlistUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+      return false;
+    }
+    return WISHLIST_URL_PATTERNS.some((pattern) => pattern.test(url));
+  } catch {
+    return false;
+  }
+}
 
 const ImageActionSchema = z
   .enum(['none', 'upload', 'url', 'auto-detect', 'remove'])
@@ -1136,6 +1173,12 @@ function EditorFormSection({
   wishlistItem?: EditorProps['wishlistItem'];
 }>) {
   const { onSubmit: conformOnSubmit, ...conformFormProps } = getFormProps(form);
+  const [listLinkSuggestionDismissed, setListLinkSuggestionDismissed] =
+    React.useState(false);
+  const showListLinkSuggestion =
+    !isListLinkType &&
+    !listLinkSuggestionDismissed &&
+    looksLikeWishlistUrl(fields.url.value ?? '');
   const fieldConfig = getEditorFieldConfig(isListLinkType);
   return (
     <Form
@@ -1177,19 +1220,49 @@ function EditorFormSection({
         }}
         errors={fields.title.errors}
       />
-      <Field
-        className="w-full"
-        labelProps={{ children: fieldConfig.urlLabel }}
-        inputProps={{
-          placeholder: fieldConfig.urlPlaceholder,
-          ...getInputProps(fields.url, {
-            type: 'url',
-            ariaAttributes: true,
-          }),
-          required: isListLinkType,
-        }}
-        errors={fields.url.errors}
-      />
+      <div className="flex flex-col gap-1.5">
+        <Field
+          className="w-full"
+          labelProps={{ children: fieldConfig.urlLabel }}
+          inputProps={{
+            placeholder: fieldConfig.urlPlaceholder,
+            ...getInputProps(fields.url, {
+              type: 'url',
+              ariaAttributes: true,
+            }),
+            required: isListLinkType,
+          }}
+          errors={fields.url.errors}
+        />
+        {showListLinkSuggestion ? (
+          <div className="flex items-start gap-2 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-xs text-blue-800 dark:border-blue-800 dark:bg-blue-950/40 dark:text-blue-300">
+            <LuInfo className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden />
+            <span className="flex-1">
+              Looks like an external wishlist. Switch to{' '}
+              <button
+                type="button"
+                className="font-medium underline underline-offset-2 hover:no-underline"
+                onClick={() => {
+                  setItemType('wishlist');
+                  resetImageChanges();
+                  setListLinkSuggestionDismissed(true);
+                }}
+              >
+                List link
+              </button>
+              ?
+            </span>
+            <button
+              type="button"
+              aria-label="Dismiss suggestion"
+              className="shrink-0 opacity-60 hover:opacity-100"
+              onClick={() => setListLinkSuggestionDismissed(true)}
+            >
+              <LuX className="h-3.5 w-3.5" aria-hidden />
+            </button>
+          </div>
+        ) : null}
+      </div>
       <TextareaField
         className="w-full"
         labelProps={{ children: fieldConfig.noteLabel }}
@@ -1221,7 +1294,7 @@ function EditorFormSection({
         </select>
       </div>
       <input type="hidden" name="imageAction" value={imageActionState} />
-      <div className="space-y-3">
+      <div className={cn('space-y-3', isListLinkType && 'hidden')}>
         <div className="flex items-center justify-between">
           <label htmlFor={imageFileInputProps.id} className="text-sm font-medium">
             Image


### PR DESCRIPTION
## Summary

Stacked on #365 (Phase 1). Implements the remaining Phase 2 UX polish for wishlist item types.

- **Label polish**: "Description" → "Note" for gift ideas; updated placeholder copy throughout
- **Image section collapse**: Image upload/URL section is hidden when List link type is selected, and image state is reset on type switch so the hidden `imageAction` input always submits `none`
- **Auto-detect suggestion**: When a recognised wishlist/registry URL is pasted into the Link field while type is "Gift idea", a dismissible inline suggestion appears offering to switch to "List link". Covers Amazon wishlist + registry, Steam wishlist, Babylist, The Knot, MyRegistry, Target registry, and Zola. No silent auto-switching; no nagging (dismissed per dialog session).
- **Pool item picker filter**: Deferred — the picker UI for selecting recipient wishlist items in pool creation doesn't exist yet. Documented in progress file with a note to filter `type != 'wishlist'` when that UI is built.

## Test plan

- [ ] `looksLikeWishlistUrl` — 9 unit tests added (schema test file, node env)
- [ ] All 728 unit tests pass, typecheck clean
- [ ] Manual: open editor on a gift idea, paste an Amazon wishlist URL → suggestion appears
- [ ] Manual: dismiss suggestion → does not reappear while dialog is open
- [ ] Manual: accept suggestion → type switches to List link, image section collapses
- [ ] Manual: switch type to List link → image section collapses immediately
- [ ] Manual: switch back to Gift idea → image section reappears