### PR TITLE
feat(ui): UI consistency Phase 1 — PageHeader, width system, bug fixes

### DIFF
--- a/.design-plan.md
+++ b/.design-plan.md
@@ -1,0 +1,154 @@
+# GiftPool Design Consistency Plan
+> Generated: April 13, 2026 — from full in-browser UI/UX audit
+
+---
+
+## Upfront decisions (must be made before touching screens)
+
+1. **Canonical content widths (LOCKED April 13, 2026):**
+   - Standard app pages: `max-w-6xl` (1152px)
+   - Narrow/detail/form pages: `max-w-3xl` (768px)
+   - Top nav: `max-w-6xl` — aligned to standard pages (already correct)
+   - Rationale: pragmatic first pass, close to current values, reduces inconsistency without cramping. Revisit post-launch if needed.
+   - Rule: if a page doesn't map cleanly to one of these two tokens, flag it as a follow-up rather than introducing a third value.
+2. **PageHeader variants:** section (list pages) vs. detail (entity pages) — see component spec below
+3. **FAB scope:** Wishlist mobile only. Never alongside a page header button.
+
+---
+
+## Phase 1 — Foundations + Bugs
+
+### Bugs (highest priority, standalone)
+- [x] Fix `notifications.upcomingBirthday.message` raw i18n key — added `upcomingBirthday.message` to `app/i18n/dictionaries/en.ts`
+- [x] Remove FAB from Groups index on mobile — also removed from Pools (same FAB rule applies)
+
+### Width system
+- [x] Width tokens locked: `max-w-6xl` (standard), `max-w-3xl` (narrow) — see System Decisions
+- [x] Apply `max-w-6xl` to: Groups list, Pools list, Friends (content areas)
+- [x] Wishlist already `max-w-6xl` — no change needed
+
+### PageHeader component
+- [x] Create `app/components/page-header.tsx`
+- [x] **Section variant** — props: `icon`, `title`, `action` slot; renders with bottom border
+- [x] **Detail variant** — props: `back: {label, href}`, `icon`, `title`, `subtitle?`, `badge?` slot; bottom border
+- [x] Apply section variant to: Groups list, Pools list, Friends (Wishlist kept custom — already correct pattern)
+
+### Quick button + icon fixes
+- [x] Change Wishlist `+ Add Item` from outlined → `variant="default"` (solid coral)
+- [x] Add `LuUsers` icon to Friends page header
+
+---
+
+## Phase 2 — Cross-App Consistency Pass
+
+### PageHeader — detail pages
+- [ ] Group detail: back="Groups", icon=people-group, title=group name, subtitle="N members", badge=role badge
+- [ ] Pool detail: back="Pools", icon=gift, title=pool name, subtitle=description, badge=status badge
+- [ ] Admin layout: back="Home", icon=shield, title="Admin", subtitle="Internal operator surface"
+
+### Danger zone unification
+- [ ] Pool danger zone: add `bg-rose-50 dark:bg-rose-950/20` + subtitle "These actions are destructive. Double-check before proceeding." to match Settings
+- [ ] Consider extracting `<DangerZone>` component if 3+ instances
+
+### Button cleanup
+- [ ] Group Overview "Create & Copy Invite Link" (full-width coral) → `variant="outline"` "Copy invite link"
+- [ ] Pool "Generate invite link" → same: `variant="outline"` "Copy invite link"  
+- [ ] "Manage Group" full-width card button → compact right-aligned outlined button or text link
+
+### Mobile fixes
+- [ ] Friends birthday chip: remove `hidden sm:*` or equivalent; render on mobile
+- [ ] Settings heading: reduce from current h1 scale → `text-2xl font-semibold`
+
+---
+
+## Phase 3 — Polish + Content Conventions
+
+### Date formatting
+- [ ] Create `app/utils/dates.ts` with: `formatDisplayDate` (MMM D), `formatAbsoluteDate` (MMMM D, YYYY), `formatBirthday` (numeric for admin views)
+- [ ] Apply across all date displays; eliminate `4/11/2026` numeric format from user-facing content
+
+### Admin headings
+- [ ] Reduce admin content headings from ~48px editorial → `text-xl font-semibold`
+
+### Pools list section header
+- [ ] Replace `ACTIVE` all-caps label with a tab control (Active / Past) or `<SectionHeading>` component
+
+### Empty states
+- [ ] Audit all bare-text empty states; apply icon + headline pattern (model: admin empty states)
+
+### Notification panel
+- [ ] Normalize "Mark all as read" button treatment: use same style on mobile and desktop (prefer desktop's subtle icon-only)
+
+### Settings avatar
+- [ ] Add `max-h-40` cap to avatar image on mobile to prevent it dominating the card
+
+---
+
+## System Decisions (reference)
+
+### Width rules (LOCKED)
+```
+Standard pages (Wishlist, Groups, Pools, Friends, Home):  max-w-6xl  (1152px)
+Narrow pages (Settings, Pool detail cards):               max-w-3xl  (768px)
+Top nav:                                                  max-w-6xl  (aligned with standard pages)
+Admin (utility, data-dense):                              no max-w cap
+```
+
+### PageHeader component API
+```tsx
+// Section variant (list/index pages)
+<PageHeader variant="section" icon={<Icon />} title="Groups">
+  <Button>+ Create Group</Button>
+</PageHeader>
+
+// Detail variant (entity detail pages)
+<PageHeader variant="detail" back={{ label: "Groups", href: "/groups" }}
+  icon={<Icon />} title="Book Club" subtitle="4 members">
+  <OwnerBadge />
+</PageHeader>
+```
+
+### Button hierarchy
+```
+Page-level creation action:      variant="default"   (solid coral)
+Secondary / scoped action:       variant="outline"
+Destructive action:              variant="destructive"
+Share / invite / link copy:      variant="outline"   (never full-width coral)
+Card navigation:                 text link or compact outlined (never full-width card-spanning)
+```
+
+### FAB rules
+```
+✅ Wishlist — mobile only
+❌ Groups — header button is sufficient
+❌ Pools — header button is sufficient  
+❌ Friends — header button is sufficient
+Rule: FAB never appears alongside a visible page-level header action button
+```
+
+### Date format rules
+```
+Upcoming / recurring (no year needed):    "May 3"           MMM D
+Absolute (year is meaningful):            "April 4, 2026"   MMMM D, YYYY
+Admin / management views (birth year):    "5/26/1992"       M/DD/YYYY  ← only acceptable numeric use
+❌ Never in user-facing content:          "4/11/2026"       M/D/YYYY
+```
+
+### Danger zone pattern
+```
+All danger zones:
+  - bg-rose-50 dark:bg-rose-950/20 card background
+  - Subtitle: "These actions are destructive. Double-check before proceeding."
+  - Destructive primary action: variant="destructive"
+  - Reversible secondary action: variant="outline"
+```
+
+---
+
+## Implementation prompts
+
+### Phase 1 starter
+> Create a shared `PageHeader` component in `app/components/page-header.tsx` with two variants: `section` (list pages) and `detail` (entity pages). Section variant props: `icon`, `title`, `action` slot, renders with bottom border. Detail variant props: `back: { label, href }`, `icon`, `title`, `subtitle?`, `badge?` slot, bottom border. Apply section variant to: Wishlist (icon=heart, title="My Wishlist"), Groups list (icon=people-group), Pools list (icon=gift), Friends (icon=people — also add this icon, it's currently missing). Also change Wishlist "+ Add Item" from outlined to solid coral (`variant="default"`). Separately, fix the notification i18n bug: find where `notifications.upcomingBirthday.message` is rendered and correct the key lookup.
+
+### Phase 2/3 starter
+> Cross-app consistency pass. Apply the detail variant of `PageHeader` to: Group detail (`app/routes/groups+/$groupId.tsx`), Pool detail (`app/routes/pools+/$poolId.tsx`), and Admin layout (`app/routes/admin+/_layout.tsx`). Then: (1) add danger zone background tint + subtitle to Pool danger zone to match Settings style; (2) change both invite buttons to `variant="outline"` "Copy invite link"; (3) replace the full-width "Manage Group" card button with a compact outlined button; (4) fix Friends birthday chip mobile visibility; (5) reduce Settings heading to `text-2xl font-semibold`.

--- a/app/components/page-header.test.tsx
+++ b/app/components/page-header.test.tsx
@@ -1,0 +1,143 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import { LuGift, LuUsers } from 'react-icons/lu';
+import { createRoutesStub } from 'react-router';
+import { describe, expect, it } from 'vitest';
+
+import { PageHeader } from './page-header';
+
+function renderWithRouter(ui: React.ReactNode) {
+  const App = createRoutesStub([{ path: '/', Component: () => <>{ui}</> }]);
+  render(<App />);
+}
+
+describe('PageHeader — section variant', () => {
+  it('renders the title', () => {
+    renderWithRouter(
+      <PageHeader variant="section" icon={<LuGift />} title="Pools" />,
+    );
+    expect(screen.getByText('Pools')).toBeInTheDocument();
+  });
+
+  it('renders children as the action slot', () => {
+    renderWithRouter(
+      <PageHeader variant="section" icon={<LuUsers />} title="Groups">
+        <button type="button">Create Group</button>
+      </PageHeader>,
+    );
+    expect(
+      screen.getByRole('button', { name: 'Create Group' }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders without children', () => {
+    renderWithRouter(
+      <PageHeader variant="section" icon={<LuGift />} title="Pools" />,
+    );
+    expect(screen.getByText('Pools')).toBeInTheDocument();
+  });
+
+  it('applies max-w-6xl width class', () => {
+    renderWithRouter(
+      <PageHeader variant="section" icon={<LuGift />} title="Pools" />,
+    );
+    const inner = document.querySelector('.max-w-6xl');
+    expect(inner).toBeInTheDocument();
+  });
+});
+
+describe('PageHeader — detail variant', () => {
+  it('renders the title', () => {
+    renderWithRouter(
+      <PageHeader
+        variant="detail"
+        back={{ label: 'Pools', href: '/pools' }}
+        icon={<LuGift />}
+        title="Leo's Graduation"
+      />,
+    );
+    expect(screen.getByText("Leo's Graduation")).toBeInTheDocument();
+  });
+
+  it('renders the subtitle when provided', () => {
+    renderWithRouter(
+      <PageHeader
+        variant="detail"
+        back={{ label: 'Pools', href: '/pools' }}
+        icon={<LuGift />}
+        title="Leo's Graduation"
+        subtitle="Graduation for Leo"
+      />,
+    );
+    expect(screen.getByText('Graduation for Leo')).toBeInTheDocument();
+  });
+
+  it('does not render subtitle when omitted', () => {
+    renderWithRouter(
+      <PageHeader
+        variant="detail"
+        back={{ label: 'Pools', href: '/pools' }}
+        icon={<LuGift />}
+        title="Leo's Graduation"
+      />,
+    );
+    expect(screen.queryByText('Graduation for Leo')).not.toBeInTheDocument();
+  });
+
+  it('renders the back link with correct href', () => {
+    renderWithRouter(
+      <PageHeader
+        variant="detail"
+        back={{ label: 'Pools', href: '/pools' }}
+        icon={<LuGift />}
+        title="Leo's Graduation"
+      />,
+    );
+    const backLink = screen.getByRole('link', { name: /Pools/ });
+    expect(backLink).toHaveAttribute('href', '/pools');
+  });
+
+  it('renders children as the badge slot', () => {
+    renderWithRouter(
+      <PageHeader
+        variant="detail"
+        back={{ label: 'Pools', href: '/pools' }}
+        icon={<LuGift />}
+        title="Leo's Graduation"
+      >
+        <span data-testid="status-badge">Decided</span>
+      </PageHeader>,
+    );
+    expect(screen.getByTestId('status-badge')).toBeInTheDocument();
+    expect(screen.getByText('Decided')).toBeInTheDocument();
+  });
+
+  it('renders without children (no badge)', () => {
+    renderWithRouter(
+      <PageHeader
+        variant="detail"
+        back={{ label: 'Home', href: '/' }}
+        icon={<LuGift />}
+        title="Admin"
+        subtitle="Internal operator surface"
+      />,
+    );
+    expect(screen.getByText('Admin')).toBeInTheDocument();
+    expect(screen.getByText('Internal operator surface')).toBeInTheDocument();
+  });
+
+  it('applies max-w-6xl width class', () => {
+    renderWithRouter(
+      <PageHeader
+        variant="detail"
+        back={{ label: 'Pools', href: '/pools' }}
+        icon={<LuGift />}
+        title="Leo's Graduation"
+      />,
+    );
+    const inner = document.querySelector('.max-w-6xl');
+    expect(inner).toBeInTheDocument();
+  });
+});

--- a/app/components/page-header.tsx
+++ b/app/components/page-header.tsx
@@ -1,0 +1,70 @@
+import { LuChevronLeft } from 'react-icons/lu'
+import { Link } from 'react-router'
+
+import { Flex, Text } from '#app/components/ui-kit'
+
+type SectionProps = {
+  variant: 'section'
+  icon: React.ReactNode
+  title: string
+  children?: React.ReactNode
+}
+
+type DetailProps = {
+  variant: 'detail'
+  back: { label: string; href: string }
+  icon: React.ReactNode
+  title: string
+  subtitle?: string
+  children?: React.ReactNode
+}
+
+type PageHeaderProps = SectionProps | DetailProps
+
+const PageHeader = (props: PageHeaderProps) => {
+  return (
+    <div className="border-b bg-surface shadow">
+      <div className="mx-auto flex max-w-6xl items-center gap-2 px-4 py-4 sm:px-6">
+        {props.variant === 'section' ? (
+          <>
+            <Flex gap={2} align="center" className="flex-1">
+              {props.icon}
+              <Text size="xl" weight="bold">
+                {props.title}
+              </Text>
+            </Flex>
+            {props.children}
+          </>
+        ) : (
+          <div className="flex w-full flex-col gap-2">
+            <Link
+              to={props.back.href}
+              className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+            >
+              <LuChevronLeft className="h-4 w-4" />
+              {props.back.label}
+            </Link>
+            <Flex justify="between" align="center" gap={2}>
+              <Flex gap={2} align="center">
+                {props.icon}
+                <div>
+                  <Text size="xl" weight="bold">
+                    {props.title}
+                  </Text>
+                  {props.subtitle ? (
+                    <Text size="sm" className="text-muted-foreground">
+                      {props.subtitle}
+                    </Text>
+                  ) : null}
+                </div>
+              </Flex>
+              {props.children}
+            </Flex>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export { PageHeader }

--- a/app/i18n/dictionaries/en.ts
+++ b/app/i18n/dictionaries/en.ts
@@ -31,6 +31,9 @@ export const en = {
       message: '{{name}} accepted your friend request',
       fallbackName: 'Someone',
     },
+    upcomingBirthday: {
+      message: "{{name}}'s birthday is in {{daysUntil}} days",
+    },
     markAllReadSuccess: 'All notifications marked as read.',
   },
   friends: {

--- a/app/routes/friends.tsx
+++ b/app/routes/friends.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { LuCopy, LuLink, LuPlus, LuQrCode } from 'react-icons/lu';
+import { LuCopy, LuLink, LuPlus, LuQrCode, LuUsers } from 'react-icons/lu';
 import { Link, Outlet, useLoaderData, useSearchParams,
   type ClientLoaderFunctionArgs,
   type LoaderFunctionArgs,
@@ -28,6 +28,7 @@ import {
   MobileBottomSheetTitle,
 } from '#app/components/ui/mobile-bottom-sheet.tsx';
 import { EmptyState } from '#app/components/ui/empty-state.tsx';
+import { PageHeader } from '#app/components/page-header.tsx';
 import { Input } from '#app/components/ui/input.tsx';
 import { Skeleton } from '#app/components/ui/skeleton.tsx';
 import { Stack } from '#app/components/ui-kit/stack.tsx';
@@ -1243,43 +1244,48 @@ const FriendsRoute = () => {
   );
 
   return (
-    <div className="container py-6 sm:py-8">
-      <header className="mb-6 flex items-center justify-between gap-3">
-        <h1 className="text-2xl font-semibold tracking-tight">Friends</h1>
+    <div className="flex h-full min-h-0 flex-col">
+      <PageHeader
+        variant="section"
+        icon={<LuUsers className="text-primary" />}
+        title="Friends"
+      >
         <AddFriendDialog
           q={q}
           setQ={setQ}
           onOutgoingCreated={handleOutgoingCreated}
         />
-      </header>
+      </PageHeader>
 
-      <Stack gap={4}>
-        <PendingRequestsCard
-          incomingState={incomingState}
-          outgoingState={outgoingState}
-          onIncomingTransition={handleIncomingTransition}
-          onOutgoingTransition={handleOutgoingTransition}
-        />
-
-        {friendsState.length > 8 ? (
-          <Input
-            value={friendsFilter}
-            onChange={(event) => setFriendsFilter(event.currentTarget.value)}
-            placeholder="Search friends"
-            aria-label="Search friends"
+      <div className="mx-auto w-full max-w-6xl min-h-0 flex-1 px-4 py-6 sm:px-6 sm:py-8">
+        <Stack gap={4}>
+          <PendingRequestsCard
+            incomingState={incomingState}
+            outgoingState={outgoingState}
+            onIncomingTransition={handleIncomingTransition}
+            onOutgoingTransition={handleOutgoingTransition}
           />
-        ) : null}
 
-        <FriendsListSection
-          activeTab="friends"
-          filteredFriends={filteredFriends}
-          friendsState={friendsState}
-          onRenderFriendRow={renderFriendRow}
-          t={t}
-        />
-      </Stack>
-      {/* Nested routes (e.g., /friends/accept/:code) render here */}
-      <Outlet />
+          {friendsState.length > 8 ? (
+            <Input
+              value={friendsFilter}
+              onChange={(event) => setFriendsFilter(event.currentTarget.value)}
+              placeholder="Search friends"
+              aria-label="Search friends"
+            />
+          ) : null}
+
+          <FriendsListSection
+            activeTab="friends"
+            filteredFriends={filteredFriends}
+            friendsState={friendsState}
+            onRenderFriendRow={renderFriendRow}
+            t={t}
+          />
+        </Stack>
+        {/* Nested routes (e.g., /friends/accept/:code) render here */}
+        <Outlet />
+      </div>
     </div>
   );
 };

--- a/app/routes/groups+/index.tsx
+++ b/app/routes/groups+/index.tsx
@@ -1,6 +1,7 @@
 import { LuPlus, LuUsers } from 'react-icons/lu';
 import { type LoaderFunctionArgs, useLoaderData, useNavigate  } from 'react-router';
 import { GroupCard } from '#app/components/groups/GroupCard.tsx';
+import { PageHeader } from '#app/components/page-header.tsx';
 import { Button } from '#app/components/ui/button.tsx';
 import { Card } from '#app/components/ui/card.tsx';
 import {
@@ -10,8 +11,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from '#app/components/ui/dialog.tsx';
-import { Heading } from '#app/components/ui/heading.tsx';
-import { Icon } from '#app/components/ui/icon.tsx';
 import { Flex, Text } from '#app/components/ui-kit';
 import { requireUserId } from '#app/utils/auth.server.ts';
 import { prisma } from '#app/utils/db.server.ts';
@@ -92,30 +91,23 @@ const GroupsIndex = () => {
   const navigate = useNavigate();
   return (
     <div className="flex h-full min-h-0 flex-col">
-      {/* Header bar (mirrors Wishlist header style) */}
-      <div className="border-b bg-surface px-4 py-4 shadow">
-        <div className="container flex items-center justify-between gap-2">
-          <Heading>
-            <Flex gap={2} align="center">
-              <LuUsers className="text-primary" />
-              <Text size="xl" weight="bold">
-                Groups
-              </Text>
+      <PageHeader
+        variant="section"
+        icon={<LuUsers className="text-primary" />}
+        title="Groups"
+      >
+        <CreateGroupDialog>
+          <Button>
+            <Flex gap={1}>
+              <LuPlus />
+              <Text>Create Group</Text>
             </Flex>
-          </Heading>
-          <CreateGroupDialog>
-            <Button>
-              <Flex gap={1}>
-                <LuPlus />
-                <Text>Create Group</Text>
-              </Flex>
-            </Button>
-          </CreateGroupDialog>
-        </div>
-      </div>
+          </Button>
+        </CreateGroupDialog>
+      </PageHeader>
 
       {/* Content */}
-      <div className="container min-h-0 flex-1 py-8">
+      <div className="mx-auto w-full max-w-6xl min-h-0 flex-1 px-4 py-8 sm:px-6">
         {groups.length === 0 ? (
           <div className="mx-auto max-w-lg">{EmptyState}</div>
         ) : (
@@ -129,21 +121,6 @@ const GroupsIndex = () => {
             ))}
           </div>
         )}
-      </div>
-
-      {/* Floating create button for mobile */}
-      <div className="fixed bottom-[calc(theme(spacing.4)+theme(spacing.bottom-nav))] right-4 z-40 sm:hidden">
-        <CreateGroupDialog>
-          <Button
-            type="button"
-            size="icon"
-            aria-label="Create Group"
-            title="Create Group"
-            className="h-14 w-14 rounded-full border bg-primary text-primary-foreground shadow-lg"
-          >
-            <Icon name="plus" />
-          </Button>
-        </CreateGroupDialog>
       </div>
     </div>
   );

--- a/app/routes/pools+/index.tsx
+++ b/app/routes/pools+/index.tsx
@@ -1,8 +1,8 @@
 import { LuGift, LuPlus } from 'react-icons/lu'
 import { Link, type LoaderFunctionArgs, useLoaderData } from 'react-router'
+import { PageHeader } from '#app/components/page-header.tsx'
 import { Button } from '#app/components/ui/button.tsx'
 import { Card } from '#app/components/ui/card.tsx'
-import { Icon } from '#app/components/ui/icon.tsx'
 import { Flex, Stack, Text } from '#app/components/ui-kit'
 import { requireUserId } from '#app/utils/auth.server.ts'
 import { prisma } from '#app/utils/db.server.ts'
@@ -133,28 +133,23 @@ const PoolsIndex = () => {
 
 	return (
 		<div className="flex h-full min-h-0 flex-col">
-			{/* Header */}
-			<div className="border-b bg-surface px-4 py-4 shadow">
-				<div className="container flex items-center justify-between gap-2">
-					<Flex gap={2} align="center">
-						<LuGift className="text-primary" size={22} />
-						<Text size="xl" weight="bold">
-							Pools
-						</Text>
-					</Flex>
-					<Button asChild>
-						<Link to="/pools/new">
-							<Flex gap={1}>
-								<LuPlus />
-								<Text>Start a Pool</Text>
-							</Flex>
-						</Link>
-					</Button>
-				</div>
-			</div>
+			<PageHeader
+				variant="section"
+				icon={<LuGift className="text-primary" size={22} />}
+				title="Pools"
+			>
+				<Button asChild>
+					<Link to="/pools/new">
+						<Flex gap={1}>
+							<LuPlus />
+							<Text>Start a Pool</Text>
+						</Flex>
+					</Link>
+				</Button>
+			</PageHeader>
 
 			{/* Content */}
-			<div className="container min-h-0 flex-1 py-8">
+			<div className="mx-auto w-full max-w-6xl min-h-0 flex-1 px-4 py-8 sm:px-6">
 				{active.length === 0 && completed.length === 0 ? (
 					<div className="mx-auto max-w-lg">
 						<Card padding="lg" className="rounded-2xl text-center">
@@ -205,19 +200,6 @@ const PoolsIndex = () => {
 				)}
 			</div>
 
-			{/* Floating create button for mobile */}
-			<div className="fixed bottom-[calc(theme(spacing.4)+theme(spacing.bottom-nav))] right-4 z-40 sm:hidden">
-				<Button
-					asChild
-					size="icon"
-					aria-label="Start a Pool"
-					className="h-14 w-14 rounded-full border bg-primary text-primary-foreground shadow-lg"
-				>
-					<Link to="/pools/new">
-						<Icon name="plus" />
-					</Link>
-				</Button>
-			</div>
 		</div>
 	)
 }

--- a/app/routes/wishlist+/__wishlist-item-editor.tsx
+++ b/app/routes/wishlist+/__wishlist-item-editor.tsx
@@ -943,7 +943,6 @@ function EditorTrigger({
       <DialogTriggerComponent asChild>
         <Button
           className="hidden sm:inline-flex"
-          variant="outline"
           onClick={() => setMode('create')}
         >
           <Flex gap={1}>


### PR DESCRIPTION
## Summary

Phase 1 of a systematic UI consistency pass based on a full in-browser audit (April 2026). Establishes shared foundations before touching individual screens.

- **Bug fix**: `notifications.upcomingBirthday.message` was rendering as a raw i18n key in the notification panel — adds the missing translation entry
- **New component**: `PageHeader` with `section` and `detail` variants — canonical header strip (border-b, shadow, max-w-6xl) shared across all list and detail pages
- **PageHeader applied** to Groups, Pools, and Friends list pages — replaces three independently-constructed headers with the shared component
- **Width unified**: content areas on Groups, Pools, Friends updated from `container` (1400px) to `max-w-6xl` (1152px), matching the locked standard-page width token
- **FAB removed** from Groups and Pools mobile — the header button is sufficient; FAB is Wishlist-only per the new FAB rule
- **Friends icon** added (`LuUsers`) — was the only nav section without a header icon
- **Wishlist "Add Item"** changed from `variant="outline"` to `variant="default"` (solid coral) — all page-level creation actions should be solid coral

## System decisions adopted (locked)

| Token | Value | Pages |
|---|---|---|
| Standard pages | `max-w-6xl` (1152px) | Home, Wishlist, Groups, Pools, Friends |
| Narrow/form pages | `max-w-3xl` (768px) | Settings, Pool detail, Group detail |
| FAB | Wishlist mobile only | Never alongside a header button |

## Test plan

- [ ] Notification bell: birthday notifications show resolved text, not raw key
- [ ] Groups page: header renders with icon + title + "Create Group" button; no FAB on mobile
- [ ] Pools page: header renders with icon + title + "Start a Pool" button; no FAB on mobile
- [ ] Friends page: header renders with LuUsers icon + "Friends" title + "Add friend" button; border-b strip present
- [ ] Wishlist: "Add Item" button is solid coral (not outlined)
- [ ] All three list pages: content aligns to ~1152px max, not 1400px