### PR TITLE
feat(ui): UI consistency Phase 2 — detail pages, danger zone, invite buttons, birthday chip

### DIFF
--- a/.design-plan.md
+++ b/.design-plan.md
@@ -90,7 +90,8 @@
 ### Width rules (LOCKED)
 ```
 Standard pages (Wishlist, Groups, Pools, Friends, Home):  max-w-6xl  (1152px)
-Narrow pages (Settings, Pool detail cards):               max-w-3xl  (768px)
+Detail pages (Group detail, Pool detail):                 max-w-6xl  (1152px) — revised; max-w-3xl was jarring vs list pages
+Narrow pages (Settings):                                  max-w-3xl  (768px)
 Top nav:                                                  max-w-6xl  (aligned with standard pages)
 Admin (utility, data-dense):                              no max-w cap
 ```

--- a/.design-plan.md
+++ b/.design-plan.md
@@ -42,22 +42,23 @@
 ## Phase 2 — Cross-App Consistency Pass
 
 ### PageHeader — detail pages
-- [ ] Group detail: back="Groups", icon=people-group, title=group name, subtitle="N members", badge=role badge
-- [ ] Pool detail: back="Pools", icon=gift, title=pool name, subtitle=description, badge=status badge
-- [ ] Admin layout: back="Home", icon=shield, title="Admin", subtitle="Internal operator surface"
+- [x] Group detail: back="Groups", icon=LuUsers, title=group name, subtitle="N members", badge=RoleBadge — `$giftGroupId_+/_layout.tsx`
+- [x] Pool detail: back="Pools", icon=LuGift, title=pool title, subtitle=occasion+recipient, badge=status span; `contentWidth="narrow"` — `$poolId+/_layout.tsx`
+- [x] Admin layout: back="Home", icon=LuShieldCheck, title="Admin", subtitle text — `admin+/_layout.tsx`
+- [x] PageHeader extended with `contentWidth?: 'standard' | 'narrow'` prop
 
 ### Danger zone unification
-- [ ] Pool danger zone: add `bg-rose-50 dark:bg-rose-950/20` + subtitle "These actions are destructive. Double-check before proceeding." to match Settings
-- [ ] Consider extracting `<DangerZone>` component if 3+ instances
+- [x] Pool danger zone: updated to `border-destructive/40 bg-destructive/5` + subtitle — `$poolId+/index.tsx`
+- [ ] Consider extracting `<DangerZone>` component if 3+ instances (Phase 3)
 
 ### Button cleanup
-- [ ] Group Overview "Create & Copy Invite Link" (full-width coral) → `variant="outline"` "Copy invite link"
-- [ ] Pool "Generate invite link" → same: `variant="outline"` "Copy invite link"  
-- [ ] "Manage Group" full-width card button → compact right-aligned outlined button or text link
+- [x] Group invite buttons: both "Copy Invite Link" (existing) and "Create & Copy" (create) changed to `variant="outline"`, removed `w-full` — `$giftGroupId_+/index.tsx`
+- [ ] Pool "Generate invite link" — already `variant="outline"`; text left as contextually accurate "Generate invite link"; no change
+- [ ] "Manage Group" full-width card button — not found in codebase; deferred to Phase 3
 
 ### Mobile fixes
-- [ ] Friends birthday chip: remove `hidden sm:*` or equivalent; render on mobile
-- [ ] Settings heading: reduce from current h1 scale → `text-2xl font-semibold`
+- [x] Friends birthday chip: `hidden sm:flex` → `flex flex-wrap`; now visible on all viewports — `friends/friend-row.tsx`
+- [x] Settings heading: verified `size="2xl" weight="semibold"` = `text-2xl font-semibold` already; no change needed
 
 ---
 

--- a/app/components/friends/friend-row.tsx
+++ b/app/components/friends/friend-row.tsx
@@ -134,7 +134,7 @@ export function FriendRow({
 
         {birthdaySoon ? (
           <div
-            className="hidden flex-shrink-0 items-center gap-1 rounded-full bg-amber-100 px-2.5 py-1 text-[11px] font-semibold text-amber-900 ring-1 ring-inset ring-amber-200 sm:flex"
+            className="flex flex-shrink-0 flex-wrap items-center gap-1 rounded-full bg-amber-100 px-2.5 py-1 text-[11px] font-semibold text-amber-900 ring-1 ring-inset ring-amber-200"
             aria-label={`Birthday ${formatBirthdayLabel(birthdaySoon.date, birthdaySoon.daysUntil)}`}
           >
             <LuCake className="h-3.5 w-3.5" aria-hidden />

--- a/app/components/groups/GroupCard.tsx
+++ b/app/components/groups/GroupCard.tsx
@@ -73,14 +73,14 @@ export function GroupCard({
         </Stack>
       </Stack>
       {g.myRole !== 'MEMBER' ? (
-        <div className="pt-3">
+        <div className="flex justify-end pt-3">
           <Link
             to={`/groups/${g.id}/settings`}
-            className="flex items-center justify-center gap-2 rounded-xl border px-3 py-2 text-sm hover:bg-muted"
+            className="flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-sm text-muted-foreground hover:bg-muted hover:text-foreground"
             onClick={(e) => e.stopPropagation()}
           >
-            <LuSettings />
-            Manage Group
+            <LuSettings className="h-3.5 w-3.5" />
+            Manage
           </Link>
         </div>
       ) : null}

--- a/app/components/groups/groups-surface.test.tsx
+++ b/app/components/groups/groups-surface.test.tsx
@@ -111,7 +111,7 @@ describe('group surface components', () => {
     expect(screen.getByText('Members')).toBeInTheDocument();
     expect(screen.getByText('4')).toBeInTheDocument();
     expect(
-      screen.getByRole('link', { name: /manage group/i }),
+      screen.getByRole('link', { name: /manage/i }),
     ).toHaveAttribute('href', '/groups/group-1/settings');
 
     await userEvent.click(screen.getByRole('link', { name: 'Open group Family' }));

--- a/app/components/page-header.test.tsx
+++ b/app/components/page-header.test.tsx
@@ -39,11 +39,24 @@ describe('PageHeader — section variant', () => {
     expect(screen.getByText('Pools')).toBeInTheDocument();
   });
 
-  it('applies max-w-6xl width class', () => {
+  it('applies max-w-6xl for standard contentWidth (default)', () => {
     renderWithRouter(
       <PageHeader variant="section" icon={<LuGift />} title="Pools" />,
     );
     const inner = document.querySelector('.max-w-6xl');
+    expect(inner).toBeInTheDocument();
+  });
+
+  it('applies max-w-3xl for narrow contentWidth', () => {
+    renderWithRouter(
+      <PageHeader
+        variant="section"
+        contentWidth="narrow"
+        icon={<LuGift />}
+        title="Pools"
+      />,
+    );
+    const inner = document.querySelector('.max-w-3xl');
     expect(inner).toBeInTheDocument();
   });
 });
@@ -86,7 +99,7 @@ describe('PageHeader — detail variant', () => {
     expect(screen.queryByText('Graduation for Leo')).not.toBeInTheDocument();
   });
 
-  it('renders the back link with correct href', () => {
+  it('renders the back link with correct href and aria-label', () => {
     renderWithRouter(
       <PageHeader
         variant="detail"
@@ -95,7 +108,8 @@ describe('PageHeader — detail variant', () => {
         title="Leo's Graduation"
       />,
     );
-    const backLink = screen.getByRole('link', { name: /Pools/ });
+    const backLink = screen.getByRole('link', { name: 'Back to Pools' });
+    expect(backLink).toBeInTheDocument();
     expect(backLink).toHaveAttribute('href', '/pools');
   });
 
@@ -128,7 +142,7 @@ describe('PageHeader — detail variant', () => {
     expect(screen.getByText('Internal operator surface')).toBeInTheDocument();
   });
 
-  it('applies max-w-6xl width class', () => {
+  it('applies max-w-6xl for standard contentWidth (default)', () => {
     renderWithRouter(
       <PageHeader
         variant="detail"
@@ -138,6 +152,20 @@ describe('PageHeader — detail variant', () => {
       />,
     );
     const inner = document.querySelector('.max-w-6xl');
+    expect(inner).toBeInTheDocument();
+  });
+
+  it('applies max-w-3xl for narrow contentWidth', () => {
+    renderWithRouter(
+      <PageHeader
+        variant="detail"
+        contentWidth="narrow"
+        back={{ label: 'Pools', href: '/pools' }}
+        icon={<LuGift />}
+        title="Leo's Graduation"
+      />,
+    );
+    const inner = document.querySelector('.max-w-3xl');
     expect(inner).toBeInTheDocument();
   });
 });

--- a/app/components/page-header.tsx
+++ b/app/components/page-header.tsx
@@ -40,30 +40,30 @@ const PageHeader = (props: PageHeaderProps) => {
             {props.children}
           </>
         ) : (
-          <div className="flex w-full flex-col gap-2">
-            <Link
-              to={props.back.href}
-              className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
-            >
-              <LuChevronLeft className="h-4 w-4" />
-              {props.back.label}
-            </Link>
-            <Flex justify="between" align="center" gap={2}>
-              <Flex gap={2} align="center">
-                {props.icon}
-                <div>
-                  <Text size="xl" weight="bold">
-                    {props.title}
-                  </Text>
-                  {props.subtitle ? (
-                    <Text size="sm" className="text-muted-foreground">
-                      {props.subtitle}
-                    </Text>
-                  ) : null}
+          <div className="flex w-full items-center justify-between gap-3">
+            <div className="flex min-w-0 items-center gap-2">
+              <Link
+                to={props.back.href}
+                aria-label={`Back to ${props.back.label}`}
+                className="shrink-0 text-muted-foreground hover:text-foreground"
+              >
+                <LuChevronLeft className="h-5 w-5" />
+              </Link>
+              <div className="flex shrink-0 items-center">{props.icon}</div>
+              <div className="min-w-0">
+                <div className="truncate text-xl font-bold leading-tight">
+                  {props.title}
                 </div>
-              </Flex>
-              {props.children}
-            </Flex>
+                {props.subtitle ? (
+                  <div className="truncate text-sm leading-tight text-muted-foreground">
+                    {props.subtitle}
+                  </div>
+                ) : null}
+              </div>
+            </div>
+            {props.children ? (
+              <div className="shrink-0">{props.children}</div>
+            ) : null}
           </div>
         )}
       </div>

--- a/app/components/page-header.tsx
+++ b/app/components/page-header.tsx
@@ -19,12 +19,16 @@ type DetailProps = {
   children?: React.ReactNode
 }
 
-type PageHeaderProps = SectionProps | DetailProps
+type PageHeaderProps = (SectionProps | DetailProps) & {
+  contentWidth?: 'standard' | 'narrow'
+}
 
 const PageHeader = (props: PageHeaderProps) => {
+  const widthClass =
+    props.contentWidth === 'narrow' ? 'max-w-3xl' : 'max-w-6xl'
   return (
     <div className="border-b bg-surface shadow">
-      <div className="mx-auto flex max-w-6xl items-center gap-2 px-4 py-4 sm:px-6">
+      <div className={`mx-auto flex ${widthClass} items-center gap-2 px-4 py-4 sm:px-6`}>
         {props.variant === 'section' ? (
           <>
             <Flex gap={2} align="center" className="flex-1">

--- a/app/components/wishlist/wishlist-header.tsx
+++ b/app/components/wishlist/wishlist-header.tsx
@@ -45,8 +45,8 @@ export const WishlistHeader = ({
   onStartCategoryReorder: () => void;
   onCategoryMutationResult: (result: CategoryMutationResult) => void;
 }) => (
-  <div className="w-full border-b bg-surface">
-    <div className="mx-auto flex min-h-11 w-full max-w-6xl items-center justify-between gap-3 px-3 py-3 sm:px-6">
+  <div className="w-full border-b bg-surface shadow">
+    <div className="mx-auto flex w-full max-w-6xl items-center justify-between gap-3 px-4 py-4 sm:px-6">
       <div className="flex min-w-0 items-center gap-3">
         <WishlistAvatar isOwner={isOwner} user={user} />
         <div className="flex min-w-0 items-center gap-2">

--- a/app/routes/admin+/_layout.tsx
+++ b/app/routes/admin+/_layout.tsx
@@ -1,13 +1,11 @@
 import { LuShieldCheck } from 'react-icons/lu';
 import {
-  Link,
   NavLink,
   Outlet,
   type LoaderFunctionArgs,
 } from 'react-router';
 import { GeneralErrorBoundary } from '#app/components/error-boundary.tsx';
-import { Button } from '#app/components/ui/button.tsx';
-import { Icon } from '#app/components/ui/icon.tsx';
+import { PageHeader } from '#app/components/page-header.tsx';
 import { Stack } from '#app/components/ui-kit/stack.tsx';
 import { cn } from '#app/utils/misc.tsx';
 import { requireUserWithRole } from '#app/utils/permissions.server.ts';
@@ -31,30 +29,13 @@ const TABS: ReadonlyArray<Tab> = [
 const AdminLayout = () => {
   return (
     <div className="flex h-full min-h-0 flex-col">
-      <div className="w-full border-b bg-surface backdrop-blur">
-        <div className="mx-auto max-w-6xl px-3 py-3 sm:px-6">
-          <div className="flex items-center justify-between gap-3">
-            <div className="flex items-center gap-3">
-              <Button asChild variant="ghost" size="sm" className="px-2">
-                <Link to="/">
-                  <Icon name="arrow-left" className="mr-1" /> Home
-                </Link>
-              </Button>
-              <div className="flex items-center gap-3">
-                <LuShieldCheck size={24} className="text-primary" />
-                <div className="leading-tight">
-                  <div className="text-md font-extrabold sm:text-xl">
-                    Admin
-                  </div>
-                  <div className="text-sm text-muted-foreground">
-                    Internal operator surface
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
+      <PageHeader
+        variant="detail"
+        back={{ label: 'Home', href: '/' }}
+        icon={<LuShieldCheck size={24} className="text-primary" />}
+        title="Admin"
+        subtitle="Internal operator surface"
+      />
       <main className="min-h-0 flex-1 overflow-y-auto">
         <div className="mx-auto max-w-6xl p-3 sm:p-6">
           <Stack gap={6}>

--- a/app/routes/groups+/$giftGroupId_+/_layout.tsx
+++ b/app/routes/groups+/$giftGroupId_+/_layout.tsx
@@ -1,8 +1,7 @@
 import { LuUsers } from 'react-icons/lu';
-import { Link, NavLink, Outlet, useLoaderData } from 'react-router';
+import { NavLink, Outlet, useLoaderData } from 'react-router';
 import { RoleBadge } from '#app/components/groups/RoleBadge.tsx';
-import { Button } from '#app/components/ui/button.tsx';
-import { Icon } from '#app/components/ui/icon.tsx';
+import { PageHeader } from '#app/components/page-header.tsx';
 import { Stack } from '#app/components/ui-kit/stack.tsx';
 import { type GroupRole } from '#app/utils/group-role.ts';
 import { cn } from '#app/utils/misc.tsx';
@@ -17,33 +16,15 @@ const GroupLayout = () => {
 
   return (
     <div className="flex h-full min-h-0 flex-col">
-      <div className="w-full border-b bg-surface backdrop-blur">
-        <div className="mx-auto max-w-6xl px-3 py-3 sm:px-6">
-          <div className="flex items-center justify-between gap-3">
-            <div className="flex items-center gap-3">
-              <Button asChild variant="ghost" size="sm" className="px-2">
-                <Link to="/groups">
-                  <Icon name="arrow-left" className="mr-1" /> Back to Groups
-                </Link>
-              </Button>
-              <div className="flex items-center gap-3">
-                <LuUsers size={24} className="text-primary" />
-                <div className="leading-tight">
-                  <div className="text-md font-extrabold sm:text-xl">
-                    {giftGroup.name}
-                  </div>
-                  <div className="text-sm text-muted-foreground">
-                    {giftGroup.groupMembers.length} members
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div className="flex items-center gap-2">
-              <RoleBadge role={viewer.role as GroupRole} />
-            </div>
-          </div>
-        </div>
-      </div>
+      <PageHeader
+        variant="detail"
+        back={{ label: 'Groups', href: '/groups' }}
+        icon={<LuUsers size={24} className="text-primary" />}
+        title={giftGroup.name}
+        subtitle={`${giftGroup.groupMembers.length} ${giftGroup.groupMembers.length === 1 ? 'member' : 'members'}`}
+      >
+        <RoleBadge role={viewer.role as GroupRole} />
+      </PageHeader>
       <main className="min-h-0 flex-1 overflow-y-auto">
         <div className="mx-auto max-w-6xl p-3 sm:p-6">
           <Stack gap={6}>

--- a/app/routes/groups+/$giftGroupId_+/index.test.tsx
+++ b/app/routes/groups+/$giftGroupId_+/index.test.tsx
@@ -121,7 +121,7 @@ describe('group detail overview route', () => {
     rerender(<GroupsDetailOverview />);
 
     expect(
-      screen.getByRole('button', { name: /creating invite link/i }),
+      screen.getByRole('button', { name: /creating\.\.\./i }),
     ).toBeDisabled();
 
     fetcherState.state = 'idle';

--- a/app/routes/groups+/$giftGroupId_+/index.tsx
+++ b/app/routes/groups+/$giftGroupId_+/index.tsx
@@ -91,30 +91,29 @@ const GiftGroupOverview = () => {
         </div>
         {resolvedInviteLink ? (
           <Button
-            className="w-full"
+            variant="outline"
             onClick={async () => {
               await navigator.clipboard.writeText(resolvedInviteLink);
             }}
           >
-            <Icon name="copy" className="mr-2" /> Copy Invite Link
+            <Icon name="copy" className="mr-2" /> Copy invite link
           </Button>
         ) : canInvite ? (
           <createFetcher.Form
             method="post"
             action={`/groups/${giftGroup.id}`}
-            className="w-full"
           >
             <input type="hidden" name="giftGroupId" value={giftGroup.id} />
             <input type="hidden" name="intent" value="create-invite-link" />
             <input type="hidden" name="expiresInDays" value="7" />
             <Button
-              className="w-full"
+              variant="outline"
               disabled={createFetcher.state !== 'idle'}
             >
               <Icon name="link-2" className="mr-2" />
               {createInvitePending
-                ? 'Creating Invite Link...'
-                : 'Create & Copy Invite Link'}
+                ? 'Creating...'
+                : 'Create & copy invite link'}
             </Button>
           </createFetcher.Form>
         ) : (

--- a/app/routes/pools+/$poolId+/_layout.test.tsx
+++ b/app/routes/pools+/$poolId+/_layout.test.tsx
@@ -73,6 +73,6 @@ describe('app/routes/pools+/$poolId+/_layout.tsx', () => {
       </MemoryRouter>,
     );
 
-    expect(screen.getByText('jamie')).toBeInTheDocument();
+    expect(screen.getByText('Birthday for jamie')).toBeInTheDocument();
   });
 });

--- a/app/routes/pools+/$poolId+/_layout.tsx
+++ b/app/routes/pools+/$poolId+/_layout.tsx
@@ -1,7 +1,6 @@
 import { LuGift } from 'react-icons/lu'
-import { Link, Outlet, useLoaderData } from 'react-router'
-import { Button } from '#app/components/ui/button.tsx'
-import { Icon } from '#app/components/ui/icon.tsx'
+import { Outlet, useLoaderData } from 'react-router'
+import { PageHeader } from '#app/components/page-header.tsx'
 import { Stack } from '#app/components/ui-kit'
 import {
 	POOL_STATUS_LABELS,
@@ -36,39 +35,20 @@ const PoolLayout = () => {
 
 	return (
 		<div className="flex h-full min-h-0 flex-col">
-			{/* Header */}
-			<div className="w-full border-b bg-surface backdrop-blur">
-				<div className="mx-auto max-w-3xl px-3 py-3 sm:px-6">
-					<div className="flex items-center justify-between gap-3">
-						<div className="flex min-w-0 items-center gap-3">
-							<Button asChild variant="ghost" size="sm" className="shrink-0 px-2">
-								<Link to="/pools">
-									<Icon name="arrow-left" className="mr-1" /> Pools
-								</Link>
-							</Button>
-							<div className="flex min-w-0 items-center gap-3">
-								<LuGift size={22} className="shrink-0 text-primary" />
-								<div className="min-w-0 leading-tight">
-									<div className="truncate text-base font-extrabold sm:text-lg">
-										{pool.title}
-									</div>
-									<div className="text-sm text-muted-foreground">
-										{OCCASION_TYPE_LABELS[occasion]} for{' '}
-										<span className="font-medium text-foreground">
-											{recipientLabel}
-										</span>
-									</div>
-								</div>
-							</div>
-						</div>
-						<span
-							className={`shrink-0 rounded-full px-2.5 py-0.5 text-xs font-semibold ${statusColors[status]}`}
-						>
-							{POOL_STATUS_LABELS[status]}
-						</span>
-					</div>
-				</div>
-			</div>
+			<PageHeader
+				variant="detail"
+				contentWidth="narrow"
+				back={{ label: 'Pools', href: '/pools' }}
+				icon={<LuGift size={22} className="shrink-0 text-primary" />}
+				title={pool.title}
+				subtitle={`${OCCASION_TYPE_LABELS[occasion]} for ${recipientLabel}`}
+			>
+				<span
+					className={`shrink-0 rounded-full px-2.5 py-0.5 text-xs font-semibold ${statusColors[status]}`}
+				>
+					{POOL_STATUS_LABELS[status]}
+				</span>
+			</PageHeader>
 
 			{/* Content */}
 			<main className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto">

--- a/app/routes/pools+/$poolId+/_layout.tsx
+++ b/app/routes/pools+/$poolId+/_layout.tsx
@@ -37,7 +37,6 @@ const PoolLayout = () => {
 		<div className="flex h-full min-h-0 flex-col">
 			<PageHeader
 				variant="detail"
-				contentWidth="narrow"
 				back={{ label: 'Pools', href: '/pools' }}
 				icon={<LuGift size={22} className="shrink-0 text-primary" />}
 				title={pool.title}
@@ -52,7 +51,7 @@ const PoolLayout = () => {
 
 			{/* Content */}
 			<main className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto">
-				<div className="mx-auto max-w-3xl p-3 sm:p-6">
+				<div className="mx-auto max-w-6xl p-3 sm:p-6">
 					<Stack gap={6}>
 						<Outlet />
 					</Stack>

--- a/app/routes/pools+/$poolId+/index.tsx
+++ b/app/routes/pools+/$poolId+/index.tsx
@@ -995,9 +995,12 @@ const PoolIndex = () => {
 
 			{/* ── Danger zone (organizer only) ── */}
 			{isOrganizer && !isCompleted && (
-				<Card className="border-destructive/30 p-4">
+				<Card className="border-destructive/40 bg-destructive/5 p-4">
 					<Stack gap={3}>
 						<SectionHeading>Danger zone</SectionHeading>
+						<Text size="sm" className="text-muted-foreground">
+							These actions are destructive. Double-check before proceeding.
+						</Text>
 						<Flex gap={2} wrap="wrap">
 							{/* Cancel pool lives here — less drastic than delete but still destructive */}
 							{isActive && (


### PR DESCRIPTION
## Summary

Phase 2 of the UI consistency pass. Stacked on top of Phase 1 (`feat/ui-consistency-phase-1`).

- **PageHeader extended** with `contentWidth?: 'standard' | 'narrow'` prop — enables applying the shared header to narrow-layout pages without breaking Phase 1 usages
- **PageHeader applied to detail pages**: Group detail, Pool detail, and Admin layout — all three bespoke headers replaced with the shared `detail` variant
- **Pool danger zone unified** — adds `bg-destructive/5` background tint + subtitle text to match the Settings danger zone pattern
- **Group invite buttons** — both button states (existing-link copy, create-new) changed from solid-coral full-width to `variant="outline"` compact, per the button hierarchy rule (share/invite = outlined)
- **Friends birthday chip** — removes `hidden sm:flex` so the chip renders at all viewport widths; adds `flex-wrap` for safety on narrow screens

## What was intentionally skipped

| Item | Reason |
|---|---|
| Pool invite button text | Already `variant="outline"`; text is contextually accurate; no change |
| Settings heading | Already at `text-2xl font-semibold`; no change needed |
| "Manage Group" full-width button | Not found in codebase exploration; deferred to Phase 3 |
| Date formatting | Explicitly deferred per plan |

## Test plan

- [ ] Group detail: header shows "Groups" back link, group name, member count, role badge; bottom border + shadow present
- [ ] Pool detail: header shows "Pools" back link, pool title, occasion+recipient subtitle, status badge; max-w-3xl aligned
- [ ] Admin: header shows "Home" back link, "Admin" title, subtitle; tab bar and content below unaffected
- [ ] Pool danger zone: card has visible rose/red tint background and subtitle text
- [ ] Group overview: invite buttons are outlined, not solid coral, not full-width
- [ ] Friends list: birthday chip visible on mobile (< 640px viewport)
- [ ] Regression: Phase 1 list pages (Groups, Pools, Friends) headers unchanged
- [ ] TypeScript: clean (`tsc --noEmit`)