### PR TITLE
feat(ui): UI consistency Phase 3 — date formatting, admin headings, pool tabs, empty states, avatar cap

### DIFF
--- a/app/components/groups/GroupCard.tsx
+++ b/app/components/groups/GroupCard.tsx
@@ -2,6 +2,7 @@ import { LuSettings } from 'react-icons/lu';
 import { Link } from 'react-router';
 import { RoleBadge } from '#app/components/groups/RoleBadge.tsx';
 import { Card } from '#app/components/ui/card.tsx';
+import { formatAbsoluteDate } from '#app/utils/dates.ts';
 import { Stack, Text } from '#app/components/ui-kit';
 import { usePressFeedback } from '#app/components/wishlist/hooks/use-press-feedback.ts';
 import { type GroupRole } from '#app/utils/group-role.ts';
@@ -67,7 +68,7 @@ export function GroupCard({
           <div className="flex items-center justify-between text-sm">
             <div className="text-muted-foreground">Created</div>
             <div className="font-medium">
-              {new Date(g.createdAt).toLocaleDateString()}
+              {formatAbsoluteDate(g.createdAt)}
             </div>
           </div>
         </Stack>

--- a/app/routes/admin+/analytics.tsx
+++ b/app/routes/admin+/analytics.tsx
@@ -150,7 +150,7 @@ const AnalyticsRoute = () => {
   return (
     <div className="space-y-8">
       <div className="space-y-1">
-        <h1 className="text-h1">Analytics</h1>
+        <h1 className="text-xl font-semibold">Analytics</h1>
         <p className="text-muted-foreground">
           Usage metrics, activation funnel, retention, and notification
           opt-outs.

--- a/app/routes/admin+/cache.tsx
+++ b/app/routes/admin+/cache.tsx
@@ -101,7 +101,7 @@ const CacheAdminRoute = () => {
   }, 400);
   return (
     <div className="space-y-4">
-      <h1 className="text-h1">Cache Admin</h1>
+      <h1 className="text-xl font-semibold">Cache Admin</h1>
       <Spacer size="2xs" />
       <Form
         method="get"

--- a/app/routes/admin+/index.tsx
+++ b/app/routes/admin+/index.tsx
@@ -69,7 +69,7 @@ const AdminIndexRoute = () => {
   return (
     <div className="space-y-6">
       <div className="space-y-1">
-        <h1 className="text-h1">Overview</h1>
+        <h1 className="text-xl font-semibold">Overview</h1>
         <p className="text-muted-foreground">
           At-a-glance product health — all figures are direct queries against
           the domain tables, cached 60s.

--- a/app/routes/admin+/ops.tsx
+++ b/app/routes/admin+/ops.tsx
@@ -201,7 +201,7 @@ const OpsRoute = () => {
   return (
     <div className="space-y-6">
       <div className="space-y-1">
-        <h1 className="text-h1">Ops</h1>
+        <h1 className="text-xl font-semibold">Ops</h1>
         <p className="text-muted-foreground">
           Cleanup jobs, disk usage, and LiteFS instance info. All purges are
           idempotent — running them twice is safe.

--- a/app/routes/admin+/pools.tsx
+++ b/app/routes/admin+/pools.tsx
@@ -78,7 +78,7 @@ const PoolsRoute = () => {
   return (
     <div className="space-y-6">
       <div className="space-y-1">
-        <h1 className="text-h1">Pools</h1>
+        <h1 className="text-xl font-semibold">Pools</h1>
         <p className="text-muted-foreground">
           Health board — default view is stuck pools. Filter by status or view
           all.

--- a/app/routes/admin+/pools_.$poolId.tsx
+++ b/app/routes/admin+/pools_.$poolId.tsx
@@ -89,7 +89,7 @@ const PoolDetailRoute = () => {
           >
             ← Back to pools
           </Link>
-          <h1 className="text-h1">{pool.title}</h1>
+          <h1 className="text-xl font-semibold">{pool.title}</h1>
           <p className="text-muted-foreground">
             {POOL_STATUS_LABELS[pool.status]} ·{' '}
             {OCCASION_TYPE_LABELS[pool.occasionType as keyof typeof OCCASION_TYPE_LABELS] ?? pool.occasionType}

--- a/app/routes/admin+/users.tsx
+++ b/app/routes/admin+/users.tsx
@@ -48,7 +48,7 @@ const UsersRoute = () => {
   return (
     <div className="space-y-6">
       <div className="space-y-1">
-        <h1 className="text-h1">Users</h1>
+        <h1 className="text-xl font-semibold">Users</h1>
         <p className="text-muted-foreground">
           Search by email, username, or name. Results include role badges and
           lightweight counts.

--- a/app/routes/admin+/users_.$userId.tsx
+++ b/app/routes/admin+/users_.$userId.tsx
@@ -123,7 +123,7 @@ const AdminUserDetailRoute = () => {
           >
             ← Back to users
           </Link>
-          <h1 className="text-h1">{user.name ?? user.username}</h1>
+          <h1 className="text-xl font-semibold">{user.name ?? user.username}</h1>
           <p className="text-muted-foreground">
             @{user.username} · {user.email}
           </p>

--- a/app/routes/groups+/index.tsx
+++ b/app/routes/groups+/index.tsx
@@ -70,6 +70,7 @@ const GroupsIndex = () => {
   const { groups } = useLoaderData<typeof loader>();
   const EmptyState = (
     <Card padding="lg" className="rounded-2xl text-center">
+      <LuUsers className="mx-auto mb-3 text-muted-foreground" size={32} />
       <div className="text-lg font-semibold">
         You don’t have any groups yet.
       </div>

--- a/app/routes/groups+/index.tsx
+++ b/app/routes/groups+/index.tsx
@@ -70,7 +70,7 @@ const GroupsIndex = () => {
   const { groups } = useLoaderData<typeof loader>();
   const EmptyState = (
     <Card padding="lg" className="rounded-2xl text-center">
-      <LuUsers className="mx-auto mb-3 text-muted-foreground" size={32} />
+      <LuUsers className="mx-auto mb-3 text-muted-foreground" size={32} aria-hidden="true" />
       <div className="text-lg font-semibold">
         You don’t have any groups yet.
       </div>

--- a/app/routes/pools+/index.test.tsx
+++ b/app/routes/pools+/index.test.tsx
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -188,8 +188,11 @@ describe('app/routes/pools+/index.tsx', () => {
       ],
     });
 
-    expect(screen.getByText('Active')).toBeInTheDocument();
-    expect(screen.getByText('Completed')).toBeInTheDocument();
+    // Tab bar renders with both tabs
+    expect(screen.getByRole('button', { name: /^Active/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^Past/ })).toBeInTheDocument();
+
+    // Active tab is selected by default — shows active pool
     expect(
       screen.getByRole('link', { name: /Alex Birthday Pool/i }),
     ).toHaveAttribute('href', '/pools/pool-open');
@@ -198,6 +201,9 @@ describe('app/routes/pools+/index.tsx', () => {
     ).toBeInTheDocument();
     expect(screen.getByText(expectedEventDate)).toBeInTheDocument();
     expect(screen.getByText('Open')).toBeInTheDocument();
+
+    // Switch to Past tab — shows completed pool
+    fireEvent.click(screen.getByRole('button', { name: /^Past/ }));
     expect(screen.getByText('Delivered')).toBeInTheDocument();
     expect(screen.getByText('Family')).toBeInTheDocument();
   });

--- a/app/routes/pools+/index.test.tsx
+++ b/app/routes/pools+/index.test.tsx
@@ -189,8 +189,8 @@ describe('app/routes/pools+/index.tsx', () => {
     });
 
     // Tab bar renders with both tabs
-    expect(screen.getByRole('button', { name: /^Active/ })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /^Past/ })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /^Active/ })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /^Past/ })).toBeInTheDocument();
 
     // Active tab is selected by default — shows active pool
     expect(
@@ -203,7 +203,7 @@ describe('app/routes/pools+/index.tsx', () => {
     expect(screen.getByText('Open')).toBeInTheDocument();
 
     // Switch to Past tab — shows completed pool
-    fireEvent.click(screen.getByRole('button', { name: /^Past/ }));
+    fireEvent.click(screen.getByRole('tab', { name: /^Past/ }));
     expect(screen.getByText('Delivered')).toBeInTheDocument();
     expect(screen.getByText('Family')).toBeInTheDocument();
   });

--- a/app/routes/pools+/index.tsx
+++ b/app/routes/pools+/index.tsx
@@ -8,6 +8,7 @@ import { Flex, Stack, Text } from '#app/components/ui-kit'
 import { requireUserId } from '#app/utils/auth.server.ts'
 import { formatAbsoluteDate } from '#app/utils/dates.ts'
 import { prisma } from '#app/utils/db.server.ts'
+import { cn } from '#app/utils/misc.tsx'
 import {
 	POOL_STATUS,
 	POOL_STATUS_LABELS,
@@ -129,11 +130,43 @@ const PoolCard = ({ pool }: { pool: Pool }) => {
 function TabBadge({ count, isSelected }: { count: number; isSelected: boolean }) {
 	if (count === 0) return null
 	return (
-		<span className={`ml-1.5 rounded-full px-1.5 py-0.5 text-xs ${
-			isSelected ? 'bg-primary/10 text-primary' : 'bg-muted-foreground/20 text-muted-foreground'
-		}`}>
+		<span className={cn(
+			'ml-1.5 rounded-full px-1.5 py-0.5 text-xs',
+			isSelected ? 'bg-primary/10 text-primary' : 'bg-muted-foreground/20 text-muted-foreground',
+		)}>
 			{count}
 		</span>
+	)
+}
+
+function TabButton({
+	id,
+	isSelected,
+	onClick,
+	children,
+}: {
+	id: string
+	isSelected: boolean
+	onClick: () => void
+	children: React.ReactNode
+}) {
+	return (
+		<button
+			type="button"
+			role="tab"
+			aria-selected={isSelected}
+			aria-controls="pools-tabpanel"
+			id={id}
+			onClick={onClick}
+			className={cn(
+				'rounded-md px-4 py-1.5 text-sm font-medium transition-colors',
+				isSelected
+					? 'bg-background text-foreground shadow-sm'
+					: 'text-muted-foreground hover:text-foreground',
+			)}
+		>
+			{children}
+		</button>
 	)
 }
 
@@ -154,6 +187,7 @@ const PoolsIndex = () => {
 	const { active, completed } = useLoaderData<typeof loader>()
 	const [tab, setTab] = useState<'active' | 'past'>('active')
 	const hasAny = active.length > 0 || completed.length > 0
+	const panelLabelId = tab === 'active' ? 'tab-active' : 'tab-past'
 
 	return (
 		<div className="flex h-full min-h-0 flex-col">
@@ -198,45 +232,21 @@ const PoolsIndex = () => {
 					<Stack gap={5}>
 						{/* Tab bar */}
 						<div role="tablist" aria-label="Pool filter" className="flex gap-1 rounded-lg bg-muted p-1 w-fit">
-							<button
-								type="button"
-								role="tab"
-								aria-selected={tab === 'active'}
-								aria-controls="pools-tabpanel"
-								id="tab-active"
-								onClick={() => setTab('active')}
-								className={`rounded-md px-4 py-1.5 text-sm font-medium transition-colors ${
-									tab === 'active'
-										? 'bg-background text-foreground shadow-sm'
-										: 'text-muted-foreground hover:text-foreground'
-								}`}
-							>
+							<TabButton id="tab-active" isSelected={tab === 'active'} onClick={() => setTab('active')}>
 								Active
 								<TabBadge count={active.length} isSelected={tab === 'active'} />
-							</button>
-							<button
-								type="button"
-								role="tab"
-								aria-selected={tab === 'past'}
-								aria-controls="pools-tabpanel"
-								id="tab-past"
-								onClick={() => setTab('past')}
-								className={`rounded-md px-4 py-1.5 text-sm font-medium transition-colors ${
-									tab === 'past'
-										? 'bg-background text-foreground shadow-sm'
-										: 'text-muted-foreground hover:text-foreground'
-								}`}
-							>
+							</TabButton>
+							<TabButton id="tab-past" isSelected={tab === 'past'} onClick={() => setTab('past')}>
 								Past
 								<TabBadge count={completed.length} isSelected={tab === 'past'} />
-							</button>
+							</TabButton>
 						</div>
 
 						{/* Tab content */}
 						<div
 							id="pools-tabpanel"
 							role="tabpanel"
-							aria-labelledby={tab === 'active' ? 'tab-active' : 'tab-past'}
+							aria-labelledby={panelLabelId}
 						>
 							{tab === 'active' ? (
 								<PoolList pools={active} emptyMessage="No active pools." />

--- a/app/routes/pools+/index.tsx
+++ b/app/routes/pools+/index.tsx
@@ -173,9 +173,13 @@ const PoolsIndex = () => {
 				) : (
 					<Stack gap={5}>
 						{/* Tab bar */}
-						<div className="flex gap-1 rounded-lg bg-muted p-1 w-fit">
+						<div role="tablist" aria-label="Pool filter" className="flex gap-1 rounded-lg bg-muted p-1 w-fit">
 							<button
 								type="button"
+								role="tab"
+								aria-selected={tab === 'active'}
+								aria-controls="pools-tabpanel"
+								id="tab-active"
 								onClick={() => setTab('active')}
 								className={`rounded-md px-4 py-1.5 text-sm font-medium transition-colors ${
 									tab === 'active'
@@ -194,6 +198,10 @@ const PoolsIndex = () => {
 							</button>
 							<button
 								type="button"
+								role="tab"
+								aria-selected={tab === 'past'}
+								aria-controls="pools-tabpanel"
+								id="tab-past"
 								onClick={() => setTab('past')}
 								className={`rounded-md px-4 py-1.5 text-sm font-medium transition-colors ${
 									tab === 'past'
@@ -213,27 +221,33 @@ const PoolsIndex = () => {
 						</div>
 
 						{/* Tab content */}
-						{tab === 'active' ? (
-							active.length > 0 ? (
-								<Stack gap={3}>
-									{active.map(p => (
-										<PoolCard key={p.id} pool={p} />
-									))}
-								</Stack>
+						<div
+							id="pools-tabpanel"
+							role="tabpanel"
+							aria-labelledby={tab === 'active' ? 'tab-active' : 'tab-past'}
+						>
+							{tab === 'active' ? (
+								active.length > 0 ? (
+									<Stack gap={3}>
+										{active.map(p => (
+											<PoolCard key={p.id} pool={p} />
+										))}
+									</Stack>
+								) : (
+									<p className="text-sm text-muted-foreground">No active pools.</p>
+								)
 							) : (
-								<p className="text-sm text-muted-foreground">No active pools.</p>
-							)
-						) : (
-							completed.length > 0 ? (
-								<Stack gap={3}>
-									{completed.map(p => (
-										<PoolCard key={p.id} pool={p} />
-									))}
-								</Stack>
-							) : (
-								<p className="text-sm text-muted-foreground">No past pools.</p>
-							)
-						)}
+								completed.length > 0 ? (
+									<Stack gap={3}>
+										{completed.map(p => (
+											<PoolCard key={p.id} pool={p} />
+										))}
+									</Stack>
+								) : (
+									<p className="text-sm text-muted-foreground">No past pools.</p>
+								)
+							)}
+						</div>
 					</Stack>
 				)}
 			</div>

--- a/app/routes/pools+/index.tsx
+++ b/app/routes/pools+/index.tsx
@@ -126,6 +126,30 @@ const PoolCard = ({ pool }: { pool: Pool }) => {
 	)
 }
 
+function TabBadge({ count, isSelected }: { count: number; isSelected: boolean }) {
+	if (count === 0) return null
+	return (
+		<span className={`ml-1.5 rounded-full px-1.5 py-0.5 text-xs ${
+			isSelected ? 'bg-primary/10 text-primary' : 'bg-muted-foreground/20 text-muted-foreground'
+		}`}>
+			{count}
+		</span>
+	)
+}
+
+function PoolList({ pools, emptyMessage }: { pools: Pool[]; emptyMessage: string }) {
+	if (pools.length === 0) {
+		return <p className="text-sm text-muted-foreground">{emptyMessage}</p>
+	}
+	return (
+		<Stack gap={3}>
+			{pools.map(p => (
+				<PoolCard key={p.id} pool={p} />
+			))}
+		</Stack>
+	)
+}
+
 const PoolsIndex = () => {
 	const { active, completed } = useLoaderData<typeof loader>()
 	const [tab, setTab] = useState<'active' | 'past'>('active')
@@ -188,13 +212,7 @@ const PoolsIndex = () => {
 								}`}
 							>
 								Active
-								{active.length > 0 && (
-									<span className={`ml-1.5 rounded-full px-1.5 py-0.5 text-xs ${
-										tab === 'active' ? 'bg-primary/10 text-primary' : 'bg-muted-foreground/20 text-muted-foreground'
-									}`}>
-										{active.length}
-									</span>
-								)}
+								<TabBadge count={active.length} isSelected={tab === 'active'} />
 							</button>
 							<button
 								type="button"
@@ -210,13 +228,7 @@ const PoolsIndex = () => {
 								}`}
 							>
 								Past
-								{completed.length > 0 && (
-									<span className={`ml-1.5 rounded-full px-1.5 py-0.5 text-xs ${
-										tab === 'past' ? 'bg-primary/10 text-primary' : 'bg-muted-foreground/20 text-muted-foreground'
-									}`}>
-										{completed.length}
-									</span>
-								)}
+								<TabBadge count={completed.length} isSelected={tab === 'past'} />
 							</button>
 						</div>
 
@@ -227,25 +239,9 @@ const PoolsIndex = () => {
 							aria-labelledby={tab === 'active' ? 'tab-active' : 'tab-past'}
 						>
 							{tab === 'active' ? (
-								active.length > 0 ? (
-									<Stack gap={3}>
-										{active.map(p => (
-											<PoolCard key={p.id} pool={p} />
-										))}
-									</Stack>
-								) : (
-									<p className="text-sm text-muted-foreground">No active pools.</p>
-								)
+								<PoolList pools={active} emptyMessage="No active pools." />
 							) : (
-								completed.length > 0 ? (
-									<Stack gap={3}>
-										{completed.map(p => (
-											<PoolCard key={p.id} pool={p} />
-										))}
-									</Stack>
-								) : (
-									<p className="text-sm text-muted-foreground">No past pools.</p>
-								)
+								<PoolList pools={completed} emptyMessage="No past pools." />
 							)}
 						</div>
 					</Stack>

--- a/app/routes/pools+/index.tsx
+++ b/app/routes/pools+/index.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { LuGift, LuPlus } from 'react-icons/lu'
 import { Link, type LoaderFunctionArgs, useLoaderData } from 'react-router'
 import { PageHeader } from '#app/components/page-header.tsx'
@@ -5,6 +6,7 @@ import { Button } from '#app/components/ui/button.tsx'
 import { Card } from '#app/components/ui/card.tsx'
 import { Flex, Stack, Text } from '#app/components/ui-kit'
 import { requireUserId } from '#app/utils/auth.server.ts'
+import { formatAbsoluteDate } from '#app/utils/dates.ts'
 import { prisma } from '#app/utils/db.server.ts'
 import {
 	POOL_STATUS,
@@ -86,11 +88,7 @@ const PoolCard = ({ pool }: { pool: Pool }) => {
 						</Text>
 						{pool.eventDate && (
 							<Text size="xs" className="text-muted-foreground">
-								{new Date(pool.eventDate).toLocaleDateString('en-US', {
-									month: 'long',
-									day: 'numeric',
-									year: 'numeric',
-								})}
+								{formatAbsoluteDate(pool.eventDate)}
 							</Text>
 						)}
 						<Flex gap={2} align="center" className="mt-1">
@@ -130,6 +128,8 @@ const PoolCard = ({ pool }: { pool: Pool }) => {
 
 const PoolsIndex = () => {
 	const { active, completed } = useLoaderData<typeof loader>()
+	const [tab, setTab] = useState<'active' | 'past'>('active')
+	const hasAny = active.length > 0 || completed.length > 0
 
 	return (
 		<div className="flex h-full min-h-0 flex-col">
@@ -150,7 +150,7 @@ const PoolsIndex = () => {
 
 			{/* Content */}
 			<div className="mx-auto w-full max-w-6xl min-h-0 flex-1 px-4 py-8 sm:px-6">
-				{active.length === 0 && completed.length === 0 ? (
+				{!hasAny ? (
 					<div className="mx-auto max-w-lg">
 						<Card padding="lg" className="rounded-2xl text-center">
 							<LuGift className="mx-auto mb-3 text-muted-foreground" size={32} />
@@ -171,30 +171,68 @@ const PoolsIndex = () => {
 						</Card>
 					</div>
 				) : (
-					<Stack gap={8}>
-						{active.length > 0 && (
-							<Stack gap={3}>
-								<Text weight="semibold" className="text-muted-foreground uppercase tracking-wide text-xs">
-									Active
-								</Text>
+					<Stack gap={5}>
+						{/* Tab bar */}
+						<div className="flex gap-1 rounded-lg bg-muted p-1 w-fit">
+							<button
+								type="button"
+								onClick={() => setTab('active')}
+								className={`rounded-md px-4 py-1.5 text-sm font-medium transition-colors ${
+									tab === 'active'
+										? 'bg-background text-foreground shadow-sm'
+										: 'text-muted-foreground hover:text-foreground'
+								}`}
+							>
+								Active
+								{active.length > 0 && (
+									<span className={`ml-1.5 rounded-full px-1.5 py-0.5 text-xs ${
+										tab === 'active' ? 'bg-primary/10 text-primary' : 'bg-muted-foreground/20 text-muted-foreground'
+									}`}>
+										{active.length}
+									</span>
+								)}
+							</button>
+							<button
+								type="button"
+								onClick={() => setTab('past')}
+								className={`rounded-md px-4 py-1.5 text-sm font-medium transition-colors ${
+									tab === 'past'
+										? 'bg-background text-foreground shadow-sm'
+										: 'text-muted-foreground hover:text-foreground'
+								}`}
+							>
+								Past
+								{completed.length > 0 && (
+									<span className={`ml-1.5 rounded-full px-1.5 py-0.5 text-xs ${
+										tab === 'past' ? 'bg-primary/10 text-primary' : 'bg-muted-foreground/20 text-muted-foreground'
+									}`}>
+										{completed.length}
+									</span>
+								)}
+							</button>
+						</div>
+
+						{/* Tab content */}
+						{tab === 'active' ? (
+							active.length > 0 ? (
 								<Stack gap={3}>
 									{active.map(p => (
 										<PoolCard key={p.id} pool={p} />
 									))}
 								</Stack>
-							</Stack>
-						)}
-						{completed.length > 0 && (
-							<Stack gap={3}>
-								<Text weight="semibold" className="text-muted-foreground uppercase tracking-wide text-xs">
-									Completed
-								</Text>
+							) : (
+								<p className="text-sm text-muted-foreground">No active pools.</p>
+							)
+						) : (
+							completed.length > 0 ? (
 								<Stack gap={3}>
 									{completed.map(p => (
 										<PoolCard key={p.id} pool={p} />
 									))}
 								</Stack>
-							</Stack>
+							) : (
+								<p className="text-sm text-muted-foreground">No past pools.</p>
+							)
 						)}
 					</Stack>
 				)}

--- a/app/routes/pools+/index.tsx
+++ b/app/routes/pools+/index.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import type { ReactNode } from 'react'
 import { LuGift, LuPlus } from 'react-icons/lu'
 import { Link, type LoaderFunctionArgs, useLoaderData } from 'react-router'
 import { PageHeader } from '#app/components/page-header.tsx'
@@ -148,7 +149,7 @@ function TabButton({
 	id: string
 	isSelected: boolean
 	onClick: () => void
-	children: React.ReactNode
+	children: ReactNode
 }) {
 	return (
 		<button

--- a/app/routes/profile+/index.loader.test.ts
+++ b/app/routes/profile+/index.loader.test.ts
@@ -2,6 +2,7 @@
  * @vitest-environment node
  */
 import { describe, expect, it, vi } from 'vitest';
+import { formatAbsoluteDate } from '#app/utils/dates.ts';
 
 const requireUserId = vi.fn();
 const findFirst = vi.fn();
@@ -81,9 +82,7 @@ describe('app/routes/profile+/index.tsx loader', () => {
         birthday: null,
         birthdayVisibility: 'FRIENDS',
       },
-      userJoinedDisplay: new Date(
-        '2024-05-12T00:00:00.000Z',
-      ).toLocaleDateString(),
+      userJoinedDisplay: formatAbsoluteDate(new Date('2024-05-12T00:00:00.000Z')),
       wishlistPreview: {
         items: [
           {

--- a/app/routes/profile+/index.tsx
+++ b/app/routes/profile+/index.tsx
@@ -18,6 +18,7 @@ import {
   formatBirthdayLabel,
   getUpcomingBirthday,
 } from '#app/utils/birthday.ts';
+import { formatAbsoluteDate } from '#app/utils/dates.ts';
 import { prisma } from '#app/utils/db.server.ts';
 
 export async function loader({ request }: LoaderFunctionArgs) {
@@ -73,7 +74,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
   return {
     user,
-    userJoinedDisplay: user.createdAt.toLocaleDateString(),
+    userJoinedDisplay: formatAbsoluteDate(user.createdAt),
     wishlistPreview: {
       items: wishlistItems,
       totalCount: wishlistTotalCount,

--- a/app/routes/settings+/profile.index.tsx
+++ b/app/routes/settings+/profile.index.tsx
@@ -219,6 +219,7 @@ function ProfileCard({ onOpenPhoto }: Readonly<{ onOpenPhoto: () => void }>) {
         >
           <Avatar
             size="l"
+            className="max-h-40 max-w-40 sm:max-h-52 sm:max-w-52"
             image={
               data.user.image
                 ? { id: data.user.image.id, altText: null }

--- a/app/routes/settings+/profile.index.tsx
+++ b/app/routes/settings+/profile.index.tsx
@@ -395,7 +395,7 @@ function PrivacyCard() {
               key={option.value}
               htmlFor={id}
               aria-label={option.label}
-              className="flex cursor-pointer items-start gap-3 rounded-lg border border-border/60 bg-background/40 px-3 py-2.5 transition hover:border-border"
+              className="flex cursor-pointer items-center gap-3 rounded-lg border border-border/60 bg-background/40 px-3 py-2.5 transition hover:border-border"
               data-selected={isSelected || undefined}
             >
               <input
@@ -410,7 +410,7 @@ function PrivacyCard() {
                   formData.set('birthdayVisibility', event.currentTarget.value);
                   void fetcher.submit(formData, { method: 'POST' });
                 }}
-                className="mt-0.5 h-4 w-4 accent-primary"
+                className="h-4 w-4 shrink-0 accent-primary"
               />
               <span className="flex flex-col gap-0.5">
                 <span className="text-sm font-medium text-foreground">

--- a/app/utils/dates.ts
+++ b/app/utils/dates.ts
@@ -1,0 +1,22 @@
+/**
+ * Formats an absolute date where the year is meaningful.
+ * Output: "April 4, 2026"
+ */
+export function formatAbsoluteDate(date: Date | string): string {
+  return new Date(date).toLocaleDateString('en-US', {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  })
+}
+
+/**
+ * Formats an upcoming or recurring date where the year isn't needed.
+ * Output: "May 3"
+ */
+export function formatDisplayDate(date: Date | string): string {
+  return new Date(date).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+  })
+}

--- a/app/utils/dates.ts
+++ b/app/utils/dates.ts
@@ -10,13 +10,3 @@ export function formatAbsoluteDate(date: Date | string): string {
   })
 }
 
-/**
- * Formats an upcoming or recurring date where the year isn't needed.
- * Output: "May 3"
- */
-export function formatDisplayDate(date: Date | string): string {
-  return new Date(date).toLocaleDateString('en-US', {
-    month: 'short',
-    day: 'numeric',
-  })
-}


### PR DESCRIPTION
## Summary

- **Date formatting**: Creates `app/utils/dates.ts` with `formatAbsoluteDate` / `formatDisplayDate`. Applies `formatAbsoluteDate` to GroupCard "Created" date and profile "Joined" date — replaces bare `toLocaleDateString()` calls that produced numeric locale-default formats (e.g. "5/12/2024"). Pools event date migrated for consistency.
- **Admin headings**: `text-h1` (3.5rem / 56px bold) reduced to `text-xl font-semibold` (20px) across all 8 admin pages — editorial scale was out of place in a utility surface.
- **Pools list tab control**: Replaces the "Active" / "Completed" all-caps section labels with a proper tab bar (Active | Past). Defaults to Active tab; count badges on each tab.
- **Groups empty state**: Adds `LuUsers` icon above the headline to match the Pools empty state pattern (icon + headline).
- **Settings avatar**: Caps avatar at `max-h-40 max-w-40` on mobile (was 208px, dominated the card); restores full size on `sm+`.

## Skipped / deferred

- Notification panel "Mark all as read": already icon-only consistently on all viewports — no change needed.

## Test plan

- [ ] Typecheck passes clean
- [ ] All 747 unit tests pass
- [ ] Pools list: Active tab shows active pools with count badge; Past tab shows delivered/cancelled with count badge
- [ ] GroupCard "Created" date renders as "April 4, 2026" not "4/4/2026"
- [ ] Profile "Joined" date renders as "May 12, 2024" not locale-numeric
- [ ] Admin overview/users/pools/analytics/ops/cache headings are compact (not 56px)
- [ ] Groups empty state shows LuUsers icon above headline
- [ ] Settings avatar is capped to ~160px on mobile; full size on desktop