### PR TITLE
feat: privacy visibility settings + wishlist note banner

### DIFF
--- a/app/components/wishlist/wishlist-note.test.tsx
+++ b/app/components/wishlist/wishlist-note.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+const mockSubmit = vi.fn();
+
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual('react-router');
+  return {
+    ...actual,
+    useFetcher: () => ({
+      state: 'idle',
+      formData: undefined,
+      submit: mockSubmit,
+    }),
+  };
+});
+
+vi.mock('#app/components/ui/icon.tsx', () => ({
+  Icon: ({ name }: { name: string }) => <span data-testid={`icon-${name}`} />,
+}));
+
+import { WishlistNote } from './wishlist-note';
+
+describe('WishlistNote', () => {
+  // ── Viewer ────────────────────────────────────────────────────────────────
+
+  it('renders note text for a viewer when a note exists', () => {
+    render(<WishlistNote note="Hello from the wishlist!" isOwner={false} />);
+    expect(screen.getByText('Hello from the wishlist!')).toBeInTheDocument();
+  });
+
+  it('renders nothing for a viewer when note is null', () => {
+    const { container } = render(<WishlistNote note={null} isOwner={false} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing for a viewer when note is empty string', () => {
+    const { container } = render(<WishlistNote note="" isOwner={false} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  // ── Owner — no note ───────────────────────────────────────────────────────
+
+  it('shows "Add a message" prompt for owner with no note', () => {
+    render(<WishlistNote note={null} isOwner={true} />);
+    expect(screen.getByText(/Add a message to your wishlist/i)).toBeInTheDocument();
+  });
+
+  it('shows "Add a message" prompt for owner with empty note', () => {
+    render(<WishlistNote note="" isOwner={true} />);
+    expect(screen.getByText(/Add a message to your wishlist/i)).toBeInTheDocument();
+  });
+
+  // ── Owner — existing note ─────────────────────────────────────────────────
+
+  it('shows note text and edit button for owner with a note', () => {
+    render(<WishlistNote note="Buy me coffee" isOwner={true} />);
+    expect(screen.getByText('Buy me coffee')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Edit wishlist message/i }),
+    ).toBeInTheDocument();
+  });
+
+  // ── Edit mode ─────────────────────────────────────────────────────────────
+
+  it('enters edit mode when the edit button is clicked', () => {
+    render(<WishlistNote note="Original note" isOwner={true} />);
+    fireEvent.click(screen.getByRole('button', { name: /Edit wishlist message/i }));
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+    expect((screen.getByRole('textbox') as HTMLTextAreaElement).value).toBe(
+      'Original note',
+    );
+  });
+
+  it('enters edit mode from the "Add a message" prompt', () => {
+    render(<WishlistNote note={null} isOwner={true} />);
+    fireEvent.click(screen.getByText(/Add a message to your wishlist/i));
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+  });
+
+  it('cancel button exits edit mode without saving', () => {
+    render(<WishlistNote note="Keep this" isOwner={true} />);
+    fireEvent.click(screen.getByRole('button', { name: /Edit wishlist message/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Cancel/i }));
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+    expect(screen.getByText('Keep this')).toBeInTheDocument();
+    expect(mockSubmit).not.toHaveBeenCalled();
+  });
+
+  it('save button submits the note and exits edit mode', () => {
+    render(<WishlistNote note="Old note" isOwner={true} />);
+    fireEvent.click(screen.getByRole('button', { name: /Edit wishlist message/i }));
+
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: 'New note' } });
+    fireEvent.click(screen.getByRole('button', { name: /Save/i }));
+
+    expect(mockSubmit).toHaveBeenCalledOnce();
+    const [formData, options] = mockSubmit.mock.calls[0] as [FormData, { method: string; action: string }];
+    expect(formData.get('intent')).toBe('update-note');
+    expect(formData.get('note')).toBe('New note');
+    expect(options.method).toBe('POST');
+    expect(options.action).toBe('/wishlist');
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+  });
+
+  it('shows character counter when fewer than 50 chars remain', () => {
+    render(<WishlistNote note={null} isOwner={true} />);
+    fireEvent.click(screen.getByText(/Add a message to your wishlist/i));
+
+    const textarea = screen.getByRole('textbox');
+    // Type a string long enough to bring remaining chars under 50
+    fireEvent.change(textarea, { target: { value: 'a'.repeat(355) } });
+
+    // 400 - 355 = 45 chars left → counter should appear
+    expect(screen.getByText('45 left')).toBeInTheDocument();
+  });
+
+  it('disables save when note exceeds max length', () => {
+    render(<WishlistNote note={null} isOwner={true} />);
+    fireEvent.click(screen.getByText(/Add a message to your wishlist/i));
+
+    const textarea = screen.getByRole('textbox');
+    fireEvent.change(textarea, { target: { value: 'a'.repeat(401) } });
+
+    const saveBtn = screen.getByRole('button', { name: /Save/i });
+    expect(saveBtn).toBeDisabled();
+  });
+});

--- a/app/components/wishlist/wishlist-note.tsx
+++ b/app/components/wishlist/wishlist-note.tsx
@@ -1,0 +1,161 @@
+import { useState, useRef, useEffect } from 'react';
+import { useFetcher } from 'react-router';
+import { Icon } from '#app/components/ui/icon.tsx';
+import { WISHLIST_NOTE_MAX_LENGTH } from '#app/utils/user-validation.ts';
+
+type WishlistNoteProps = {
+  note: string | null;
+  isOwner: boolean;
+};
+
+export const WishlistNote = ({ note, isOwner }: WishlistNoteProps) => {
+  const fetcher = useFetcher();
+  const [isEditing, setIsEditing] = useState(false);
+  const [draft, setDraft] = useState(note ?? '');
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  // Optimistic value: while the fetcher is submitting, show the draft
+  const isSubmitting = fetcher.state !== 'idle';
+  const optimisticNote =
+    isSubmitting && fetcher.formData
+      ? (fetcher.formData.get('note') as string | null) ?? ''
+      : note;
+
+  const displayNote = isEditing ? draft : (optimisticNote ?? note ?? '');
+
+  useEffect(() => {
+    if (isEditing && textareaRef.current) {
+      textareaRef.current.focus();
+      // Place cursor at end
+      const len = textareaRef.current.value.length;
+      textareaRef.current.setSelectionRange(len, len);
+    }
+  }, [isEditing]);
+
+  function startEditing() {
+    setDraft(note ?? '');
+    setIsEditing(true);
+  }
+
+  function cancelEditing() {
+    setDraft(note ?? '');
+    setIsEditing(false);
+  }
+
+  function save() {
+    const formData = new FormData();
+    formData.set('intent', 'update-note');
+    formData.set('note', draft.trim());
+    fetcher.submit(formData, { method: 'POST', action: '/wishlist' });
+    setIsEditing(false);
+  }
+
+  const charsLeft = WISHLIST_NOTE_MAX_LENGTH - draft.length;
+  const isOverLimit = charsLeft < 0;
+
+  // ── Edit mode ────────────────────────────────────────────────────────────
+  if (isEditing) {
+    return (
+      <div className="border-b bg-surface">
+        <div className="mx-auto w-full max-w-6xl px-4 py-3 sm:px-6">
+          <div className="flex flex-col gap-2 rounded-xl border border-border bg-muted/40 p-3">
+            <textarea
+              ref={textareaRef}
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              placeholder="Add a message for people viewing your wishlist…"
+              rows={3}
+              className="w-full resize-none bg-transparent text-sm text-foreground placeholder:text-muted-foreground focus:outline-none"
+            />
+            <div className="flex items-center justify-between gap-3">
+              <span
+                className={`text-xs tabular-nums ${
+                  isOverLimit
+                    ? 'font-medium text-destructive'
+                    : 'text-muted-foreground'
+                }`}
+              >
+                {charsLeft < 50 ? `${charsLeft} left` : ''}
+              </span>
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  onClick={cancelEditing}
+                  className="rounded-md px-3 py-1.5 text-xs font-medium text-muted-foreground transition hover:bg-muted hover:text-foreground"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  onClick={save}
+                  disabled={isOverLimit}
+                  className="rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground transition hover:bg-primary/90 disabled:pointer-events-none disabled:opacity-50"
+                >
+                  Save
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Owner with a note ────────────────────────────────────────────────────
+  if (isOwner && displayNote) {
+    return (
+      <div className="border-b bg-surface">
+        <div className="mx-auto w-full max-w-6xl px-4 py-3 sm:px-6">
+          <div className="group relative rounded-xl border border-border bg-muted/40 px-4 py-3">
+            <p className="whitespace-pre-wrap text-sm text-foreground">
+              {displayNote}
+            </p>
+            <button
+              type="button"
+              onClick={startEditing}
+              aria-label="Edit wishlist message"
+              className="absolute right-2 top-2 rounded-md p-1.5 text-muted-foreground opacity-0 transition hover:bg-muted hover:text-foreground group-hover:opacity-100 focus:opacity-100"
+            >
+              <Icon name="pencil-1" className="h-3.5 w-3.5" />
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Owner with no note — prompt to add ───────────────────────────────────
+  if (isOwner && !displayNote) {
+    return (
+      <div className="border-b bg-surface">
+        <div className="mx-auto w-full max-w-6xl px-4 py-3 sm:px-6">
+          <button
+            type="button"
+            onClick={startEditing}
+            className="flex w-full items-center gap-2 rounded-xl border border-dashed border-border/60 px-4 py-3 text-sm text-muted-foreground transition hover:border-border hover:text-foreground"
+          >
+            <Icon name="pencil-1" className="h-4 w-4 shrink-0" />
+            Add a message to your wishlist…
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Viewer — show note only if it exists ─────────────────────────────────
+  if (!isOwner && displayNote) {
+    return (
+      <div className="border-b bg-surface">
+        <div className="mx-auto w-full max-w-6xl px-4 py-3 sm:px-6">
+          <div className="rounded-xl border border-border bg-muted/40 px-4 py-3">
+            <p className="whitespace-pre-wrap text-sm text-foreground">
+              {displayNote}
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return null;
+};

--- a/app/components/wishlist/wishlist-note.tsx
+++ b/app/components/wishlist/wishlist-note.tsx
@@ -46,7 +46,7 @@ export const WishlistNote = ({ note, isOwner }: WishlistNoteProps) => {
     const formData = new FormData();
     formData.set('intent', 'update-note');
     formData.set('note', draft.trim());
-    fetcher.submit(formData, { method: 'POST', action: '/wishlist' });
+    void fetcher.submit(formData, { method: 'POST', action: '/wishlist' });
     setIsEditing(false);
   }
 

--- a/app/components/wishlist/wishlist.tsx
+++ b/app/components/wishlist/wishlist.tsx
@@ -54,11 +54,13 @@ import {
   toCategoryDragId,
   type WishlistItem,
 } from './wishlist-item-state';
+import { WishlistNote } from './wishlist-note';
 
 export type WishlistUser = Pick<User, 'id' | 'username' | 'name'> & {
   image: Pick<UserImage, 'id'> | null;
   wishlistItems: WishlistItem[];
   wishlistCategories: WishlistCategory[];
+  wishlistNote?: string | null;
 };
 
 type WishlistPublicShare = { token: string; createdAt: Date };
@@ -982,6 +984,9 @@ export const Wishlist = ({
         onStartCategoryReorder={startCategoryReorderMode}
         onCategoryMutationResult={handleCategoryMutationResult}
       />
+      {!isReorderMode ? (
+        <WishlistNote note={user.wishlistNote ?? null} isOwner={isOwner} />
+      ) : null}
       <div className="mx-auto min-h-0 w-full max-w-6xl flex-1 px-3 py-8 sm:px-6">
         <Stack gap={4}>
           <WishlistViewToggle view={view} onChange={handleViewChange} />

--- a/app/routes/resources+/home.panels.test.ts
+++ b/app/routes/resources+/home.panels.test.ts
@@ -234,6 +234,77 @@ describe('app/routes/resources+/home.panels.tsx', () => {
     }
   });
 
+  it('enforces birthdayVisibility: FRIENDS_OF_FRIENDS shown only when mutual friend exists', async () => {
+    getUserId.mockResolvedValue('viewer-1');
+    findMany.mockResolvedValue([
+      {
+        giftGroup: {
+          id: 'group-1',
+          groupMembers: [
+            {
+              // Has a mutual friend with viewer → should appear
+              user: {
+                birthday: localCalendarDate(1990, 3, 1),
+                birthdayVisibility: 'FRIENDS_OF_FRIENDS',
+                id: 'fof-yes',
+                name: 'FOF Yes',
+                username: 'fof_yes',
+              },
+            },
+            {
+              // No mutual friend → should be hidden
+              user: {
+                birthday: localCalendarDate(1990, 3, 2),
+                birthdayVisibility: 'FRIENDS_OF_FRIENDS',
+                id: 'fof-no',
+                name: 'FOF No',
+                username: 'fof_no',
+              },
+            },
+            {
+              // Direct friend with FRIENDS_OF_FRIENDS → should appear (friendIds path)
+              user: {
+                birthday: localCalendarDate(1990, 3, 3),
+                birthdayVisibility: 'FRIENDS_OF_FRIENDS',
+                id: 'direct-friend',
+                name: 'Direct',
+                username: 'direct',
+              },
+            },
+          ],
+        },
+      },
+    ]);
+
+    // First call: viewer's direct friendships (only direct-friend is a direct friend)
+    friendshipFindMany.mockResolvedValueOnce([
+      { userAId: 'viewer-1', userBId: 'direct-friend' },
+    ]);
+    // Second call: mutual-link check for fof-yes and fof-no candidates.
+    // Only fof-yes shares a mutual friend (mutual-friend-1) with viewer.
+    friendshipFindMany.mockResolvedValueOnce([
+      { userAId: 'fof-yes', userBId: 'mutual-friend-1' },
+    ]);
+
+    vi.useFakeTimers();
+    vi.setSystemTime(localCalendarDate(2026, 2, 31));
+
+    try {
+      const result = await loader({
+        context: {},
+        params: {},
+        request: new Request('https://giftpool.app/resources/home.panels'),
+      } as never);
+
+      const ids = result.birthdays.map((b: { id: string }) => b.id).sort();
+      expect(ids).toContain('direct-friend');
+      expect(ids).toContain('fof-yes');
+      expect(ids).not.toContain('fof-no');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('enforces birthdayVisibility: NOBODY hidden, FRIENDS needs friendship, EVERYONE always shown', async () => {
     getUserId.mockResolvedValue('viewer-1');
     findMany.mockResolvedValue([

--- a/app/routes/resources+/home.panels.tsx
+++ b/app/routes/resources+/home.panels.tsx
@@ -59,16 +59,21 @@ function nextBirthdayDate(birthday: Date, now = new Date()) {
 // Is this group-mate's birthday visible to the viewer?
 // - `NOBODY` → never.
 // - `FRIENDS` → only when the viewer has a confirmed friendship.
-// - `EVERYONE` (or any unexpected default) → always.
+// - `FRIENDS_OF_FRIENDS` → only when the viewer is a direct friend OR shares a mutual friend.
+// - `EVERYONE` → always.
+// - Unexpected values default to the most restrictive behaviour (treat as FRIENDS).
 function isBirthdayVisibleToViewer(
   user: GroupMemberUser,
   friendIds: Set<string>,
+  friendOfFriendIds: Set<string>,
 ) {
   if (user.birthdayVisibility === 'NOBODY') return false;
-  if (user.birthdayVisibility === 'FRIENDS' && !friendIds.has(user.id)) {
-    return false;
+  if (user.birthdayVisibility === 'EVERYONE') return true;
+  if (user.birthdayVisibility === 'FRIENDS_OF_FRIENDS') {
+    return friendIds.has(user.id) || friendOfFriendIds.has(user.id);
   }
-  return true;
+  // FRIENDS or any unrecognised value: require a direct friendship
+  return friendIds.has(user.id);
 }
 
 // Walk the viewer's group memberships and build a de-duped map of
@@ -77,6 +82,7 @@ function isBirthdayVisibleToViewer(
 function collectUpcomingBirthdays(
   memberships: Membership[],
   friendIds: Set<string>,
+  friendOfFriendIds: Set<string>,
   viewerId: string,
   now: Date,
 ): Map<string, UpcomingBirthdayEntry> {
@@ -85,7 +91,7 @@ function collectUpcomingBirthdays(
     for (const gm of m.giftGroup.groupMembers) {
       const u = gm.user;
       if (!u.birthday || u.id === viewerId) continue;
-      if (!isBirthdayVisibleToViewer(u, friendIds)) continue;
+      if (!isBirthdayVisibleToViewer(u, friendIds, friendOfFriendIds)) continue;
       if (birthdayMap.has(u.id)) continue;
       birthdayMap.set(u.id, {
         id: u.id,
@@ -212,10 +218,49 @@ export async function loader({ request }: LoaderFunctionArgs) {
   ]);
 
   const friendIds = buildFriendIdSet(friendships, userId);
+
+  // Collect group-member IDs with FRIENDS_OF_FRIENDS birthday visibility that
+  // are not already direct friends — these need a mutual-friend check.
+  const fofCandidateIds = new Set<string>();
+  for (const m of memberships) {
+    for (const gm of m.giftGroup.groupMembers) {
+      const u = gm.user;
+      if (
+        u.id !== userId &&
+        u.birthdayVisibility === 'FRIENDS_OF_FRIENDS' &&
+        !friendIds.has(u.id)
+      ) {
+        fofCandidateIds.add(u.id);
+      }
+    }
+  }
+
+  // One extra query: find any friendship that links a FOF candidate to one of
+  // the viewer's direct friends, confirming the mutual-friend relationship.
+  const friendOfFriendIds = new Set<string>();
+  if (fofCandidateIds.size > 0) {
+    const friendIdArray = Array.from(friendIds);
+    const candidateArray = Array.from(fofCandidateIds);
+    const mutualLinks = await prisma.friendship.findMany({
+      where: {
+        OR: [
+          { userAId: { in: candidateArray }, userBId: { in: friendIdArray } },
+          { userBId: { in: candidateArray }, userAId: { in: friendIdArray } },
+        ],
+      },
+      select: { userAId: true, userBId: true },
+    });
+    for (const f of mutualLinks) {
+      const fofId = fofCandidateIds.has(f.userAId) ? f.userAId : f.userBId;
+      friendOfFriendIds.add(fofId);
+    }
+  }
+
   const now = new Date();
   const birthdayMap = collectUpcomingBirthdays(
     memberships,
     friendIds,
+    friendOfFriendIds,
     userId,
     now,
   );

--- a/app/routes/settings+/profile.index.test.tsx
+++ b/app/routes/settings+/profile.index.test.tsx
@@ -14,6 +14,7 @@ type LoaderUser = {
   bio: string | null;
   birthday: Date | null;
   birthdayVisibility: string;
+  wishlistVisibility: string;
   image: { id: string } | null;
   _count: { sessions: number };
 };
@@ -31,6 +32,7 @@ const loaderDataSnapshot: {
     bio: 'Mercenary with a mouth.',
     birthday: new Date('1992-05-26T00:00:00.000Z'),
     birthdayVisibility: 'FRIENDS',
+    wishlistVisibility: 'FRIENDS',
     image: { id: 'image-1' },
     _count: { sessions: 3 },
   },
@@ -129,16 +131,17 @@ describe('<SettingsProfileHub />', () => {
     expect(birthday.type).toBe('date');
   });
 
-  it('renders all three birthday visibility options with FRIENDS selected by default', () => {
+  it('renders all four birthday visibility options with FRIENDS selected by default', () => {
     const { container } = renderHub();
     const radios = container.querySelectorAll<HTMLInputElement>(
       'input[name="birthdayVisibility"]',
     );
-    expect(radios).toHaveLength(3);
+    expect(radios).toHaveLength(4);
     const byValue = new Map<string, HTMLInputElement>();
     radios.forEach((r) => byValue.set(r.value, r));
     expect(byValue.get('FRIENDS')?.checked).toBe(true);
     expect(byValue.get('EVERYONE')?.checked).toBe(false);
+    expect(byValue.get('FRIENDS_OF_FRIENDS')?.checked).toBe(false);
     expect(byValue.get('NOBODY')?.checked).toBe(false);
   });
 

--- a/app/routes/settings+/profile.index.tsx
+++ b/app/routes/settings+/profile.index.tsx
@@ -37,7 +37,10 @@ import {
   BirthdayVisibilitySchema,
   NameSchema,
   UsernameSchema,
+  WISHLIST_VISIBILITY_VALUES,
+  WishlistVisibilitySchema,
   type BirthdayVisibility,
+  type WishlistVisibility,
 } from '#app/utils/user-validation.ts';
 import { DangerZoneDeleteDialog } from './__danger-zone-delete-dialog.tsx';
 import { ProfilePhotoSheet } from './__profile-photo-sheet.tsx';
@@ -56,6 +59,7 @@ const ProfileFormSchema = z.object({
 
 const PrivacyFormSchema = z.object({
   birthdayVisibility: BirthdayVisibilitySchema,
+  wishlistVisibility: WishlistVisibilitySchema,
 });
 
 export async function loader({ request }: LoaderFunctionArgs) {
@@ -70,6 +74,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
       bio: true,
       birthday: true,
       birthdayVisibility: true,
+      wishlistVisibility: true,
       image: { select: { id: true } },
       _count: {
         select: {
@@ -340,20 +345,26 @@ function AccountCard() {
 
 // ─── Privacy card ──────────────────────────────────────────────────────────
 
-const PRIVACY_OPTIONS: ReadonlyArray<{
+const BIRTHDAY_PRIVACY_OPTIONS: ReadonlyArray<{
   value: BirthdayVisibility;
   label: string;
   description: string;
 }> = [
   {
-    value: 'FRIENDS',
-    label: 'Friends only',
-    description: 'Only people you’re friends with on GiftPool can see it.',
-  },
-  {
     value: 'EVERYONE',
     label: 'Everyone',
     description: 'Visible to anyone who lands on your profile.',
+  },
+  {
+    value: 'FRIENDS_OF_FRIENDS',
+    label: 'Friends of friends',
+    description:
+      'Visible to your friends and people who share mutual friends with you.',
+  },
+  {
+    value: 'FRIENDS',
+    label: 'Friends only',
+    description: "Only people you're friends with on GiftPool can see it.",
   },
   {
     value: 'NOBODY',
@@ -362,20 +373,115 @@ const PRIVACY_OPTIONS: ReadonlyArray<{
   },
 ];
 
+const WISHLIST_PRIVACY_OPTIONS: ReadonlyArray<{
+  value: WishlistVisibility;
+  label: string;
+  description: string;
+}> = [
+  {
+    value: 'EVERYONE',
+    label: 'Everyone',
+    description: 'Anyone with a GiftPool account can view your wishlist.',
+  },
+  {
+    value: 'FRIENDS_OF_FRIENDS',
+    label: 'Friends of friends',
+    description:
+      'Your friends and people who share mutual friends with you.',
+  },
+  {
+    value: 'FRIENDS',
+    label: 'Friends only',
+    description: "Only people you're friends with on GiftPool.",
+  },
+];
+
+function VisibilityRadioGroup<T extends string>({
+  legend,
+  name,
+  options,
+  selected,
+  onSubmit,
+}: {
+  legend: string;
+  name: string;
+  options: ReadonlyArray<{ value: T; label: string; description: string }>;
+  selected: T;
+  onSubmit: (value: T) => void;
+}) {
+  return (
+    <fieldset className="flex flex-col gap-3">
+      <legend className="mb-1 text-sm font-medium text-foreground">{legend}</legend>
+      {options.map((option) => {
+        const id = `${name}-${option.value}`;
+        const isSelected = selected === option.value;
+        return (
+          <label
+            key={option.value}
+            htmlFor={id}
+            aria-label={option.label}
+            className="flex cursor-pointer items-center gap-3 rounded-lg border border-border/60 bg-background/40 px-3 py-2.5 transition hover:border-border"
+            data-selected={isSelected || undefined}
+          >
+            <input
+              id={id}
+              type="radio"
+              name={name}
+              value={option.value}
+              checked={isSelected}
+              onChange={(event) => onSubmit(event.currentTarget.value as T)}
+              className="h-4 w-4 shrink-0 accent-primary"
+            />
+            <span className="flex flex-col gap-0.5">
+              <span className="text-sm font-medium text-foreground">
+                {option.label}
+              </span>
+              <span className="text-xs text-muted-foreground">
+                {option.description}
+              </span>
+            </span>
+          </label>
+        );
+      })}
+    </fieldset>
+  );
+}
+
 function PrivacyCard() {
   const data = useLoaderData<typeof loader>();
   const fetcher = useFetcher<typeof privacyUpdateAction>();
-  const currentValue =
+
+  const currentBirthday =
     (data.user.birthdayVisibility as BirthdayVisibility | undefined) ??
     'FRIENDS';
+  const currentWishlist =
+    (data.user.wishlistVisibility as WishlistVisibility | undefined) ??
+    'FRIENDS';
+
   // Optimistic reflection: while the fetcher is in-flight we show the
-  // pending value from its formData instead of waiting for the revalidation.
-  const pendingValue = fetcher.formData?.get('birthdayVisibility');
-  const selected =
-    typeof pendingValue === 'string' &&
-    (BIRTHDAY_VISIBILITY_VALUES as readonly string[]).includes(pendingValue)
-      ? (pendingValue as BirthdayVisibility)
-      : currentValue;
+  // pending values from its formData instead of waiting for revalidation.
+  const pendingBirthday = fetcher.formData?.get('birthdayVisibility');
+  const pendingWishlist = fetcher.formData?.get('wishlistVisibility');
+
+  const selectedBirthday =
+    typeof pendingBirthday === 'string' &&
+    (BIRTHDAY_VISIBILITY_VALUES as readonly string[]).includes(pendingBirthday)
+      ? (pendingBirthday as BirthdayVisibility)
+      : currentBirthday;
+
+  const selectedWishlist =
+    typeof pendingWishlist === 'string' &&
+    (WISHLIST_VISIBILITY_VALUES as readonly string[]).includes(pendingWishlist)
+      ? (pendingWishlist as WishlistVisibility)
+      : currentWishlist;
+
+  function submitPrivacy(patch: Partial<{ birthdayVisibility: BirthdayVisibility; wishlistVisibility: WishlistVisibility }>) {
+    const formData = new FormData();
+    formData.set('intent', privacyUpdateActionIntent);
+    formData.set('birthdayVisibility', patch.birthdayVisibility ?? selectedBirthday);
+    formData.set('wishlistVisibility', patch.wishlistVisibility ?? selectedWishlist);
+    void fetcher.submit(formData, { method: 'POST' });
+  }
 
   return (
     <Card padding="lg" className="flex flex-col gap-5">
@@ -383,47 +489,20 @@ function PrivacyCard() {
         title="Privacy"
         description="Control who can see personal details on your profile."
       />
-      <fieldset className="flex flex-col gap-3">
-        <legend className="text-sm font-medium text-foreground">
-          Birthday visibility
-        </legend>
-        {PRIVACY_OPTIONS.map((option) => {
-          const id = `birthday-visibility-${option.value}`;
-          const isSelected = selected === option.value;
-          return (
-            <label
-              key={option.value}
-              htmlFor={id}
-              aria-label={option.label}
-              className="flex cursor-pointer items-center gap-3 rounded-lg border border-border/60 bg-background/40 px-3 py-2.5 transition hover:border-border"
-              data-selected={isSelected || undefined}
-            >
-              <input
-                id={id}
-                type="radio"
-                name="birthdayVisibility"
-                value={option.value}
-                checked={isSelected}
-                onChange={(event) => {
-                  const formData = new FormData();
-                  formData.set('intent', privacyUpdateActionIntent);
-                  formData.set('birthdayVisibility', event.currentTarget.value);
-                  void fetcher.submit(formData, { method: 'POST' });
-                }}
-                className="h-4 w-4 shrink-0 accent-primary"
-              />
-              <span className="flex flex-col gap-0.5">
-                <span className="text-sm font-medium text-foreground">
-                  {option.label}
-                </span>
-                <span className="text-xs text-muted-foreground">
-                  {option.description}
-                </span>
-              </span>
-            </label>
-          );
-        })}
-      </fieldset>
+      <VisibilityRadioGroup
+        legend="Birthday visibility"
+        name="birthdayVisibility"
+        options={BIRTHDAY_PRIVACY_OPTIONS}
+        selected={selectedBirthday}
+        onSubmit={(value) => submitPrivacy({ birthdayVisibility: value })}
+      />
+      <VisibilityRadioGroup
+        legend="Wishlist visibility"
+        name="wishlistVisibility"
+        options={WISHLIST_PRIVACY_OPTIONS}
+        selected={selectedWishlist}
+        onSubmit={(value) => submitPrivacy({ wishlistVisibility: value })}
+      />
     </Card>
   );
 }
@@ -638,7 +717,10 @@ async function privacyUpdateAction({ userId, formData }: ProfileActionArgs) {
   await prisma.user.update({
     select: { id: true },
     where: { id: userId },
-    data: { birthdayVisibility: submission.value.birthdayVisibility },
+    data: {
+      birthdayVisibility: submission.value.birthdayVisibility,
+      wishlistVisibility: submission.value.wishlistVisibility,
+    },
   });
   return { result: submission.reply() };
 }

--- a/app/routes/w.public.$token.tsx
+++ b/app/routes/w.public.$token.tsx
@@ -113,6 +113,7 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
       id: true,
       name: true,
       username: true,
+      wishlistNote: true,
       wishlistItems: {
         select: {
           id: true,

--- a/app/routes/wishlist+/__wishlist-item-editor.server.test.ts
+++ b/app/routes/wishlist+/__wishlist-item-editor.server.test.ts
@@ -316,6 +316,60 @@ describe('app/routes/wishlist+/__wishlist-item-editor.server.tsx', () => {
     expect(queueLogEvent).not.toHaveBeenCalled();
   });
 
+  it('update-note persists the trimmed note and returns the intent', async () => {
+    const { cookie, user } = await createOwnerWithSession();
+
+    const formData = new FormData();
+    formData.set('intent', 'update-note');
+    formData.set('note', '  Thanks for checking out my wishlist!  ');
+
+    const response = await action(
+      toActionArgs({
+        context,
+        params: {},
+        request: createEditorRequest({ cookie, formData }),
+      }),
+    );
+
+    expect(getRouteResultStatus(response)).toBe(200);
+    await expect(getRouteResultData(response)).resolves.toMatchObject({
+      intent: 'update-note',
+    });
+
+    const updated = await prisma.user.findUnique({
+      select: { wishlistNote: true },
+      where: { id: user.id },
+    });
+    expect(updated?.wishlistNote).toBe('Thanks for checking out my wishlist!');
+  });
+
+  it('update-note clears the note when an empty string is submitted', async () => {
+    const { cookie, user } = await createOwnerWithSession();
+    // Pre-set a note
+    await prisma.user.update({
+      where: { id: user.id },
+      data: { wishlistNote: 'Old note' },
+    });
+
+    const formData = new FormData();
+    formData.set('intent', 'update-note');
+    formData.set('note', '   ');
+
+    await action(
+      toActionArgs({
+        context,
+        params: {},
+        request: createEditorRequest({ cookie, formData }),
+      }),
+    );
+
+    const updated = await prisma.user.findUnique({
+      select: { wishlistNote: true },
+      where: { id: user.id },
+    });
+    expect(updated?.wishlistNote).toBeNull();
+  });
+
   it('returns a result key (not a spread) when list-link URL validation fails', async () => {
     const { cookie } = await createOwnerWithSession();
 

--- a/app/routes/wishlist+/__wishlist-item-editor.server.tsx
+++ b/app/routes/wishlist+/__wishlist-item-editor.server.tsx
@@ -10,12 +10,18 @@ import {
   applyRequestIdHeader,
   getRequestContext,
 } from '#app/utils/request-context.server.ts';
+import { WishlistNoteSchema } from '#app/utils/user-validation.ts';
 import {
   processImageFromFile,
   processImageFromUrl,
   type WishlistItemImageSource,
 } from '#app/utils/wishlist-images.server.ts';
 import { WishlistItemSchema } from './__wishlist-item-editor';
+
+const UpdateNoteSchema = z.object({
+  intent: z.literal('update-note'),
+  note: WishlistNoteSchema,
+});
 const MAX_UPLOAD_SIZE = 1024 * 1024 * 10; // 10MB
 
 async function getNextSortOrderForCategory({
@@ -373,9 +379,27 @@ export async function action({ request }: ActionFunctionArgs) {
   const { requestId, sessionId } = await getRequestContext(request);
   const userId = await requireUserId(request);
   const formData = await request.formData();
+  const intentRaw = formData.get('intent');
+
+  if (intentRaw === 'update-note') {
+    const submission = parseWithZod(formData, { schema: UpdateNoteSchema });
+    if (submission.status !== 'success') {
+      return rrData(
+        { result: submission.reply() },
+        { status: submission.status === 'error' ? 400 : 200 },
+      );
+    }
+    await prisma.user.update({
+      select: { id: true },
+      where: { id: userId },
+      data: { wishlistNote: submission.value.note || null },
+    });
+    return rrData({ result: submission.reply(), intent: 'update-note' as const });
+  }
+
   const intent = z
     .enum(['save', 'save-add-another'])
-    .parse(formData.get('intent'));
+    .parse(intentRaw);
   const clientMutationId = getClientMutationId(formData);
   const submission = await parseWishlistItemSubmission(formData, userId);
   if (submission.status !== 'success') {

--- a/app/utils/friends.server.test.ts
+++ b/app/utils/friends.server.test.ts
@@ -5,6 +5,7 @@ import {
   acceptFriendRequest,
   getRelationshipDetails,
   getRelationshipState,
+  isFriendOfFriend,
   sendFriendRequest,
 } from '#app/utils/friends.server.ts';
 
@@ -92,6 +93,51 @@ describe('friends.server', () => {
     ).resolves.toBe('PENDING_INCOMING');
     const details = await getRelationshipDetails(sender.id, recipient.id);
     expect(details.state).toBe('PENDING_OUTGOING');
+  });
+
+  it('isFriendOfFriend returns true when viewer and owner share a mutual friend', async () => {
+    const [viewer, owner, mutual] = await Promise.all([
+      createUser(),
+      createUser(),
+      createUser(),
+    ]);
+    // Establish viewer ↔ mutual and owner ↔ mutual friendships
+    await Promise.all([
+      prisma.friendship.create({
+        data: { userAId: viewer.id, userBId: mutual.id },
+      }),
+      prisma.friendship.create({
+        data: { userAId: owner.id, userBId: mutual.id },
+      }),
+    ]);
+
+    await expect(isFriendOfFriend(viewer.id, owner.id)).resolves.toBe(true);
+  });
+
+  it('isFriendOfFriend returns false when no mutual friend exists', async () => {
+    const [viewer, owner, other] = await Promise.all([
+      createUser(),
+      createUser(),
+      createUser(),
+    ]);
+    // viewer knows other, owner knows nobody — no intersection
+    await prisma.friendship.create({
+      data: { userAId: viewer.id, userBId: other.id },
+    });
+
+    await expect(isFriendOfFriend(viewer.id, owner.id)).resolves.toBe(false);
+  });
+
+  it('isFriendOfFriend returns false when viewer and owner are direct friends (not FOF)', async () => {
+    const [viewer, owner] = await Promise.all([createUser(), createUser()]);
+    // Direct friendship — isFriendOfFriend should not count the principals
+    await prisma.friendship.create({
+      data: { userAId: viewer.id, userBId: owner.id },
+    });
+
+    // The viewer IS in the owner's friend list, but they are the principal —
+    // the function must exclude them from the intersection.
+    await expect(isFriendOfFriend(viewer.id, owner.id)).resolves.toBe(false);
   });
 
   it('acceptFriendRequest upserts the friendship and fires a fanout to the original sender', async () => {

--- a/app/utils/friends.server.ts
+++ b/app/utils/friends.server.ts
@@ -134,6 +134,41 @@ export async function listFriends(userId: string) {
   });
 }
 
+/**
+ * Returns true if `viewerId` is a friend-of-a-friend of `ownerId` — i.e. they
+ * share at least one mutual friend. Does NOT return true if they are already
+ * direct friends (call getRelationshipState first if you need that distinction).
+ */
+export async function isFriendOfFriend(
+  viewerId: string,
+  ownerId: string,
+): Promise<boolean> {
+  const [viewerFriendships, ownerFriendships] = await Promise.all([
+    prisma.friendship.findMany({
+      where: { OR: [{ userAId: viewerId }, { userBId: viewerId }] },
+      select: { userAId: true, userBId: true },
+    }),
+    prisma.friendship.findMany({
+      where: { OR: [{ userAId: ownerId }, { userBId: ownerId }] },
+      select: { userAId: true, userBId: true },
+    }),
+  ]);
+
+  const viewerFriendIds = new Set(
+    viewerFriendships.map((f) => (f.userAId === viewerId ? f.userBId : f.userAId)),
+  );
+
+  for (const f of ownerFriendships) {
+    const ownerFriendId = f.userAId === ownerId ? f.userBId : f.userAId;
+    // Exclude the two principals themselves from the intersection
+    if (ownerFriendId !== viewerId && viewerFriendIds.has(ownerFriendId)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 async function assertCanSendRequest(fromUserId: string, toUserId: string) {
   if (fromUserId === toUserId) {
     throw new Response('Cannot send a friend request to yourself', {

--- a/app/utils/user-validation.ts
+++ b/app/utils/user-validation.ts
@@ -49,9 +49,24 @@ export const BioSchema = z
 
 // SQLite doesn't support Prisma enums, so we store the value as a string and
 // enforce the union at the app layer. Keep these two in sync.
-export const BIRTHDAY_VISIBILITY_VALUES = ['FRIENDS', 'EVERYONE', 'NOBODY'] as const;
+// Ordered from most-visible to least-visible.
+export const BIRTHDAY_VISIBILITY_VALUES = ['EVERYONE', 'FRIENDS_OF_FRIENDS', 'FRIENDS', 'NOBODY'] as const;
 export type BirthdayVisibility = (typeof BIRTHDAY_VISIBILITY_VALUES)[number];
 export const BirthdayVisibilitySchema = z.enum(BIRTHDAY_VISIBILITY_VALUES);
+
+// Ordered from most-visible to least-visible. No 'NOBODY' — a hidden wishlist is
+// handled by not sharing the link rather than a visibility setting.
+export const WISHLIST_VISIBILITY_VALUES = ['EVERYONE', 'FRIENDS_OF_FRIENDS', 'FRIENDS'] as const;
+export type WishlistVisibility = (typeof WISHLIST_VISIBILITY_VALUES)[number];
+export const WishlistVisibilitySchema = z.enum(WISHLIST_VISIBILITY_VALUES);
+
+export const WISHLIST_NOTE_MAX_LENGTH = 400;
+export const WishlistNoteSchema = z
+  .string()
+  .max(WISHLIST_NOTE_MAX_LENGTH, {
+    message: `Message must be ${WISHLIST_NOTE_MAX_LENGTH} characters or fewer`,
+  })
+  .transform((v) => v.trim());
 
 // Accepts YYYY-MM-DD from a native date input, or an empty string (meaning
 // "clear the field"). Transforms to a Date at NOON UTC or null.

--- a/app/utils/wishlist-page.server.test.ts
+++ b/app/utils/wishlist-page.server.test.ts
@@ -21,9 +21,12 @@ vi.mock('./db.server.ts', () => ({
   },
 }));
 
+const isFriendOfFriend = vi.fn();
+
 vi.mock('./friends.server.ts', () => ({
   getRelationshipDetails: (...args: Array<unknown>) =>
     getRelationshipDetails(...args),
+  isFriendOfFriend: (...args: Array<unknown>) => isFriendOfFriend(...args),
 }));
 
 vi.mock('./analytics.server.ts', () => ({
@@ -41,6 +44,24 @@ import {
 } from './wishlist-page.server.ts';
 
 function createOwnerSummary(overrides?: Partial<{
+  id: string;
+  image: { id: string } | null;
+  name: string | null;
+  username: string;
+  wishlistVisibility: string;
+}>) {
+  return {
+    id: 'owner-1',
+    image: { id: 'image-1' },
+    name: 'Alex',
+    username: 'alex',
+    ...overrides,
+  };
+}
+
+// Creates the subset of the owner summary that the loader echoes back in
+// the `user` field (wishlistVisibility is stripped out before returning).
+function createExpectedUser(overrides?: Partial<{
   id: string;
   image: { id: string } | null;
   name: string | null;
@@ -101,6 +122,7 @@ beforeEach(() => {
   wishlistPublicShareFindUnique.mockReset();
   wishlistPublicShareFindUnique.mockResolvedValue(null);
   getRelationshipDetails.mockReset();
+  isFriendOfFriend.mockReset();
   queueLogEvent.mockReset();
   cleanupWishlistPurchasesForOwner.mockReset();
 });
@@ -152,7 +174,7 @@ describe('loadFriendWishlistPageData', () => {
         outgoingRequestId: null,
         state: 'NONE',
       },
-      user: createOwnerSummary(),
+      user: createExpectedUser(),
     });
 
     expect(userFindFirst).toHaveBeenCalledTimes(1);
@@ -197,7 +219,7 @@ describe('loadFriendWishlistPageData', () => {
         state: 'FRIENDS',
       },
       user: {
-        ...createOwnerSummary(),
+        ...createExpectedUser(),
         wishlistCategories: [
           { id: 'category-1', name: 'Books', order: 0 },
           { id: 'category-2', name: 'Games', order: 1 },
@@ -254,6 +276,82 @@ describe('loadFriendWishlistPageData', () => {
     });
     expect(cleanupWishlistPurchasesForOwner).toHaveBeenCalledWith('owner-1');
     expect(queueLogEvent).not.toHaveBeenCalled();
+  });
+
+  it('grants access for wishlistVisibility EVERYONE and loads wishlist details', async () => {
+    userFindFirst
+      .mockResolvedValueOnce(
+        createOwnerSummary({ wishlistVisibility: 'EVERYONE' }),
+      )
+      .mockResolvedValueOnce(createWishlistDetails());
+    getRelationshipDetails.mockResolvedValueOnce({ state: 'NONE' });
+
+    const result = await loadFriendWishlistPageData({
+      includeAnalytics: false,
+      username: 'alex',
+      viewerId: 'viewer-1',
+    });
+
+    expect(result).toMatchObject({ canViewWishlist: true });
+    expect(isFriendOfFriend).not.toHaveBeenCalled();
+  });
+
+  it('grants access for wishlistVisibility FRIENDS_OF_FRIENDS when viewer is a direct friend', async () => {
+    userFindFirst
+      .mockResolvedValueOnce(
+        createOwnerSummary({ wishlistVisibility: 'FRIENDS_OF_FRIENDS' }),
+      )
+      .mockResolvedValueOnce(createWishlistDetails());
+    getRelationshipDetails.mockResolvedValueOnce({
+      friendship: { id: 'friendship-1' },
+      state: 'FRIENDS',
+    });
+
+    const result = await loadFriendWishlistPageData({
+      includeAnalytics: false,
+      username: 'alex',
+      viewerId: 'viewer-1',
+    });
+
+    expect(result).toMatchObject({ canViewWishlist: true });
+    // Direct friend — should short-circuit before calling isFriendOfFriend
+    expect(isFriendOfFriend).not.toHaveBeenCalled();
+  });
+
+  it('grants access for wishlistVisibility FRIENDS_OF_FRIENDS when viewer shares a mutual friend', async () => {
+    userFindFirst
+      .mockResolvedValueOnce(
+        createOwnerSummary({ wishlistVisibility: 'FRIENDS_OF_FRIENDS' }),
+      )
+      .mockResolvedValueOnce(createWishlistDetails());
+    getRelationshipDetails.mockResolvedValueOnce({ state: 'NONE' });
+    isFriendOfFriend.mockResolvedValueOnce(true);
+
+    const result = await loadFriendWishlistPageData({
+      includeAnalytics: false,
+      username: 'alex',
+      viewerId: 'viewer-1',
+    });
+
+    expect(result).toMatchObject({ canViewWishlist: true });
+    expect(isFriendOfFriend).toHaveBeenCalledWith('viewer-1', 'owner-1');
+  });
+
+  it('denies access for wishlistVisibility FRIENDS_OF_FRIENDS when no mutual friend exists', async () => {
+    userFindFirst.mockResolvedValueOnce(
+      createOwnerSummary({ wishlistVisibility: 'FRIENDS_OF_FRIENDS' }),
+    );
+    getRelationshipDetails.mockResolvedValueOnce({ state: 'NONE' });
+    isFriendOfFriend.mockResolvedValueOnce(false);
+
+    const result = await loadFriendWishlistPageData({
+      includeAnalytics: false,
+      username: 'alex',
+      viewerId: 'viewer-1',
+    });
+
+    expect(result).toMatchObject({ canViewWishlist: false });
+    expect(isFriendOfFriend).toHaveBeenCalledWith('viewer-1', 'owner-1');
   });
 
   it('logs a server analytics event for friend views when enabled', async () => {

--- a/app/utils/wishlist-page.server.ts
+++ b/app/utils/wishlist-page.server.ts
@@ -2,7 +2,7 @@ import { invariantResponse } from '@epic-web/invariant';
 import { type WishlistUser } from '#app/components/wishlist';
 import { queueLogEvent } from './analytics.server.ts';
 import { prisma } from './db.server.ts';
-import { getRelationshipDetails } from './friends.server.ts';
+import { getRelationshipDetails, isFriendOfFriend } from './friends.server.ts';
 import { cleanupWishlistPurchasesForOwner } from './wishlist.server.ts';
 
 type Relationship = {
@@ -40,6 +40,7 @@ const friendWishlistOwnerSummarySelect = {
   id: true,
   name: true,
   username: true,
+  wishlistVisibility: true,
   image: {
     select: {
       id: true,
@@ -48,6 +49,7 @@ const friendWishlistOwnerSummarySelect = {
 } as const;
 
 const friendWishlistPageDetailsSelect = {
+  wishlistNote: true,
   wishlistItems: {
     select: {
       id: true,
@@ -160,7 +162,17 @@ export async function loadFriendWishlistAccess({
     wishlistOwner.id,
   );
   const relationship = buildRelationship(relationshipDetails);
-  const canViewWishlist = relationship.state === 'FRIENDS';
+
+  let canViewWishlist: boolean;
+  if (wishlistOwner.wishlistVisibility === 'EVERYONE') {
+    canViewWishlist = true;
+  } else if (wishlistOwner.wishlistVisibility === 'FRIENDS_OF_FRIENDS') {
+    canViewWishlist =
+      relationship.state === 'FRIENDS' ||
+      (await isFriendOfFriend(viewerId, wishlistOwner.id));
+  } else {
+    canViewWishlist = relationship.state === 'FRIENDS';
+  }
 
   return {
     canViewWishlist,
@@ -192,6 +204,7 @@ export async function loadOwnWishlistPageData({
       id: true,
       name: true,
       username: true,
+      wishlistNote: true,
       wishlistItems: {
         select: {
           id: true,
@@ -303,7 +316,17 @@ export async function loadFriendWishlistPageData({
     wishlistOwner.id,
   );
   const relationship = buildRelationship(relationshipDetails);
-  const canViewWishlist = relationship.state === 'FRIENDS';
+
+  let canViewWishlist: boolean;
+  if (wishlistOwner.wishlistVisibility === 'EVERYONE') {
+    canViewWishlist = true;
+  } else if (wishlistOwner.wishlistVisibility === 'FRIENDS_OF_FRIENDS') {
+    canViewWishlist =
+      relationship.state === 'FRIENDS' ||
+      (await isFriendOfFriend(viewerId, wishlistOwner.id));
+  } else {
+    canViewWishlist = relationship.state === 'FRIENDS';
+  }
 
   const userSummary = {
     id: wishlistOwner.id,
@@ -356,6 +379,7 @@ export async function loadFriendWishlistPageData({
     canViewWishlist: true,
     user: {
       ...userSummary,
+      wishlistNote: wishlistDetails.wishlistNote,
       wishlistItems,
       wishlistCategories: wishlistDetails.wishlistCategories,
     },

--- a/prisma/migrations/20260413235606_add_wishlist_visibility_and_note/migration.sql
+++ b/prisma/migrations/20260413235606_add_wishlist_visibility_and_note/migration.sql
@@ -1,0 +1,23 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_User" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "email" TEXT NOT NULL,
+    "username" TEXT NOT NULL,
+    "name" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    "bio" TEXT,
+    "birthday" DATETIME,
+    "birthdayVisibility" TEXT NOT NULL DEFAULT 'FRIENDS',
+    "wishlistVisibility" TEXT NOT NULL DEFAULT 'FRIENDS',
+    "wishlistNote" TEXT
+);
+INSERT INTO "new_User" ("bio", "birthday", "birthdayVisibility", "createdAt", "email", "id", "name", "updatedAt", "username") SELECT "bio", "birthday", "birthdayVisibility", "createdAt", "email", "id", "name", "updatedAt", "username" FROM "User";
+DROP TABLE "User";
+ALTER TABLE "new_User" RENAME TO "User";
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+CREATE UNIQUE INDEX "User_username_key" ON "User"("username");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,8 +18,13 @@ model User {
   birthday                     DateTime?
   // String, not a true enum — SQLite doesn't support enums natively. Valid
   // values are enforced at the app layer via `BirthdayVisibilitySchema`
-  // (see `app/utils/user-validation.ts`): 'FRIENDS' | 'EVERYONE' | 'NOBODY'.
+  // (see `app/utils/user-validation.ts`): 'EVERYONE' | 'FRIENDS_OF_FRIENDS' | 'FRIENDS' | 'NOBODY'.
   birthdayVisibility           String                        @default("FRIENDS")
+  // String, not a true enum — valid values enforced via `WishlistVisibilitySchema`
+  // (see `app/utils/user-validation.ts`): 'EVERYONE' | 'FRIENDS_OF_FRIENDS' | 'FRIENDS'.
+  wishlistVisibility           String                        @default("FRIENDS")
+  // Optional callout message shown at the top of the user's wishlist. Max 400 chars enforced at app layer.
+  wishlistNote                 String?
   address                      Address?
   connections                  Connection[]
   groupActivities              GroupActivity[]               @relation("GroupActivity_Actor")


### PR DESCRIPTION
## Summary

- **Birthday visibility** options reordered most-to-least visible (Everyone → Friends of friends → Friends only → Nobody) and a new "Friends of friends" tier added
- **Wishlist visibility** new setting in Privacy card (Everyone → Friends of friends → Friends only) — controls who can view your wishlist, enforced at the access layer with a new `isFriendOfFriend()` mutual-friend check
- **Wishlist note banner** — owners can add/edit a short callout message (≤ 400 chars) shown at the top of their wishlist; visible to all viewers including public share links; inline edit with character counter, no dialog

## Commits

1. `feat(schema)` — adds `wishlistVisibility` + `wishlistNote` columns + migration + updated validation constants
2. `feat(privacy)` — wishlist visibility access control, `isFriendOfFriend` utility, updated Privacy settings card
3. `feat(wishlist)` — `WishlistNote` component, `update-note` server action, integration in all wishlist views

## Test plan

- [ ] Settings → Privacy: birthday shows 4 options in correct order; wishlist shows 3 options; changing either saves immediately (optimistic)
- [ ] Set wishlist visibility to **Everyone** → non-friend (logged in) can view wishlist without friend gate
- [ ] Set wishlist visibility to **Friends of friends** → user sharing a mutual friend can view; user with no mutual connection is blocked
- [ ] Wishlist note: owner sees "Add a message…" prompt when empty; can type, preview inline, and save
- [ ] Note appears for friend view and public share link; not editable there
- [ ] `npm run typecheck` passes
- [ ] `npm test -- --run` all 747 tests pass