### PR TITLE
fix(server): intercept OPTIONS preflights before React Router

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -225,6 +225,12 @@ if (!ALLOW_INDEXING) {
   });
 }
 
+// Handle CORS preflight before React Router — React Router only accepts
+// GET/POST/PUT/PATCH/DELETE and throws on OPTIONS, causing Sentry noise.
+app.options('*', (_req, res) => {
+  res.sendStatus(204);
+});
+
 app.all(
   '*',
   createRequestHandler({

--- a/tests/e2e/cors-preflight.test.ts
+++ b/tests/e2e/cors-preflight.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from '#tests/playwright-utils.ts';
+
+/**
+ * Regression guard: confirms that CORS preflight OPTIONS requests are handled
+ * by Express before reaching React Router.
+ *
+ * React Router only handles GET/POST/PUT/PATCH/DELETE — an OPTIONS request
+ * that reaches its handler throws `Error: Invalid request method "OPTIONS"`,
+ * producing a 405 and Sentry noise (GIFTPOOL-UI-19, GIFTPOOL-UI-Z).
+ *
+ * The fix is an `app.options('*', ...)` handler registered in server/index.ts
+ * before the `createRequestHandler` catch-all.
+ */
+test('OPTIONS / returns 204 and never reaches React Router', async ({
+  page,
+}) => {
+  const response = await page.request.fetch('/', { method: 'OPTIONS' });
+  expect(response.status()).toBe(204);
+});


### PR DESCRIPTION
## Summary

- Adds `app.options('*', (_req, res) => res.sendStatus(204))` in `server/index.ts` before the `createRequestHandler` catch-all, so CORS preflight requests are handled by Express and never reach React Router
- React Router only accepts GET/POST/PUT/PATCH/DELETE; OPTIONS caused `Error: Invalid request method "OPTIONS"` and generated Sentry noise
- Adds an e2e regression guard (`tests/e2e/cors-preflight.test.ts`) that sends `OPTIONS /` and asserts a 204 response

Fixes GIFTPOOL-UI-19, Fixes GIFTPOOL-UI-Z

## Test plan

- [ ] `npm run typecheck` passes (verified locally)
- [ ] `npm test -- --run` passes — 769 tests, 129 files (verified locally)
- [ ] e2e test `cors-preflight.test.ts` can be run against a live server with `npm run test:e2e`