### PR TITLE
fix(resources): remove null default export from home.panels — Fixes GIFTPOOL-UI-13

### DIFF
--- a/app/routes/resources+/home.panels.test.ts
+++ b/app/routes/resources+/home.panels.test.ts
@@ -22,6 +22,7 @@ vi.mock('#app/utils/db.server', () => ({
   },
 }));
 
+import * as HomePanelsModule from './home.panels.tsx';
 import { loader } from './home.panels.tsx';
 
 function localCalendarDate(year: number, monthIndex: number, day: number) {
@@ -374,5 +375,13 @@ describe('app/routes/resources+/home.panels.tsx', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it('regression GIFTPOOL-UI-13: default export is not null (would crash SSR renderer)', () => {
+    // React Router SSR calls renderToString on the default export for every
+    // route module. An explicit `export default null` causes the renderer to
+    // throw "Element type is invalid … but got: null".  Resource-only routes
+    // must have NO default export (undefined), not null.
+    expect((HomePanelsModule as Record<string, unknown>)['default']).toBeUndefined();
   });
 });

--- a/app/routes/resources+/home.panels.tsx
+++ b/app/routes/resources+/home.panels.tsx
@@ -274,4 +274,3 @@ export async function loader({ request }: LoaderFunctionArgs) {
   }> = [];
   return { birthdays, activity };
 }
-export default null;


### PR DESCRIPTION
## Summary

- Removes `export default null` from `app/routes/resources+/home.panels.tsx`, which was causing React Router's SSR renderer to throw `Element type is invalid: expected a string or class/function but got: null` on every `GET /resources/home/panels` request (GIFTPOOL-UI-13, 13 events, first seen 2026-03-17)
- Resource-only routes (loader, no component) must have **no default export** — not `null` — consistent with all other resource routes in this codebase (`prefetch.friends.ts`, `prefetch.wishlist.ts`, etc.)
- Adds a regression test that asserts the module's default export is `undefined`

## Test plan

- [ ] `npm test -- --run` — all tests pass, including new regression test `regression GIFTPOOL-UI-13: default export is not null`
- [ ] `npm run typecheck` — no errors