### PR TITLE
fix(groups): catch clipboard.writeText rejection on iOS Safari (GIFTPOOL-UI-14)

### DIFF
--- a/app/routes/groups+/$giftGroupId_+/index.test.tsx
+++ b/app/routes/groups+/$giftGroupId_+/index.test.tsx
@@ -140,6 +140,36 @@ describe('group detail overview route', () => {
     ).toBeInTheDocument();
   });
 
+  it('does not throw when clipboard.writeText rejects after fetcher resolves', async () => {
+    clipboardWriteText.mockRejectedValue(
+      new DOMException(
+        'The request is not allowed by the user agent or the platform in the current context, possibly because the user denied permission.',
+        'NotAllowedError',
+      ),
+    );
+    loaderDataSnapshot.inviteLink = null;
+
+    const { rerender } = render(<GroupsDetailOverview />);
+
+    fetcherState.state = 'idle';
+    fetcherState.data = {
+      inviteUrl: 'https://giftpool.app/groups/join/invite-3',
+    };
+    rerender(<GroupsDetailOverview />);
+
+    // The clipboard rejection should be swallowed — the component must remain mounted
+    await waitFor(() => {
+      expect(clipboardWriteText).toHaveBeenCalledWith(
+        'https://giftpool.app/groups/join/invite-3',
+      );
+    });
+
+    // Component is still functional after the rejection
+    expect(
+      screen.getByRole('button', { name: /copy invite link/i }),
+    ).toBeInTheDocument();
+  });
+
   it('shows the admin-only fallback when invite creation is unavailable', () => {
     loaderDataSnapshot.canInvite = false;
     loaderDataSnapshot.inviteLink = null;

--- a/app/routes/groups+/$giftGroupId_+/index.tsx
+++ b/app/routes/groups+/$giftGroupId_+/index.tsx
@@ -42,7 +42,9 @@ const GiftGroupOverview = () => {
     const url = (createFetcher.data as any)?.inviteUrl as string | undefined;
     if (createFetcher.state === 'idle' && url) {
       setLocalInviteLink(url);
-      void navigator.clipboard.writeText(url);
+      navigator.clipboard.writeText(url).catch(() => {
+        // Clipboard access denied (iOS Safari requires a direct user gesture)
+      });
     }
   }, [createFetcher.state, createFetcher.data]);
 


### PR DESCRIPTION
## Summary

- Wraps `navigator.clipboard.writeText(url)` in a `.catch(() => {})` inside the `useEffect` that fires when the create-invite fetcher completes
- iOS Safari requires clipboard access to originate from a direct user gesture; firing it from a `useEffect` reacting to fetcher state loses that gesture context, producing an unhandled `NotAllowedError` that was reaching Sentry
- Adds a unit test that mocks `clipboard.writeText` to reject with a `NotAllowedError` and asserts the component remains mounted and functional

## Test plan

- [ ] `npm test -- --run "app/routes/groups+/\$giftGroupId_+/index.test.tsx"` — 4 tests pass including the new rejection test
- [ ] `npm run typecheck` — no errors
- [ ] Manually verify on iOS Safari: creating an invite link no longer surfaces a Sentry `NotAllowedError`

Fixes GIFTPOOL-UI-14