### PR TITLE
fix(root): guard isChunkLoadError for SSR + add root action to handle POST /

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -502,7 +502,11 @@ export const ErrorBoundary = () => {
   // Just make sure your root route never errors out and you'll always be able
   // to give the user a better UX.
 
-  const isChunkError = isChunkLoadError(error);
+  // Guard against SSR context where the .client.ts module resolves to
+  // undefined — calling an undefined value throws "isChunkLoadError is not a
+  // function" (GIFTPOOL-UI-17).
+  const isChunkError =
+    typeof isChunkLoadError === 'function' && isChunkLoadError(error);
 
   useEffect(() => {
     reloadOnceForChunkError(error);

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -220,6 +220,11 @@ export const headers: HeadersFunction = ({ loaderHeaders }) => {
   };
   return headers;
 };
+// The root route has no meaningful action handler. Return 405 for unexpected
+// POST requests (e.g. bots, stale forms) so React Router doesn't 405-error
+// with an unhandled "no action" message. (Fixes GIFTPOOL-UI-18, GIFTPOOL-UI-12)
+export const action = () =>
+  new Response('Method Not Allowed', { status: 405 });
 const ThemeFormSchema = z.object({
   theme: z.enum(['system', 'light', 'dark']),
 });

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -113,3 +113,18 @@ test.describe('Home page', () => {
     'snapshots of hero at mobile and desktop (baselines not yet committed)',
   );
 });
+
+test.describe('Root route resilience', () => {
+  test('POST / returns 405, not a 500', async ({ request }) => {
+    // Bots and stale forms sometimes POST to `/`. The root action should
+    // return a graceful 405 instead of letting React Router throw an
+    // unhandled "no action" error (GIFTPOOL-UI-18, GIFTPOOL-UI-12).
+    const response = await request.post('/');
+    expect(response.status()).toBe(405);
+  });
+
+  test('GET / still returns 200', async ({ request }) => {
+    const response = await request.get('/');
+    expect(response.status()).toBe(200);
+  });
+});


### PR DESCRIPTION
## Summary

- **Fixes GIFTPOOL-UI-17** (`TypeError: isChunkLoadError is not a function`): `chunk-error.client.ts` is a `.client.ts` module that may resolve to `undefined` during SSR. The `ErrorBoundary` in `root.tsx` called `isChunkLoadError(error)` unconditionally; added a `typeof isChunkLoadError === 'function'` guard so SSR rendering of the error page no longer crashes.
- **Fixes GIFTPOOL-UI-18 + GIFTPOOL-UI-12** (`POST / has no root action, 405`): React Router throws an unhandled "no action for route root" error when anything POSTs to `/` (bots, stale forms). Added a minimal `action` export that returns `405 Method Not Allowed`, intercepting these before React Router can 405-error. This also breaks the UI-17 ↔ UI-18 crash loop since the 405 response is now graceful.

## Test plan

- [ ] `npm run typecheck` passes
- [ ] `npm test -- --run` — `app/utils/chunk-error.client.test.ts` (12 tests) passes
- [ ] New e2e tests in `tests/e2e/home.spec.ts` under `Root route resilience`:
  - `POST / returns 405, not a 500`
  - `GET / still returns 200`