### PR TITLE
fix(top-bar): eliminate layout shift on header hide/show

### DIFF
--- a/app/components/nav/top-bar.test.tsx
+++ b/app/components/nav/top-bar.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+vi.mock('#app/components/nav/top/top-nav', () => ({
+  TopNav: () => <div data-testid="top-nav" />,
+}));
+
+import { TopBar } from './top-bar.tsx';
+
+describe('<TopBar />', () => {
+  let resizeCallback: ResizeObserverCallback;
+  const observeMock = vi.fn();
+  const disconnectMock = vi.fn();
+
+  beforeEach(() => {
+    observeMock.mockReset();
+    disconnectMock.mockReset();
+
+    vi.stubGlobal(
+      'ResizeObserver',
+      vi.fn((cb: ResizeObserverCallback) => {
+        resizeCallback = cb;
+        return { observe: observeMock, disconnect: disconnectMock };
+      }),
+    );
+
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+      height: 56,
+      bottom: 56,
+      left: 0,
+      right: 0,
+      top: 0,
+      width: 0,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    document.documentElement.style.removeProperty('--top-bar-height');
+  });
+
+  test('renders the top nav', () => {
+    render(<TopBar />);
+    expect(screen.getByTestId('top-nav')).toBeInTheDocument();
+  });
+
+  test('is visible by default', () => {
+    render(<TopBar />);
+    const header = screen.getByTestId('top-bar');
+    expect(header).not.toHaveClass('-translate-y-full');
+    expect(header).not.toHaveClass('pointer-events-none');
+    expect(header).not.toHaveClass('opacity-0');
+  });
+
+  test('applies hidden classes when hidden=true', () => {
+    render(<TopBar hidden />);
+    const header = screen.getByTestId('top-bar');
+    expect(header).toHaveClass('-translate-y-full');
+    expect(header).toHaveClass('pointer-events-none');
+    expect(header).toHaveClass('opacity-0');
+  });
+
+  test('uses --pwa-banner-height CSS variable for top offset', () => {
+    render(<TopBar />);
+    const header = screen.getByTestId('top-bar');
+    expect(header.style.top).toBe('var(--pwa-banner-height, 0px)');
+  });
+
+  test('sets --top-bar-height CSS variable after mount', () => {
+    render(<TopBar />);
+    expect(
+      document.documentElement.style.getPropertyValue('--top-bar-height'),
+    ).toBe('56px');
+  });
+
+  test('calls onHeightChange with measured height', () => {
+    const onHeightChange = vi.fn();
+    render(<TopBar onHeightChange={onHeightChange} />);
+    expect(onHeightChange).toHaveBeenCalledWith(56);
+  });
+
+  test('updates --top-bar-height when ResizeObserver fires with new height', () => {
+    render(<TopBar />);
+
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+      height: 72,
+      bottom: 72,
+      left: 0,
+      right: 0,
+      top: 0,
+      width: 0,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    });
+
+    act(() => {
+      resizeCallback([], {} as ResizeObserver);
+    });
+
+    expect(
+      document.documentElement.style.getPropertyValue('--top-bar-height'),
+    ).toBe('72px');
+  });
+
+  test('attaches ResizeObserver to the header element', () => {
+    render(<TopBar />);
+    expect(observeMock).toHaveBeenCalledTimes(1);
+    expect(observeMock).toHaveBeenCalledWith(screen.getByTestId('top-bar'));
+  });
+
+  test('disconnects ResizeObserver on unmount', () => {
+    const { unmount } = render(<TopBar />);
+    unmount();
+    expect(disconnectMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/components/nav/top-bar.tsx
+++ b/app/components/nav/top-bar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { useEffect, useLayoutEffect, useRef } from 'react';
 import { TopNav } from '#app/components/nav/top/top-nav';
 import { cn } from '#app/utils/misc.tsx';
 
@@ -13,7 +13,6 @@ export const TopBar = ({
   onHeightChange?: (height: number) => void;
 }) => {
   const headerRef = useRef<HTMLElement>(null);
-  const [measuredHeight, setMeasuredHeight] = useState<number>(0);
 
   useIsomorphicLayoutEffect(() => {
     const el = headerRef.current;
@@ -21,8 +20,13 @@ export const TopBar = ({
     const measure = () => {
       const height = el.getBoundingClientRect().height;
       if (height > 0) {
-        setMeasuredHeight(height);
         onHeightChange?.(height);
+        if (typeof document !== 'undefined') {
+          document.documentElement.style.setProperty(
+            '--top-bar-height',
+            `${height}px`,
+          );
+        }
       }
     };
     measure();
@@ -37,10 +41,9 @@ export const TopBar = ({
       data-hidden={hidden ? 'true' : 'false'}
       data-testid="top-bar"
       className={cn(
-        'sticky top-0 z-40 border-b border-surface-border bg-surface py-3 transition-[transform,opacity,margin] duration-200 ease-out will-change-transform sm:py-4',
+        'fixed top-0 z-40 w-full border-b border-surface-border bg-surface py-3 transition-[transform,opacity] duration-200 ease-out will-change-transform sm:py-4',
         hidden && 'pointer-events-none -translate-y-full opacity-0',
       )}
-      style={{ marginBottom: hidden ? -measuredHeight : 0 }}
     >
       <TopNav />
     </header>

--- a/app/components/nav/top-bar.tsx
+++ b/app/components/nav/top-bar.tsx
@@ -40,8 +40,9 @@ export const TopBar = ({
       ref={headerRef}
       data-hidden={hidden ? 'true' : 'false'}
       data-testid="top-bar"
+      style={{ top: 'var(--pwa-banner-height, 0px)' }}
       className={cn(
-        'fixed top-0 z-40 w-full border-b border-surface-border bg-surface py-3 transition-[transform,opacity] duration-200 ease-out will-change-transform sm:py-4',
+        'fixed z-40 w-full border-b border-surface-border bg-surface py-3 transition-[transform,opacity] duration-200 ease-out will-change-transform sm:py-4',
         hidden && 'pointer-events-none -translate-y-full opacity-0',
       )}
     >

--- a/app/root.banner-height.test.tsx
+++ b/app/root.banner-height.test.tsx
@@ -1,0 +1,314 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Covers the --pwa-banner-height ResizeObserver effect in root.tsx.
+ * All heavy dependencies are mocked; this test focuses solely on whether
+ * the CSS variable is set and cleared based on banner visibility.
+ */
+import { act, render } from '@testing-library/react';
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { testConsole } from '#tests/setup/setup-test-env.ts';
+
+// ─── Module mocks (must be hoisted above imports) ────────────────────────────
+
+const useLoaderData = vi.fn();
+const useLocation = vi.fn();
+const useNavigation = vi.fn();
+const useFetchers = vi.fn();
+const useRequestInfo = vi.fn();
+const useHints = vi.fn();
+const usePwaInstallPrompt = vi.fn();
+const useToast = vi.fn();
+const setPrefetchCacheScope = vi.fn();
+
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual('react-router');
+  return {
+    ...actual,
+    Links: () => null,
+    Meta: () => null,
+    Outlet: () => <div data-testid="route-outlet">Outlet</div>,
+    Scripts: () => null,
+    ScrollRestoration: () => null,
+    useFetchers: () => useFetchers(),
+    useLoaderData: () => useLoaderData(),
+    useLocation: () => useLocation(),
+    useNavigation: () => useNavigation(),
+  };
+});
+
+vi.mock('remix-utils/honeypot/react', () => ({
+  HoneypotProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), info: vi.fn(), success: vi.fn() },
+}));
+
+vi.mock('./components/error-boundary.tsx', () => ({
+  GeneralErrorBoundary: () => <div>error boundary</div>,
+}));
+
+vi.mock('./components/nav/bottom/bottom-nav.tsx', () => ({
+  BottomNav: () => <div>bottom nav</div>,
+}));
+
+vi.mock('./components/site-footer.tsx', () => ({
+  SiteFooter: () => <div>site footer</div>,
+}));
+
+vi.mock('./components/nav/top-bar.tsx', () => ({
+  TopBar: () => <div>top bar</div>,
+}));
+
+vi.mock('./components/notifications/notifications-context.tsx', () => ({
+  NotificationsProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+vi.mock('./components/progress-bar.tsx', () => ({
+  EpicProgress: () => <div />,
+}));
+
+vi.mock('./components/pwa-install-banner.tsx', () => ({
+  PwaInstallBanner: () => (
+    <div data-testid="pwa-install-banner">install banner</div>
+  ),
+}));
+
+vi.mock('./components/toaster.tsx', () => ({
+  useToast: (...args: Array<unknown>) => useToast(...args),
+}));
+
+vi.mock('./components/ui/icon.tsx', () => ({ href: '/icons.svg' }));
+
+vi.mock('./components/ui/sonner.tsx', () => ({
+  EpicToaster: () => null,
+}));
+
+vi.mock('./components/friends/friends-route-skeleton.tsx', () => ({
+  FriendsRouteSkeleton: () => <div />,
+}));
+
+vi.mock('./components/wishlist/wishlist-route-skeleton.tsx', () => ({
+  WishlistRouteSkeleton: () => <div />,
+}));
+
+vi.mock('./hooks/use-pwa-install-prompt.ts', () => ({
+  usePwaInstallPrompt: (...args: Array<unknown>) => usePwaInstallPrompt(...args),
+}));
+
+vi.mock('./utils/auth.server.ts', () => ({
+  getUserId: vi.fn(),
+  logout: vi.fn(),
+}));
+
+vi.mock('./utils/chunk-error.client.ts', () => ({
+  isChunkLoadError: () => false,
+  reloadOnceForChunkError: vi.fn(),
+}));
+
+vi.mock('./utils/client-hints.tsx', () => ({
+  ClientHintCheck: () => null,
+  getHints: vi.fn(),
+  useHints: () => useHints(),
+}));
+
+vi.mock('./utils/db.server.ts', () => ({
+  prisma: { user: { findUniqueOrThrow: vi.fn() } },
+}));
+
+vi.mock('./utils/honeypot.server.ts', () => ({ honeypot: {} }));
+
+vi.mock('./utils/i18n.tsx', () => ({
+  I18nProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  getLocaleFromRequest: vi.fn(),
+}));
+
+vi.mock('./utils/misc.tsx', () => ({
+  combineHeaders: vi.fn(),
+  getDomainUrl: vi.fn(),
+}));
+
+vi.mock('./utils/nonce-provider.ts', () => ({ useNonce: () => 'nonce' }));
+
+vi.mock('./utils/prefetch-cache.client.ts', () => ({
+  setPrefetchCacheScope: (...args: Array<unknown>) =>
+    setPrefetchCacheScope(...args),
+}));
+
+vi.mock('./utils/request-context.server.ts', () => ({
+  applyRequestIdHeader: vi.fn(),
+  getRequestContext: vi.fn(),
+}));
+
+vi.mock('./utils/request-info.ts', () => ({
+  useRequestInfo: () => useRequestInfo(),
+}));
+
+vi.mock('./utils/theme.server.ts', () => ({ getTheme: vi.fn() }));
+
+vi.mock('./utils/timing.server.ts', () => ({
+  makeTimings: vi.fn(),
+  time: vi.fn(),
+}));
+
+vi.mock('./utils/toast.server.ts', () => ({ getToast: vi.fn() }));
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+import AppWithProviders from './root.tsx';
+
+const BASE_LOADER_DATA = {
+  ENV: {},
+  honeyProps: {},
+  notifications: { unreadCount: 0 },
+  requestInfo: { locale: 'en', userPrefs: { theme: 'light' } },
+  toast: null,
+  user: null,
+};
+
+const BASE_LOCATION = { hash: '', pathname: '/', search: '' };
+
+const BASE_NAVIGATION = {
+  location: undefined,
+  state: 'idle',
+};
+
+function makePwaPrompt(overrides = {}) {
+  return {
+    capability: 'unavailable' as const,
+    dismissBanner: vi.fn(),
+    isPrompting: false,
+    manualPlatform: null,
+    promptInstall: vi.fn(),
+    shouldShowBanner: false,
+    ...overrides,
+  };
+}
+
+function setupMocks(pwaOverrides = {}) {
+  useLoaderData.mockReturnValue(BASE_LOADER_DATA);
+  useLocation.mockReturnValue(BASE_LOCATION);
+  useNavigation.mockReturnValue(BASE_NAVIGATION);
+  useFetchers.mockReturnValue([]);
+  useRequestInfo.mockReturnValue({
+    requestId: 'req-1',
+    userPrefs: { theme: 'light' },
+  });
+  useHints.mockReturnValue({ theme: 'light' });
+  usePwaInstallPrompt.mockReturnValue(makePwaPrompt(pwaOverrides));
+  useToast.mockReset();
+  setPrefetchCacheScope.mockReset();
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('root.tsx — PWA banner height CSS variable', () => {
+  let observeMock: ReturnType<typeof vi.fn>;
+  let disconnectMock: ReturnType<typeof vi.fn>;
+  let resizeCallback: ResizeObserverCallback;
+
+  beforeEach(() => {
+    // React fires recoverable internal warnings during concurrent-mode
+    // reconciliation in jsdom. Suppress to keep test output clean.
+    testConsole.error.mockImplementation(() => {});
+
+    observeMock = vi.fn();
+    disconnectMock = vi.fn();
+
+    vi.stubGlobal(
+      'ResizeObserver',
+      vi.fn((cb: ResizeObserverCallback) => {
+        resizeCallback = cb;
+        return { observe: observeMock, disconnect: disconnectMock };
+      }),
+    );
+
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+      height: 48,
+      bottom: 48,
+      left: 0,
+      right: 0,
+      top: 0,
+      width: 0,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    document.documentElement.style.removeProperty('--pwa-banner-height');
+  });
+
+  it('resets --pwa-banner-height to 0px when the banner is not shown', () => {
+    setupMocks({ shouldShowBanner: false });
+    render(<AppWithProviders />);
+    expect(
+      document.documentElement.style.getPropertyValue('--pwa-banner-height'),
+    ).toBe('0px');
+  });
+
+  it('sets --pwa-banner-height to the measured banner height when shown', () => {
+    setupMocks({ capability: 'prompt', shouldShowBanner: true });
+
+    render(<AppWithProviders />);
+
+    expect(
+      document.documentElement.style.getPropertyValue('--pwa-banner-height'),
+    ).toBe('48px');
+  });
+
+  it('updates --pwa-banner-height when the banner resizes', () => {
+    setupMocks({ capability: 'prompt', shouldShowBanner: true });
+
+    render(<AppWithProviders />);
+
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+      height: 96,
+      bottom: 96,
+      left: 0,
+      right: 0,
+      top: 0,
+      width: 0,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    });
+
+    act(() => {
+      resizeCallback([], {} as ResizeObserver);
+    });
+
+    expect(
+      document.documentElement.style.getPropertyValue('--pwa-banner-height'),
+    ).toBe('96px');
+  });
+
+  it('resets --pwa-banner-height to 0px when banner is dismissed', () => {
+    setupMocks({ capability: 'prompt', shouldShowBanner: true });
+
+    const { rerender } = render(<AppWithProviders />);
+
+    expect(
+      document.documentElement.style.getPropertyValue('--pwa-banner-height'),
+    ).toBe('48px');
+
+    setupMocks({ shouldShowBanner: false });
+
+    act(() => {
+      rerender(<AppWithProviders />);
+    });
+
+    expect(
+      document.documentElement.style.getPropertyValue('--pwa-banner-height'),
+    ).toBe('0px');
+  });
+});

--- a/app/root.banner-height.test.tsx
+++ b/app/root.banner-height.test.tsx
@@ -303,9 +303,7 @@ describe('root.tsx — PWA banner height CSS variable', () => {
 
     setupMocks({ shouldShowBanner: false });
 
-    act(() => {
-      rerender(<AppWithProviders />);
-    });
+    rerender(<AppWithProviders />);
 
     expect(
       document.documentElement.style.getPropertyValue('--pwa-banner-height'),

--- a/app/root.test.tsx
+++ b/app/root.test.tsx
@@ -223,4 +223,10 @@ describe('app/root.tsx', () => {
     expect(markup).not.toContain('data-testid="route-outlet"');
     expect(markup).not.toContain('data-testid="wishlist-route-skeleton"');
   });
+
+  it('applies --top-bar-height padding-top to the scroll container', () => {
+    const markup = renderToStaticMarkup(<AppWithProviders />);
+    expect(markup).toContain('style="padding-top:var(--top-bar-height)"');
+    expect(markup).toContain('data-testid="app-scroll-area"');
+  });
 });

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -433,6 +433,7 @@ const App = () => {
 
             <div
               ref={scrollRef}
+              style={{ paddingTop: 'var(--top-bar-height)' }}
               className="min-h-0 flex-1 overflow-y-auto bg-gradient-to-br from-background to-background-muted pb-bottom-nav sm:pb-0"
               data-testid="app-scroll-area"
             >

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -321,6 +321,28 @@ const App = () => {
   }, [installCapability, promptInstall]);
   const [hideHeader, setHideHeader] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
+  const bannerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = bannerRef.current;
+    if (!el) {
+      document.documentElement.style.setProperty('--pwa-banner-height', '0px');
+      return;
+    }
+    const measure = () => {
+      document.documentElement.style.setProperty(
+        '--pwa-banner-height',
+        `${el.getBoundingClientRect().height}px`,
+      );
+    };
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => {
+      ro.disconnect();
+      document.documentElement.style.setProperty('--pwa-banner-height', '0px');
+    };
+  }, [showPwaInstallBanner]);
   const location = useLocation();
   const navigation = useNavigation();
   const lastRouteKey = useRef(
@@ -411,23 +433,25 @@ const App = () => {
         >
           <div className="flex max-h-[100dvh] min-h-[100dvh] flex-col overflow-hidden">
             {showPwaInstallBanner ? (
-              <PwaInstallBanner
-                capability={installCapability}
-                isPrompting={isPrompting}
-                manualHref={
-                  installCapability === 'manual' && manualPlatform
-                    ? `/pwa-install?platform=${manualPlatform}`
-                    : '/pwa-install'
-                }
-                manualPlatform={manualPlatform}
-                onDismiss={dismissInstallBanner}
-                onDismissPermanently={() =>
-                  dismissInstallBanner({
-                    persist: true,
-                  })
-                }
-                onPromptInstall={handleInstallClick}
-              />
+              <div ref={bannerRef}>
+                <PwaInstallBanner
+                  capability={installCapability}
+                  isPrompting={isPrompting}
+                  manualHref={
+                    installCapability === 'manual' && manualPlatform
+                      ? `/pwa-install?platform=${manualPlatform}`
+                      : '/pwa-install'
+                  }
+                  manualPlatform={manualPlatform}
+                  onDismiss={dismissInstallBanner}
+                  onDismissPermanently={() =>
+                    dismissInstallBanner({
+                      persist: true,
+                    })
+                  }
+                  onPromptInstall={handleInstallClick}
+                />
+              </div>
             ) : null}
             <TopBar hidden={hideHeader} />
 

--- a/app/styles/tailwind.css
+++ b/app/styles/tailwind.css
@@ -72,6 +72,8 @@
     --pool: 174 66% 47%; /* #2EC4B6 in HSL */
     --pool-foreground: 0 0% 100%;
     --pool-badge-foreground: 0 0% 100%;
+    /* Height of top bar — updated at runtime by ResizeObserver in top-bar.tsx */
+    --top-bar-height: 3.5rem;
     /* Height of bottom nav including safe area for PWAs/iOS */
     --bottom-nav-height: calc(3.5rem + env(safe-area-inset-bottom));
 

--- a/app/styles/tailwind.css
+++ b/app/styles/tailwind.css
@@ -74,6 +74,8 @@
     --pool-badge-foreground: 0 0% 100%;
     /* Height of top bar — updated at runtime by ResizeObserver in top-bar.tsx */
     --top-bar-height: 3.5rem;
+    /* Height of PWA install banner — updated at runtime in root.tsx; 0 when not shown */
+    --pwa-banner-height: 0px;
     /* Height of bottom nav including safe area for PWAs/iOS */
     --bottom-nav-height: calc(3.5rem + env(safe-area-inset-bottom));
 


### PR DESCRIPTION
## Summary

- The header was using both `transform: translateY(-100%)` **and** `marginBottom: -measuredHeight` simultaneously to hide, with both animated over 200ms
- This caused the scroll container to grow by ~56px mid-scroll, disrupting iOS momentum deceleration and making flick-scrolls feel abnormally fast
- Fix: switch `TopBar` to `position: fixed` with a `--top-bar-height` CSS custom property (defaulting to `3.5rem` before JS measures); add a constant `padding-top: var(--top-bar-height)` to the scroll container so its bounds never change when the header hides or appears

## Root cause

```
Before: flex column → [TopBar: sticky, in flow] + [ScrollContainer: flex-1]
        When hidden: marginBottom: -56px → ScrollContainer grows 56px mid-scroll

After:  flex column → [TopBar: fixed, out of flow] + [ScrollContainer: flex-1, pt: 56px constant]
        When hidden: only transform changes → ScrollContainer bounds unchanged
```

## Test plan

- [ ] Open on mobile or Chrome DevTools mobile emulator
- [ ] Scroll down — header slides up with no content jump
- [ ] Flick fast upward — scroll speed feels consistent, no acceleration artifact
- [ ] Scroll back to top — header reappears smoothly
- [ ] Resize browser — ResizeObserver updates `--top-bar-height`, padding adjusts
- [ ] `npm run typecheck && npm run lint` pass
- [ ] `npm test -- --run` — all 771 tests pass