### PR TITLE
Group overhaul: group-first model, recipient privacy, overview rebuild

### DIFF
--- a/app/components/groups/GroupCard.tsx
+++ b/app/components/groups/GroupCard.tsx
@@ -76,7 +76,7 @@ export function GroupCard({
       {g.myRole !== 'MEMBER' ? (
         <div className="flex justify-end pt-3">
           <Link
-            to={`/groups/${g.id}/settings`}
+            to={`/groups/${g.id}`}
             className="flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-sm text-muted-foreground hover:bg-muted hover:text-foreground"
             onClick={(e) => e.stopPropagation()}
           >

--- a/app/components/groups/groups-surface.test.tsx
+++ b/app/components/groups/groups-surface.test.tsx
@@ -112,7 +112,7 @@ describe('group surface components', () => {
     expect(screen.getByText('4')).toBeInTheDocument();
     expect(
       screen.getByRole('link', { name: /manage/i }),
-    ).toHaveAttribute('href', '/groups/group-1/settings');
+    ).toHaveAttribute('href', '/groups/group-1');
 
     await userEvent.click(screen.getByRole('link', { name: 'Open group Family' }));
     expect(onOpen).toHaveBeenCalledTimes(1);

--- a/app/routes/groups+/$giftGroupId_+/index.test.tsx
+++ b/app/routes/groups+/$giftGroupId_+/index.test.tsx
@@ -23,6 +23,23 @@ const loaderDataSnapshot = {
   },
 };
 
+const overviewData = {
+  actionQueue: [] as Array<{
+    type: string;
+    priority: number;
+    poolId: string | null;
+    poolTitle: string | null;
+    recipientName: string;
+    eventDate: null;
+    daysUntilEvent: null;
+    ctaLabel: string;
+    ctaUrl: string;
+  }>,
+  activePools: [] as Array<unknown>,
+  upcomingOccasions: [] as Array<unknown>,
+  pastGifts: [] as Array<unknown>,
+};
+
 const fetcherState = {
   data: undefined as undefined | { inviteUrl?: string; status?: string },
   formData: undefined as FormData | undefined,
@@ -35,6 +52,11 @@ vi.mock('react-router', async () => {
 
   return {
     ...actual,
+    Link: ({ to, children, ...rest }: { to: string; children: React.ReactNode }) => (
+      <a href={to} {...rest}>
+        {children}
+      </a>
+    ),
     useFetcher: () => ({
       Form: (props: React.ComponentProps<'form'>) => <form {...props} />,
       data: fetcherState.data,
@@ -42,6 +64,7 @@ vi.mock('react-router', async () => {
       state: fetcherState.state,
       submit: fetcherState.submit,
     }),
+    useLoaderData: () => overviewData,
     useRouteLoaderData: () => loaderDataSnapshot,
   };
 });
@@ -77,6 +100,11 @@ beforeEach(() => {
   loaderDataSnapshot.inviteLink = 'https://giftpool.app/groups/join/invite-1';
   loaderDataSnapshot.viewer.contributionCents = 1500;
 
+  overviewData.actionQueue = [];
+  overviewData.activePools = [];
+  overviewData.upcomingOccasions = [];
+  overviewData.pastGifts = [];
+
   vi.stubGlobal('navigator', {
     clipboard: {
       writeText: clipboardWriteText,
@@ -85,15 +113,13 @@ beforeEach(() => {
 });
 
 describe('group detail overview route', () => {
-  it('renders an existing invite link and copies it on demand', async () => {
+  it('renders group essentials and copies invite link on demand', async () => {
     clipboardWriteText.mockResolvedValue(undefined);
 
     render(<GroupsDetailOverview />);
 
-    expect(screen.getByText('Group Information')).toBeInTheDocument();
-    expect(screen.getByText('Family')).toBeInTheDocument();
+    expect(screen.getByText('Group info')).toBeInTheDocument();
     expect(screen.getByText('Birthday planning')).toBeInTheDocument();
-    expect(screen.getByTestId('budget-amount')).toHaveTextContent('$15.00');
 
     await userEvent.click(
       screen.getByRole('button', { name: /copy invite link/i }),
@@ -111,7 +137,7 @@ describe('group detail overview route', () => {
     const { rerender } = render(<GroupsDetailOverview />);
 
     expect(
-      screen.getByRole('button', { name: /create & copy invite link/i }),
+      screen.getByRole('button', { name: /create invite link/i }),
     ).toBeInTheDocument();
 
     const pendingFormData = new FormData();
@@ -157,14 +183,12 @@ describe('group detail overview route', () => {
     };
     rerender(<GroupsDetailOverview />);
 
-    // The clipboard rejection should be swallowed — the component must remain mounted
     await waitFor(() => {
       expect(clipboardWriteText).toHaveBeenCalledWith(
         'https://giftpool.app/groups/join/invite-3',
       );
     });
 
-    // Component is still functional after the rejection
     expect(
       screen.getByRole('button', { name: /copy invite link/i }),
     ).toBeInTheDocument();
@@ -180,7 +204,73 @@ describe('group detail overview route', () => {
       screen.getByText('No active invite link. Ask an admin to create one.'),
     ).toBeInTheDocument();
     expect(
-      screen.queryByRole('button', { name: /create & copy invite link/i }),
+      screen.queryByRole('button', { name: /create invite link/i }),
     ).not.toBeInTheDocument();
+  });
+
+  it('renders the For You section with action items', () => {
+    overviewData.actionQueue = [
+      {
+        type: 'CAST_VOTE',
+        priority: 1,
+        poolId: 'pool-1',
+        poolTitle: 'Birthday Gift',
+        recipientName: 'Marco',
+        eventDate: null,
+        daysUntilEvent: null,
+        ctaLabel: 'Cast your vote',
+        ctaUrl: '/pools/pool-1',
+      },
+    ];
+
+    render(<GroupsDetailOverview />);
+
+    expect(screen.getByText('For you')).toBeInTheDocument();
+    expect(screen.getByText("Vote on Marco's gift")).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /cast your vote/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('shows empty state when action queue is empty', () => {
+    render(<GroupsDetailOverview />);
+
+    expect(screen.getByText('For you')).toBeInTheDocument();
+    expect(
+      screen.getByText(/all caught up/i),
+    ).toBeInTheDocument();
+  });
+
+  it('past gifts section toggles open and closed on click', async () => {
+    overviewData.pastGifts = [
+      {
+        id: 'past-1',
+        title: 'Birthday Gift',
+        status: 'DELIVERED',
+        occasionType: 'BIRTHDAY',
+        updatedAt: '2026-01-15T00:00:00.000Z',
+        recipientName: 'Alex',
+        recipientUsername: 'alex',
+        chosenIdeaName: 'Headphones',
+        totalCents: 5000,
+      },
+    ];
+
+    render(<GroupsDetailOverview />);
+
+    const toggle = screen.getByRole('button', { name: /past gifts/i });
+    expect(toggle).toBeInTheDocument();
+
+    // Initially collapsed — no gift row visible
+    expect(screen.queryByText('Headphones')).not.toBeInTheDocument();
+
+    // Click to expand
+    await userEvent.click(toggle);
+    expect(screen.getByText('Headphones')).toBeInTheDocument();
+    expect(screen.getByText('Alex')).toBeInTheDocument();
+
+    // Click again to collapse
+    await userEvent.click(toggle);
+    expect(screen.queryByText('Headphones')).not.toBeInTheDocument();
   });
 });

--- a/app/routes/groups+/$giftGroupId_+/index.test.tsx
+++ b/app/routes/groups+/$giftGroupId_+/index.test.tsx
@@ -23,18 +23,22 @@ const loaderDataSnapshot = {
   },
 };
 
+type ActionItemFixture = {
+  type: string;
+  priority: number;
+  poolId: string | null;
+  poolTitle: string | null;
+  recipientName: string;
+  eventDate: string | null;
+  daysUntilEvent: number | null;
+  ctaLabel: string;
+  ctaUrl: string;
+  description?: string;
+  amountCents?: number;
+};
+
 const overviewData = {
-  actionQueue: [] as Array<{
-    type: string;
-    priority: number;
-    poolId: string | null;
-    poolTitle: string | null;
-    recipientName: string;
-    eventDate: null;
-    daysUntilEvent: null;
-    ctaLabel: string;
-    ctaUrl: string;
-  }>,
+  actionQueue: [] as ActionItemFixture[],
   activePools: [] as Array<unknown>,
   upcomingOccasions: [] as Array<unknown>,
   pastGifts: [] as Array<unknown>,

--- a/app/routes/groups+/$giftGroupId_+/index.test.tsx
+++ b/app/routes/groups+/$giftGroupId_+/index.test.tsx
@@ -273,4 +273,128 @@ describe('group detail overview route', () => {
     await userEvent.click(toggle);
     expect(screen.queryByText('Headphones')).not.toBeInTheDocument();
   });
+
+  it('renders the active pools section with status chips and viewer role', () => {
+    overviewData.activePools = [
+      {
+        id: 'pool-1',
+        title: "Marco's Birthday",
+        occasionType: 'BIRTHDAY',
+        eventDate: '2026-05-03T00:00:00.000Z',
+        status: 'OPEN',
+        recipientName: 'Marco',
+        recipientUsername: 'marco',
+        ideaCount: 3,
+        contributorCount: 4,
+        paidCount: 0,
+        viewerRole: 'organizing' as const,
+        viewerContributionCents: 2500,
+      },
+    ];
+
+    render(<GroupsDetailOverview />);
+
+    expect(screen.getByText('Active pools')).toBeInTheDocument();
+    expect(screen.getByText("Marco's Birthday")).toBeInTheDocument();
+    expect(screen.getByText(/birthday for/i)).toBeInTheDocument();
+    expect(screen.getByText('Open')).toBeInTheDocument();
+    expect(screen.getByText('Organizing')).toBeInTheDocument();
+  });
+
+  it('renders the upcoming occasions section with start-pool links', () => {
+    overviewData.upcomingOccasions = [
+      {
+        userId: 'leo',
+        name: 'Leo',
+        username: 'leo',
+        daysUntil: 12,
+        imageId: null,
+        groupId: 'group-1',
+      },
+    ];
+
+    render(<GroupsDetailOverview />);
+
+    expect(screen.getByText('Coming up')).toBeInTheDocument();
+    expect(screen.getByText('Leo')).toBeInTheDocument();
+    expect(
+      screen.getAllByText((_, el) =>
+        /birthday in 12 days/i.test(el?.textContent ?? ''),
+      ).length,
+    ).toBeGreaterThan(0);
+    const startLink = screen.getByRole('link', { name: /start a pool/i });
+    expect(startLink).toHaveAttribute(
+      'href',
+      '/pools/new?groupId=group-1&recipientId=leo',
+    );
+  });
+
+  it('renders different action types with correct CTA labels and descriptions', () => {
+    overviewData.actionQueue = [
+      {
+        type: 'MARK_PAID',
+        priority: 2,
+        poolId: 'pool-1',
+        poolTitle: 'P',
+        recipientName: 'Marco',
+        eventDate: null,
+        daysUntilEvent: null,
+        ctaLabel: 'Mark as paid',
+        ctaUrl: '/pools/pool-1',
+        amountCents: 2500,
+      },
+      {
+        type: 'CHOOSE_GIFT',
+        priority: 1,
+        poolId: 'pool-2',
+        poolTitle: 'P2',
+        recipientName: 'Leo',
+        eventDate: null,
+        daysUntilEvent: null,
+        ctaLabel: 'Choose a gift',
+        ctaUrl: '/pools/pool-2',
+      },
+      {
+        type: 'IDEA_CHOSEN',
+        priority: 3,
+        poolId: 'pool-3',
+        poolTitle: 'P3',
+        recipientName: 'Sofia',
+        eventDate: null,
+        daysUntilEvent: null,
+        ctaLabel: 'View pool',
+        ctaUrl: '/pools/pool-3',
+      },
+      {
+        type: 'POOL_STUCK',
+        priority: 0,
+        poolId: 'pool-4',
+        poolTitle: 'P4',
+        recipientName: 'Ana',
+        eventDate: null,
+        daysUntilEvent: 3,
+        ctaLabel: 'Close voting',
+        ctaUrl: '/pools/pool-4',
+        description: '2 of 3 haven\'t voted yet — close voting?',
+      },
+    ];
+
+    render(<GroupsDetailOverview />);
+
+    expect(
+      screen.getByText("You owe $25.00 for Marco's gift"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Ideas are in — pick Leo's gift"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Your idea was picked for Sofia!'),
+    ).toBeInTheDocument();
+    // Server-provided description for POOL_STUCK
+    expect(
+      screen.getByText("2 of 3 haven't voted yet — close voting?"),
+    ).toBeInTheDocument();
+    // P0 urgency badge
+    expect(screen.getByText(/in 3 days/i)).toBeInTheDocument();
+  });
 });

--- a/app/routes/groups+/$giftGroupId_+/index.tsx
+++ b/app/routes/groups+/$giftGroupId_+/index.tsx
@@ -760,7 +760,10 @@ const InlineBudgetEditor = ({
         <span className="hidden items-center gap-2 sm:inline-flex">
           {value > 0 ? (
             <>
-              <span className="text-base font-bold text-foreground">
+              <span
+                className="text-base font-bold text-foreground"
+                data-testid="budget-amount"
+              >
                 ${dollars}
               </span>
               <Button

--- a/app/routes/groups+/$giftGroupId_+/index.tsx
+++ b/app/routes/groups+/$giftGroupId_+/index.tsx
@@ -1,5 +1,27 @@
 import { useEffect, useRef, useState } from 'react';
-import { useFetcher, useRouteLoaderData } from 'react-router';
+import {
+  LuAlarmClock,
+  LuTriangleAlert,
+  LuCake,
+  LuCheck,
+  LuChevronDown,
+  LuChevronRight,
+  LuGift,
+  LuHand,
+  LuLightbulb,
+  LuPackage,
+  LuStar,
+  LuTruck,
+  LuVote,
+  LuWallet,
+} from 'react-icons/lu';
+import {
+  type LoaderFunctionArgs,
+  Link,
+  useFetcher,
+  useLoaderData,
+  useRouteLoaderData,
+} from 'react-router';
 import { Button } from '#app/components/ui/button.tsx';
 import { Card } from '#app/components/ui/card.tsx';
 import {
@@ -14,17 +36,478 @@ import {
 import { Icon } from '#app/components/ui/icon.tsx';
 import { Input } from '#app/components/ui/input.tsx';
 import { Label } from '#app/components/ui/label.tsx';
+import { Flex, Stack, Text } from '#app/components/ui-kit';
 import { track } from '#app/utils/analytics.client.ts';
+import {
+  ACTION_TYPE,
+  type ActionItem,
+  type ActionType,
+  type PastGift,
+  type PoolSummary,
+  type UpcomingOccasion,
+} from '#app/utils/group-overview.ts';
+import { cn, getUserImgSrc } from '#app/utils/misc.tsx';
+import {
+  POOL_STATUS_LABELS,
+  OCCASION_TYPE_LABELS,
+  type PoolStatus,
+  type OccasionType,
+} from '#app/utils/pool-constants.ts';
 import {
   type loader as routeLoader,
   type action as routeAction,
 } from './__route.server';
 import { type action as settingsAction } from './settings';
 
+export async function loader({ params, request }: LoaderFunctionArgs) {
+  const groupId = params.giftGroupId!;
+  const { requireUserIdInGroup } = await import(
+    '#app/utils/groups.server.ts'
+  );
+  const { getGroupOverviewData } = await import(
+    '#app/utils/group-overview.server.ts'
+  );
+  const viewerId = await requireUserIdInGroup(request, groupId);
+  return getGroupOverviewData(groupId, viewerId);
+}
+
+// ─── Status chip colors (shared with pools list) ────────────────────────────
+
+const statusColors: Record<PoolStatus, string> = {
+  OPEN: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900 dark:text-emerald-200',
+  VOTING:
+    'bg-violet-100 text-violet-800 dark:bg-violet-900 dark:text-violet-200',
+  DECIDED:
+    'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200',
+  PURCHASED:
+    'bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200',
+  DELIVERED: 'bg-muted text-muted-foreground',
+  CANCELLED: 'bg-muted text-muted-foreground',
+};
+
+// ─── Action queue icon map ───────────────────────────────────────────────────
+
+const actionIcons: Record<ActionType, React.ReactNode> = {
+  [ACTION_TYPE.CAST_VOTE]: <LuVote className="text-violet-500" />,
+  [ACTION_TYPE.CLOSE_VOTE]: <LuHand className="text-violet-500" />,
+  [ACTION_TYPE.CALL_VOTE]: <LuVote className="text-violet-500" />,
+  [ACTION_TYPE.CHOOSE_GIFT]: <LuGift className="text-blue-500" />,
+  [ACTION_TYPE.MARK_PAID]: <LuWallet className="text-emerald-500" />,
+  [ACTION_TYPE.MARK_PURCHASED]: <LuPackage className="text-amber-500" />,
+  [ACTION_TYPE.MARK_DELIVERED]: <LuTruck className="text-amber-500" />,
+  [ACTION_TYPE.SET_CONTRIBUTION]: <LuWallet className="text-muted-foreground" />,
+  [ACTION_TYPE.PROPOSE_IDEA]: <LuLightbulb className="text-yellow-500" />,
+  [ACTION_TYPE.IDEA_CHOSEN]: <LuStar className="text-blue-500" />,
+  [ACTION_TYPE.UPCOMING_OCCASION]: <LuCake className="text-pink-500" />,
+  [ACTION_TYPE.POOL_STUCK]: <LuTriangleAlert className="text-orange-500" />,
+};
+
+// ─── Page component ──────────────────────────────────────────────────────────
+
 const GiftGroupOverview = () => {
+  const data = useLoaderData<typeof loader>();
   const { giftGroup, inviteLink, viewer, canInvite } = useRouteLoaderData<
     typeof routeLoader
   >('routes/groups+/$giftGroupId_+/_layout')!;
+
+  return (
+    <Stack gap={6}>
+      <ForYouSection
+        items={data.actionQueue}
+        nextOccasion={data.upcomingOccasions[0] ?? null}
+      />
+      <ActivePoolsSection
+        pools={data.activePools}
+        groupId={giftGroup.id}
+      />
+      <UpcomingOccasionsSection occasions={data.upcomingOccasions} />
+      <PastGiftsSection gifts={data.pastGifts} />
+      <GroupEssentialsCard
+        giftGroupId={giftGroup.id}
+        description={giftGroup.description}
+        contributionCents={viewer.contributionCents ?? 0}
+        inviteLink={inviteLink}
+        canInvite={canInvite}
+      />
+    </Stack>
+  );
+};
+export default GiftGroupOverview;
+
+// ─── For You ─────────────────────────────────────────────────────────────────
+
+const ForYouSection = ({
+  items,
+  nextOccasion,
+}: {
+  items: ActionItem[];
+  nextOccasion: UpcomingOccasion | null;
+}) => (
+  <section>
+    <SectionHeader title="For you" />
+    {items.length > 0 ? (
+      <Stack gap={2}>
+        {items.map((item, i) => (
+          <ActionQueueItem key={`${item.type}-${item.poolId ?? item.memberId}-${i}`} item={item} />
+        ))}
+      </Stack>
+    ) : (
+      <Card padding="md">
+        <Flex gap={3} align="center">
+          <LuCheck className="shrink-0 text-emerald-500" size={20} />
+          <Text size="sm" className="text-muted-foreground">
+            {nextOccasion
+              ? `All caught up. Next: ${nextOccasion.name}'s birthday in ${nextOccasion.daysUntil} days.`
+              : 'All caught up. No upcoming actions right now.'}
+          </Text>
+        </Flex>
+      </Card>
+    )}
+  </section>
+);
+
+const ActionQueueItem = ({ item }: { item: ActionItem }) => {
+  const isUrgent = item.priority === 0;
+  const isPrimary = item.priority <= 1;
+
+  const description = buildActionDescription(item);
+
+  return (
+    <Link to={item.ctaUrl} className="block">
+      <Card
+        padding="md"
+        className={cn(
+          'transition-shadow hover:shadow-md',
+          isUrgent && 'border-amber-300 dark:border-amber-700',
+        )}
+      >
+        <Flex justify="between" align="center" gap={3}>
+          <Flex gap={3} align="center" className="min-w-0 flex-1">
+            <span className="shrink-0 text-lg">{actionIcons[item.type]}</span>
+            <Stack gap={0} className="min-w-0 flex-1">
+              <Text size="sm" weight="medium" className="truncate">
+                {description}
+              </Text>
+              {isUrgent && item.daysUntilEvent !== null && (
+                <Flex gap={1} align="center">
+                  <LuAlarmClock className="text-amber-500" size={12} />
+                  <Text size="xs" className="text-amber-600 dark:text-amber-400">
+                    in {item.daysUntilEvent} {item.daysUntilEvent === 1 ? 'day' : 'days'}
+                  </Text>
+                </Flex>
+              )}
+            </Stack>
+          </Flex>
+          <Button
+            variant={isPrimary ? 'default' : 'secondary'}
+            size="sm"
+            className="shrink-0"
+            tabIndex={-1}
+          >
+            {item.ctaLabel}
+          </Button>
+        </Flex>
+      </Card>
+    </Link>
+  );
+};
+
+function buildActionDescription(item: ActionItem): string {
+  // Server-provided description wins (used for POOL_STUCK where copy depends
+  // on runtime state like idea count / vote counts).
+  if (item.description) return item.description;
+
+  switch (item.type) {
+    case ACTION_TYPE.PROPOSE_IDEA:
+      return `No ideas yet for ${item.recipientName}'s gift`;
+    case ACTION_TYPE.CALL_VOTE:
+      return `Ideas are in for ${item.recipientName} — call the vote?`;
+    case ACTION_TYPE.CHOOSE_GIFT:
+      return `Ideas are in — pick ${item.recipientName}'s gift`;
+    case ACTION_TYPE.CAST_VOTE:
+      return `Vote on ${item.recipientName}'s gift`;
+    case ACTION_TYPE.CLOSE_VOTE:
+      return `Voting open for ${item.recipientName} — close it?`;
+    case ACTION_TYPE.SET_CONTRIBUTION:
+      return `Set how much you'll chip in for ${item.recipientName}`;
+    case ACTION_TYPE.MARK_PAID:
+      return `You owe $${((item.amountCents ?? 0) / 100).toFixed(2)} for ${item.recipientName}'s gift`;
+    case ACTION_TYPE.MARK_PURCHASED:
+      return `${item.recipientName}'s gift decided — time to buy`;
+    case ACTION_TYPE.MARK_DELIVERED:
+      return `${item.recipientName}'s gift purchased — mark delivered`;
+    case ACTION_TYPE.IDEA_CHOSEN:
+      return `Your idea was picked for ${item.recipientName}!`;
+    case ACTION_TYPE.UPCOMING_OCCASION:
+      return `${item.recipientName}'s birthday in ${item.daysUntilEvent} days — no pool yet`;
+    default:
+      return '';
+  }
+}
+
+// ─── Active Pools ────────────────────────────────────────────────────────────
+
+const ACTIVE_POOLS_LIMIT = 5;
+
+const ActivePoolsSection = ({
+  pools,
+  groupId,
+}: {
+  pools: PoolSummary[];
+  groupId: string;
+}) => {
+  if (pools.length === 0) return null;
+
+  const visible = pools.slice(0, ACTIVE_POOLS_LIMIT);
+  const hasMore = pools.length > ACTIVE_POOLS_LIMIT;
+
+  return (
+    <section>
+      <SectionHeader
+        title="Active pools"
+        trailing={
+          <Text size="xs" className="text-muted-foreground">
+            {pools.length}
+          </Text>
+        }
+      />
+      <Stack gap={2}>
+        {visible.map((pool) => (
+          <PoolRow key={pool.id} pool={pool} />
+        ))}
+      </Stack>
+      {hasMore && (
+        <Link
+          to={`/groups/${groupId}/pools`}
+          className="mt-2 block text-center text-sm text-primary hover:underline"
+        >
+          See all active pools →
+        </Link>
+      )}
+    </section>
+  );
+};
+
+const PoolRow = ({ pool }: { pool: PoolSummary }) => {
+  const status = pool.status as PoolStatus;
+  const occasion = pool.occasionType as OccasionType;
+
+  const progressLabel =
+    status === 'DECIDED' || status === 'PURCHASED'
+      ? `${pool.paidCount} of ${pool.contributorCount} paid`
+      : pool.ideaCount > 0
+        ? `${pool.ideaCount} ${pool.ideaCount === 1 ? 'idea' : 'ideas'}`
+        : `${pool.contributorCount} ${pool.contributorCount === 1 ? 'contributor' : 'contributors'}`;
+
+  const viewerLabel =
+    pool.viewerRole === 'organizing'
+      ? 'Organizing'
+      : pool.viewerContributionCents
+        ? `$${(pool.viewerContributionCents / 100).toFixed(0)}`
+        : pool.viewerRole === 'contributing'
+          ? 'Contributing'
+          : null;
+
+  return (
+    <Link to={`/pools/${pool.id}`} className="block">
+      <Card padding="md" className="transition-shadow hover:shadow-md">
+        <Flex justify="between" align="start" gap={3}>
+          <Stack gap={1} className="min-w-0 flex-1">
+            <Text weight="semibold" className="truncate">
+              {pool.title}
+            </Text>
+            <Text size="sm" className="text-muted-foreground">
+              {OCCASION_TYPE_LABELS[occasion]} for{' '}
+              <span className="font-medium text-foreground">
+                {pool.recipientName}
+              </span>
+            </Text>
+            <Flex gap={2} align="center" className="mt-0.5">
+              <Text size="xs" className="text-muted-foreground">
+                {progressLabel}
+              </Text>
+              {viewerLabel && (
+                <>
+                  <span className="text-muted-foreground">·</span>
+                  <Text size="xs" className="font-medium text-foreground">
+                    {viewerLabel}
+                  </Text>
+                </>
+              )}
+              {pool.eventDate && (
+                <>
+                  <span className="text-muted-foreground">·</span>
+                  <Text size="xs" className="text-muted-foreground">
+                    {new Date(pool.eventDate).toLocaleDateString('en-US', {
+                      month: 'short',
+                      day: 'numeric',
+                    })}
+                  </Text>
+                </>
+              )}
+            </Flex>
+          </Stack>
+          <span
+            className={`shrink-0 rounded-full px-2.5 py-0.5 text-xs font-semibold ${statusColors[status]}`}
+          >
+            {POOL_STATUS_LABELS[status]}
+          </span>
+        </Flex>
+      </Card>
+    </Link>
+  );
+};
+
+// ─── Upcoming Occasions ──────────────────────────────────────────────────────
+
+const OCCASIONS_LIMIT = 5;
+
+const UpcomingOccasionsSection = ({
+  occasions,
+}: {
+  occasions: UpcomingOccasion[];
+}) => {
+  if (occasions.length === 0) return null;
+
+  const visible = occasions.slice(0, OCCASIONS_LIMIT);
+
+  return (
+    <section>
+      <SectionHeader title="Coming up" />
+      <Stack gap={2}>
+        {visible.map((o) => (
+          <OccasionRow key={o.userId} occasion={o} />
+        ))}
+      </Stack>
+    </section>
+  );
+};
+
+const OccasionRow = ({ occasion }: { occasion: UpcomingOccasion }) => (
+  <Card padding="md">
+    <Flex justify="between" align="center" gap={3}>
+      <Flex gap={3} align="center" className="min-w-0 flex-1">
+        <img
+          src={getUserImgSrc(occasion.imageId, { size: 64 })}
+          alt=""
+          className="h-8 w-8 shrink-0 rounded-full object-cover"
+        />
+        <Stack gap={0} className="min-w-0">
+          <Text size="sm" weight="medium" className="truncate">
+            {occasion.name}
+          </Text>
+          <Text size="xs" className="text-muted-foreground">
+            Birthday in {occasion.daysUntil}{' '}
+            {occasion.daysUntil === 1 ? 'day' : 'days'}
+          </Text>
+        </Stack>
+      </Flex>
+      <Button
+        asChild
+        variant="outline"
+        size="sm"
+        className="shrink-0"
+      >
+        <Link
+          to={`/pools/new?groupId=${occasion.groupId}&recipientId=${occasion.userId}`}
+        >
+          Start a pool
+        </Link>
+      </Button>
+    </Flex>
+  </Card>
+);
+
+// ─── Past Gifts ──────────────────────────────────────────────────────────────
+
+const PAST_GIFTS_LIMIT = 3;
+
+const PastGiftsSection = ({ gifts }: { gifts: PastGift[] }) => {
+  const [open, setOpen] = useState(false);
+
+  if (gifts.length === 0) return null;
+
+  return (
+    <section>
+      <button
+        onClick={() => setOpen(!open)}
+        className="mb-2 flex w-full items-center gap-1 text-left"
+      >
+        <Text size="sm" weight="semibold" className="text-muted-foreground">
+          Past gifts
+        </Text>
+        <Text size="xs" className="text-muted-foreground">
+          ({gifts.length})
+        </Text>
+        {open ? (
+          <LuChevronDown className="text-muted-foreground" size={14} />
+        ) : (
+          <LuChevronRight className="text-muted-foreground" size={14} />
+        )}
+      </button>
+      {open && (
+        <Stack gap={2}>
+          {gifts.slice(0, PAST_GIFTS_LIMIT).map((gift) => (
+            <PastGiftRow key={gift.id} gift={gift} />
+          ))}
+        </Stack>
+      )}
+    </section>
+  );
+};
+
+const PastGiftRow = ({ gift }: { gift: PastGift }) => {
+  const isCancelled = gift.status === 'CANCELLED';
+
+  return (
+    <Link to={`/pools/${gift.id}`} className="block">
+      <Card padding="sm" className="transition-shadow hover:shadow-md">
+        <Flex justify="between" align="center" gap={3}>
+          <Stack gap={0} className="min-w-0 flex-1">
+            <Flex gap={2} align="center">
+              <Text size="sm" weight="medium" className="truncate">
+                {gift.recipientName}
+              </Text>
+              <Text size="xs" className="text-muted-foreground">
+                · {OCCASION_TYPE_LABELS[gift.occasionType as OccasionType]}
+              </Text>
+            </Flex>
+            <Text size="xs" className="truncate text-muted-foreground">
+              {isCancelled
+                ? 'Cancelled'
+                : gift.chosenIdeaName ?? 'No gift chosen'}
+            </Text>
+          </Stack>
+          {!isCancelled && gift.totalCents > 0 && (
+            <Text
+              size="xs"
+              weight="medium"
+              className="shrink-0 text-muted-foreground"
+            >
+              ${(gift.totalCents / 100).toFixed(0)}
+            </Text>
+          )}
+        </Flex>
+      </Card>
+    </Link>
+  );
+};
+
+// ─── Group Essentials ────────────────────────────────────────────────────────
+
+const GroupEssentialsCard = ({
+  giftGroupId,
+  description,
+  contributionCents,
+  inviteLink,
+  canInvite,
+}: {
+  giftGroupId: string;
+  description: string | null;
+  contributionCents: number;
+  inviteLink: string | null;
+  canInvite: boolean;
+}) => {
   const createFetcher = useFetcher<typeof routeAction>();
   const [localInviteLink, setLocalInviteLink] = useState<string | null>(
     inviteLink,
@@ -42,208 +525,100 @@ const GiftGroupOverview = () => {
     const url = (createFetcher.data as any)?.inviteUrl as string | undefined;
     if (createFetcher.state === 'idle' && url) {
       setLocalInviteLink(url);
-      navigator.clipboard.writeText(url).catch(() => {
-        // Clipboard access denied (iOS Safari requires a direct user gesture)
-      });
+      navigator.clipboard.writeText(url).catch(() => {});
     }
   }, [createFetcher.state, createFetcher.data]);
 
   return (
-    <div className="grid gap-4 sm:gap-6 md:grid-cols-2">
-      <Card padding="lg">
-        <div className="mb-4 text-lg font-semibold">Group Information</div>
-        <div className="space-y-4 text-sm">
-          <div>
-            <div className="text-muted-foreground">Name</div>
-            <div className="text-foreground">{giftGroup.name}</div>
-          </div>
-          {giftGroup.description ? (
-            <div>
-              <div className="text-muted-foreground">Description</div>
-              <div className="text-foreground">{giftGroup.description}</div>
-            </div>
-          ) : null}
-          <div>
-            <div className="text-muted-foreground">Created</div>
-            <div className="text-foreground">
-              {new Date(
-                giftGroup.createdAt as unknown as string,
-              ).toLocaleDateString()}
-            </div>
-          </div>
-          <div>
-            <div className="text-muted-foreground">Your Contribution Limit</div>
-            <div>
-              <InlineBudgetEditor
-                giftGroupId={giftGroup.id}
-                initialCents={viewer.contributionCents ?? 0}
-              />
-            </div>
-            <div className="text-xs text-muted-foreground">
-              Maximum amount you'll contribute per gift
-            </div>
-          </div>
-        </div>
-      </Card>
-
-      <Card padding="lg">
-        <div className="mb-1 text-lg font-semibold">Invite Members</div>
-        <div className="mb-4 text-sm text-muted-foreground">
-          Share this link to invite new members to the group
-        </div>
-        {resolvedInviteLink ? (
-          <Button
-            variant="outline"
-            onClick={async () => {
-              await navigator.clipboard.writeText(resolvedInviteLink);
-            }}
+    <Card padding="md">
+      <Text size="sm" weight="semibold" className="text-muted-foreground">
+        Group info
+      </Text>
+      <Stack gap={3} className="mt-3">
+        {description && (
+          <Text size="sm" className="text-muted-foreground">
+            {description}
+          </Text>
+        )}
+        <Flex justify="between" align="center">
+          <Stack gap={0}>
+            <Text size="xs" className="text-muted-foreground">
+              Your per-gift cap
+            </Text>
+            <InlineBudgetEditor
+              giftGroupId={giftGroupId}
+              initialCents={contributionCents}
+            />
+          </Stack>
+        </Flex>
+        <div>
+          <Text
+            as="div"
+            size="xs"
+            className="mb-1.5 text-muted-foreground"
           >
-            <Icon name="copy" className="mr-2" /> Copy invite link
-          </Button>
-        ) : canInvite ? (
-          <createFetcher.Form
-            method="post"
-            action={`/groups/${giftGroup.id}`}
-          >
-            <input type="hidden" name="giftGroupId" value={giftGroup.id} />
-            <input type="hidden" name="intent" value="create-invite-link" />
-            <input type="hidden" name="expiresInDays" value="7" />
+            Invite link
+          </Text>
+          {resolvedInviteLink ? (
             <Button
               variant="outline"
-              disabled={createFetcher.state !== 'idle'}
+              size="sm"
+              onClick={async () => {
+                await navigator.clipboard.writeText(resolvedInviteLink);
+              }}
             >
-              <Icon name="link-2" className="mr-2" />
-              {createInvitePending
-                ? 'Creating...'
-                : 'Create & copy invite link'}
+              <Icon name="copy" className="mr-1.5" /> Copy invite link
             </Button>
-          </createFetcher.Form>
-        ) : (
-          <div className="text-sm text-muted-foreground">
-            No active invite link. Ask an admin to create one.
-          </div>
-        )}
-      </Card>
-    </div>
+          ) : canInvite ? (
+            <createFetcher.Form
+              method="post"
+              action={`/groups/${giftGroupId}`}
+            >
+              <input type="hidden" name="giftGroupId" value={giftGroupId} />
+              <input
+                type="hidden"
+                name="intent"
+                value="create-invite-link"
+              />
+              <input type="hidden" name="expiresInDays" value="7" />
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={createFetcher.state !== 'idle'}
+              >
+                <Icon name="link-2" className="mr-1.5" />
+                {createInvitePending ? 'Creating...' : 'Create invite link'}
+              </Button>
+            </createFetcher.Form>
+          ) : (
+            <Text size="xs" className="text-muted-foreground">
+              No active invite link. Ask an admin to create one.
+            </Text>
+          )}
+        </div>
+      </Stack>
+    </Card>
   );
 };
-export default GiftGroupOverview;
 
-// The rest of this file contains the inline budget editor used above.
+// ─── Shared ──────────────────────────────────────────────────────────────────
 
-/* const DeleteGroupDialog = ({ id }: { id: string }) => {
-  const actionData = useActionData<typeof action>();
-  const isPending = useIsPending();
-  const [form] = useForm({
-    id: GiftGroupIdFormIntent.DeleteGiftGroup,
-    lastResult: actionData,
-  });
+const SectionHeader = ({
+  title,
+  trailing,
+}: {
+  title: string;
+  trailing?: React.ReactNode;
+}) => (
+  <Flex justify="between" align="center" className="mb-2">
+    <Text size="sm" weight="semibold">
+      {title}
+    </Text>
+    {trailing}
+  </Flex>
+);
 
-  return (
-    <Dialog>
-      <DialogTrigger asChild>
-        <Button
-          variant={'destructive'}
-          onClick={() => track('group_deleted', { groupId: id })}
-        >
-          <Icon name="trash" className="scale-125 max-md:scale-150">
-            <span className="max-md:hidden">Delete</span>
-          </Icon>
-        </Button>
-      </DialogTrigger>
-      <DialogContent className="sm:max-w-[425px]">
-        <DialogHeader>
-          <DialogTitle>Delete group</DialogTitle>
-          <DialogDescription>
-            Warning! This action cannot be undone.
-          </DialogDescription>
-        </DialogHeader>
-        <div className="grid gap-4 py-4">
-          Are you sure you want to delete this group?
-        </div>
-        <DialogFooter>
-          <DialogClose asChild>
-            <Button variant={'secondary'} type="button">
-              Cancel
-            </Button>
-          </DialogClose>
-          <Form method="POST" {...getFormProps(form)}>
-            <input type="hidden" name="giftGroupId" value={id} />
-            <StatusButton
-              type="submit"
-              name="intent"
-              value={GiftGroupIdFormIntent.DeleteGiftGroup}
-              variant="destructive"
-              status={isPending ? 'pending' : (actionData?.status ?? 'idle')}
-              disabled={isPending}
-              className="w-full max-md:aspect-square max-md:px-0"
-            >
-              Delete group
-            </StatusButton>
-            <ErrorList errors={form.errors} id={form.errorId} />
-          </Form>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
-  );
-}; */
-
-/* const LeaveGroupDialog = ({ id }: { id: string }) => {
-  const actionData = useActionData<typeof action>();
-  const isPending = useIsPending();
-  const [form] = useForm({
-    id: GiftGroupIdFormIntent.LeaveGiftGroup,
-    lastResult: actionData,
-  });
-
-  return (
-    <Dialog>
-      <DialogTrigger asChild>
-        <Button
-          variant={'destructive'}
-          onClick={() => track('group_left', { groupId: id })}
-        >
-          <Icon name="exit" className="scale-125 max-md:scale-150">
-            <span className="max-md:hidden">Leave group</span>
-          </Icon>
-        </Button>
-      </DialogTrigger>
-      <DialogContent className="sm:max-w-[425px]">
-        <DialogHeader>
-          <DialogTitle>Leave group</DialogTitle>
-          <DialogDescription>
-            Are you sure you want to leave this group?
-          </DialogDescription>
-        </DialogHeader>
-        <DialogFooter>
-          <DialogClose asChild>
-            <Button variant={'secondary'} type="button">
-              Cancel
-            </Button>
-          </DialogClose>
-          <Form method="POST" {...getFormProps(form)}>
-            <input type="hidden" name="giftGroupId" value={id} />
-            <StatusButton
-              type="submit"
-              name="intent"
-              value={GiftGroupIdFormIntent.LeaveGiftGroup}
-              variant="destructive"
-              status={isPending ? 'pending' : (actionData?.status ?? 'idle')}
-              disabled={isPending}
-              className="w-full max-md:aspect-square max-md:px-0"
-            >
-              Leave group
-            </StatusButton>
-          </Form>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
-  );
-}; */
-
-// no skeletons/empty-state needed on overview
-
-// activity helpers not needed on the overview page
+// ─── Inline Budget Editor ────────────────────────────────────────────────────
 
 const InlineBudgetEditor = ({
   giftGroupId,
@@ -289,7 +664,7 @@ const InlineBudgetEditor = ({
   const submit = (next: number) => {
     const cents = Math.max(0, Math.round(next));
     pendingChangeRef.current = { previous: value };
-    setValue(cents); // optimistic
+    setValue(cents);
     const fd = new FormData();
     fd.set('intent', 'member-update-self');
     fd.set('giftGroupId', giftGroupId);
@@ -315,8 +690,7 @@ const InlineBudgetEditor = ({
     e.preventDefault();
   };
 
-  // Mobile: open modal instead of inline edit
-  const MobileButton = (
+  const MobileEditor = (
     <Dialog>
       <DialogTrigger asChild>
         {value > 0 ? (
@@ -324,7 +698,7 @@ const InlineBudgetEditor = ({
             ${dollars} <Icon name="pencil-1" className="ml-1" />
           </Button>
         ) : (
-          <Button>Set your budget</Button>
+          <Button size="sm">Set your budget</Button>
         )}
       </DialogTrigger>
       <DialogContent>
@@ -382,14 +756,11 @@ const InlineBudgetEditor = ({
   if (!editing) {
     return (
       <div className="flex items-center gap-2">
-        <span className="sm:hidden">{MobileButton}</span>
+        <span className="sm:hidden">{MobileEditor}</span>
         <span className="hidden items-center gap-2 sm:inline-flex">
           {value > 0 ? (
             <>
-              <span
-                className="text-xl font-bold text-foreground"
-                data-testid="budget-amount"
-              >
+              <span className="text-base font-bold text-foreground">
                 ${dollars}
               </span>
               <Button
@@ -402,7 +773,9 @@ const InlineBudgetEditor = ({
               </Button>
             </>
           ) : (
-            <Button onClick={() => setEditing(true)}>Set your budget</Button>
+            <Button size="sm" onClick={() => setEditing(true)}>
+              Set your budget
+            </Button>
           )}
         </span>
       </div>
@@ -420,8 +793,8 @@ const InlineBudgetEditor = ({
           'input[name="dollars"]',
         ) as HTMLInputElement;
         const next = Math.max(
-              0,
-              Math.round(Number.parseFloat(input.value || '0') * 100),
+          0,
+          Math.round(Number.parseFloat(input.value || '0') * 100),
         );
         submit(next);
         setEditing(false);

--- a/app/routes/groups+/$giftGroupId_+/index.tsx
+++ b/app/routes/groups+/$giftGroupId_+/index.tsx
@@ -288,25 +288,32 @@ const ActivePoolsSection = ({
   );
 };
 
+function buildProgressLabel(pool: PoolSummary): string {
+  if (pool.status === 'DECIDED' || pool.status === 'PURCHASED') {
+    return `${pool.paidCount} of ${pool.contributorCount} paid`;
+  }
+  if (pool.ideaCount > 0) {
+    const noun = pool.ideaCount === 1 ? 'idea' : 'ideas';
+    return `${pool.ideaCount} ${noun}`;
+  }
+  const noun = pool.contributorCount === 1 ? 'contributor' : 'contributors';
+  return `${pool.contributorCount} ${noun}`;
+}
+
+function buildViewerLabel(pool: PoolSummary): string | null {
+  if (pool.viewerRole === 'organizing') return 'Organizing';
+  if (pool.viewerContributionCents) {
+    return `$${(pool.viewerContributionCents / 100).toFixed(0)}`;
+  }
+  if (pool.viewerRole === 'contributing') return 'Contributing';
+  return null;
+}
+
 const PoolRow = ({ pool }: { pool: PoolSummary }) => {
   const status = pool.status as PoolStatus;
   const occasion = pool.occasionType as OccasionType;
-
-  const progressLabel =
-    status === 'DECIDED' || status === 'PURCHASED'
-      ? `${pool.paidCount} of ${pool.contributorCount} paid`
-      : pool.ideaCount > 0
-        ? `${pool.ideaCount} ${pool.ideaCount === 1 ? 'idea' : 'ideas'}`
-        : `${pool.contributorCount} ${pool.contributorCount === 1 ? 'contributor' : 'contributors'}`;
-
-  const viewerLabel =
-    pool.viewerRole === 'organizing'
-      ? 'Organizing'
-      : pool.viewerContributionCents
-        ? `$${(pool.viewerContributionCents / 100).toFixed(0)}`
-        : pool.viewerRole === 'contributing'
-          ? 'Contributing'
-          : null;
+  const progressLabel = buildProgressLabel(pool);
+  const viewerLabel = buildViewerLabel(pool);
 
   return (
     <Link to={`/pools/${pool.id}`} className="block">

--- a/app/routes/groups+/$giftGroupId_+/members.component.test.tsx
+++ b/app/routes/groups+/$giftGroupId_+/members.component.test.tsx
@@ -68,7 +68,9 @@ const layoutLoaderData = {
   viewer: { userId: 'viewer-1', role: 'OWNER' as const },
 };
 
-const overviewLoaderData = {
+const overviewLoaderData: {
+  activePoolsByRecipient: Record<string, { id: string; title: string }>;
+} = {
   activePoolsByRecipient: {
     marco: { id: 'pool-1', title: "Marco's Birthday" },
   },

--- a/app/routes/groups+/$giftGroupId_+/members.component.test.tsx
+++ b/app/routes/groups+/$giftGroupId_+/members.component.test.tsx
@@ -1,0 +1,168 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+const layoutLoaderData = {
+  giftGroup: {
+    id: 'group-1',
+    groupMembers: [
+      {
+        user: {
+          id: 'viewer-1',
+          username: 'viewer',
+          name: 'Viewer',
+          birthday: new Date('1990-05-01'),
+          image: null,
+        },
+        role: 'OWNER' as const,
+        contributionCents: 2000,
+        budgetVisibilityOverride: null,
+        friendRelationship: {
+          state: 'FRIENDS',
+          friendshipId: null,
+          incomingRequestId: null,
+          outgoingRequestId: null,
+        },
+      },
+      {
+        user: {
+          id: 'marco',
+          username: 'marco',
+          name: 'Marco',
+          birthday: new Date('1992-05-26'),
+          image: null,
+        },
+        role: 'MEMBER' as const,
+        contributionCents: 2000,
+        budgetVisibilityOverride: null,
+        friendRelationship: {
+          state: 'NONE',
+          friendshipId: null,
+          incomingRequestId: null,
+          outgoingRequestId: null,
+        },
+      },
+      {
+        user: {
+          id: 'alex',
+          username: 'alex',
+          name: 'Alex',
+          birthday: null,
+          image: null,
+        },
+        role: 'MEMBER' as const,
+        contributionCents: 2000,
+        budgetVisibilityOverride: null,
+        friendRelationship: {
+          state: 'NONE',
+          friendshipId: null,
+          incomingRequestId: null,
+          outgoingRequestId: null,
+        },
+      },
+    ],
+  },
+  viewer: { userId: 'viewer-1', role: 'OWNER' as const },
+};
+
+const overviewLoaderData = {
+  activePoolsByRecipient: {
+    marco: { id: 'pool-1', title: "Marco's Birthday" },
+  },
+};
+
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual('react-router');
+  return {
+    ...actual,
+    Link: ({
+      to,
+      children,
+      ...rest
+    }: {
+      to: string;
+      children: React.ReactNode;
+    }) => (
+      <a href={to} {...rest}>
+        {children}
+      </a>
+    ),
+    useFetcher: () => ({
+      Form: (props: React.ComponentProps<'form'>) => <form {...props} />,
+      data: undefined,
+      state: 'idle',
+      submit: vi.fn(),
+    }),
+    useFetchers: () => [],
+    useLoaderData: () => overviewLoaderData,
+    useRouteLoaderData: () => layoutLoaderData,
+  };
+});
+
+vi.mock('#app/components/friends/friend-action-button.tsx', () => ({
+  FriendActionButton: () => <div data-testid="friend-button" />,
+}));
+
+import GroupMembersRoute from './members.tsx';
+
+describe('Members tab — PoolActionForMember per row', () => {
+  it('shows "View pool" for members with an active pool', () => {
+    render(<GroupMembersRoute />);
+    const viewLink = screen.getByRole('link', { name: /^view pool$/i });
+    expect(viewLink).toHaveAttribute('href', '/pools/pool-1');
+    expect(viewLink).toHaveAttribute(
+      'title',
+      "View pool: Marco's Birthday",
+    );
+  });
+
+  it('omits the pool action for a member without a birthday and no active pool', () => {
+    render(<GroupMembersRoute />);
+    // Alex has no birthday and no active pool → no Start a pool link rendered.
+    // Marco's row provides the only "View pool" link — see other test.
+    const startLinks = screen.queryAllByRole('link', { name: /start a pool/i });
+    expect(startLinks).toHaveLength(0);
+  });
+
+  it('shows "Start a pool" for members with a birthday and no active pool', () => {
+    // Override the overview loader to remove the active pool entry — so
+    // Marco (who has a birthday) now needs a Start-a-pool CTA.
+    overviewLoaderData.activePoolsByRecipient = {};
+    try {
+      render(<GroupMembersRoute />);
+      const startLink = screen.getByRole('link', { name: /^start a pool$/i });
+      expect(startLink).toHaveAttribute(
+        'href',
+        '/pools/new?groupId=group-1&recipientId=marco',
+      );
+    } finally {
+      overviewLoaderData.activePoolsByRecipient = {
+        marco: { id: 'pool-1', title: "Marco's Birthday" },
+      };
+    }
+  });
+
+  it("hides the pool action on the viewer's own row", () => {
+    render(<GroupMembersRoute />);
+    // Viewer's row shows "viewer (You)" — confirm presence by partial match.
+    expect(
+      screen.getByText((_, el) => el?.textContent === 'viewer (You)'),
+    ).toBeInTheDocument();
+    // Total pool action links = 1 (only Marco's "View pool").
+    const allLinks = screen.getAllByRole('link');
+    const poolLinks = allLinks.filter((link) =>
+      /^(start a pool|view pool)$/i.test((link.textContent ?? '').trim()),
+    );
+    expect(poolLinks).toHaveLength(1);
+  });
+
+  it('renders "gift budget" labels for non-viewer rows', () => {
+    render(<GroupMembersRoute />);
+    const labels = screen.getAllByText(/gift budget/i);
+    // 3 members → 3 rows → 3 labels
+    expect(labels.length).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/app/routes/groups+/$giftGroupId_+/members.loader.test.ts
+++ b/app/routes/groups+/$giftGroupId_+/members.loader.test.ts
@@ -1,0 +1,120 @@
+/**
+ * @vitest-environment node
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { toLoaderArgs } from '#tests/route-module-test-utils.ts';
+
+const requireUserIdInGroup = vi.fn();
+const poolFindMany = vi.fn();
+
+vi.mock('#app/utils/groups.server.ts', () => ({
+  requireUserIdInGroup: (...args: Array<unknown>) =>
+    requireUserIdInGroup(...args),
+}));
+
+vi.mock('#app/utils/db.server.ts', () => ({
+  prisma: {
+    pool: {
+      findMany: (...args: Array<unknown>) => poolFindMany(...args),
+    },
+  },
+}));
+
+import { loader } from './members.tsx';
+
+beforeEach(() => {
+  requireUserIdInGroup.mockReset().mockResolvedValue('viewer-1');
+  poolFindMany.mockReset().mockResolvedValue([]);
+});
+
+describe('members tab loader — active pool cross-reference', () => {
+  it('returns an empty map when there are no active pools', async () => {
+    const result = await loader(
+      toLoaderArgs({
+        context: {} as never,
+        params: { giftGroupId: 'group-1' },
+        request: new Request('https://giftpool.app/groups/group-1/members'),
+      }),
+    );
+
+    expect(result).toEqual({ activePoolsByRecipient: {} });
+  });
+
+  it('indexes active pools by recipient user id', async () => {
+    poolFindMany.mockResolvedValue([
+      { id: 'pool-1', title: "Marco's Birthday", recipientUserId: 'marco' },
+      { id: 'pool-2', title: "Leo's Graduation", recipientUserId: 'leo' },
+    ]);
+
+    const result = await loader(
+      toLoaderArgs({
+        context: {} as never,
+        params: { giftGroupId: 'group-1' },
+        request: new Request('https://giftpool.app/groups/group-1/members'),
+      }),
+    );
+
+    expect(result).toEqual({
+      activePoolsByRecipient: {
+        marco: { id: 'pool-1', title: "Marco's Birthday" },
+        leo: { id: 'pool-2', title: "Leo's Graduation" },
+      },
+    });
+  });
+
+  it('skips pools without a recipient user id (standalone / name-only recipients)', async () => {
+    poolFindMany.mockResolvedValue([
+      { id: 'pool-1', title: 'Name-only recipient', recipientUserId: null },
+      { id: 'pool-2', title: "Marco's Birthday", recipientUserId: 'marco' },
+    ]);
+
+    const result = await loader(
+      toLoaderArgs({
+        context: {} as never,
+        params: { giftGroupId: 'group-1' },
+        request: new Request('https://giftpool.app/groups/group-1/members'),
+      }),
+    );
+
+    expect(result.activePoolsByRecipient).toEqual({
+      marco: { id: 'pool-2', title: "Marco's Birthday" },
+    });
+  });
+
+  it('enforces the privacy filter in the query (recipient must not see their own pool)', async () => {
+    await loader(
+      toLoaderArgs({
+        context: {} as never,
+        params: { giftGroupId: 'group-1' },
+        request: new Request('https://giftpool.app/groups/group-1/members'),
+      }),
+    );
+
+    expect(poolFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          giftGroupId: 'group-1',
+          recipientUserId: { not: 'viewer-1' },
+        }),
+      }),
+    );
+  });
+
+  it('only queries non-terminal pools (not DELIVERED or CANCELLED)', async () => {
+    await loader(
+      toLoaderArgs({
+        context: {} as never,
+        params: { giftGroupId: 'group-1' },
+        request: new Request('https://giftpool.app/groups/group-1/members'),
+      }),
+    );
+
+    const call = poolFindMany.mock.calls[0]?.[0] as
+      | { where: { status: { notIn: string[] } } }
+      | undefined;
+    expect(call?.where.status.notIn).toEqual(
+      expect.arrayContaining(['DELIVERED', 'CANCELLED']),
+    );
+  });
+});

--- a/app/routes/groups+/$giftGroupId_+/members.tsx
+++ b/app/routes/groups+/$giftGroupId_+/members.tsx
@@ -1,8 +1,11 @@
 import { useMemo } from 'react';
+import { LuGift, LuPlus } from 'react-icons/lu';
 import {
+  type LoaderFunctionArgs,
   Link,
   useFetcher,
   useFetchers,
+  useLoaderData,
   useRouteLoaderData,
 } from 'react-router';
 
@@ -15,9 +18,53 @@ import { Icon } from '#app/components/ui/icon.tsx';
 import { type loader as routeLoader } from './__route.server';
 import { applyPendingSettingsMemberMutations } from './__route.shared';
 
+export async function loader({ params, request }: LoaderFunctionArgs) {
+  const groupId = params.giftGroupId!;
+  const { requireUserIdInGroup } = await import(
+    '#app/utils/groups.server.ts'
+  );
+  const { prisma } = await import('#app/utils/db.server.ts');
+  const { POOL_STATUS } = await import('#app/utils/pool-constants.ts');
+
+  const viewerId = await requireUserIdInGroup(request, groupId);
+
+  // Privacy: exclude pools where the viewer is the recipient — they must
+  // not be able to see a "View pool" link for their own gift pool.
+  const activePools = await prisma.pool.findMany({
+    where: {
+      giftGroupId: groupId,
+      status: {
+        notIn: [POOL_STATUS.DELIVERED, POOL_STATUS.CANCELLED],
+      },
+      recipientUserId: { not: viewerId },
+    },
+    select: {
+      id: true,
+      title: true,
+      recipientUserId: true,
+    },
+  });
+
+  const activePoolsByRecipient: Record<
+    string,
+    { id: string; title: string }
+  > = {};
+  for (const pool of activePools) {
+    if (pool.recipientUserId) {
+      activePoolsByRecipient[pool.recipientUserId] = {
+        id: pool.id,
+        title: pool.title,
+      };
+    }
+  }
+
+  return { activePoolsByRecipient };
+}
+
 type GroupMemberRole = 'OWNER' | 'ADMIN' | 'MEMBER';
 
 const GroupMembersRoute = () => {
+  const { activePoolsByRecipient } = useLoaderData<typeof loader>();
   const { giftGroup, viewer } = useRouteLoaderData<typeof routeLoader>(
     'routes/groups+/$giftGroupId_+/_layout',
   )!;
@@ -237,12 +284,28 @@ const GroupMembersRoute = () => {
                 ) : null}
 
                 {!isViewer ? (
-                  <FriendActionButton
-                    targetUserId={m.user.id}
-                    targetUserName={memberDisplayName}
-                    relationship={friendRelationship}
-                    variant="compact"
-                  />
+                  <>
+                    <PoolActionForMember
+                      groupId={giftGroup.id}
+                      memberId={m.user.id}
+                      memberHasBirthday={birthday !== null}
+                      activePool={activePoolsByRecipient[m.user.id] ?? null}
+                    />
+                    <Link
+                      to={`/groups/${giftGroup.id}/members/${m.user.id}/history`}
+                      aria-label={`View gift history for ${memberDisplayName}`}
+                      title={`Gifts for ${memberDisplayName}`}
+                      className="inline-flex h-8 w-8 items-center justify-center rounded-xl text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+                    >
+                      <LuGift size={14} />
+                    </Link>
+                    <FriendActionButton
+                      targetUserId={m.user.id}
+                      targetUserName={memberDisplayName}
+                      relationship={friendRelationship}
+                      variant="compact"
+                    />
+                  </>
                 ) : null}
               </div>
             </li>
@@ -254,3 +317,42 @@ const GroupMembersRoute = () => {
 };
 
 export default GroupMembersRoute;
+
+type ActivePool = { id: string; title: string } | null;
+
+const PoolActionForMember = ({
+  groupId,
+  memberId,
+  memberHasBirthday,
+  activePool,
+}: {
+  groupId: string;
+  memberId: string;
+  memberHasBirthday: boolean;
+  activePool: ActivePool;
+}) => {
+  if (activePool) {
+    return (
+      <Link
+        to={`/pools/${activePool.id}`}
+        title={`View pool: ${activePool.title}`}
+        className="inline-flex h-8 items-center justify-center rounded-xl border border-input bg-background px-2.5 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+      >
+        View pool
+      </Link>
+    );
+  }
+
+  if (!memberHasBirthday) return null;
+
+  return (
+    <Link
+      to={`/pools/new?groupId=${groupId}&recipientId=${memberId}`}
+      title="Start a pool for this member"
+      className="inline-flex h-8 items-center justify-center gap-1 rounded-xl border border-input bg-background px-2.5 text-xs text-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+    >
+      <LuPlus size={12} />
+      Start a pool
+    </Link>
+  );
+};

--- a/app/routes/groups+/$giftGroupId_+/members.tsx
+++ b/app/routes/groups+/$giftGroupId_+/members.tsx
@@ -93,12 +93,12 @@ const GroupMembersRoute = () => {
               </Link>
 
               <div className="ml-auto flex items-center gap-3">
-                <div className="text-right">
+                <div className="text-right" title="Sum of everyone else's per-gift caps — what this person could receive">
                   <div className="text-sm font-semibold">
                     ${(giftBudget / 100).toFixed(2)}
                   </div>
                   <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
-                    budget
+                    gift budget
                   </div>
                 </div>
                 <RoleBadge role={m.role as any} />

--- a/app/routes/groups+/$giftGroupId_+/members_.$userId.history.component.test.tsx
+++ b/app/routes/groups+/$giftGroupId_+/members_.$userId.history.component.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { createRoutesStub } from 'react-router';
+import { describe, expect, it } from 'vitest';
+
+import MemberGiftHistoryPage from './members_.$userId.history.tsx';
+
+function renderWithLoader(loaderData: unknown) {
+  const App = createRoutesStub([
+    {
+      path: '/groups/:giftGroupId/members/:userId/history',
+      loader: async () => loaderData,
+      HydrateFallback: () => null,
+      Component: MemberGiftHistoryPage,
+    },
+  ]);
+  return render(
+    <App initialEntries={['/groups/g1/members/marco/history']} />,
+  );
+}
+
+describe('MemberGiftHistoryPage component', () => {
+  it('renders the empty state when no gifts have been delivered', async () => {
+    renderWithLoader({
+      member: { id: 'marco', username: 'marco', name: 'Marco' },
+      gifts: [],
+    });
+
+    expect(await screen.findByText('Gifts for Marco')).toBeInTheDocument();
+    expect(
+      screen.getByText('Past pools delivered to @marco in this group.'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('No gifts delivered yet.')).toBeInTheDocument();
+  });
+
+  it('renders gift rows with totals, occasion labels, and back link', async () => {
+    renderWithLoader({
+      member: { id: 'marco', username: 'marco', name: 'Marco' },
+      gifts: [
+        {
+          id: 'pool-1',
+          title: "Marco's 30th",
+          occasionType: 'BIRTHDAY',
+          eventDate: '2025-05-03T00:00:00.000Z',
+          deliveredAt: '2025-05-04T00:00:00.000Z',
+          giftName: 'Sony WH-1000XM5',
+          totalCents: 12500,
+        },
+        {
+          id: 'pool-2',
+          title: 'Anniversary thing',
+          occasionType: 'ANNIVERSARY',
+          eventDate: null,
+          deliveredAt: '2024-12-01T00:00:00.000Z',
+          giftName: null,
+          totalCents: 0,
+        },
+      ],
+    });
+
+    expect(await screen.findByText("Marco's 30th")).toBeInTheDocument();
+    expect(screen.getByText('Sony WH-1000XM5')).toBeInTheDocument();
+    expect(screen.getByText('$125.00')).toBeInTheDocument();
+    expect(
+      screen.getByText('No specific gift recorded'),
+    ).toBeInTheDocument();
+    // Back link is present
+    expect(
+      screen.getByRole('link', { name: /back to members/i }),
+    ).toBeInTheDocument();
+    // Both rows link to their pool
+    expect(
+      screen.getByRole('link', { name: /Marco's 30th/i }),
+    ).toHaveAttribute('href', '/pools/pool-1');
+  });
+});

--- a/app/routes/groups+/$giftGroupId_+/members_.$userId.history.test.ts
+++ b/app/routes/groups+/$giftGroupId_+/members_.$userId.history.test.ts
@@ -1,0 +1,187 @@
+/**
+ * @vitest-environment node
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { toLoaderArgs } from '#tests/route-module-test-utils.ts';
+
+const requireUserIdInGroup = vi.fn();
+const usersInGiftGroupsFindUnique = vi.fn();
+const poolFindMany = vi.fn();
+
+vi.mock('#app/utils/groups.server.ts', () => ({
+  requireUserIdInGroup: (...args: Array<unknown>) =>
+    requireUserIdInGroup(...args),
+}));
+
+vi.mock('#app/utils/db.server.ts', () => ({
+  prisma: {
+    usersInGiftGroups: {
+      findUnique: (...args: Array<unknown>) =>
+        usersInGiftGroupsFindUnique(...args),
+    },
+    pool: {
+      findMany: (...args: Array<unknown>) => poolFindMany(...args),
+    },
+  },
+}));
+
+import { loader } from './members_.$userId.history.tsx';
+
+beforeEach(() => {
+  requireUserIdInGroup.mockReset();
+  usersInGiftGroupsFindUnique.mockReset();
+  poolFindMany.mockReset().mockResolvedValue([]);
+});
+
+describe('member gift history loader', () => {
+  it('throws 404 when the viewer is the target member (privacy — no self-lookup)', async () => {
+    requireUserIdInGroup.mockResolvedValue('viewer-1');
+
+    await expect(
+      loader(
+        toLoaderArgs({
+          context: {} as never,
+          params: { giftGroupId: 'group-1', userId: 'viewer-1' },
+          request: new Request(
+            'https://giftpool.app/groups/group-1/members/viewer-1/history',
+          ),
+        }),
+      ),
+    ).rejects.toMatchObject({ status: 404 });
+
+    // Must not even query the DB for membership — the privacy check
+    // short-circuits before any data access.
+    expect(usersInGiftGroupsFindUnique).not.toHaveBeenCalled();
+    expect(poolFindMany).not.toHaveBeenCalled();
+  });
+
+  it('throws 404 when the target user is not a member of the group', async () => {
+    requireUserIdInGroup.mockResolvedValue('viewer-1');
+    usersInGiftGroupsFindUnique.mockResolvedValue(null);
+
+    await expect(
+      loader(
+        toLoaderArgs({
+          context: {} as never,
+          params: { giftGroupId: 'group-1', userId: 'stranger' },
+          request: new Request(
+            'https://giftpool.app/groups/group-1/members/stranger/history',
+          ),
+        }),
+      ),
+    ).rejects.toMatchObject({ status: 404 });
+
+    expect(poolFindMany).not.toHaveBeenCalled();
+  });
+
+  it('returns delivered pools where the target was the recipient, shaped with gift details', async () => {
+    requireUserIdInGroup.mockResolvedValue('viewer-1');
+    usersInGiftGroupsFindUnique.mockResolvedValue({
+      user: { id: 'marco', username: 'marco', name: 'Marco Rodríguez' },
+    });
+    poolFindMany.mockResolvedValue([
+      {
+        id: 'pool-1',
+        title: "Marco's 30th Birthday",
+        occasionType: 'BIRTHDAY',
+        eventDate: new Date('2025-05-03T00:00:00.000Z'),
+        updatedAt: new Date('2025-05-04T00:00:00.000Z'),
+        finalPriceCents: 15000,
+        chosenIdea: { name: 'Sony headphones' },
+        contributors: [
+          { contributionCents: 5000 },
+          { contributionCents: 5000 },
+          { contributionCents: 5000 },
+        ],
+      },
+    ]);
+
+    const result = await loader(
+      toLoaderArgs({
+        context: {} as never,
+        params: { giftGroupId: 'group-1', userId: 'marco' },
+        request: new Request(
+          'https://giftpool.app/groups/group-1/members/marco/history',
+        ),
+      }),
+    );
+
+    expect(result).toMatchObject({
+      member: { id: 'marco', username: 'marco', name: 'Marco Rodríguez' },
+      gifts: [
+        {
+          id: 'pool-1',
+          title: "Marco's 30th Birthday",
+          occasionType: 'BIRTHDAY',
+          giftName: 'Sony headphones',
+          totalCents: 15000,
+        },
+      ],
+    });
+  });
+
+  it('queries only DELIVERED pools scoped to this group and this recipient', async () => {
+    requireUserIdInGroup.mockResolvedValue('viewer-1');
+    usersInGiftGroupsFindUnique.mockResolvedValue({
+      user: { id: 'marco', username: 'marco', name: 'Marco' },
+    });
+    poolFindMany.mockResolvedValue([]);
+
+    await loader(
+      toLoaderArgs({
+        context: {} as never,
+        params: { giftGroupId: 'group-1', userId: 'marco' },
+        request: new Request(
+          'https://giftpool.app/groups/group-1/members/marco/history',
+        ),
+      }),
+    );
+
+    expect(poolFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          giftGroupId: 'group-1',
+          recipientUserId: 'marco',
+          status: 'DELIVERED',
+        },
+        orderBy: { updatedAt: 'desc' },
+      }),
+    );
+  });
+
+  it('falls back to summed contributions when finalPriceCents is null', async () => {
+    requireUserIdInGroup.mockResolvedValue('viewer-1');
+    usersInGiftGroupsFindUnique.mockResolvedValue({
+      user: { id: 'marco', username: 'marco', name: 'Marco' },
+    });
+    poolFindMany.mockResolvedValue([
+      {
+        id: 'pool-1',
+        title: 'Old pool',
+        occasionType: 'BIRTHDAY',
+        eventDate: null,
+        updatedAt: new Date('2025-01-01'),
+        finalPriceCents: null,
+        chosenIdea: null,
+        contributors: [
+          { contributionCents: 2000 },
+          { contributionCents: 3000 },
+          { contributionCents: null },
+        ],
+      },
+    ]);
+
+    const result = await loader(
+      toLoaderArgs({
+        context: {} as never,
+        params: { giftGroupId: 'group-1', userId: 'marco' },
+        request: new Request(
+          'https://giftpool.app/groups/group-1/members/marco/history',
+        ),
+      }),
+    );
+
+    expect(result.gifts[0]?.totalCents).toBe(5000);
+  });
+});

--- a/app/routes/groups+/$giftGroupId_+/members_.$userId.history.tsx
+++ b/app/routes/groups+/$giftGroupId_+/members_.$userId.history.tsx
@@ -1,0 +1,204 @@
+import { LuChevronLeft, LuGift } from 'react-icons/lu';
+import {
+  type LoaderFunctionArgs,
+  Link,
+  useLoaderData,
+} from 'react-router';
+import { Card } from '#app/components/ui/card.tsx';
+import { Flex, Stack, Text } from '#app/components/ui-kit';
+import { formatAbsoluteDate } from '#app/utils/dates.ts';
+import {
+  OCCASION_TYPE_LABELS,
+  POOL_STATUS,
+  type OccasionType,
+} from '#app/utils/pool-constants.ts';
+
+export async function loader({ params, request }: LoaderFunctionArgs) {
+  const groupId = params.giftGroupId!;
+  const memberUserId = params.userId!;
+  const { requireUserIdInGroup } = await import(
+    '#app/utils/groups.server.ts'
+  );
+  const { prisma } = await import('#app/utils/db.server.ts');
+
+  const viewerId = await requireUserIdInGroup(request, groupId);
+
+  // Privacy: the target member must never see their own gift history.
+  // 404 (indistinguishable from nonexistent route).
+  if (memberUserId === viewerId) {
+    throw new Response('Not Found', { status: 404 });
+  }
+
+  // Target user must be a member of this group (404 otherwise).
+  const membership = await prisma.usersInGiftGroups.findUnique({
+    where: {
+      userId_giftGroupId: { userId: memberUserId, giftGroupId: groupId },
+    },
+    select: {
+      user: {
+        select: {
+          id: true,
+          username: true,
+          name: true,
+        },
+      },
+    },
+  });
+
+  if (!membership) {
+    throw new Response('Not Found', { status: 404 });
+  }
+
+  const pools = await prisma.pool.findMany({
+    where: {
+      giftGroupId: groupId,
+      recipientUserId: memberUserId,
+      status: POOL_STATUS.DELIVERED,
+    },
+    select: {
+      id: true,
+      title: true,
+      occasionType: true,
+      eventDate: true,
+      updatedAt: true,
+      finalPriceCents: true,
+      chosenIdea: { select: { name: true } },
+      contributors: {
+        select: { contributionCents: true },
+      },
+    },
+    orderBy: { updatedAt: 'desc' },
+  });
+
+  const gifts = pools.map((pool) => ({
+    id: pool.id,
+    title: pool.title,
+    occasionType: pool.occasionType,
+    eventDate: pool.eventDate,
+    deliveredAt: pool.updatedAt,
+    giftName: pool.chosenIdea?.name ?? null,
+    totalCents:
+      pool.finalPriceCents ??
+      pool.contributors.reduce(
+        (sum, c) => sum + (c.contributionCents ?? 0),
+        0,
+      ),
+  }));
+
+  return {
+    member: {
+      id: membership.user.id,
+      username: membership.user.username,
+      name: membership.user.name ?? membership.user.username,
+    },
+    gifts,
+  };
+}
+
+const MemberGiftHistoryPage = () => {
+  const { member, gifts } = useLoaderData<typeof loader>();
+
+  return (
+    <Stack gap={4}>
+      <Link
+        to="../members"
+        relative="path"
+        className="inline-flex w-fit items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+      >
+        <LuChevronLeft size={14} />
+        Back to members
+      </Link>
+
+      <div>
+        <Text size="lg" weight="semibold" as="h2">
+          Gifts for {member.name}
+        </Text>
+        <Text size="sm" className="text-muted-foreground">
+          Past pools delivered to @{member.username} in this group.
+        </Text>
+      </div>
+
+      {gifts.length === 0 ? (
+        <Card padding="md">
+          <Flex gap={3} align="center">
+            <LuGift className="text-muted-foreground" size={18} />
+            <Text size="sm" className="text-muted-foreground">
+              No gifts delivered yet.
+            </Text>
+          </Flex>
+        </Card>
+      ) : (
+        <Stack gap={2}>
+          {gifts.map((gift) => (
+            <GiftHistoryRow key={gift.id} gift={gift} />
+          ))}
+        </Stack>
+      )}
+    </Stack>
+  );
+};
+
+export default MemberGiftHistoryPage;
+
+const GiftHistoryRow = ({
+  gift,
+}: {
+  gift: {
+    id: string;
+    title: string;
+    occasionType: string;
+    eventDate: Date | string | null;
+    deliveredAt: Date | string;
+    giftName: string | null;
+    totalCents: number;
+  };
+}) => {
+  const occasion = OCCASION_TYPE_LABELS[gift.occasionType as OccasionType];
+  const eventLabel = gift.eventDate
+    ? formatAbsoluteDate(gift.eventDate)
+    : formatAbsoluteDate(gift.deliveredAt);
+
+  return (
+    <Link to={`/pools/${gift.id}`} className="block">
+      <Card padding="md" className="transition-shadow hover:shadow-md">
+        <Flex justify="between" align="start" gap={3}>
+          <Stack gap={1} className="min-w-0 flex-1">
+            <Flex gap={2} align="center" wrap="wrap">
+              <Text weight="semibold" className="truncate">
+                {gift.title}
+              </Text>
+              <Text size="xs" className="text-muted-foreground">
+                · {occasion}
+              </Text>
+            </Flex>
+            <Text size="sm" className="text-muted-foreground">
+              {gift.giftName ? (
+                <>
+                  Gave:{' '}
+                  <span className="font-medium text-foreground">
+                    {gift.giftName}
+                  </span>
+                </>
+              ) : (
+                'No specific gift recorded'
+              )}
+            </Text>
+            <Text size="xs" className="text-muted-foreground">
+              {eventLabel}
+            </Text>
+          </Stack>
+          {gift.totalCents > 0 && (
+            <div className="shrink-0 text-right">
+              <Text size="sm" weight="semibold">
+                ${(gift.totalCents / 100).toFixed(2)}
+              </Text>
+              <Text size="xs" className="text-muted-foreground">
+                total
+              </Text>
+            </div>
+          )}
+        </Flex>
+      </Card>
+    </Link>
+  );
+};

--- a/app/routes/groups+/$giftGroupId_+/settings.tsx
+++ b/app/routes/groups+/$giftGroupId_+/settings.tsx
@@ -653,7 +653,9 @@ const GroupSettingsRoute = () => {
               Danger Zone
             </div>
             <div className="mb-3 text-sm text-destructive/80">
-              These actions cannot be undone. Please be careful.
+              These actions cannot be undone. Please be careful. As the owner,
+              you can't leave directly — transfer ownership first or delete
+              the group.
             </div>
             <Form method="post" id="delete-group-form">
               <input type="hidden" name="giftGroupId" value={giftGroup.id} />

--- a/app/routes/pools+/$poolId+/__route.server.test.ts
+++ b/app/routes/pools+/$poolId+/__route.server.test.ts
@@ -186,7 +186,49 @@ describe('pool detail route loader', () => {
           request: new Request('https://giftpool.app/pools/pool-1'),
         }),
       ),
-    ).rejects.toMatchObject({ init: { status: 404 } });
+    ).rejects.toMatchObject({ status: 404 });
+  });
+
+  it('throws 404 when the viewer is the recipient (privacy — must not confirm pool exists)', async () => {
+    poolFindUnique.mockResolvedValue(
+      createPool({ recipientUserId: 'viewer-1' }),
+    );
+
+    await expect(
+      loader(
+        toLoaderArgs({
+          context: {} as never,
+          params: { poolId: 'pool-1' },
+          request: new Request('https://giftpool.app/pools/pool-1'),
+        }),
+      ),
+    ).rejects.toMatchObject({ status: 404 });
+  });
+
+  it('throws 404 when the viewer is not a contributor (privacy — no 403 leak)', async () => {
+    poolFindUnique.mockResolvedValue(
+      createPool({
+        contributors: [
+          {
+            contributionCents: null,
+            hasPaid: false,
+            joinedAt: new Date('2026-01-01T00:00:00.000Z'),
+            user: { id: 'other-1', image: null, name: 'Other', username: 'other' },
+            userId: 'other-1',
+          },
+        ],
+      }),
+    );
+
+    await expect(
+      loader(
+        toLoaderArgs({
+          context: {} as never,
+          params: { poolId: 'pool-1' },
+          request: new Request('https://giftpool.app/pools/pool-1'),
+        }),
+      ),
+    ).rejects.toMatchObject({ status: 404 });
   });
 
   it('returns viewer state, vote, breakdown, and invite URL for decided pools', async () => {

--- a/app/routes/pools+/$poolId+/__route.server.test.ts
+++ b/app/routes/pools+/$poolId+/__route.server.test.ts
@@ -799,7 +799,8 @@ describe('pool detail route action', () => {
     expect(deletePool).not.toHaveBeenCalled();
   });
 
-  it('redirects after deleting the pool as organizer', async () => {
+  it('redirects to /pools after deleting a standalone pool as organizer', async () => {
+    // poolFindUnique returns a pool with giftGroupId: null by default
     const result = await action(
       toActionArgs({
         context: {} as never,
@@ -814,6 +815,30 @@ describe('pool detail route action', () => {
     expect(result).toBeInstanceOf(Response);
     expect(deletePool).toHaveBeenCalledWith('pool-1', 'viewer-1');
     expect(redirectWithToast).toHaveBeenCalledWith('/pools', {
+      description: 'The pool has been deleted.',
+      title: 'Pool deleted',
+      type: 'success',
+    });
+  });
+
+  it('redirects to the parent group after deleting a group-backed pool', async () => {
+    poolFindUnique.mockResolvedValue(
+      createPool({ giftGroupId: 'group-42' }),
+    );
+
+    await action(
+      toActionArgs({
+        context: {} as never,
+        params: { poolId: 'pool-1' },
+        request: createFormRequest({
+          intent: 'delete-pool',
+          poolId: 'pool-1',
+        }),
+      }),
+    );
+
+    expect(deletePool).toHaveBeenCalledWith('pool-1', 'viewer-1');
+    expect(redirectWithToast).toHaveBeenCalledWith('/groups/group-42', {
       description: 'The pool has been deleted.',
       title: 'Pool deleted',
       type: 'success',

--- a/app/routes/pools+/$poolId+/__route.server.ts
+++ b/app/routes/pools+/$poolId+/__route.server.ts
@@ -462,7 +462,13 @@ export async function action({ request, params }: ActionFunctionArgs) {
 				throw data({ error: 'Only the organizer can delete a pool.' }, { status: 403 })
 			}
 			await deletePool(poolId, userId)
-			return redirectWithToast('/pools', {
+			// If the pool belonged to a group, send the organizer back there
+			// rather than to the global pools list. Matches the Cancel button
+			// on /pools/new when launched from a group context.
+			const redirectTo = pool.giftGroupId
+				? `/groups/${pool.giftGroupId}`
+				: '/pools'
+			return redirectWithToast(redirectTo, {
 				type: 'success',
 				title: 'Pool deleted',
 				description: 'The pool has been deleted.',

--- a/app/routes/pools+/$poolId+/__route.server.ts
+++ b/app/routes/pools+/$poolId+/__route.server.ts
@@ -41,15 +41,22 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 	const userId = await requireUserId(request)
 	const poolId = params.poolId!
 
-	await requirePoolContributor(userId, poolId)
-
 	const pool = await prisma.pool.findUnique({
 		where: { id: poolId },
 		select: poolSelect,
 	})
 
-	if (!pool) {
-		throw data({ error: 'Pool not found.' }, { status: 404 })
+	// Privacy: the recipient of a pool must never be able to confirm it exists.
+	// Return 404 (indistinguishable from a nonexistent pool) rather than 403.
+	// Non-contributors also get 404 so the recipient case is not distinguishable
+	// from any other unauthorized viewer.
+	if (!pool || pool.recipientUserId === userId) {
+		throw new Response('Not Found', { status: 404 })
+	}
+
+	const isContributor = pool.contributors.some((c) => c.userId === userId)
+	if (!isContributor) {
+		throw new Response('Not Found', { status: 404 })
 	}
 
 	const poolForPerms: PoolForPermissions = {
@@ -247,8 +254,6 @@ export async function action({ request, params }: ActionFunctionArgs) {
 	const userId = await requireUserId(request)
 	const poolId = params.poolId!
 
-	await requirePoolContributor(userId, poolId)
-
 	const pool = await prisma.pool.findUnique({
 		where: { id: poolId },
 		select: {
@@ -258,12 +263,16 @@ export async function action({ request, params }: ActionFunctionArgs) {
 			status: true,
 			purchaserId: true,
 			delivererId: true,
+			recipientUserId: true,
 		},
 	})
 
-	if (!pool) {
+	// Privacy: same invariant as the loader — recipient never sees/mutates.
+	if (!pool || pool.recipientUserId === userId) {
 		throw data({ error: 'Pool not found.' }, { status: 404 })
 	}
+
+	await requirePoolContributor(userId, poolId)
 
 	const poolForPerms: PoolForPermissions = {
 		id: pool.id,

--- a/app/routes/pools+/$poolId+/_layout.tsx
+++ b/app/routes/pools+/$poolId+/_layout.tsx
@@ -1,7 +1,7 @@
-import { LuGift } from 'react-icons/lu'
-import { Outlet, useLoaderData } from 'react-router'
+import { LuGift, LuUsers } from 'react-icons/lu'
+import { Link, Outlet, useLoaderData } from 'react-router'
 import { PageHeader } from '#app/components/page-header.tsx'
-import { Stack } from '#app/components/ui-kit'
+import { Stack, Text } from '#app/components/ui-kit'
 import {
 	POOL_STATUS_LABELS,
 	OCCASION_TYPE_LABELS,
@@ -33,11 +33,15 @@ const PoolLayout = () => {
 		pool.recipientUser?.username ??
 		'Someone special'
 
+	const back = pool.giftGroup
+		? { label: pool.giftGroup.name, href: `/groups/${pool.giftGroup.id}` }
+		: { label: 'Pools', href: '/pools' }
+
 	return (
 		<div className="flex h-full min-h-0 flex-col">
 			<PageHeader
 				variant="detail"
-				back={{ label: 'Pools', href: '/pools' }}
+				back={back}
 				icon={<LuGift size={22} className="shrink-0 text-primary" />}
 				title={pool.title}
 				subtitle={`${OCCASION_TYPE_LABELS[occasion]} for ${recipientLabel}`}
@@ -53,6 +57,18 @@ const PoolLayout = () => {
 			<main className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto">
 				<div className="mx-auto max-w-6xl p-3 sm:p-6">
 					<Stack gap={6}>
+						{pool.giftGroup && (
+							<Link
+								to={`/groups/${pool.giftGroup.id}`}
+								className="inline-flex w-fit items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground"
+							>
+								<LuUsers size={12} />
+								<Text size="xs">In group</Text>
+								<Text size="xs" weight="medium" className="text-foreground">
+									{pool.giftGroup.name}
+								</Text>
+							</Link>
+						)}
 						<Outlet />
 					</Stack>
 				</div>

--- a/app/routes/pools+/$poolId+/index.tsx
+++ b/app/routes/pools+/$poolId+/index.tsx
@@ -560,6 +560,9 @@ const ContributorsList = ({
 		<Card className="p-4">
 			<Stack gap={3}>
 				<SectionHeading>Contributors ({contributors.length})</SectionHeading>
+				<p className="text-xs text-muted-foreground">
+					How much each person is chipping in for this one gift.
+				</p>
 				<Stack gap={2}>
 					{contributors.map(c => {
 						const isMe = c.userId === viewerUserId

--- a/app/routes/pools+/join.$code.test.tsx
+++ b/app/routes/pools+/join.$code.test.tsx
@@ -94,7 +94,7 @@ describe('app/routes/pools+/join.$code.tsx', () => {
     );
   });
 
-  it('redirects for missing codes, recipients, and existing contributors', async () => {
+  it('redirects to /pools when the URL is missing a code param', async () => {
     const missingCode = await loader(
       toLoaderArgs({
         context: {} as never,
@@ -104,31 +104,71 @@ describe('app/routes/pools+/join.$code.tsx', () => {
     );
     expect(missingCode).toBeInstanceOf(Response);
     expect((missingCode as Response).status).toBe(302);
+  });
 
+  it('throws 404 when the recipient loads their own pool invite (privacy — indistinguishable from invalid code)', async () => {
     findUnique.mockResolvedValueOnce(
       createInvitePool({ recipientUserId: 'viewer-1' }),
     );
-    const recipientRedirect = await loader(
-      toLoaderArgs({
-        context: {} as never,
-        params: { code: 'invite-1' },
-        request: new Request('https://giftpool.app/pools/join/invite-1'),
-      }),
-    );
-    expect((recipientRedirect as Response).status).toBe(302);
 
-    findUnique.mockResolvedValueOnce(createInvitePool());
+    await expect(
+      loader(
+        toLoaderArgs({
+          context: {} as never,
+          params: { code: 'invite-1' },
+          request: new Request('https://giftpool.app/pools/join/invite-1'),
+        }),
+      ),
+    ).rejects.toMatchObject({ status: 404 });
+  });
+
+  it('throws 404 for an invalid invite code', async () => {
+    findUnique.mockResolvedValueOnce(null);
+
+    await expect(
+      loader(
+        toLoaderArgs({
+          context: {} as never,
+          params: { code: 'bogus' },
+          request: new Request('https://giftpool.app/pools/join/bogus'),
+        }),
+      ),
+    ).rejects.toMatchObject({ status: 404 });
+  });
+
+  it('redirects existing contributors straight to the pool', async () => {
     isUserInPool.mockResolvedValueOnce(true);
-    const contributorRedirect = await loader(
+
+    const result = await loader(
       toLoaderArgs({
         context: {} as never,
         params: { code: 'invite-1' },
         request: new Request('https://giftpool.app/pools/join/invite-1'),
       }),
     );
-    expect((contributorRedirect as Response).headers.get('Location')).toBe(
-      '/pools/pool-1',
+
+    expect((result as Response).status).toBe(302);
+    expect((result as Response).headers.get('Location')).toBe('/pools/pool-1');
+  });
+
+  it('does NOT create a contributor row when the recipient submits their own invite (privacy)', async () => {
+    findUnique.mockResolvedValueOnce(
+      createInvitePool({ recipientUserId: 'viewer-1' }),
     );
+
+    await expect(
+      action(
+        toActionArgs({
+          context: {} as never,
+          params: { code: 'invite-1' },
+          request: new Request('https://giftpool.app/pools/join/invite-1', {
+            method: 'POST',
+          }),
+        }),
+      ),
+    ).rejects.toMatchObject({ status: 404 });
+
+    expect(createContributor).not.toHaveBeenCalled();
   });
 
   it('returns invite details for valid links', async () => {

--- a/app/routes/pools+/join.$code.tsx
+++ b/app/routes/pools+/join.$code.tsx
@@ -38,7 +38,7 @@ async function requireValidInvite(code: string) {
 	})
 
 	if (!pool) {
-		throw data({ error: 'Invite link not found.' }, { status: 404 })
+		throw new Response('Not Found', { status: 404 })
 	}
 
 	if (
@@ -58,9 +58,10 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
 	const userId = await requireUserId(request)
 	const pool = await requireValidInvite(code)
 
-	// If they're the recipient, quietly redirect — they shouldn't know this exists
+	// Privacy: if they're the recipient, 404 — indistinguishable from an
+	// invalid code. A redirect would be a signal that the code is valid.
 	if (pool.recipientUserId === userId) {
-		return redirect('/pools')
+		throw new Response('Not Found', { status: 404 })
 	}
 
 	// Already a contributor — just send them to the pool
@@ -90,7 +91,10 @@ export async function action({ params, request }: ActionFunctionArgs) {
 	const userId = await requireUserId(request)
 	const pool = await requireValidInvite(code)
 
-	if (pool.recipientUserId === userId) return redirect('/pools')
+	// Privacy: recipient must never be added as a contributor to their own pool.
+	if (pool.recipientUserId === userId) {
+		throw new Response('Not Found', { status: 404 })
+	}
 
 	const alreadyIn = await isUserInPool(userId, pool.id)
 	if (!alreadyIn) {

--- a/app/routes/pools+/new.test.tsx
+++ b/app/routes/pools+/new.test.tsx
@@ -270,6 +270,80 @@ describe('app/routes/pools+/new.tsx', () => {
     ).toBeChecked();
   });
 
+  it('filters candidates as the user types and selects one to fill the hidden field', async () => {
+    const userEvent = (await import('@testing-library/user-event')).default;
+    const App = createRoutesStub([
+      {
+        path: '/pools/new',
+        loader: async () => ({
+          groupContext: null,
+          candidates: [
+            { id: 'marco', name: 'Marco', username: 'marco', imageId: null },
+            { id: 'alex', name: 'Alex', username: 'alex', imageId: null },
+            {
+              id: 'leo',
+              name: 'Leonardo Bianchi',
+              username: 'leo',
+              imageId: null,
+            },
+          ],
+        }),
+        HydrateFallback: () => null,
+        Component: NewPoolPage,
+      },
+    ]);
+
+    const { container } = render(<App initialEntries={['/pools/new']} />);
+
+    const search = await screen.findByLabelText(
+      /Find a friend or group member/i,
+    );
+    await userEvent.type(search, 'leo');
+
+    // Dropdown shows Leonardo
+    const leoButton = await screen.findByRole('button', {
+      name: /Leonardo Bianchi/i,
+    });
+    expect(leoButton).toBeInTheDocument();
+
+    // Select
+    await userEvent.click(leoButton);
+
+    // After selection: chip shows the name; hidden input is set
+    expect(screen.getByText('Leonardo Bianchi')).toBeInTheDocument();
+    const hidden = container.querySelector(
+      'input[name="recipientUserId"]',
+    ) as HTMLInputElement | null;
+    expect(hidden?.value).toBe('leo');
+
+    // Clear and verify the search input returns
+    await userEvent.click(
+      screen.getByRole('button', { name: /clear selection/i }),
+    );
+    expect(
+      screen.getByLabelText(/Find a friend or group member/i),
+    ).toBeInTheDocument();
+  });
+
+  it('shows a helper hint when no candidates are available', async () => {
+    const App = createRoutesStub([
+      {
+        path: '/pools/new',
+        loader: async () => ({ groupContext: null, candidates: [] }),
+        HydrateFallback: () => null,
+        Component: NewPoolPage,
+      },
+    ]);
+
+    render(<App initialEntries={['/pools/new']} />);
+
+    expect(
+      await screen.findByText(
+        /Once you add friends or join groups, they'll show up here/i,
+      ),
+    ).toBeInTheDocument();
+  });
+
   it('creates a group-backed pool with re-derived member defaults', async () => {
     // Organizer is a member of the group
     usersInGiftGroupsFindUnique

--- a/app/routes/pools+/new.test.tsx
+++ b/app/routes/pools+/new.test.tsx
@@ -16,6 +16,10 @@ import {
 const requireUserId = vi.fn();
 const findUnique = vi.fn();
 const createPool = vi.fn();
+const usersInGiftGroupsFindUnique = vi.fn();
+const usersInGiftGroupsFindMany = vi.fn();
+const giftGroupFindUnique = vi.fn();
+const friendshipFindMany = vi.fn();
 
 vi.mock('#app/utils/auth.server.ts', () => ({
   requireUserId: (...args: Array<unknown>) => requireUserId(...args),
@@ -25,6 +29,16 @@ vi.mock('#app/utils/db.server.ts', () => ({
   prisma: {
     user: {
       findUnique: (...args: Array<unknown>) => findUnique(...args),
+    },
+    giftGroup: {
+      findUnique: (...args: Array<unknown>) => giftGroupFindUnique(...args),
+    },
+    usersInGiftGroups: {
+      findUnique: (...args: Array<unknown>) => usersInGiftGroupsFindUnique(...args),
+      findMany: (...args: Array<unknown>) => usersInGiftGroupsFindMany(...args),
+    },
+    friendship: {
+      findMany: (...args: Array<unknown>) => friendshipFindMany(...args),
     },
   },
 }));
@@ -50,20 +64,70 @@ describe('app/routes/pools+/new.tsx', () => {
     requireUserId.mockReset().mockResolvedValue('viewer-1');
     findUnique.mockReset();
     createPool.mockReset().mockResolvedValue({ id: 'pool-1' });
+    usersInGiftGroupsFindUnique.mockReset();
+    usersInGiftGroupsFindMany.mockReset().mockResolvedValue([]);
+    giftGroupFindUnique.mockReset();
+    friendshipFindMany.mockReset().mockResolvedValue([]);
   });
 
-  it('requires an authenticated user in the loader', async () => {
-    await expect(
-      loader(
-        toLoaderArgs({
-          context: {} as never,
-          params: {},
-          request: new Request('https://giftpool.app/pools/new'),
-        }),
-      ),
-    ).resolves.toEqual({});
+  it('requires an authenticated user in the loader and returns a candidates list', async () => {
+    const result = await loader(
+      toLoaderArgs({
+        context: {} as never,
+        params: {},
+        request: new Request('https://giftpool.app/pools/new'),
+      }),
+    );
 
+    expect(result).toEqual({ groupContext: null, candidates: [] });
     expect(requireUserId).toHaveBeenCalledWith(expect.any(Request));
+  });
+
+  it('returns deduped candidates (friends ∪ group members) sorted by name', async () => {
+    friendshipFindMany.mockResolvedValue([
+      {
+        userA: {
+          id: 'viewer-1',
+          name: 'Viewer',
+          username: 'viewer',
+          image: null,
+        },
+        userB: {
+          id: 'marco',
+          name: 'Marco',
+          username: 'marco',
+          image: { id: 'img-marco' },
+        },
+      },
+    ]);
+    usersInGiftGroupsFindMany.mockResolvedValue([
+      {
+        user: {
+          id: 'marco', // duplicate — friend AND group member
+          name: 'Marco',
+          username: 'marco',
+          image: { id: 'img-marco' },
+        },
+      },
+      {
+        user: {
+          id: 'alex',
+          name: 'Alex',
+          username: 'alex',
+          image: null,
+        },
+      },
+    ]);
+
+    const result = await loader(
+      toLoaderArgs({
+        context: {} as never,
+        params: {},
+        request: new Request('https://giftpool.app/pools/new'),
+      }),
+    );
+
+    expect(result.candidates.map((c: any) => c.id)).toEqual(['alex', 'marco']);
   });
 
   it('returns a validation payload for invalid form data', async () => {
@@ -85,8 +149,10 @@ describe('app/routes/pools+/new.tsx', () => {
     });
   });
 
-  it('returns a recipient username error when the user does not exist', async () => {
-    findUnique.mockResolvedValue(null);
+  it('rejects a standalone pool when recipientUserId is not in the viewer candidate pool', async () => {
+    // Candidate pool is empty (no friends, no groups)
+    friendshipFindMany.mockResolvedValue([]);
+    usersInGiftGroupsFindMany.mockResolvedValue([]);
 
     const result = await action(
       toActionArgs({
@@ -95,8 +161,8 @@ describe('app/routes/pools+/new.tsx', () => {
         request: createFormRequest({
           decisionMode: 'VOTE',
           occasionType: 'BIRTHDAY',
-          recipientUsername: 'missing-user',
-          title: 'Alex Birthday Pool',
+          recipientUserId: 'random-stranger-id',
+          title: 'Tampered Pool',
         }),
       }),
     );
@@ -104,13 +170,26 @@ describe('app/routes/pools+/new.tsx', () => {
     expect(getRouteResultStatus(result)).toBe(400);
     await expect(getRouteResultData(result)).resolves.toMatchObject({
       error: {
-        recipientUsername: ['No user found with that username.'],
+        '': ['That person is not in your friends or group members.'],
       },
     });
+    expect(createPool).not.toHaveBeenCalled();
   });
 
-  it('creates a pool and redirects to the new pool page', async () => {
-    findUnique.mockResolvedValue({ id: 'recipient-1' });
+  it('creates a pool from a selected candidate and redirects to the new pool page', async () => {
+    // Candidate pool includes recipient-1
+    friendshipFindMany.mockResolvedValue([
+      {
+        userA: { id: 'viewer-1', name: 'V', username: 'viewer', image: null },
+        userB: {
+          id: 'recipient-1',
+          name: 'Alex',
+          username: 'alex',
+          image: null,
+        },
+      },
+    ]);
+    usersInGiftGroupsFindMany.mockResolvedValue([]);
 
     const result = await action(
       toActionArgs({
@@ -120,8 +199,8 @@ describe('app/routes/pools+/new.tsx', () => {
           decisionMode: 'VOTE',
           eventDate: '2026-06-14',
           occasionType: 'BIRTHDAY',
-          recipientName: 'Alex',
-          recipientUsername: 'alex',
+          recipientName: '',
+          recipientUserId: 'recipient-1',
           title: 'Alex Birthday Pool',
         }),
       }),
@@ -130,9 +209,11 @@ describe('app/routes/pools+/new.tsx', () => {
     expect(createPool).toHaveBeenCalledWith({
       decisionMode: 'VOTE',
       eventDate: new Date('2026-06-14'),
+      giftGroupId: null,
+      groupMemberDefaults: [],
       occasionType: 'BIRTHDAY',
       organizerId: 'viewer-1',
-      recipientName: 'Alex',
+      recipientName: null,
       recipientUserId: 'recipient-1',
       title: 'Alex Birthday Pool',
     });
@@ -141,11 +222,35 @@ describe('app/routes/pools+/new.tsx', () => {
     expect((result as Response).headers.get('Location')).toBe('/pools/pool-1');
   });
 
-  it('renders the pool creation form', async () => {
+  it('creates a pool with a free-text recipientName when no GiftPool user is selected', async () => {
+    const result = await action(
+      toActionArgs({
+        context: {} as never,
+        params: {},
+        request: createFormRequest({
+          decisionMode: 'ORGANIZER_PICKS',
+          occasionType: 'BIRTHDAY',
+          recipientName: 'Offline Friend',
+          title: 'Offline Pool',
+        }),
+      }),
+    );
+
+    expect(createPool).toHaveBeenCalledWith(
+      expect.objectContaining({
+        recipientUserId: null,
+        recipientName: 'Offline Friend',
+      }),
+    );
+    expect(result).toBeInstanceOf(Response);
+    expect((result as Response).status).toBe(302);
+  });
+
+  it('renders the pool creation form with the recipient search picker', async () => {
     const App = createRoutesStub([
       {
         path: '/pools/new',
-        loader: async () => ({}),
+        loader: async () => ({ groupContext: null, candidates: [] }),
         HydrateFallback: () => null,
         Component: NewPoolPage,
       },
@@ -156,11 +261,137 @@ describe('app/routes/pools+/new.tsx', () => {
     expect(await screen.findByLabelText('Pool title')).toBeInTheDocument();
     expect(screen.getByLabelText('Occasion')).toBeInTheDocument();
     expect(
-      screen.getByLabelText(/Gift Pool username/i),
+      screen.getByLabelText(/Find a friend or group member/i),
     ).toBeInTheDocument();
+    expect(screen.getByLabelText(/Or just their name/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Start Pool' })).toBeInTheDocument();
     expect(
       screen.getByRole('radio', { name: /Organizer chooses/i }),
     ).toBeChecked();
+  });
+
+  it('creates a group-backed pool with re-derived member defaults', async () => {
+    // Organizer is a member of the group
+    usersInGiftGroupsFindUnique
+      .mockResolvedValueOnce({ userId: 'viewer-1' })
+      // Recipient is a member of the group
+      .mockResolvedValueOnce({ userId: 'recipient-1' });
+    // Authoritative contribution defaults from DB
+    usersInGiftGroupsFindMany.mockResolvedValue([
+      { userId: 'viewer-1', contributionCents: 3000 },
+      { userId: 'member-2', contributionCents: 2000 },
+    ]);
+
+    const result = await action(
+      toActionArgs({
+        context: {} as never,
+        params: {},
+        request: createFormRequest({
+          contributorIds: 'viewer-1,member-2',
+          decisionMode: 'VOTE',
+          eventDate: '2026-06-14',
+          giftGroupId: 'group-1',
+          occasionType: 'BIRTHDAY',
+          recipientUserId: 'recipient-1',
+          title: 'Recipient Birthday Pool',
+        }),
+      }),
+    );
+
+    expect(createPool).toHaveBeenCalledWith({
+      decisionMode: 'VOTE',
+      eventDate: new Date('2026-06-14'),
+      giftGroupId: 'group-1',
+      groupMemberDefaults: [
+        { userId: 'viewer-1', contributionCents: 3000 },
+        { userId: 'member-2', contributionCents: 2000 },
+      ],
+      occasionType: 'BIRTHDAY',
+      organizerId: 'viewer-1',
+      recipientName: null,
+      recipientUserId: 'recipient-1',
+      title: 'Recipient Birthday Pool',
+    });
+    expect(result).toBeInstanceOf(Response);
+    expect((result as Response).status).toBe(302);
+  });
+
+  it('rejects a group-backed submission when organizer is not in the group', async () => {
+    usersInGiftGroupsFindUnique.mockResolvedValueOnce(null);
+
+    const result = await action(
+      toActionArgs({
+        context: {} as never,
+        params: {},
+        request: createFormRequest({
+          contributorIds: 'viewer-1',
+          decisionMode: 'VOTE',
+          giftGroupId: 'group-1',
+          occasionType: 'BIRTHDAY',
+          recipientUserId: 'recipient-1',
+          title: 'Bad Pool',
+        }),
+      }),
+    );
+
+    expect(getRouteResultStatus(result)).toBe(403);
+    expect(createPool).not.toHaveBeenCalled();
+  });
+
+  it('rejects a group-backed submission with no selected contributors', async () => {
+    usersInGiftGroupsFindUnique
+      .mockResolvedValueOnce({ userId: 'viewer-1' })
+      .mockResolvedValueOnce({ userId: 'recipient-1' });
+
+    const result = await action(
+      toActionArgs({
+        context: {} as never,
+        params: {},
+        request: createFormRequest({
+          contributorIds: '',
+          decisionMode: 'VOTE',
+          giftGroupId: 'group-1',
+          occasionType: 'BIRTHDAY',
+          recipientUserId: 'recipient-1',
+          title: 'Empty Contributors',
+        }),
+      }),
+    );
+
+    expect(getRouteResultStatus(result)).toBe(400);
+    expect(createPool).not.toHaveBeenCalled();
+  });
+
+  it('filters the recipient out of contributors even if passed in the form', async () => {
+    usersInGiftGroupsFindUnique
+      .mockResolvedValueOnce({ userId: 'viewer-1' })
+      .mockResolvedValueOnce({ userId: 'recipient-1' });
+    usersInGiftGroupsFindMany.mockResolvedValue([
+      { userId: 'viewer-1', contributionCents: 3000 },
+      { userId: 'recipient-1', contributionCents: 2000 },
+      { userId: 'member-2', contributionCents: 1000 },
+    ]);
+
+    await action(
+      toActionArgs({
+        context: {} as never,
+        params: {},
+        request: createFormRequest({
+          contributorIds: 'viewer-1,recipient-1,member-2',
+          decisionMode: 'VOTE',
+          giftGroupId: 'group-1',
+          occasionType: 'BIRTHDAY',
+          recipientUserId: 'recipient-1',
+          title: 'Privacy-safe Pool',
+        }),
+      }),
+    );
+
+    const call = createPool.mock.calls[0]?.[0];
+    const contributorIds = call.groupMemberDefaults.map(
+      (m: { userId: string }) => m.userId,
+    );
+    expect(contributorIds).not.toContain('recipient-1');
+    expect(contributorIds).toEqual(['viewer-1', 'member-2']);
   });
 });

--- a/app/routes/pools+/new.tsx
+++ b/app/routes/pools+/new.tsx
@@ -215,6 +215,135 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
 // ─── Action ──────────────────────────────────────────────────────────────────
 
+type RecipientResolution = {
+	recipientUserId: string | null
+	groupMemberDefaults: Array<{ userId: string; contributionCents: number }>
+}
+
+type ResolutionResult =
+	| { ok: true; value: RecipientResolution }
+	| { ok: false; response: ReturnType<typeof data> }
+
+async function resolveGroupBackedRecipient(
+	userId: string,
+	giftGroupId: string,
+	formRecipientUserId: string,
+	contributorIdsRaw: string | undefined,
+	submission: Awaited<
+		ReturnType<typeof parseWithZod<typeof CreatePoolSchema>>
+	>,
+): Promise<ResolutionResult> {
+	// Validate: organizer must be in the group
+	const membership = await prisma.usersInGiftGroups.findUnique({
+		where: { userId_giftGroupId: { userId, giftGroupId } },
+		select: { userId: true },
+	})
+	if (!membership) {
+		return {
+			ok: false,
+			response: data(
+				submission.reply({
+					formErrors: ['You are not a member of this group.'],
+				}),
+				{ status: 403 },
+			),
+		}
+	}
+
+	// Validate: recipient must be in the group
+	const recipientMembership = await prisma.usersInGiftGroups.findUnique({
+		where: {
+			userId_giftGroupId: { userId: formRecipientUserId, giftGroupId },
+		},
+		select: { userId: true },
+	})
+	if (!recipientMembership) {
+		return {
+			ok: false,
+			response: data(
+				submission.reply({
+					formErrors: ['The recipient is not a member of this group.'],
+				}),
+				{ status: 400 },
+			),
+		}
+	}
+
+	const selectedIds = contributorIdsRaw
+		? contributorIdsRaw.split(',').filter(Boolean)
+		: []
+	if (selectedIds.length === 0) {
+		return {
+			ok: false,
+			response: data(
+				submission.reply({
+					formErrors: ['Select at least one contributor.'],
+				}),
+				{ status: 400 },
+			),
+		}
+	}
+
+	// Re-derive authoritative contribution defaults from the DB; filter out
+	// the recipient — they must never be a contributor.
+	const members = await prisma.usersInGiftGroups.findMany({
+		where: {
+			giftGroupId,
+			userId: { in: selectedIds },
+			removedAt: null,
+		},
+		select: { userId: true, contributionCents: true },
+	})
+	const groupMemberDefaults = members
+		.filter((m) => m.userId !== formRecipientUserId)
+		.map((m) => ({
+			userId: m.userId,
+			contributionCents: m.contributionCents,
+		}))
+
+	return {
+		ok: true,
+		value: {
+			recipientUserId: formRecipientUserId,
+			groupMemberDefaults,
+		},
+	}
+}
+
+async function resolveStandaloneRecipient(
+	userId: string,
+	formRecipientUserId: string,
+	submission: Awaited<
+		ReturnType<typeof parseWithZod<typeof CreatePoolSchema>>
+	>,
+): Promise<ResolutionResult> {
+	// Validate the picker selection against the viewer's candidate pool
+	// (friends + group members). Prevents arbitrary user ids being
+	// submitted via a tampered form.
+	const candidates = await fetchRecipientCandidates(userId)
+	const match = candidates.find((c) => c.id === formRecipientUserId)
+	if (!match) {
+		return {
+			ok: false,
+			response: data(
+				submission.reply({
+					formErrors: [
+						'That person is not in your friends or group members.',
+					],
+				}),
+				{ status: 400 },
+			),
+		}
+	}
+	return {
+		ok: true,
+		value: {
+			recipientUserId: match.id,
+			groupMemberDefaults: [],
+		},
+	}
+}
+
 export async function action({ request }: ActionFunctionArgs) {
 	const userId = await requireUserId(request)
 	const formData = await request.formData()
@@ -242,93 +371,23 @@ export async function action({ request }: ActionFunctionArgs) {
 	}> = []
 
 	if (giftGroupId && formRecipientUserId) {
-		// ── Group-backed flow ──
-		// Validate: organizer must be in the group
-		const membership = await prisma.usersInGiftGroups.findUnique({
-			where: {
-				userId_giftGroupId: { userId, giftGroupId },
-			},
-			select: { userId: true },
-		})
-		if (!membership) {
-			return data(
-				submission.reply({ formErrors: ['You are not a member of this group.'] }),
-				{ status: 403 },
-			)
-		}
-
-		// Validate: recipient must be in the group
-		const recipientMembership = await prisma.usersInGiftGroups.findUnique({
-			where: {
-				userId_giftGroupId: {
-					userId: formRecipientUserId,
-					giftGroupId,
-				},
-			},
-			select: { userId: true },
-		})
-		if (!recipientMembership) {
-			return data(
-				submission.reply({
-					formErrors: ['The recipient is not a member of this group.'],
-				}),
-				{ status: 400 },
-			)
-		}
-
-		recipientUserId = formRecipientUserId
-
-		// Parse selected contributor IDs from the comma-separated hidden field
-		const selectedIds = contributorIdsRaw
-			? contributorIdsRaw.split(',').filter(Boolean)
-			: []
-
-		if (selectedIds.length === 0) {
-			return data(
-				submission.reply({
-					formErrors: ['Select at least one contributor.'],
-				}),
-				{ status: 400 },
-			)
-		}
-
-		// Re-derive authoritative contribution defaults from the DB
-		const members = await prisma.usersInGiftGroups.findMany({
-			where: {
-				giftGroupId,
-				userId: { in: selectedIds },
-				removedAt: null,
-			},
-			select: { userId: true, contributionCents: true },
-		})
-
-		// Filter out the recipient — they must never be a contributor
-		groupMemberDefaults = members
-			.filter((m) => m.userId !== formRecipientUserId)
-			.map((m) => ({
-				userId: m.userId,
-				contributionCents: m.contributionCents,
-			}))
-	} else {
-		// ── Standalone flow ──
-		// If the picker selected a user, validate the id against the viewer's
-		// candidate pool (friends + group members). Prevents arbitrary user
-		// ids being submitted via a tampered form.
-		if (formRecipientUserId) {
-			const candidates = await fetchRecipientCandidates(userId)
-			const match = candidates.find((c) => c.id === formRecipientUserId)
-			if (!match) {
-				return data(
-					submission.reply({
-						formErrors: [
-							'That person is not in your friends or group members.',
-						],
-					}),
-					{ status: 400 },
-				)
-			}
-			recipientUserId = match.id
-		}
+		const result = await resolveGroupBackedRecipient(
+			userId,
+			giftGroupId,
+			formRecipientUserId,
+			contributorIdsRaw,
+			submission,
+		)
+		if (!result.ok) return result.response
+		;({ recipientUserId, groupMemberDefaults } = result.value)
+	} else if (formRecipientUserId) {
+		const result = await resolveStandaloneRecipient(
+			userId,
+			formRecipientUserId,
+			submission,
+		)
+		if (!result.ok) return result.response
+		recipientUserId = result.value.recipientUserId
 	}
 
 	const pool = await createPool({
@@ -352,8 +411,13 @@ const NewPool = () => {
 	const { groupContext, candidates } = useLoaderData<typeof loader>()
 	const actionData = useActionData<typeof action>()
 
-	const [form, fields] = useForm({
-		lastResult: actionData,
+	const [form, fields] = useForm<z.input<typeof CreatePoolSchema>>({
+		// `action` returns a union of data() responses with differently-shaped
+		// formErrors (string[] in some branches, unknown in others). Cast so
+		// useForm's stricter SubmissionResult<string[]> binding is satisfied.
+		lastResult: actionData as
+			| Parameters<typeof useForm<z.input<typeof CreatePoolSchema>>>[0]['lastResult']
+			| undefined,
 		onValidate({ formData }) {
 			return parseWithZod(formData, { schema: CreatePoolSchema })
 		},
@@ -404,8 +468,8 @@ const NewPool = () => {
 
 					{form.errors && form.errors.length > 0 && (
 						<Card padding="md" className="mb-6 border-destructive">
-							{form.errors.map((error, i) => (
-								<Text key={i} size="sm" className="text-destructive">
+							{form.errors.map((error) => (
+								<Text key={error} size="sm" className="text-destructive">
 									{error}
 								</Text>
 							))}

--- a/app/routes/pools+/new.tsx
+++ b/app/routes/pools+/new.tsx
@@ -1,5 +1,6 @@
 import { getFormProps, getInputProps, useForm } from '@conform-to/react'
 import { parseWithZod } from '@conform-to/zod'
+import { useState } from 'react'
 import { LuGift } from 'react-icons/lu'
 import {
 	data,
@@ -13,12 +14,14 @@ import {
 } from 'react-router'
 import { z } from 'zod'
 import { Button } from '#app/components/ui/button.tsx'
+import { Card } from '#app/components/ui/card.tsx'
 import { Icon } from '#app/components/ui/icon.tsx'
 import { Input } from '#app/components/ui/input.tsx'
 import { Label } from '#app/components/ui/label.tsx'
 import { Flex, Stack, Text } from '#app/components/ui-kit'
 import { requireUserId } from '#app/utils/auth.server.ts'
 import { prisma } from '#app/utils/db.server.ts'
+import { getUserImgSrc } from '#app/utils/misc.tsx'
 import {
 	OCCASION_TYPE,
 	OCCASION_TYPE_LABELS,
@@ -28,6 +31,8 @@ import {
 } from '#app/utils/pool-constants.ts'
 import { createPool } from '#app/utils/pool.server.ts'
 
+// ─── Schema ──────────────────────────────────────────────────────────────────
+
 const CreatePoolSchema = z.object({
 	title: z.string().min(1, 'Give your pool a title').max(100),
 	occasionType: z.enum(
@@ -35,15 +40,180 @@ const CreatePoolSchema = z.object({
 	),
 	eventDate: z.string().optional(),
 	decisionMode: z.enum(['ORGANIZER_PICKS', 'VOTE']),
-	// Recipient: either a platform username or a free-text name
-	recipientUsername: z.string().optional(),
 	recipientName: z.string().optional(),
+	giftGroupId: z.string().optional(),
+	recipientUserId: z.string().optional(),
+	contributorIds: z.string().optional(),
 })
 
-export async function loader({ request }: LoaderFunctionArgs) {
-	await requireUserId(request)
-	return {}
+// ─── Loader ──────────────────────────────────────────────────────────────────
+
+type GroupContext = {
+	groupId: string
+	groupName: string
+	recipient: { id: string; name: string; username: string }
+	members: Array<{
+		userId: string
+		name: string
+		username: string
+		imageId: string | null
+		contributionCents: number
+	}>
 }
+
+type RecipientCandidate = {
+	id: string
+	name: string
+	username: string
+	imageId: string | null
+}
+
+async function fetchRecipientCandidates(
+	viewerId: string,
+): Promise<RecipientCandidate[]> {
+	const [friendships, groupMemberships] = await Promise.all([
+		prisma.friendship.findMany({
+			where: {
+				OR: [{ userAId: viewerId }, { userBId: viewerId }],
+			},
+			select: {
+				userA: {
+					select: {
+						id: true,
+						name: true,
+						username: true,
+						image: { select: { id: true } },
+					},
+				},
+				userB: {
+					select: {
+						id: true,
+						name: true,
+						username: true,
+						image: { select: { id: true } },
+					},
+				},
+			},
+		}),
+		prisma.usersInGiftGroups.findMany({
+			where: {
+				giftGroup: { groupMembers: { some: { userId: viewerId } } },
+				userId: { not: viewerId },
+				removedAt: null,
+			},
+			select: {
+				user: {
+					select: {
+						id: true,
+						name: true,
+						username: true,
+						image: { select: { id: true } },
+					},
+				},
+			},
+		}),
+	])
+
+	const map = new Map<string, RecipientCandidate>()
+	for (const f of friendships) {
+		const other = f.userA.id === viewerId ? f.userB : f.userA
+		map.set(other.id, {
+			id: other.id,
+			name: other.name ?? other.username,
+			username: other.username,
+			imageId: other.image?.id ?? null,
+		})
+	}
+	for (const m of groupMemberships) {
+		if (map.has(m.user.id)) continue
+		map.set(m.user.id, {
+			id: m.user.id,
+			name: m.user.name ?? m.user.username,
+			username: m.user.username,
+			imageId: m.user.image?.id ?? null,
+		})
+	}
+
+	return [...map.values()].sort((a, b) => a.name.localeCompare(b.name))
+}
+
+export async function loader({ request }: LoaderFunctionArgs) {
+	const userId = await requireUserId(request)
+	const url = new URL(request.url)
+	const groupId = url.searchParams.get('groupId')
+	const recipientId = url.searchParams.get('recipientId')
+
+	if (!groupId || !recipientId) {
+		const candidates = await fetchRecipientCandidates(userId)
+		return {
+			groupContext: null as GroupContext | null,
+			candidates,
+		}
+	}
+
+	const group = await prisma.giftGroup.findUnique({
+		where: { id: groupId },
+		select: {
+			name: true,
+			groupMembers: {
+				where: { removedAt: null },
+				select: {
+					userId: true,
+					contributionCents: true,
+					user: {
+						select: {
+							id: true,
+							name: true,
+							username: true,
+							image: { select: { id: true } },
+						},
+					},
+				},
+			},
+		},
+	})
+
+	if (!group) {
+		return { groupContext: null as GroupContext | null, candidates: [] as RecipientCandidate[] }
+	}
+
+	const viewerMember = group.groupMembers.find((m) => m.userId === userId)
+	if (!viewerMember) {
+		return { groupContext: null as GroupContext | null, candidates: [] as RecipientCandidate[] }
+	}
+
+	const recipientMember = group.groupMembers.find(
+		(m) => m.userId === recipientId,
+	)
+	if (!recipientMember) {
+		return { groupContext: null as GroupContext | null, candidates: [] as RecipientCandidate[] }
+	}
+
+	const members = group.groupMembers
+		.filter((m) => m.userId !== recipientId)
+		.map((m) => ({
+			userId: m.userId,
+			name: m.user.name ?? m.user.username,
+			username: m.user.username,
+			imageId: m.user.image?.id ?? null,
+			contributionCents: m.contributionCents,
+		}))
+
+	const groupContext: GroupContext = {
+		groupId,
+		groupName: group.name,
+		recipient: {
+			id: recipientMember.userId,
+			name: recipientMember.user.name ?? recipientMember.user.username,
+			username: recipientMember.user.username,
+		},
+		members,
+	}
+
+	return { groupContext, candidates: [] as RecipientCandidate[] }
+}
+
+// ─── Action ──────────────────────────────────────────────────────────────────
 
 export async function action({ request }: ActionFunctionArgs) {
 	const userId = await requireUserId(request)
@@ -59,28 +229,106 @@ export async function action({ request }: ActionFunctionArgs) {
 		occasionType,
 		eventDate,
 		decisionMode,
-		recipientUsername,
 		recipientName,
+		giftGroupId,
+		recipientUserId: formRecipientUserId,
+		contributorIds: contributorIdsRaw,
 	} = submission.value
 
-	// Resolve recipient user if a username was provided
 	let recipientUserId: string | null = null
-	if (recipientUsername) {
-		const recipient = await prisma.user.findUnique({
-			where: { username: recipientUsername },
-			select: { id: true },
+	let groupMemberDefaults: Array<{
+		userId: string
+		contributionCents: number
+	}> = []
+
+	if (giftGroupId && formRecipientUserId) {
+		// ── Group-backed flow ──
+		// Validate: organizer must be in the group
+		const membership = await prisma.usersInGiftGroups.findUnique({
+			where: {
+				userId_giftGroupId: { userId, giftGroupId },
+			},
+			select: { userId: true },
 		})
-		if (!recipient) {
+		if (!membership) {
+			return data(
+				submission.reply({ formErrors: ['You are not a member of this group.'] }),
+				{ status: 403 },
+			)
+		}
+
+		// Validate: recipient must be in the group
+		const recipientMembership = await prisma.usersInGiftGroups.findUnique({
+			where: {
+				userId_giftGroupId: {
+					userId: formRecipientUserId,
+					giftGroupId,
+				},
+			},
+			select: { userId: true },
+		})
+		if (!recipientMembership) {
 			return data(
 				submission.reply({
-					fieldErrors: {
-						recipientUsername: ['No user found with that username.'],
-					},
+					formErrors: ['The recipient is not a member of this group.'],
 				}),
 				{ status: 400 },
 			)
 		}
-		recipientUserId = recipient.id
+
+		recipientUserId = formRecipientUserId
+
+		// Parse selected contributor IDs from the comma-separated hidden field
+		const selectedIds = contributorIdsRaw
+			? contributorIdsRaw.split(',').filter(Boolean)
+			: []
+
+		if (selectedIds.length === 0) {
+			return data(
+				submission.reply({
+					formErrors: ['Select at least one contributor.'],
+				}),
+				{ status: 400 },
+			)
+		}
+
+		// Re-derive authoritative contribution defaults from the DB
+		const members = await prisma.usersInGiftGroups.findMany({
+			where: {
+				giftGroupId,
+				userId: { in: selectedIds },
+				removedAt: null,
+			},
+			select: { userId: true, contributionCents: true },
+		})
+
+		// Filter out the recipient — they must never be a contributor
+		groupMemberDefaults = members
+			.filter((m) => m.userId !== formRecipientUserId)
+			.map((m) => ({
+				userId: m.userId,
+				contributionCents: m.contributionCents,
+			}))
+	} else {
+		// ── Standalone flow ──
+		// If the picker selected a user, validate the id against the viewer's
+		// candidate pool (friends + group members). Prevents arbitrary user
+		// ids being submitted via a tampered form.
+		if (formRecipientUserId) {
+			const candidates = await fetchRecipientCandidates(userId)
+			const match = candidates.find((c) => c.id === formRecipientUserId)
+			if (!match) {
+				return data(
+					submission.reply({
+						formErrors: [
+							'That person is not in your friends or group members.',
+						],
+					}),
+					{ status: 400 },
+				)
+			}
+			recipientUserId = match.id
+		}
 	}
 
 	const pool = await createPool({
@@ -90,14 +338,18 @@ export async function action({ request }: ActionFunctionArgs) {
 		decisionMode,
 		recipientUserId,
 		recipientName: recipientName || null,
+		giftGroupId: giftGroupId || null,
 		organizerId: userId,
+		groupMemberDefaults,
 	})
 
 	return redirect(`/pools/${pool.id}`)
 }
 
+// ─── Component ───────────────────────────────────────────────────────────────
+
 const NewPool = () => {
-	useLoaderData<typeof loader>()
+	const { groupContext, candidates } = useLoaderData<typeof loader>()
 	const actionData = useActionData<typeof action>()
 
 	const [form, fields] = useForm({
@@ -111,14 +363,19 @@ const NewPool = () => {
 		},
 	})
 
+	const cancelHref = groupContext
+		? `/groups/${groupContext.groupId}`
+		: '/pools'
+	const backLabel = groupContext ? groupContext.groupName : 'Pools'
+	const backHref = cancelHref
+
 	return (
 		<div className="flex h-full min-h-0 flex-col">
-			{/* Header */}
 			<div className="border-b bg-surface px-4 py-4 shadow">
 				<div className="container flex items-center gap-3">
 					<Button asChild variant="ghost" size="sm" className="px-2">
-						<Link to="/pools">
-							<Icon name="arrow-left" className="mr-1" /> Pools
+						<Link to={backHref}>
+							<Icon name="arrow-left" className="mr-1" /> {backLabel}
 						</Link>
 					</Button>
 					<Flex gap={2} align="center">
@@ -128,16 +385,61 @@ const NewPool = () => {
 				</div>
 			</div>
 
-			{/* Form */}
 			<div className="container max-w-lg py-8">
 				<Form method="post" {...getFormProps(form)}>
+					{groupContext && (
+						<>
+							<input
+								type="hidden"
+								name="giftGroupId"
+								value={groupContext.groupId}
+							/>
+							<input
+								type="hidden"
+								name="recipientUserId"
+								value={groupContext.recipient.id}
+							/>
+						</>
+					)}
+
+					{form.errors && form.errors.length > 0 && (
+						<Card padding="md" className="mb-6 border-destructive">
+							{form.errors.map((error, i) => (
+								<Text key={i} size="sm" className="text-destructive">
+									{error}
+								</Text>
+							))}
+						</Card>
+					)}
+
 					<Stack gap={6}>
-						{/* Title */}
+						{groupContext && (
+							<Card padding="md" className="border-primary/20 bg-primary/5">
+								<Flex gap={2} align="center">
+									<LuGift className="shrink-0 text-primary" size={16} />
+									<Text size="sm">
+										Creating a pool in{' '}
+										<span className="font-semibold">
+											{groupContext.groupName}
+										</span>{' '}
+										for{' '}
+										<span className="font-semibold">
+											{groupContext.recipient.name}
+										</span>
+									</Text>
+								</Flex>
+							</Card>
+						)}
+
 						<Stack gap={2}>
 							<Label htmlFor={fields.title.id}>Pool title</Label>
 							<Input
 								{...getInputProps(fields.title, { type: 'text' })}
-								placeholder="e.g. Marco's 30th Birthday"
+								placeholder={
+									groupContext
+										? `e.g. ${groupContext.recipient.name}'s Birthday`
+										: "e.g. Marco's 30th Birthday"
+								}
 								autoFocus
 							/>
 							{fields.title.errors && (
@@ -147,22 +449,22 @@ const NewPool = () => {
 							)}
 						</Stack>
 
-						{/* Occasion */}
 						<Stack gap={2}>
 							<Label htmlFor={fields.occasionType.id}>Occasion</Label>
 							<select
 								{...getInputProps(fields.occasionType, { type: 'text' })}
 								className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring"
 							>
-								{Object.entries(OCCASION_TYPE_LABELS).map(([value, label]) => (
-									<option key={value} value={value}>
-										{label}
-									</option>
-								))}
+								{Object.entries(OCCASION_TYPE_LABELS).map(
+									([value, label]) => (
+										<option key={value} value={value}>
+											{label}
+										</option>
+									),
+								)}
 							</select>
 						</Stack>
 
-						{/* Event date */}
 						<Stack gap={2}>
 							<Label htmlFor={fields.eventDate.id}>
 								Event date{' '}
@@ -173,71 +475,55 @@ const NewPool = () => {
 							/>
 						</Stack>
 
-						{/* Recipient */}
-						<Stack gap={4}>
-							<Text weight="medium">Who is this for?</Text>
-							<Stack gap={2}>
-								<Label htmlFor={fields.recipientUsername.id}>
-									Gift Pool username{' '}
-									<span className="text-muted-foreground">(optional)</span>
-								</Label>
-								<Input
-									{...getInputProps(fields.recipientUsername, { type: 'text' })}
-									placeholder="their username"
-								/>
-								{fields.recipientUsername.errors && (
-									<Text size="sm" className="text-destructive">
-										{fields.recipientUsername.errors[0]}
-									</Text>
-								)}
-								<Text size="xs" className="text-muted-foreground">
-									If they're on Gift Pool we'll link their wishlist. They'll
-									never see this pool.
-								</Text>
-							</Stack>
-							<Stack gap={2}>
-								<Label htmlFor={fields.recipientName.id}>
-									Or just their name{' '}
-									<span className="text-muted-foreground">(optional)</span>
-								</Label>
-								<Input
-									{...getInputProps(fields.recipientName, { type: 'text' })}
-									placeholder="e.g. Marco"
-								/>
-							</Stack>
-						</Stack>
+						{groupContext ? (
+							<ContributorPicker members={groupContext.members} />
+						) : (
+							<RecipientPicker
+								candidates={candidates}
+								nameFieldName={fields.recipientName.name}
+							/>
+						)}
 
-						{/* Decision mode */}
 						<Stack gap={2}>
 							<Label>How will you pick the gift?</Label>
 							<Stack gap={2}>
-								{Object.entries(DECISION_MODE_LABELS).map(([value, label]) => (
-									<label key={value} className="flex cursor-pointer items-center gap-3">
-										<input
-											type="radio"
-											name={fields.decisionMode.name}
-											value={value}
-											defaultChecked={value === DECISION_MODE.ORGANIZER_PICKS}
-											className="text-primary"
-										/>
-										<Stack gap={0}>
-											<Text weight="medium" size="sm">
-												{label}
-											</Text>
-											<Text size="xs" className="text-muted-foreground">
-												{value === DECISION_MODE.ORGANIZER_PICKS
-													? 'You pick the winner from the ideas list.'
-													: 'Everyone votes and the most popular idea wins.'}
-											</Text>
-										</Stack>
-									</label>
-								))}
+								{Object.entries(DECISION_MODE_LABELS).map(
+									([value, label]) => (
+										<label
+											key={value}
+											className="flex cursor-pointer items-center gap-3"
+										>
+											<input
+												type="radio"
+												name={fields.decisionMode.name}
+												value={value}
+												defaultChecked={
+													value === DECISION_MODE.ORGANIZER_PICKS
+												}
+												className="text-primary"
+											/>
+											<Stack gap={0}>
+												<Text weight="medium" size="sm">
+													{label}
+												</Text>
+												<Text
+													size="xs"
+													className="text-muted-foreground"
+												>
+													{value === DECISION_MODE.ORGANIZER_PICKS
+														? 'You pick the winner from the ideas list.'
+														: 'Everyone votes and the most popular idea wins.'}
+												</Text>
+											</Stack>
+										</label>
+									),
+								)}
 							</Stack>
 						</Stack>
 
 						<Flex gap={3} justify="end">
 							<Button asChild variant="outline">
-								<Link to="/pools">Cancel</Link>
+								<Link to={cancelHref}>Cancel</Link>
 							</Button>
 							<Button type="submit">Start Pool</Button>
 						</Flex>
@@ -249,3 +535,273 @@ const NewPool = () => {
 }
 
 export default NewPool
+
+// ─── Recipient Picker (standalone flow) ──────────────────────────────────────
+
+const RecipientPicker = ({
+	candidates,
+	nameFieldName,
+}: {
+	candidates: RecipientCandidate[]
+	nameFieldName: string
+}) => {
+	const [selected, setSelected] = useState<RecipientCandidate | null>(null)
+	const [query, setQuery] = useState('')
+	const [open, setOpen] = useState(false)
+
+	const normalizedQuery = query.trim().toLowerCase()
+	const matches = normalizedQuery
+		? candidates
+				.filter(
+					(c) =>
+						c.name.toLowerCase().includes(normalizedQuery) ||
+						c.username.toLowerCase().includes(normalizedQuery),
+				)
+				.slice(0, 8)
+		: candidates.slice(0, 8)
+
+	if (selected) {
+		return (
+			<Stack gap={2}>
+				<Text weight="medium">Who is this for?</Text>
+				<input type="hidden" name="recipientUserId" value={selected.id} />
+				<Card padding="sm" className="border-primary/30 bg-primary/5">
+					<Flex gap={3} align="center">
+						<img
+							src={getUserImgSrc(selected.imageId, { size: 64 })}
+							alt=""
+							className="h-8 w-8 shrink-0 rounded-full object-cover"
+						/>
+						<Stack gap={0} className="min-w-0 flex-1">
+							<Text size="sm" weight="medium" className="truncate">
+								{selected.name}
+							</Text>
+							<Text size="xs" className="text-muted-foreground">
+								@{selected.username}
+							</Text>
+						</Stack>
+						<Button
+							type="button"
+							variant="ghost"
+							size="sm"
+							onClick={() => {
+								setSelected(null)
+								setQuery('')
+							}}
+							aria-label="Clear selection"
+						>
+							<Icon name="cross-1" />
+						</Button>
+					</Flex>
+				</Card>
+				<Text size="xs" className="text-muted-foreground">
+					They'll never see this pool. We'll link their wishlist if they have
+					one.
+				</Text>
+			</Stack>
+		)
+	}
+
+	return (
+		<Stack gap={4}>
+			<Text weight="medium">Who is this for?</Text>
+			<Stack gap={2}>
+				<Label htmlFor="recipient-search">
+					Find a friend or group member
+				</Label>
+				<div className="relative">
+					<Input
+						id="recipient-search"
+						type="text"
+						value={query}
+						placeholder="Search by name or @username"
+						autoComplete="off"
+						onChange={(e) => {
+							setQuery(e.target.value)
+							setOpen(true)
+						}}
+						onFocus={() => setOpen(true)}
+						onBlur={() => {
+							// Delay so a click on a dropdown row fires before we close.
+							setTimeout(() => setOpen(false), 150)
+						}}
+					/>
+					{open && matches.length > 0 && (
+						<Card
+							padding="none"
+							className="absolute top-full z-10 mt-1 max-h-72 w-full overflow-y-auto"
+						>
+							<ul>
+								{matches.map((c, i) => (
+									<li key={c.id}>
+										<button
+											type="button"
+											onMouseDown={(e) => {
+												// Prevent input blur from firing before onClick.
+												e.preventDefault()
+											}}
+											onClick={() => {
+												setSelected(c)
+												setQuery('')
+												setOpen(false)
+											}}
+											className={`flex w-full items-center gap-3 px-3 py-2 text-left transition-colors hover:bg-muted/50 ${i > 0 ? 'border-t border-border' : ''}`}
+										>
+											<img
+												src={getUserImgSrc(c.imageId, { size: 64 })}
+												alt=""
+												className="h-7 w-7 shrink-0 rounded-full object-cover"
+											/>
+											<div className="min-w-0 flex-1">
+												<div className="truncate text-sm font-medium">
+													{c.name}
+												</div>
+												<div className="text-xs text-muted-foreground">
+													@{c.username}
+												</div>
+											</div>
+										</button>
+									</li>
+								))}
+							</ul>
+						</Card>
+					)}
+					{open && query && matches.length === 0 && (
+						<Card
+							padding="sm"
+							className="absolute top-full z-10 mt-1 w-full"
+						>
+							<Text size="xs" className="text-muted-foreground">
+								No matches in your friends or groups. Use the name field
+								below instead.
+							</Text>
+						</Card>
+					)}
+				</div>
+				{candidates.length === 0 && (
+					<Text size="xs" className="text-muted-foreground">
+						Once you add friends or join groups, they'll show up here.
+					</Text>
+				)}
+			</Stack>
+			<Stack gap={2}>
+				<Label htmlFor="recipient-name-fallback">
+					Or just their name{' '}
+					<span className="text-muted-foreground">(optional)</span>
+				</Label>
+				<Input
+					id="recipient-name-fallback"
+					name={nameFieldName}
+					type="text"
+					placeholder="e.g. Marco"
+				/>
+				<Text size="xs" className="text-muted-foreground">
+					For someone who isn't on GiftPool yet.
+				</Text>
+			</Stack>
+		</Stack>
+	)
+}
+
+// ─── Contributor Picker (group-backed flow) ──────────────────────────────────
+
+type PickerMember = {
+	userId: string
+	name: string
+	username: string
+	imageId: string | null
+	contributionCents: number
+}
+
+const ContributorPicker = ({ members }: { members: PickerMember[] }) => {
+	const [selected, setSelected] = useState<Set<string>>(
+		() => new Set(members.map((m) => m.userId)),
+	)
+
+	const toggle = (userId: string) => {
+		setSelected((prev) => {
+			const next = new Set(prev)
+			if (next.has(userId)) {
+				next.delete(userId)
+			} else {
+				next.add(userId)
+			}
+			return next
+		})
+	}
+
+	const allSelected = selected.size === members.length
+	const toggleAll = () => {
+		if (allSelected) {
+			setSelected(new Set())
+		} else {
+			setSelected(new Set(members.map((m) => m.userId)))
+		}
+	}
+
+	return (
+		<Stack gap={2}>
+			<input
+				type="hidden"
+				name="contributorIds"
+				value={Array.from(selected).join(',')}
+			/>
+			<Flex justify="between" align="center">
+				<Text weight="medium">Contributors</Text>
+				<button
+					type="button"
+					onClick={toggleAll}
+					className="text-xs text-primary hover:underline"
+				>
+					{allSelected ? 'Deselect all' : 'Select all'}
+				</button>
+			</Flex>
+			<Text size="xs" className="text-muted-foreground">
+				Everyone selected will be added to this pool automatically.
+			</Text>
+			<Card padding="none">
+				<Stack gap={0}>
+					{members.map((member, i) => (
+						<label
+							key={member.userId}
+							className={`flex cursor-pointer items-center gap-3 px-3 py-2.5 transition-colors hover:bg-muted/50 ${i > 0 ? 'border-t border-border' : ''}`}
+						>
+							<input
+								type="checkbox"
+								checked={selected.has(member.userId)}
+								onChange={() => toggle(member.userId)}
+								className="h-4 w-4 rounded border-input text-primary focus:ring-primary"
+							/>
+							<img
+								src={getUserImgSrc(member.imageId, { size: 64 })}
+								alt=""
+								className="h-7 w-7 shrink-0 rounded-full object-cover"
+							/>
+							<Stack gap={0} className="min-w-0 flex-1">
+								<Text size="sm" weight="medium" className="truncate">
+									{member.name}
+								</Text>
+								<Text size="xs" className="text-muted-foreground">
+									@{member.username}
+								</Text>
+							</Stack>
+							{member.contributionCents > 0 && (
+								<Text
+									size="xs"
+									className="shrink-0 text-muted-foreground"
+								>
+									${(member.contributionCents / 100).toFixed(0)} cap
+								</Text>
+							)}
+						</label>
+					))}
+				</Stack>
+			</Card>
+			{selected.size === 0 && (
+				<Text size="xs" className="text-destructive">
+					Select at least one contributor.
+				</Text>
+			)}
+		</Stack>
+	)
+}

--- a/app/routes/pools+/new.tsx
+++ b/app/routes/pools+/new.tsx
@@ -379,7 +379,8 @@ export async function action({ request }: ActionFunctionArgs) {
 			submission,
 		)
 		if (!result.ok) return result.response
-		;({ recipientUserId, groupMemberDefaults } = result.value)
+		recipientUserId = result.value.recipientUserId
+		groupMemberDefaults = result.value.groupMemberDefaults
 	} else if (formRecipientUserId) {
 		const result = await resolveStandaloneRecipient(
 			userId,

--- a/app/utils/group-overview.server.test.ts
+++ b/app/utils/group-overview.server.test.ts
@@ -3,13 +3,28 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-// Avoid pulling in prisma/db for pure-function tests.
-vi.mock('#app/utils/db.server.ts', () => ({ prisma: {} }));
+const poolFindMany = vi.fn();
+const usersInGiftGroupsFindMany = vi.fn();
+
+vi.mock('#app/utils/db.server.ts', () => ({
+  prisma: {
+    pool: {
+      findMany: (...args: Array<unknown>) => poolFindMany(...args),
+    },
+    usersInGiftGroups: {
+      findMany: (...args: Array<unknown>) => usersInGiftGroupsFindMany(...args),
+    },
+  },
+}));
 
 import {
   ACTION_TYPE,
   _computeActionQueueForTesting as computeActionQueue,
+  _computeUpcomingOccasionsForTesting as computeUpcomingOccasions,
   _isPoolStuckForTesting as isPoolStuck,
+  _shapePastGiftsForTesting as shapePastGifts,
+  _shapePoolSummariesForTesting as shapePoolSummaries,
+  getGroupOverviewData,
   type UpcomingOccasion,
 } from './group-overview.server.ts';
 
@@ -228,5 +243,268 @@ describe('computeActionQueue — POOL_STUCK classifier', () => {
     const stuck = items.find((i) => i.type === ACTION_TYPE.POOL_STUCK);
 
     expect(stuck?.priority).toBe(1);
+  });
+});
+
+describe('shapePoolSummaries', () => {
+  it('shapes pool rows with viewer-relative role and recipient fallback', () => {
+    const pools: any = [
+      {
+        id: 'pool-1',
+        title: "Marco's Birthday",
+        occasionType: 'BIRTHDAY',
+        eventDate: new Date('2026-05-03'),
+        status: 'OPEN',
+        organizerId: 'viewer-1',
+        recipientUser: { name: 'Marco', username: 'marco' },
+        recipientName: null,
+        contributors: [
+          { userId: 'viewer-1', contributionCents: 2000, hasPaid: true },
+          { userId: 'other', contributionCents: 1000, hasPaid: false },
+        ],
+        _count: { ideas: 3, contributors: 2 },
+      },
+      {
+        id: 'pool-2',
+        title: 'Standalone',
+        occasionType: 'OTHER',
+        eventDate: null,
+        status: 'OPEN',
+        organizerId: 'other',
+        recipientUser: null,
+        recipientName: null,
+        contributors: [
+          { userId: 'other', contributionCents: 0, hasPaid: false },
+        ],
+        _count: { ideas: 0, contributors: 1 },
+      },
+    ];
+
+    const out = shapePoolSummaries(pools, 'viewer-1');
+
+    expect(out[0]).toMatchObject({
+      id: 'pool-1',
+      recipientName: 'Marco',
+      recipientUsername: 'marco',
+      paidCount: 1,
+      contributorCount: 2,
+      ideaCount: 3,
+      viewerRole: 'organizing',
+      viewerContributionCents: 2000,
+    });
+    // Falls back to "Someone" when recipientUser and recipientName are null;
+    // viewer is not a contributor on pool-2 → role 'none'.
+    expect(out[1]).toMatchObject({
+      recipientName: 'Someone',
+      recipientUsername: null,
+      viewerRole: 'none',
+      viewerContributionCents: null,
+    });
+  });
+});
+
+describe('shapePastGifts', () => {
+  it('uses finalPriceCents when present and falls back to summed contributions', () => {
+    const rows: any = [
+      {
+        id: 'p-1',
+        title: 'A',
+        status: 'DELIVERED',
+        occasionType: 'BIRTHDAY',
+        updatedAt: new Date('2025-01-01'),
+        recipientUser: { name: 'Alex', username: 'alex' },
+        recipientName: null,
+        chosenIdea: { name: 'Headphones' },
+        finalPriceCents: 5000,
+        contributors: [{ contributionCents: 9999 }], // ignored — finalPriceCents wins
+      },
+      {
+        id: 'p-2',
+        title: 'B',
+        status: 'CANCELLED',
+        occasionType: 'OTHER',
+        updatedAt: new Date('2025-02-01'),
+        recipientUser: null,
+        recipientName: 'Offline',
+        chosenIdea: null,
+        finalPriceCents: null,
+        contributors: [
+          { contributionCents: 1000 },
+          { contributionCents: 2000 },
+          { contributionCents: null },
+        ],
+      },
+    ];
+
+    const out = shapePastGifts(rows);
+    expect(out[0]?.totalCents).toBe(5000);
+    expect(out[0]?.chosenIdeaName).toBe('Headphones');
+    expect(out[1]?.totalCents).toBe(3000);
+    expect(out[1]?.chosenIdeaName).toBeNull();
+    expect(out[1]?.recipientName).toBe('Offline');
+  });
+});
+
+describe('computeUpcomingOccasions', () => {
+  it('skips members with active pools, members without birthdays, and birthdays beyond 60 days', () => {
+    const inSixtyDays = new Date(NOW);
+    inSixtyDays.setDate(inSixtyDays.getDate() + 70); // beyond window
+    const inThirtyDays = new Date(NOW);
+    inThirtyDays.setDate(inThirtyDays.getDate() + 30);
+
+    const members: any = [
+      {
+        userId: 'has-pool',
+        user: {
+          name: 'Has Pool',
+          username: 'haspool',
+          birthday: inThirtyDays,
+          image: null,
+        },
+      },
+      {
+        userId: 'no-birthday',
+        user: {
+          name: 'No Birthday',
+          username: 'nobirthday',
+          birthday: null,
+          image: null,
+        },
+      },
+      {
+        userId: 'far-away',
+        user: {
+          name: 'Far',
+          username: 'far',
+          birthday: inSixtyDays,
+          image: null,
+        },
+      },
+      {
+        userId: 'in-window',
+        user: {
+          name: 'In Window',
+          username: 'inwindow',
+          birthday: inThirtyDays,
+          image: { id: 'img-1' },
+        },
+      },
+    ];
+    const activePools: any = [
+      { recipientUserId: 'has-pool' },
+      { recipientUserId: null }, // standalone — should be ignored
+    ];
+
+    const out = computeUpcomingOccasions(members, activePools, 'group-1');
+
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      userId: 'in-window',
+      name: 'In Window',
+      username: 'inwindow',
+      imageId: 'img-1',
+      groupId: 'group-1',
+    });
+  });
+});
+
+describe('getGroupOverviewData (integration)', () => {
+  beforeEach(() => {
+    poolFindMany.mockReset();
+    usersInGiftGroupsFindMany.mockReset();
+  });
+
+  it('orchestrates the three queries and returns a fully shaped overview', async () => {
+    const inFifteenDays = new Date(NOW);
+    inFifteenDays.setDate(inFifteenDays.getDate() + 15);
+
+    // Active pools (1st findMany call)
+    poolFindMany.mockResolvedValueOnce([
+      {
+        id: 'pool-active',
+        title: "Marco's Birthday",
+        occasionType: 'BIRTHDAY',
+        eventDate: new Date(NOW.getTime() + 14 * DAY),
+        status: 'OPEN',
+        decisionMode: 'ORGANIZER_PICKS',
+        updatedAt: new Date(NOW.getTime() - 1 * DAY),
+        organizerId: 'viewer-1',
+        purchaserId: null,
+        delivererId: null,
+        chosenIdeaId: null,
+        recipientUserId: 'marco',
+        recipientName: null,
+        recipientUser: { name: 'Marco', username: 'marco' },
+        contributors: [
+          { userId: 'viewer-1', contributionCents: 2000, hasPaid: false },
+        ],
+        chosenIdea: null,
+        votes: [],
+        _count: { ideas: 1, contributors: 1, votes: 0 },
+      },
+    ]);
+
+    // Group members (usersInGiftGroups.findMany)
+    usersInGiftGroupsFindMany.mockResolvedValueOnce([
+      {
+        userId: 'leo',
+        user: {
+          name: 'Leo',
+          username: 'leo',
+          birthday: inFifteenDays,
+          image: null,
+        },
+      },
+    ]);
+
+    // Past gifts (2nd pool findMany call)
+    poolFindMany.mockResolvedValueOnce([
+      {
+        id: 'pool-past',
+        title: 'Last year',
+        status: 'DELIVERED',
+        occasionType: 'BIRTHDAY',
+        updatedAt: new Date('2025-05-01'),
+        recipientName: null,
+        recipientUser: { name: 'Alex', username: 'alex' },
+        chosenIdea: { name: 'Speaker' },
+        finalPriceCents: 6000,
+        contributors: [],
+      },
+    ]);
+
+    const result = await getGroupOverviewData('group-1', 'viewer-1');
+
+    expect(poolFindMany).toHaveBeenCalledTimes(2);
+    expect(usersInGiftGroupsFindMany).toHaveBeenCalledTimes(1);
+    expect(result.activePools).toHaveLength(1);
+    expect(result.activePools[0]?.viewerRole).toBe('organizing');
+    expect(result.upcomingOccasions).toHaveLength(1);
+    expect(result.upcomingOccasions[0]?.userId).toBe('leo');
+    expect(result.pastGifts).toHaveLength(1);
+    expect(result.pastGifts[0]?.totalCents).toBe(6000);
+    // Action queue: organizer of OPEN pool with 1 idea (ORGANIZER_PICKS)
+    // gets CHOOSE_GIFT. Plus the upcoming occasion.
+    const types = result.actionQueue.map((i) => i.type);
+    expect(types).toContain(ACTION_TYPE.CHOOSE_GIFT);
+    expect(types).toContain(ACTION_TYPE.UPCOMING_OCCASION);
+  });
+
+  it('enforces the recipient-privacy filter on every pool query', async () => {
+    poolFindMany.mockResolvedValue([]);
+    usersInGiftGroupsFindMany.mockResolvedValue([]);
+
+    await getGroupOverviewData('group-1', 'viewer-1');
+
+    for (const call of poolFindMany.mock.calls) {
+      const where = (call[0] as { where: { OR: Array<unknown> } }).where;
+      // The OR clause covers `recipientUserId: null OR { not: viewerId }`.
+      expect(where.OR).toEqual(
+        expect.arrayContaining([
+          { recipientUserId: null },
+          { recipientUserId: { not: 'viewer-1' } },
+        ]),
+      );
+    }
   });
 });

--- a/app/utils/group-overview.server.test.ts
+++ b/app/utils/group-overview.server.test.ts
@@ -1,0 +1,232 @@
+/**
+ * @vitest-environment node
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Avoid pulling in prisma/db for pure-function tests.
+vi.mock('#app/utils/db.server.ts', () => ({ prisma: {} }));
+
+import {
+  ACTION_TYPE,
+  _computeActionQueueForTesting as computeActionQueue,
+  _isPoolStuckForTesting as isPoolStuck,
+  type UpcomingOccasion,
+} from './group-overview.server.ts';
+
+const DAY = 24 * 60 * 60 * 1000;
+const NOW = new Date('2026-04-15T12:00:00Z');
+
+function makePool(overrides: Partial<any> = {}): any {
+  return {
+    id: 'pool-1',
+    title: "Marco's Birthday",
+    occasionType: 'BIRTHDAY',
+    status: 'OPEN',
+    decisionMode: 'ORGANIZER_PICKS',
+    eventDate: new Date(NOW.getTime() + 14 * DAY),
+    updatedAt: new Date(NOW.getTime() - 5 * DAY),
+    organizerId: 'other-user',
+    purchaserId: null,
+    delivererId: null,
+    chosenIdeaId: null,
+    recipientUserId: 'marco',
+    recipientName: null,
+    recipientUser: { name: 'Marco', username: 'marco' },
+    contributors: [
+      { userId: 'viewer-1', contributionCents: 2000, hasPaid: false },
+      { userId: 'other-user', contributionCents: 2000, hasPaid: false },
+      { userId: 'third-user', contributionCents: 2000, hasPaid: false },
+    ],
+    chosenIdea: null,
+    votes: [],
+    _count: { ideas: 0, contributors: 3, votes: 0 },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('isPoolStuck', () => {
+  it('is stuck when idle > 3 days and event within 30 days', () => {
+    const pool = makePool({
+      updatedAt: new Date(NOW.getTime() - 5 * DAY),
+      eventDate: new Date(NOW.getTime() + 14 * DAY),
+    });
+    expect(isPoolStuck(pool)).toBe(true);
+  });
+
+  it('is not stuck when idle <= 3 days', () => {
+    const pool = makePool({
+      updatedAt: new Date(NOW.getTime() - 2 * DAY),
+    });
+    expect(isPoolStuck(pool)).toBe(false);
+  });
+
+  it('is not stuck when event is beyond the 30-day window', () => {
+    const pool = makePool({
+      updatedAt: new Date(NOW.getTime() - 10 * DAY),
+      eventDate: new Date(NOW.getTime() + 60 * DAY),
+    });
+    expect(isPoolStuck(pool)).toBe(false);
+  });
+
+  it('is stuck when idle > 3 days and no event date (treated as urgent)', () => {
+    const pool = makePool({
+      updatedAt: new Date(NOW.getTime() - 5 * DAY),
+      eventDate: null,
+    });
+    expect(isPoolStuck(pool)).toBe(true);
+  });
+});
+
+describe('computeActionQueue — POOL_STUCK classifier', () => {
+  const occasions: UpcomingOccasion[] = [];
+
+  it('adds POOL_STUCK with "add one?" copy when an OPEN pool has 0 ideas', () => {
+    const pool = makePool({
+      status: 'OPEN',
+      organizerId: 'other-user', // not the viewer, so no CHOOSE_GIFT nudge
+      _count: { ideas: 0, contributors: 3, votes: 0 },
+      // Suppress PROPOSE_IDEA: viewer is not a contributor on this pool.
+      contributors: [
+        { userId: 'other-user', contributionCents: 2000, hasPaid: false },
+        { userId: 'third-user', contributionCents: 2000, hasPaid: false },
+        { userId: 'viewer-1', contributionCents: 2000, hasPaid: false },
+      ],
+    });
+    // Viewer must be a contributor for STUCK to fire.
+    const items = computeActionQueue([pool], occasions, 'viewer-1', 'group-1');
+    const stuck = items.filter((i) => i.type === ACTION_TYPE.POOL_STUCK);
+
+    // PROPOSE_IDEA is a direct action for viewer-1 (they are a contributor),
+    // so STUCK should be suppressed.
+    expect(stuck).toHaveLength(0);
+  });
+
+  it('adds POOL_STUCK with VOTING nudge copy mentioning outstanding vote count', () => {
+    const pool = makePool({
+      status: 'VOTING',
+      organizerId: 'other-user', // not viewer — no CLOSE_VOTE for viewer
+      _count: { ideas: 2, contributors: 3, votes: 1 },
+      votes: [{ id: 'v-1' }], // viewer HAS voted, so no CAST_VOTE
+      contributors: [
+        { userId: 'viewer-1', contributionCents: 2000, hasPaid: false },
+        { userId: 'other-user', contributionCents: 2000, hasPaid: false },
+        { userId: 'third-user', contributionCents: 2000, hasPaid: false },
+      ],
+    });
+
+    const items = computeActionQueue([pool], occasions, 'viewer-1', 'group-1');
+    const stuck = items.find((i) => i.type === ACTION_TYPE.POOL_STUCK);
+
+    expect(stuck).toBeDefined();
+    expect(stuck?.description).toContain("2 of 3 haven't voted");
+    expect(stuck?.poolId).toBe('pool-1');
+  });
+
+  it('adds POOL_STUCK with "mark as purchased" copy for DECIDED pools', () => {
+    const pool = makePool({
+      status: 'DECIDED',
+      organizerId: 'other-user', // viewer is not organizer → no MARK_PURCHASED
+      purchaserId: null,
+      chosenIdea: { proposedById: 'someone-else' },
+      _count: { ideas: 2, contributors: 3, votes: 0 },
+      // Viewer has paid and contribution set → no MARK_PAID, no SET_CONTRIBUTION
+      contributors: [
+        { userId: 'viewer-1', contributionCents: 2000, hasPaid: true },
+        { userId: 'other-user', contributionCents: 2000, hasPaid: false },
+        { userId: 'third-user', contributionCents: 2000, hasPaid: false },
+      ],
+    });
+
+    const items = computeActionQueue([pool], occasions, 'viewer-1', 'group-1');
+    const stuck = items.find((i) => i.type === ACTION_TYPE.POOL_STUCK);
+
+    expect(stuck).toBeDefined();
+    expect(stuck?.description).toContain('mark as purchased');
+  });
+
+  it('suppresses POOL_STUCK when the viewer has a direct action on the same pool', () => {
+    // VOTING pool where the viewer is the organizer AND has a vote to cast.
+    // This guarantees both CAST_VOTE and CLOSE_VOTE in items — suppression
+    // must kick in and no POOL_STUCK item should appear.
+    const pool = makePool({
+      status: 'VOTING',
+      organizerId: 'viewer-1',
+      _count: { ideas: 2, contributors: 3, votes: 0 },
+      votes: [], // viewer hasn't voted
+    });
+
+    const items = computeActionQueue([pool], occasions, 'viewer-1', 'group-1');
+
+    expect(items.some((i) => i.type === ACTION_TYPE.CLOSE_VOTE)).toBe(true);
+    expect(items.some((i) => i.type === ACTION_TYPE.CAST_VOTE)).toBe(true);
+    expect(items.some((i) => i.type === ACTION_TYPE.POOL_STUCK)).toBe(false);
+  });
+
+  it('does not add POOL_STUCK for viewers who are not contributors', () => {
+    const pool = makePool({
+      status: 'VOTING',
+      organizerId: 'other-user',
+      _count: { ideas: 2, contributors: 2, votes: 0 },
+      // Viewer not in contributors array
+      contributors: [
+        { userId: 'other-user', contributionCents: 2000, hasPaid: false },
+        { userId: 'third-user', contributionCents: 2000, hasPaid: false },
+      ],
+    });
+
+    const items = computeActionQueue([pool], occasions, 'viewer-1', 'group-1');
+    expect(items.some((i) => i.type === ACTION_TYPE.POOL_STUCK)).toBe(false);
+  });
+
+  it('does not add POOL_STUCK for fresh pools (idle <= 3 days)', () => {
+    const pool = makePool({
+      status: 'VOTING',
+      organizerId: 'other-user',
+      updatedAt: new Date(NOW.getTime() - 1 * DAY),
+      _count: { ideas: 2, contributors: 3, votes: 1 },
+      votes: [{ id: 'v-1' }],
+    });
+
+    const items = computeActionQueue([pool], occasions, 'viewer-1', 'group-1');
+    expect(items.some((i) => i.type === ACTION_TYPE.POOL_STUCK)).toBe(false);
+  });
+
+  it('promotes a stuck pool to P0 priority when the event is within 7 days', () => {
+    const pool = makePool({
+      status: 'VOTING',
+      organizerId: 'other-user',
+      eventDate: new Date(NOW.getTime() + 3 * DAY),
+      _count: { ideas: 2, contributors: 3, votes: 1 },
+      votes: [{ id: 'v-1' }], // viewer has voted — no CAST_VOTE
+    });
+
+    const items = computeActionQueue([pool], occasions, 'viewer-1', 'group-1');
+    const stuck = items.find((i) => i.type === ACTION_TYPE.POOL_STUCK);
+
+    expect(stuck?.priority).toBe(0);
+  });
+
+  it('keeps stuck pool at P1 priority when event is beyond urgency threshold', () => {
+    const pool = makePool({
+      status: 'VOTING',
+      organizerId: 'other-user',
+      eventDate: new Date(NOW.getTime() + 20 * DAY),
+      _count: { ideas: 2, contributors: 3, votes: 1 },
+      votes: [{ id: 'v-1' }],
+    });
+
+    const items = computeActionQueue([pool], occasions, 'viewer-1', 'group-1');
+    const stuck = items.find((i) => i.type === ACTION_TYPE.POOL_STUCK);
+
+    expect(stuck?.priority).toBe(1);
+  });
+});

--- a/app/utils/group-overview.server.ts
+++ b/app/utils/group-overview.server.ts
@@ -9,15 +9,16 @@ import {
 } from '#app/utils/group-overview.ts'
 import { DECISION_MODE, POOL_STATUS } from '#app/utils/pool-constants.ts'
 
-// Re-export so existing test imports from the .server module still work.
-export { ACTION_TYPE }
+// Re-export shared types/constants so existing test imports from this
+// module still work.
+export { ACTION_TYPE } from '#app/utils/group-overview.ts'
 export type {
 	ActionItem,
 	GroupOverviewData,
 	PastGift,
 	PoolSummary,
 	UpcomingOccasion,
-}
+} from '#app/utils/group-overview.ts'
 
 // ─── Constants ───────────────────────────────────────────────────────────────
 
@@ -189,215 +190,263 @@ type PastGiftRow = Awaited<ReturnType<typeof queryPastGifts>>[number]
 //   P3 — informational (your idea was chosen)
 //   P4 — future / low urgency (upcoming occasion, propose idea)
 
-function computeActionQueue(
-	pools: ActivePoolRow[],
-	occasions: UpcomingOccasion[],
+// Per-pool context used by all the per-status builder helpers.
+type PoolContext = {
+	pool: ActivePoolRow
+	viewer: ActivePoolRow['contributors'][number] | undefined
+	isOrganizer: boolean
+	isPurchaser: boolean
+	isDeliverer: boolean
+	base: {
+		poolId: string
+		poolTitle: string
+		recipientName: string
+		eventDate: Date | null
+		daysUntilEvent: number | null
+	}
+}
+
+function makePoolContext(
+	pool: ActivePoolRow,
 	viewerId: string,
-	groupId: string,
-): ActionItem[] {
-	const items: ActionItem[] = []
-
-	for (const pool of pools) {
-		const viewer = pool.contributors.find((c) => c.userId === viewerId)
-		const isOrganizer = pool.organizerId === viewerId
-		const isPurchaser = pool.purchaserId === viewerId
-		const isDeliverer = pool.delivererId === viewerId
-		const name =
-			pool.recipientUser?.name ?? pool.recipientName ?? 'someone'
-		const eventDays = pool.eventDate ? daysUntilDate(pool.eventDate) : null
-
-		const base = {
+): PoolContext {
+	const viewer = pool.contributors.find((c) => c.userId === viewerId)
+	return {
+		pool,
+		viewer,
+		isOrganizer: pool.organizerId === viewerId,
+		isPurchaser: pool.purchaserId === viewerId,
+		isDeliverer: pool.delivererId === viewerId,
+		base: {
 			poolId: pool.id,
 			poolTitle: pool.title,
-			recipientName: name,
+			recipientName:
+				pool.recipientUser?.name ?? pool.recipientName ?? 'someone',
 			eventDate: pool.eventDate,
-			daysUntilEvent: eventDays,
-		}
-
-		if (pool.status === POOL_STATUS.OPEN) {
-			if (viewer && pool._count.ideas === 0) {
-				items.push({
-					...base,
-					type: ACTION_TYPE.PROPOSE_IDEA,
-					priority: 4,
-					ctaLabel: 'Propose an idea',
-					ctaUrl: `/pools/${pool.id}`,
-				})
-			}
-			if (
-				isOrganizer &&
-				pool.decisionMode === DECISION_MODE.VOTE &&
-				pool._count.ideas >= 2
-			) {
-				items.push({
-					...base,
-					type: ACTION_TYPE.CALL_VOTE,
-					priority: 1,
-					ctaLabel: 'Call a vote',
-					ctaUrl: `/pools/${pool.id}`,
-				})
-			}
-			if (
-				isOrganizer &&
-				pool.decisionMode === DECISION_MODE.ORGANIZER_PICKS &&
-				pool._count.ideas >= 1
-			) {
-				items.push({
-					...base,
-					type: ACTION_TYPE.CHOOSE_GIFT,
-					priority: 1,
-					ctaLabel: 'Choose a gift',
-					ctaUrl: `/pools/${pool.id}`,
-				})
-			}
-			if (viewer && !viewer.contributionCents) {
-				items.push({
-					...base,
-					type: ACTION_TYPE.SET_CONTRIBUTION,
-					priority: 2,
-					ctaLabel: 'Set contribution',
-					ctaUrl: `/pools/${pool.id}`,
-				})
-			}
-		}
-
-		if (pool.status === POOL_STATUS.VOTING) {
-			if (viewer && pool.votes.length === 0) {
-				items.push({
-					...base,
-					type: ACTION_TYPE.CAST_VOTE,
-					priority: 1,
-					ctaLabel: 'Cast your vote',
-					ctaUrl: `/pools/${pool.id}`,
-				})
-			}
-			if (isOrganizer) {
-				items.push({
-					...base,
-					type: ACTION_TYPE.CLOSE_VOTE,
-					priority: 1,
-					ctaLabel: 'Close voting',
-					ctaUrl: `/pools/${pool.id}`,
-				})
-			}
-			if (viewer && !viewer.contributionCents) {
-				items.push({
-					...base,
-					type: ACTION_TYPE.SET_CONTRIBUTION,
-					priority: 2,
-					ctaLabel: 'Set contribution',
-					ctaUrl: `/pools/${pool.id}`,
-				})
-			}
-		}
-
-		if (pool.status === POOL_STATUS.DECIDED) {
-			if (
-				viewer &&
-				!viewer.hasPaid &&
-				viewer.contributionCents &&
-				viewer.contributionCents > 0
-			) {
-				items.push({
-					...base,
-					type: ACTION_TYPE.MARK_PAID,
-					priority: 2,
-					ctaLabel: 'Mark as paid',
-					ctaUrl: `/pools/${pool.id}`,
-					amountCents: viewer.contributionCents,
-				})
-			}
-			if (isOrganizer || isPurchaser) {
-				items.push({
-					...base,
-					type: ACTION_TYPE.MARK_PURCHASED,
-					priority: 2,
-					ctaLabel: 'Mark as purchased',
-					ctaUrl: `/pools/${pool.id}`,
-				})
-			}
-			if (pool.chosenIdea?.proposedById === viewerId) {
-				items.push({
-					...base,
-					type: ACTION_TYPE.IDEA_CHOSEN,
-					priority: 3,
-					ctaLabel: 'View pool',
-					ctaUrl: `/pools/${pool.id}`,
-				})
-			}
-			if (viewer && !viewer.contributionCents) {
-				items.push({
-					...base,
-					type: ACTION_TYPE.SET_CONTRIBUTION,
-					priority: 2,
-					ctaLabel: 'Set contribution',
-					ctaUrl: `/pools/${pool.id}`,
-				})
-			}
-		}
-
-		if (pool.status === POOL_STATUS.PURCHASED) {
-			if (isOrganizer || isDeliverer) {
-				items.push({
-					...base,
-					type: ACTION_TYPE.MARK_DELIVERED,
-					priority: 2,
-					ctaLabel: 'Mark as delivered',
-					ctaUrl: `/pools/${pool.id}`,
-				})
-			}
-			if (pool.chosenIdea?.proposedById === viewerId) {
-				items.push({
-					...base,
-					type: ACTION_TYPE.IDEA_CHOSEN,
-					priority: 3,
-					ctaLabel: 'View pool',
-					ctaUrl: `/pools/${pool.id}`,
-				})
-			}
-		}
+			daysUntilEvent: pool.eventDate ? daysUntilDate(pool.eventDate) : null,
+		},
 	}
+}
 
-	// POOL_STUCK pass. A stuck pool is one that's been idle for > 3 days
-	// AND the event is within 30 days (or has no event date). We suppress
-	// STUCK when the viewer already has a direct action on the same pool —
-	// the direct action is more specific, so we don't want duplicates.
+function setContributionItem(ctx: PoolContext): ActionItem | null {
+	if (!ctx.viewer || ctx.viewer.contributionCents) return null
+	return {
+		...ctx.base,
+		type: ACTION_TYPE.SET_CONTRIBUTION,
+		priority: 2,
+		ctaLabel: 'Set contribution',
+		ctaUrl: `/pools/${ctx.pool.id}`,
+	}
+}
+
+function buildOpenActions(ctx: PoolContext): ActionItem[] {
+	const out: ActionItem[] = []
+	const { pool, viewer, isOrganizer, base } = ctx
+
+	if (viewer && pool._count.ideas === 0) {
+		out.push({
+			...base,
+			type: ACTION_TYPE.PROPOSE_IDEA,
+			priority: 4,
+			ctaLabel: 'Propose an idea',
+			ctaUrl: `/pools/${pool.id}`,
+		})
+	}
+	if (
+		isOrganizer &&
+		pool.decisionMode === DECISION_MODE.VOTE &&
+		pool._count.ideas >= 2
+	) {
+		out.push({
+			...base,
+			type: ACTION_TYPE.CALL_VOTE,
+			priority: 1,
+			ctaLabel: 'Call a vote',
+			ctaUrl: `/pools/${pool.id}`,
+		})
+	}
+	if (
+		isOrganizer &&
+		pool.decisionMode === DECISION_MODE.ORGANIZER_PICKS &&
+		pool._count.ideas >= 1
+	) {
+		out.push({
+			...base,
+			type: ACTION_TYPE.CHOOSE_GIFT,
+			priority: 1,
+			ctaLabel: 'Choose a gift',
+			ctaUrl: `/pools/${pool.id}`,
+		})
+	}
+	const setContrib = setContributionItem(ctx)
+	if (setContrib) out.push(setContrib)
+	return out
+}
+
+function buildVotingActions(ctx: PoolContext): ActionItem[] {
+	const out: ActionItem[] = []
+	const { pool, viewer, isOrganizer, base } = ctx
+
+	if (viewer && pool.votes.length === 0) {
+		out.push({
+			...base,
+			type: ACTION_TYPE.CAST_VOTE,
+			priority: 1,
+			ctaLabel: 'Cast your vote',
+			ctaUrl: `/pools/${pool.id}`,
+		})
+	}
+	if (isOrganizer) {
+		out.push({
+			...base,
+			type: ACTION_TYPE.CLOSE_VOTE,
+			priority: 1,
+			ctaLabel: 'Close voting',
+			ctaUrl: `/pools/${pool.id}`,
+		})
+	}
+	const setContrib = setContributionItem(ctx)
+	if (setContrib) out.push(setContrib)
+	return out
+}
+
+function buildDecidedActions(
+	ctx: PoolContext,
+	viewerId: string,
+): ActionItem[] {
+	const out: ActionItem[] = []
+	const { pool, viewer, isOrganizer, isPurchaser, base } = ctx
+
+	if (
+		viewer &&
+		!viewer.hasPaid &&
+		viewer.contributionCents &&
+		viewer.contributionCents > 0
+	) {
+		out.push({
+			...base,
+			type: ACTION_TYPE.MARK_PAID,
+			priority: 2,
+			ctaLabel: 'Mark as paid',
+			ctaUrl: `/pools/${pool.id}`,
+			amountCents: viewer.contributionCents,
+		})
+	}
+	if (isOrganizer || isPurchaser) {
+		out.push({
+			...base,
+			type: ACTION_TYPE.MARK_PURCHASED,
+			priority: 2,
+			ctaLabel: 'Mark as purchased',
+			ctaUrl: `/pools/${pool.id}`,
+		})
+	}
+	if (pool.chosenIdea?.proposedById === viewerId) {
+		out.push({
+			...base,
+			type: ACTION_TYPE.IDEA_CHOSEN,
+			priority: 3,
+			ctaLabel: 'View pool',
+			ctaUrl: `/pools/${pool.id}`,
+		})
+	}
+	const setContrib = setContributionItem(ctx)
+	if (setContrib) out.push(setContrib)
+	return out
+}
+
+function buildPurchasedActions(
+	ctx: PoolContext,
+	viewerId: string,
+): ActionItem[] {
+	const out: ActionItem[] = []
+	const { pool, isOrganizer, isDeliverer, base } = ctx
+
+	if (isOrganizer || isDeliverer) {
+		out.push({
+			...base,
+			type: ACTION_TYPE.MARK_DELIVERED,
+			priority: 2,
+			ctaLabel: 'Mark as delivered',
+			ctaUrl: `/pools/${pool.id}`,
+		})
+	}
+	if (pool.chosenIdea?.proposedById === viewerId) {
+		out.push({
+			...base,
+			type: ACTION_TYPE.IDEA_CHOSEN,
+			priority: 3,
+			ctaLabel: 'View pool',
+			ctaUrl: `/pools/${pool.id}`,
+		})
+	}
+	return out
+}
+
+function buildDirectActionsForPool(
+	pool: ActivePoolRow,
+	viewerId: string,
+): ActionItem[] {
+	const ctx = makePoolContext(pool, viewerId)
+	switch (pool.status) {
+		case POOL_STATUS.OPEN:
+			return buildOpenActions(ctx)
+		case POOL_STATUS.VOTING:
+			return buildVotingActions(ctx)
+		case POOL_STATUS.DECIDED:
+			return buildDecidedActions(ctx, viewerId)
+		case POOL_STATUS.PURCHASED:
+			return buildPurchasedActions(ctx, viewerId)
+		default:
+			return []
+	}
+}
+
+// POOL_STUCK pass. Suppressed when the viewer already has a direct action
+// on the same pool — the direct action is more specific, so we don't want
+// duplicates.
+function buildStuckItems(
+	pools: ActivePoolRow[],
+	items: ActionItem[],
+	viewerId: string,
+): ActionItem[] {
 	const poolIdsWithDirectAction = new Set(
 		items.map((i) => i.poolId).filter((id): id is string => id !== null),
 	)
-
+	const out: ActionItem[] = []
 	for (const pool of pools) {
 		if (poolIdsWithDirectAction.has(pool.id)) continue
-
 		const viewer = pool.contributors.find((c) => c.userId === viewerId)
 		if (!viewer) continue
-
 		if (!isPoolStuck(pool)) continue
-
 		const stuck = buildStuckItem(pool)
-		if (!stuck) continue
-
-		items.push(stuck)
+		if (stuck) out.push(stuck)
 	}
+	return out
+}
 
-	for (const occasion of occasions) {
-		items.push({
-			type: ACTION_TYPE.UPCOMING_OCCASION,
-			priority: 4,
-			poolId: null,
-			poolTitle: null,
-			recipientName: occasion.name,
-			eventDate: null,
-			daysUntilEvent: occasion.daysUntil,
-			ctaLabel: 'Start a pool',
-			ctaUrl: `/pools/new?groupId=${groupId}&recipientId=${occasion.userId}`,
-			memberId: occasion.userId,
-			memberUsername: occasion.username,
-			memberImageId: occasion.imageId,
-		})
+function buildOccasionItem(
+	occasion: UpcomingOccasion,
+	groupId: string,
+): ActionItem {
+	return {
+		type: ACTION_TYPE.UPCOMING_OCCASION,
+		priority: 4,
+		poolId: null,
+		poolTitle: null,
+		recipientName: occasion.name,
+		eventDate: null,
+		daysUntilEvent: occasion.daysUntil,
+		ctaLabel: 'Start a pool',
+		ctaUrl: `/pools/new?groupId=${groupId}&recipientId=${occasion.userId}`,
+		memberId: occasion.userId,
+		memberUsername: occasion.username,
+		memberImageId: occasion.imageId,
 	}
+}
 
-	// P0 promotion: any action tied to an event within the urgency threshold
+// P0 promotion: any action tied to an event within the urgency threshold.
+function promoteUrgentItems(items: ActionItem[]): void {
 	for (const item of items) {
 		if (
 			item.daysUntilEvent !== null &&
@@ -408,14 +457,31 @@ function computeActionQueue(
 			item.priority = 0
 		}
 	}
+}
 
-	items.sort((a, b) => {
-		if (a.priority !== b.priority) return a.priority - b.priority
-		const aDays = a.daysUntilEvent ?? Infinity
-		const bDays = b.daysUntilEvent ?? Infinity
-		return aDays - bDays
-	})
+function compareActionItems(a: ActionItem, b: ActionItem): number {
+	if (a.priority !== b.priority) return a.priority - b.priority
+	const aDays = a.daysUntilEvent ?? Infinity
+	const bDays = b.daysUntilEvent ?? Infinity
+	return aDays - bDays
+}
 
+function computeActionQueue(
+	pools: ActivePoolRow[],
+	occasions: UpcomingOccasion[],
+	viewerId: string,
+	groupId: string,
+): ActionItem[] {
+	const items: ActionItem[] = []
+	for (const pool of pools) {
+		items.push(...buildDirectActionsForPool(pool, viewerId))
+	}
+	items.push(...buildStuckItems(pools, items, viewerId))
+	for (const occasion of occasions) {
+		items.push(buildOccasionItem(occasion, groupId))
+	}
+	promoteUrgentItems(items)
+	items.sort(compareActionItems)
 	return items.slice(0, ACTION_QUEUE_LIMIT)
 }
 
@@ -558,6 +624,16 @@ function computeUpcomingOccasions(
 
 // ─── Shaping helpers ─────────────────────────────────────────────────────────
 
+function viewerRoleFor(
+	pool: ActivePoolRow,
+	viewerId: string,
+	viewerContributor: ActivePoolRow['contributors'][number] | undefined,
+): PoolSummary['viewerRole'] {
+	if (pool.organizerId === viewerId) return 'organizing'
+	if (viewerContributor) return 'contributing'
+	return 'none'
+}
+
 function shapePoolSummaries(
 	pools: ActivePoolRow[],
 	viewerId: string,
@@ -579,11 +655,7 @@ function shapePoolSummaries(
 			ideaCount: pool._count.ideas,
 			contributorCount: pool.contributors.length,
 			paidCount: pool.contributors.filter((c) => c.hasPaid).length,
-			viewerRole: pool.organizerId === viewerId
-				? ('organizing' as const)
-				: viewerContributor
-					? ('contributing' as const)
-					: ('none' as const),
+			viewerRole: viewerRoleFor(pool, viewerId, viewerContributor),
 			viewerContributionCents: viewerContributor?.contributionCents ?? null,
 		}
 	})

--- a/app/utils/group-overview.server.ts
+++ b/app/utils/group-overview.server.ts
@@ -1,0 +1,615 @@
+import { prisma } from '#app/utils/db.server.ts'
+import {
+	ACTION_TYPE,
+	type ActionItem,
+	type GroupOverviewData,
+	type PastGift,
+	type PoolSummary,
+	type UpcomingOccasion,
+} from '#app/utils/group-overview.ts'
+import { DECISION_MODE, POOL_STATUS } from '#app/utils/pool-constants.ts'
+
+// Re-export so existing test imports from the .server module still work.
+export { ACTION_TYPE }
+export type {
+	ActionItem,
+	GroupOverviewData,
+	PastGift,
+	PoolSummary,
+	UpcomingOccasion,
+}
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const TERMINAL_STATUSES = [POOL_STATUS.DELIVERED, POOL_STATUS.CANCELLED]
+const ACTION_QUEUE_LIMIT = 5
+const UPCOMING_OCCASION_DAYS = 60
+const URGENCY_THRESHOLD_DAYS = 7
+
+// A pool is "stuck" if both conditions hold: the row hasn't been touched for
+// more than STUCK_IDLE_DAYS, AND the event is within STUCK_EVENT_WINDOW_DAYS
+// (or has no event date — treated as urgent).
+const STUCK_IDLE_DAYS = 3
+const STUCK_EVENT_WINDOW_DAYS = 30
+
+// ─── Main entry point ────────────────────────────────────────────────────────
+// Two parallel queries + one sequential (past gifts is independent).
+// Action queue is computed in application code over the results — no extra DB hit.
+
+export async function getGroupOverviewData(
+	groupId: string,
+	viewerId: string,
+): Promise<GroupOverviewData> {
+	const [activePoolRows, memberRows, pastGiftRows] = await Promise.all([
+		queryActivePools(groupId, viewerId),
+		queryGroupMembers(groupId, viewerId),
+		queryPastGifts(groupId, viewerId),
+	])
+
+	const activePools = shapePoolSummaries(activePoolRows, viewerId)
+	const upcomingOccasions = computeUpcomingOccasions(
+		memberRows,
+		activePoolRows,
+		groupId,
+	)
+	const actionQueue = computeActionQueue(
+		activePoolRows,
+		upcomingOccasions,
+		viewerId,
+		groupId,
+	)
+	const pastGifts = shapePastGifts(pastGiftRows)
+
+	return { actionQueue, activePools, upcomingOccasions, pastGifts }
+}
+
+// ─── Queries ─────────────────────────────────────────────────────────────────
+// Privacy invariant: every pool query includes a WHERE clause that excludes
+// rows where recipientUserId = viewerId. This is the security boundary — data
+// filtered here never reaches the client.
+
+async function queryActivePools(groupId: string, viewerId: string) {
+	const pools = await prisma.pool.findMany({
+		where: {
+			giftGroupId: groupId,
+			status: { notIn: TERMINAL_STATUSES },
+			OR: [
+				{ recipientUserId: null },
+				{ recipientUserId: { not: viewerId } },
+			],
+		},
+		select: {
+			id: true,
+			title: true,
+			occasionType: true,
+			eventDate: true,
+			status: true,
+			decisionMode: true,
+			updatedAt: true,
+			organizerId: true,
+			purchaserId: true,
+			delivererId: true,
+			chosenIdeaId: true,
+			recipientUserId: true,
+			recipientName: true,
+			recipientUser: {
+				select: { name: true, username: true },
+			},
+			contributors: {
+				select: {
+					userId: true,
+					contributionCents: true,
+					hasPaid: true,
+				},
+			},
+			chosenIdea: {
+				select: { proposedById: true },
+			},
+			votes: {
+				where: { voterId: viewerId },
+				select: { id: true },
+			},
+			_count: { select: { ideas: true, contributors: true, votes: true } },
+		},
+	})
+
+	return pools.sort((a, b) => {
+		const aDate = a.eventDate?.getTime() ?? Infinity
+		const bDate = b.eventDate?.getTime() ?? Infinity
+		return aDate - bDate
+	})
+}
+
+type ActivePoolRow = Awaited<ReturnType<typeof queryActivePools>>[number]
+
+async function queryGroupMembers(groupId: string, viewerId: string) {
+	return prisma.usersInGiftGroups.findMany({
+		where: {
+			giftGroupId: groupId,
+			userId: { not: viewerId },
+			removedAt: null,
+			shareBirthday: true,
+			user: { birthday: { not: null } },
+		},
+		select: {
+			userId: true,
+			user: {
+				select: {
+					name: true,
+					username: true,
+					birthday: true,
+					image: { select: { id: true } },
+				},
+			},
+		},
+	})
+}
+
+type MemberRow = Awaited<ReturnType<typeof queryGroupMembers>>[number]
+
+async function queryPastGifts(groupId: string, viewerId: string) {
+	return prisma.pool.findMany({
+		where: {
+			giftGroupId: groupId,
+			status: { in: TERMINAL_STATUSES },
+			OR: [
+				{ recipientUserId: null },
+				{ recipientUserId: { not: viewerId } },
+			],
+		},
+		select: {
+			id: true,
+			title: true,
+			status: true,
+			occasionType: true,
+			updatedAt: true,
+			recipientName: true,
+			recipientUser: { select: { name: true, username: true } },
+			chosenIdea: { select: { name: true } },
+			finalPriceCents: true,
+			contributors: {
+				select: { contributionCents: true },
+			},
+		},
+		orderBy: { updatedAt: 'desc' },
+		take: 3,
+	})
+}
+
+type PastGiftRow = Awaited<ReturnType<typeof queryPastGifts>>[number]
+
+// ─── Action queue classifier ─────────────────────────────────────────────────
+// Iterates active pools + upcoming occasions, classifies each into zero or
+// more action items, assigns priority, sorts, and caps at ACTION_QUEUE_LIMIT.
+//
+// Priority bands:
+//   P0 — time-urgent (event within 7 days, promoted from lower bands)
+//   P1 — blocking others (vote, close vote, choose gift, call vote)
+//   P2 — your turn (pay, purchase, deliver, set contribution)
+//   P3 — informational (your idea was chosen)
+//   P4 — future / low urgency (upcoming occasion, propose idea)
+
+function computeActionQueue(
+	pools: ActivePoolRow[],
+	occasions: UpcomingOccasion[],
+	viewerId: string,
+	groupId: string,
+): ActionItem[] {
+	const items: ActionItem[] = []
+
+	for (const pool of pools) {
+		const viewer = pool.contributors.find((c) => c.userId === viewerId)
+		const isOrganizer = pool.organizerId === viewerId
+		const isPurchaser = pool.purchaserId === viewerId
+		const isDeliverer = pool.delivererId === viewerId
+		const name =
+			pool.recipientUser?.name ?? pool.recipientName ?? 'someone'
+		const eventDays = pool.eventDate ? daysUntilDate(pool.eventDate) : null
+
+		const base = {
+			poolId: pool.id,
+			poolTitle: pool.title,
+			recipientName: name,
+			eventDate: pool.eventDate,
+			daysUntilEvent: eventDays,
+		}
+
+		if (pool.status === POOL_STATUS.OPEN) {
+			if (viewer && pool._count.ideas === 0) {
+				items.push({
+					...base,
+					type: ACTION_TYPE.PROPOSE_IDEA,
+					priority: 4,
+					ctaLabel: 'Propose an idea',
+					ctaUrl: `/pools/${pool.id}`,
+				})
+			}
+			if (
+				isOrganizer &&
+				pool.decisionMode === DECISION_MODE.VOTE &&
+				pool._count.ideas >= 2
+			) {
+				items.push({
+					...base,
+					type: ACTION_TYPE.CALL_VOTE,
+					priority: 1,
+					ctaLabel: 'Call a vote',
+					ctaUrl: `/pools/${pool.id}`,
+				})
+			}
+			if (
+				isOrganizer &&
+				pool.decisionMode === DECISION_MODE.ORGANIZER_PICKS &&
+				pool._count.ideas >= 1
+			) {
+				items.push({
+					...base,
+					type: ACTION_TYPE.CHOOSE_GIFT,
+					priority: 1,
+					ctaLabel: 'Choose a gift',
+					ctaUrl: `/pools/${pool.id}`,
+				})
+			}
+			if (viewer && !viewer.contributionCents) {
+				items.push({
+					...base,
+					type: ACTION_TYPE.SET_CONTRIBUTION,
+					priority: 2,
+					ctaLabel: 'Set contribution',
+					ctaUrl: `/pools/${pool.id}`,
+				})
+			}
+		}
+
+		if (pool.status === POOL_STATUS.VOTING) {
+			if (viewer && pool.votes.length === 0) {
+				items.push({
+					...base,
+					type: ACTION_TYPE.CAST_VOTE,
+					priority: 1,
+					ctaLabel: 'Cast your vote',
+					ctaUrl: `/pools/${pool.id}`,
+				})
+			}
+			if (isOrganizer) {
+				items.push({
+					...base,
+					type: ACTION_TYPE.CLOSE_VOTE,
+					priority: 1,
+					ctaLabel: 'Close voting',
+					ctaUrl: `/pools/${pool.id}`,
+				})
+			}
+			if (viewer && !viewer.contributionCents) {
+				items.push({
+					...base,
+					type: ACTION_TYPE.SET_CONTRIBUTION,
+					priority: 2,
+					ctaLabel: 'Set contribution',
+					ctaUrl: `/pools/${pool.id}`,
+				})
+			}
+		}
+
+		if (pool.status === POOL_STATUS.DECIDED) {
+			if (
+				viewer &&
+				!viewer.hasPaid &&
+				viewer.contributionCents &&
+				viewer.contributionCents > 0
+			) {
+				items.push({
+					...base,
+					type: ACTION_TYPE.MARK_PAID,
+					priority: 2,
+					ctaLabel: 'Mark as paid',
+					ctaUrl: `/pools/${pool.id}`,
+					amountCents: viewer.contributionCents,
+				})
+			}
+			if (isOrganizer || isPurchaser) {
+				items.push({
+					...base,
+					type: ACTION_TYPE.MARK_PURCHASED,
+					priority: 2,
+					ctaLabel: 'Mark as purchased',
+					ctaUrl: `/pools/${pool.id}`,
+				})
+			}
+			if (pool.chosenIdea?.proposedById === viewerId) {
+				items.push({
+					...base,
+					type: ACTION_TYPE.IDEA_CHOSEN,
+					priority: 3,
+					ctaLabel: 'View pool',
+					ctaUrl: `/pools/${pool.id}`,
+				})
+			}
+			if (viewer && !viewer.contributionCents) {
+				items.push({
+					...base,
+					type: ACTION_TYPE.SET_CONTRIBUTION,
+					priority: 2,
+					ctaLabel: 'Set contribution',
+					ctaUrl: `/pools/${pool.id}`,
+				})
+			}
+		}
+
+		if (pool.status === POOL_STATUS.PURCHASED) {
+			if (isOrganizer || isDeliverer) {
+				items.push({
+					...base,
+					type: ACTION_TYPE.MARK_DELIVERED,
+					priority: 2,
+					ctaLabel: 'Mark as delivered',
+					ctaUrl: `/pools/${pool.id}`,
+				})
+			}
+			if (pool.chosenIdea?.proposedById === viewerId) {
+				items.push({
+					...base,
+					type: ACTION_TYPE.IDEA_CHOSEN,
+					priority: 3,
+					ctaLabel: 'View pool',
+					ctaUrl: `/pools/${pool.id}`,
+				})
+			}
+		}
+	}
+
+	// POOL_STUCK pass. A stuck pool is one that's been idle for > 3 days
+	// AND the event is within 30 days (or has no event date). We suppress
+	// STUCK when the viewer already has a direct action on the same pool —
+	// the direct action is more specific, so we don't want duplicates.
+	const poolIdsWithDirectAction = new Set(
+		items.map((i) => i.poolId).filter((id): id is string => id !== null),
+	)
+
+	for (const pool of pools) {
+		if (poolIdsWithDirectAction.has(pool.id)) continue
+
+		const viewer = pool.contributors.find((c) => c.userId === viewerId)
+		if (!viewer) continue
+
+		if (!isPoolStuck(pool)) continue
+
+		const stuck = buildStuckItem(pool)
+		if (!stuck) continue
+
+		items.push(stuck)
+	}
+
+	for (const occasion of occasions) {
+		items.push({
+			type: ACTION_TYPE.UPCOMING_OCCASION,
+			priority: 4,
+			poolId: null,
+			poolTitle: null,
+			recipientName: occasion.name,
+			eventDate: null,
+			daysUntilEvent: occasion.daysUntil,
+			ctaLabel: 'Start a pool',
+			ctaUrl: `/pools/new?groupId=${groupId}&recipientId=${occasion.userId}`,
+			memberId: occasion.userId,
+			memberUsername: occasion.username,
+			memberImageId: occasion.imageId,
+		})
+	}
+
+	// P0 promotion: any action tied to an event within the urgency threshold
+	for (const item of items) {
+		if (
+			item.daysUntilEvent !== null &&
+			item.daysUntilEvent >= 0 &&
+			item.daysUntilEvent <= URGENCY_THRESHOLD_DAYS &&
+			item.priority > 0
+		) {
+			item.priority = 0
+		}
+	}
+
+	items.sort((a, b) => {
+		if (a.priority !== b.priority) return a.priority - b.priority
+		const aDays = a.daysUntilEvent ?? Infinity
+		const bDays = b.daysUntilEvent ?? Infinity
+		return aDays - bDays
+	})
+
+	return items.slice(0, ACTION_QUEUE_LIMIT)
+}
+
+// ─── Stuck pool detection ────────────────────────────────────────────────────
+
+function isPoolStuck(pool: ActivePoolRow): boolean {
+	const daysIdle =
+		(Date.now() - new Date(pool.updatedAt).getTime()) /
+		(1000 * 60 * 60 * 24)
+	if (daysIdle <= STUCK_IDLE_DAYS) return false
+
+	if (!pool.eventDate) return true
+	const daysToEvent = daysUntilDate(pool.eventDate)
+	return daysToEvent <= STUCK_EVENT_WINDOW_DAYS
+}
+
+function buildStuckItem(pool: ActivePoolRow): ActionItem | null {
+	const recipientName =
+		pool.recipientUser?.name ?? pool.recipientName ?? 'someone'
+	const eventDays = pool.eventDate ? daysUntilDate(pool.eventDate) : null
+	const base = {
+		type: ACTION_TYPE.POOL_STUCK,
+		priority: 1,
+		poolId: pool.id,
+		poolTitle: pool.title,
+		recipientName,
+		eventDate: pool.eventDate,
+		daysUntilEvent: eventDays,
+		ctaUrl: `/pools/${pool.id}`,
+	}
+
+	switch (pool.status) {
+		case POOL_STATUS.OPEN:
+			if (pool._count.ideas === 0) {
+				return {
+					...base,
+					ctaLabel: 'Add an idea',
+					description: `No ideas yet for ${recipientName}'s gift — add one?`,
+				}
+			}
+			return {
+				...base,
+				ctaLabel: 'Call a vote',
+				description: `Ideas are in for ${recipientName} — call a vote?`,
+			}
+		case POOL_STATUS.VOTING: {
+			const outstanding =
+				pool._count.contributors - pool._count.votes
+			const total = pool._count.contributors
+			return {
+				...base,
+				ctaLabel: 'Close voting',
+				description:
+					outstanding > 0
+						? `${outstanding} of ${total} haven't voted yet — nudge them or close voting?`
+						: `Voting is stalled on ${recipientName}'s gift — close voting?`,
+			}
+		}
+		case POOL_STATUS.DECIDED:
+			return {
+				...base,
+				ctaLabel: 'Mark as purchased',
+				description: `${recipientName}'s gift decided but not bought yet — mark as purchased?`,
+			}
+		default:
+			return null
+	}
+}
+
+// Exported for testing. Classifies pools + occasions into prioritized queue.
+export function _computeActionQueueForTesting(
+	pools: ActivePoolRow[],
+	occasions: UpcomingOccasion[],
+	viewerId: string,
+	groupId: string,
+): ActionItem[] {
+	return computeActionQueue(pools, occasions, viewerId, groupId)
+}
+
+// Exported for testing. Returns whether a pool meets the stuck criteria.
+export function _isPoolStuckForTesting(pool: ActivePoolRow): boolean {
+	return isPoolStuck(pool)
+}
+
+// ─── Upcoming occasions ──────────────────────────────────────────────────────
+
+function computeUpcomingOccasions(
+	members: MemberRow[],
+	activePools: ActivePoolRow[],
+	groupId: string,
+): UpcomingOccasion[] {
+	const recipientIdsWithActivePool = new Set(
+		activePools
+			.map((p) => p.recipientUserId)
+			.filter((id): id is string => id !== null),
+	)
+
+	const occasions: UpcomingOccasion[] = []
+
+	for (const member of members) {
+		if (!member.user.birthday) continue
+		if (recipientIdsWithActivePool.has(member.userId)) continue
+
+		const days = daysUntilBirthday(member.user.birthday)
+		if (days > UPCOMING_OCCASION_DAYS) continue
+
+		occasions.push({
+			userId: member.userId,
+			name: member.user.name ?? member.user.username,
+			username: member.user.username,
+			daysUntil: days,
+			imageId: member.user.image?.id ?? null,
+			groupId,
+		})
+	}
+
+	return occasions.sort((a, b) => a.daysUntil - b.daysUntil)
+}
+
+// ─── Shaping helpers ─────────────────────────────────────────────────────────
+
+function shapePoolSummaries(
+	pools: ActivePoolRow[],
+	viewerId: string,
+): PoolSummary[] {
+	return pools.map((pool) => {
+		const viewerContributor = pool.contributors.find(
+			(c) => c.userId === viewerId,
+		)
+
+		return {
+			id: pool.id,
+			title: pool.title,
+			occasionType: pool.occasionType,
+			eventDate: pool.eventDate,
+			status: pool.status,
+			recipientName:
+				pool.recipientUser?.name ?? pool.recipientName ?? 'Someone',
+			recipientUsername: pool.recipientUser?.username ?? null,
+			ideaCount: pool._count.ideas,
+			contributorCount: pool.contributors.length,
+			paidCount: pool.contributors.filter((c) => c.hasPaid).length,
+			viewerRole: pool.organizerId === viewerId
+				? ('organizing' as const)
+				: viewerContributor
+					? ('contributing' as const)
+					: ('none' as const),
+			viewerContributionCents: viewerContributor?.contributionCents ?? null,
+		}
+	})
+}
+
+function shapePastGifts(rows: PastGiftRow[]): PastGift[] {
+	return rows.map((pool) => ({
+		id: pool.id,
+		title: pool.title,
+		status: pool.status,
+		occasionType: pool.occasionType,
+		updatedAt: pool.updatedAt,
+		recipientName:
+			pool.recipientUser?.name ?? pool.recipientName ?? 'Someone',
+		recipientUsername: pool.recipientUser?.username ?? null,
+		chosenIdeaName: pool.chosenIdea?.name ?? null,
+		totalCents:
+			pool.finalPriceCents ??
+			pool.contributors.reduce(
+				(sum, c) => sum + (c.contributionCents ?? 0),
+				0,
+			),
+	}))
+}
+
+// ─── Date helpers ────────────────────────────────────────────────────────────
+
+function startOfDay(d: Date): Date {
+	const copy = new Date(d)
+	copy.setHours(0, 0, 0, 0)
+	return copy
+}
+
+function daysUntilDate(target: Date): number {
+	const today = startOfDay(new Date())
+	const t = startOfDay(new Date(target))
+	return Math.ceil((t.getTime() - today.getTime()) / (1000 * 60 * 60 * 24))
+}
+
+function daysUntilBirthday(birthday: Date): number {
+	const today = startOfDay(new Date())
+	const year = today.getFullYear()
+	let next = new Date(year, birthday.getMonth(), birthday.getDate())
+	next.setHours(0, 0, 0, 0)
+	if (next < today) {
+		next = new Date(year + 1, birthday.getMonth(), birthday.getDate())
+		next.setHours(0, 0, 0, 0)
+	}
+	return Math.ceil((next.getTime() - today.getTime()) / (1000 * 60 * 60 * 24))
+}

--- a/app/utils/group-overview.server.ts
+++ b/app/utils/group-overview.server.ts
@@ -500,6 +500,27 @@ export function _isPoolStuckForTesting(pool: ActivePoolRow): boolean {
 	return isPoolStuck(pool)
 }
 
+// Exported for testing. Pure shape converters and the upcoming-occasions
+// scan; thin wrappers so internal signatures stay private.
+export function _computeUpcomingOccasionsForTesting(
+	members: MemberRow[],
+	activePools: ActivePoolRow[],
+	groupId: string,
+): UpcomingOccasion[] {
+	return computeUpcomingOccasions(members, activePools, groupId)
+}
+
+export function _shapePoolSummariesForTesting(
+	pools: ActivePoolRow[],
+	viewerId: string,
+): PoolSummary[] {
+	return shapePoolSummaries(pools, viewerId)
+}
+
+export function _shapePastGiftsForTesting(rows: PastGiftRow[]): PastGift[] {
+	return shapePastGifts(rows)
+}
+
 // ─── Upcoming occasions ──────────────────────────────────────────────────────
 
 function computeUpcomingOccasions(

--- a/app/utils/group-overview.ts
+++ b/app/utils/group-overview.ts
@@ -1,0 +1,86 @@
+// Client-safe types and constants for the group overview.
+// Server-only helpers live in `group-overview.server.ts` and import from here.
+//
+// React Router's Vite plugin refuses to bundle `.server.ts` modules into the
+// client, so any value (like ACTION_TYPE) that the Overview component needs
+// at runtime has to live in a non-server file.
+
+export const ACTION_TYPE = {
+	PROPOSE_IDEA: 'PROPOSE_IDEA',
+	CALL_VOTE: 'CALL_VOTE',
+	CHOOSE_GIFT: 'CHOOSE_GIFT',
+	CAST_VOTE: 'CAST_VOTE',
+	CLOSE_VOTE: 'CLOSE_VOTE',
+	SET_CONTRIBUTION: 'SET_CONTRIBUTION',
+	MARK_PAID: 'MARK_PAID',
+	MARK_PURCHASED: 'MARK_PURCHASED',
+	MARK_DELIVERED: 'MARK_DELIVERED',
+	IDEA_CHOSEN: 'IDEA_CHOSEN',
+	UPCOMING_OCCASION: 'UPCOMING_OCCASION',
+	POOL_STUCK: 'POOL_STUCK',
+} as const
+
+export type ActionType = (typeof ACTION_TYPE)[keyof typeof ACTION_TYPE]
+
+export type ActionItem = {
+	type: ActionType
+	priority: number
+	poolId: string | null
+	poolTitle: string | null
+	recipientName: string
+	eventDate: Date | null
+	daysUntilEvent: number | null
+	ctaLabel: string
+	ctaUrl: string
+	// Optional server-generated description. Used by POOL_STUCK where the copy
+	// depends on runtime state (idea count, vote counts, etc.); other action
+	// types build their description from the item shape on the client.
+	description?: string
+	amountCents?: number
+	memberId?: string
+	memberUsername?: string
+	memberImageId?: string | null
+}
+
+export type PoolSummary = {
+	id: string
+	title: string
+	occasionType: string
+	eventDate: Date | null
+	status: string
+	recipientName: string
+	recipientUsername: string | null
+	ideaCount: number
+	contributorCount: number
+	paidCount: number
+	viewerRole: 'organizing' | 'contributing' | 'none'
+	viewerContributionCents: number | null
+}
+
+export type UpcomingOccasion = {
+	userId: string
+	name: string
+	username: string
+	daysUntil: number
+	imageId: string | null
+	groupId: string
+}
+
+export type PastGift = {
+	id: string
+	title: string
+	status: string
+	occasionType: string
+	updatedAt: Date
+	recipientName: string
+	recipientUsername: string | null
+	chosenIdeaName: string | null
+	totalCents: number
+}
+
+export type GroupOverviewData = {
+	actionQueue: ActionItem[]
+	activePools: PoolSummary[]
+	upcomingOccasions: UpcomingOccasion[]
+	pastGifts: PastGift[]
+}

--- a/app/utils/group-permissions.server.ts
+++ b/app/utils/group-permissions.server.ts
@@ -39,7 +39,8 @@ export const groupRolePermissions: Record<
     'manageSettings',
     'lockGiftPlan',
     'unlockGiftPlan',
-    'leaveGroup',
+    // Note: OWNER cannot leave without transferring ownership first.
+    // Either transfer to another admin or delete the group.
     'editOwnBudget',
     'setOwnPreferences',
   ],

--- a/app/utils/pool.server.ts
+++ b/app/utils/pool.server.ts
@@ -32,6 +32,7 @@ export const poolSelect = {
 	chosenIdeaId: true,
 	finalPriceCents: true,
 	inviteCode: true,
+	giftGroup: { select: { id: true, name: true } },
 	organizer: { select: { id: true, username: true, name: true, image: { select: { id: true } } } },
 	purchaser: { select: { id: true, username: true, name: true, image: { select: { id: true } } } },
 	deliverer: { select: { id: true, username: true, name: true, image: { select: { id: true } } } },

--- a/tests/e2e/recipient-privacy.test.ts
+++ b/tests/e2e/recipient-privacy.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Recipient-privacy audit.
+ *
+ * Contract: when a group member is the recipient of a pool, that pool must
+ * not exist for them anywhere in the product. Not in lists, not at a direct
+ * URL, not in notifications, not in email, not hinted at in member rows or
+ * activity feeds.
+ *
+ * Several of these assertions are expected to FAIL against the current
+ * codebase — that is the audit's punchlist. See the report in the PR that
+ * introduces this spec.
+ */
+
+import { getPasswordHash } from '#app/utils/auth.server.ts';
+import { prisma } from '#app/utils/db.server.ts';
+import { createPool } from '#app/utils/pool.server.ts';
+import { createUser } from '#tests/db-utils.ts';
+import { readEmail } from '#tests/mocks/utils.ts';
+import { expect, loginWithPassword, test } from '#tests/playwright-utils.ts';
+
+type SeededUser = {
+  id: string;
+  username: string;
+  email: string;
+  password: string;
+};
+
+async function seedUser(): Promise<SeededUser> {
+  const userData = createUser();
+  const password = userData.username;
+  const user = await prisma.user.create({
+    select: { id: true, username: true, email: true },
+    data: {
+      ...userData,
+      roles: { connect: { name: 'user' } },
+      password: { create: { hash: await getPasswordHash(password) } },
+    },
+  });
+  return { ...user, password };
+}
+
+test.describe('recipient privacy', () => {
+  let organizer: SeededUser;
+  let recipient: SeededUser;
+  let other: SeededUser;
+  let groupId: string;
+  let poolId: string;
+  const poolTitle = 'Surprise Birthday for Recipient';
+
+  test.beforeAll(async () => {
+    [organizer, recipient, other] = await Promise.all([
+      seedUser(),
+      seedUser(),
+      seedUser(),
+    ]);
+
+    const group = await prisma.giftGroup.create({
+      select: { id: true },
+      data: {
+        name: 'Privacy Test Crew',
+        description: 'Seeded for recipient-privacy audit',
+        groupMembers: {
+          create: [
+            { userId: organizer.id, role: 'OWNER' },
+            { userId: recipient.id, role: 'MEMBER' },
+            { userId: other.id, role: 'MEMBER' },
+          ],
+        },
+      },
+    });
+    groupId = group.id;
+
+    const pool = await createPool({
+      title: poolTitle,
+      organizerId: organizer.id,
+      recipientUserId: recipient.id,
+      giftGroupId: groupId,
+      // contributors: organizer (auto) + other. Recipient MUST NOT be here.
+      groupMemberDefaults: [{ userId: other.id, contributionCents: 0 }],
+    });
+    poolId = pool.id;
+  });
+
+  test.afterAll(async () => {
+    await prisma.pool
+      .delete({ where: { id: poolId } })
+      .catch(() => {});
+    await prisma.giftGroup
+      .delete({ where: { id: groupId } })
+      .catch(() => {});
+    await prisma.user
+      .deleteMany({
+        where: { id: { in: [organizer.id, recipient.id, other.id] } },
+      })
+      .catch(() => {});
+  });
+
+  test('recipient is NOT a contributor on their own pool (seed sanity check)', async () => {
+    const contributor = await prisma.poolContributor.findFirst({
+      where: { poolId, userId: recipient.id },
+      select: { id: true },
+    });
+    expect(contributor).toBeNull();
+  });
+
+  test('/pools list does not include a pool where viewer is the recipient', async ({
+    page,
+  }) => {
+    await loginWithPassword(page, {
+      username: recipient.username,
+      password: recipient.password,
+    });
+    await page.goto('/pools');
+
+    await expect(page.getByRole('link', { name: new RegExp(poolTitle, 'i') })).toHaveCount(0);
+    await expect(page.getByText(poolTitle, { exact: false })).toHaveCount(0);
+  });
+
+  test('direct navigation to /pools/:id as recipient does not reveal the pool', async ({
+    page,
+  }) => {
+    await loginWithPassword(page, {
+      username: recipient.username,
+      password: recipient.password,
+    });
+    const response = await page.goto(`/pools/${poolId}`);
+
+    // The server must treat this as "does not exist" for the recipient —
+    // indistinguishable from a nonexistent pool ID. No pool data, no
+    // leaky error message that would confirm the pool's existence.
+    expect(response?.status()).toBe(404);
+    await expect(page.getByText(poolTitle, { exact: false })).toHaveCount(0);
+    await expect(
+      page.getByText(/you are not a contributor|forbidden|not allowed|no access/i),
+    ).toHaveCount(0);
+  });
+
+  test('/groups/:id overview does not mention the pool when viewer is the recipient', async ({
+    page,
+  }) => {
+    await loginWithPassword(page, {
+      username: recipient.username,
+      password: recipient.password,
+    });
+    await page.goto(`/groups/${groupId}`);
+
+    await expect(page.getByText(poolTitle, { exact: false })).toHaveCount(0);
+  });
+
+  test('/groups/:id/members does not hint at a pool on the recipient row', async ({
+    page,
+  }) => {
+    await loginWithPassword(page, {
+      username: recipient.username,
+      password: recipient.password,
+    });
+    await page.goto(`/groups/${groupId}/members`);
+
+    // The recipient's own row must not carry pool-related chips/progress.
+    await expect(page.getByText(poolTitle, { exact: false })).toHaveCount(0);
+    await expect(page.getByText(/pool pending|gift in progress|contributors/i)).toHaveCount(0);
+  });
+
+  test('/groups/:id/activity does not mention the pool when viewer is the recipient', async ({
+    page,
+  }) => {
+    await loginWithPassword(page, {
+      username: recipient.username,
+      password: recipient.password,
+    });
+    await page.goto(`/groups/${groupId}/activity`);
+
+    await expect(page.getByText(poolTitle, { exact: false })).toHaveCount(0);
+  });
+
+  test('organizer CAN see the pool (negative control — proves seed is correct)', async ({
+    page,
+  }) => {
+    await loginWithPassword(page, {
+      username: organizer.username,
+      password: organizer.password,
+    });
+    await page.goto('/pools');
+
+    await expect(page.getByRole('link', { name: new RegExp(poolTitle, 'i') })).toBeVisible();
+  });
+
+  test('in-app notifications for recipient contain nothing about their own pool', async () => {
+    const notifications = await prisma.notification.findMany({
+      where: { userId: recipient.id },
+      select: { type: true, messageKey: true, messageParams: true, metadata: true, targetUrl: true },
+    });
+
+    for (const n of notifications) {
+      const blob = JSON.stringify(n);
+      expect(blob).not.toContain(poolId);
+      expect(blob.toLowerCase()).not.toContain(poolTitle.toLowerCase());
+    }
+  });
+
+  test('no email is sent to the recipient about their own pool', async () => {
+    // MSW email capture writes JSON to tests/fixtures/email/:address.json.
+    // If no email was sent, readEmail returns null.
+    const email = await readEmail(recipient.email).catch(() => null);
+    if (email) {
+      const blob = JSON.stringify(email).toLowerCase();
+      expect(blob).not.toContain(poolTitle.toLowerCase());
+      expect(blob).not.toContain(poolId);
+    }
+  });
+
+  test('recipient clicking the pool invite link is not added as a contributor', async ({
+    page,
+  }) => {
+    const invite = await prisma.pool.findUnique({
+      where: { id: poolId },
+      select: { inviteCode: true },
+    });
+    if (!invite?.inviteCode) {
+      test.skip(true, 'pool has no invite code in seed — skip');
+      return;
+    }
+
+    await loginWithPassword(page, {
+      username: recipient.username,
+      password: recipient.password,
+    });
+    await page.goto(`/pools/join/${invite.inviteCode}`);
+
+    // Landing on the pool detail would be a leak.
+    await expect(page).not.toHaveURL(new RegExp(`/pools/${poolId}`));
+
+    const contributor = await prisma.poolContributor.findFirst({
+      where: { poolId, userId: recipient.id },
+      select: { id: true },
+    });
+    expect(contributor).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Reshapes the groups + pools experience around a **group-first** mental model: groups are the workspace, pools live inside groups, and recipients (always group members) cannot see their own gift pools.

- **Group Overview rebuilt** as the anchor screen — action queue, active pools, upcoming birthdays, past gifts, group essentials. Action queue covers 12 action types with P0 urgency promotion and stuck-pool nudges.
- **Pool creation is now group-scoped** — `/pools/new?groupId=X&recipientId=Y` pre-fills the group + recipient, shows a member picker for contributors with re-derived contribution defaults from the DB. Standalone `/pools/new` keeps a recipient autocomplete picker (friends + group members) instead of a free-text username field.
- **Recipient privacy enforced end-to-end** — pool loader, action, invite-link join, and members tab all return 404 for the recipient (indistinguishable from a nonexistent pool). Audited via Playwright spec covering 9 surfaces.
- **Stuck pool nudges** — derived from `pool.updatedAt > 3 days` and `eventDate within 30 days`, suppressed when the viewer already has a direct action on the same pool.
- **Per-recipient gift history** — new sub-route at `/groups/:id/members/:userId/history`, gated 404 against self-lookup.
- **Members tab wired to pool creation** — each row shows "View pool" if active, "Start a pool" if member has a birthday and no pool yet.
- **Polish**: pool detail breadcrumbs back to its group; "per-gift cap" labels unified; owner Leave button removed (transfer or delete instead); Manage CTA points to overview not settings; delete-pool redirects to parent group.

## Test plan

- [ ] `npm run validate` passes (typecheck + lint + 823 unit tests + e2e)
- [ ] Privacy audit spec: `npx playwright test recipient-privacy` — 9/9 passing
- [ ] Live walkthrough as group **owner**:
  - [ ] Group Overview shows action queue + active pools + upcoming birthdays
  - [ ] "Start a pool" from Overview pre-fills group/recipient and shows contributor picker
  - [ ] "Start a pool" from Members tab works for members with birthdays
  - [ ] "View pool" link appears on Members tab for members with active pools
  - [ ] Pool detail shows "In group {name}" breadcrumb and back link goes to the group
  - [ ] Per-member gift icon → gift history sub-route renders
  - [ ] Settings page shows no Leave Group button (only Delete + Transfer Ownership)
  - [ ] Deleting a group-backed pool redirects to `/groups/:id`
- [ ] Live walkthrough as group **member** (non-owner): same flows minus admin actions
- [ ] Live walkthrough as **recipient** (e.g., Marco):
  - [ ] `/pools/{Marco's pool id}` → 404, no leaky message
  - [ ] `/pools/join/{Marco's invite code}` → 404 (if seed has invite code)
  - [ ] `/groups/:id` overview, members, activity → no mention of Marco's pool
  - [ ] `/groups/:id/members/{Marco's id}/history` → 404