### PR TITLE
feat: add feedback system (form, widget, admin queue, email notifications)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,10 +36,11 @@ npm test -- file.test.tsx               # Specific file
 npm test -- --grep "pattern"            # By pattern
 npm run coverage         # With coverage
 
-npm run test:e2e         # E2E tests (Playwright, headless)
+npm run test:e2e:run     # E2E tests headless — one-shot, used by `validate`. THIS is the command for CI/agents/non-interactive runs.
+npm run test:e2e:run -- feedback.test.ts        # Specific E2E test, headless
+npm run test:e2e         # Opens Playwright UI runner (interactive — never exits). Same as test:e2e:dev. Do NOT use in a non-interactive context.
 npm run test:e2e:dev     # E2E with UI (recommended for dev)
-npm run test:e2e:dev -- --grep "name"   # Specific E2E test
-npm run test:e2e:dev -- --headed        # With browser visible
+npm run test:e2e:dev -- --headed                # With browser visible
 ```
 
 ### Database
@@ -149,7 +150,7 @@ Uses Conform + Zod for validation with honeypot spam protection.
 - Server: `queueLogEvent(...)` from `analytics.server.ts` is the default for action/loader hot paths — it pre-generates the `eventId` synchronously, fires `logEvent` without awaiting, and tails errors to `captureException`. Callers can echo the returned `eventId` back to the client immediately.
 - Use `logEvent` (awaited) only when you genuinely need the persisted row before returning — e.g. `api.analytics` fanning out from a `sendBeacon`.
 - On `eventId` conflict, server writes are canonical: `logEvent` upgrades a `source: 'client'` row in place when the incoming write is `source: 'server'`, so the richer server payload always wins the client-echo race. See `recoverFromEventIdConflict`.
-- Event names in `ANALYTIC_EVENT_NAMES` constant (16 events: 5 original + 11 gifting-workflow events added in the admin rebuild — `pool_created`, `pool_contributor_joined`, `pool_vote_called`, `pool_vote_cast`, `pool_decided`, `pool_purchased`, `pool_delivered`, `pool_cancelled`, `friend_request_sent`, `friend_request_accepted`, `wishlist_purchase_recorded`).
+- Event names in `ANALYTIC_EVENT_NAMES` constant: 5 original + 11 gifting-workflow events added in the admin rebuild (`pool_created`, `pool_contributor_joined`, `pool_vote_called`, `pool_vote_cast`, `pool_decided`, `pool_purchased`, `pool_delivered`, `pool_cancelled`, `friend_request_sent`, `friend_request_accepted`, `wishlist_purchase_recorded`) + 3 admin actions (`admin_role_granted`, `admin_role_revoked`, `admin_sessions_revoked`) + `feedback_submitted`. Note: `feedback_submitted` is NOT in `USER_REQUIRED_EVENTS` — anonymous visitors can submit feedback.
 - `queueLogEvent` must be called AFTER `$transaction` closes, never inside the transaction callback — a concurrent write inside the parent's lock produces spurious SQLITE_BUSY in Sentry.
 - Admin dashboard at `/admin/analytics` (DAU/WAU/MAU, activation funnel, weekly retention, notification opt-out matrix, event count tables)
 
@@ -163,11 +164,12 @@ Mutation handlers should return after committing the primary change; anything th
 
 ### Admin surface
 
-`/admin` is gated by `requireUserWithRole(request, 'admin')` in the layout loader. All admin routes share a persistent layout with a 6-tab NavLink bar. Bootstrap a first admin via `other/ensure-admin.js`; subsequent grants/revokes happen from the UI (`/admin/users/:id`).
+`/admin` is gated by `requireUserWithRole(request, 'admin')` in the layout loader. All admin routes share a persistent layout with a 7-tab NavLink bar. Bootstrap a first admin via `other/ensure-admin.js`; subsequent grants/revokes happen from the UI (`/admin/users/:id`).
 
 - **Overview** (`/admin`): metric cards, stuck-pool alerts, cleanup queue, recent activity feed. Queries domain tables directly (not `AnalyticsEvent`). Cached 60s in `lruCache` (instance-local).
 - **Users** (`/admin/users`): search + drill-down with role toggle (transactional last-admin guard in `$transaction`) and session + verification revoke.
 - **Pools** (`/admin/pools`): health board with stuck detection (OPEN+overdue, VOTING+stalled, DECIDED+stale), per-status tabs, drill-down with admin-cancel action. Break-out filename: `pools_.$poolId.tsx`.
+- **Feedback** (`/admin/feedback`): triage queue for user-submitted bugs/ideas/questions (`Feedback` model). Per-status tabs (NEW default), inline status + admin-notes mutation. NOT cached — it's a live queue where a status flip must show on the next render. Submissions arrive via the `api.feedback` action (used by both the support page form and the global `FeedbackWidget`).
 - **Ops** (`/admin/ops`): 5 idempotent cleanup jobs (verifications, sessions, friend requests, group invitations, group bans), disk usage, LiteFS instance panel.
 - **Analytics** (`/admin/analytics`): DAU/WAU/MAU + daily-active chart + activation funnel (domain tables, 1h cache) + weekly retention (via `Session.createdAt`, 1h cache) + notification opt-out matrix + event count tables.
 - **Cache** (`/admin/cache`): LRU + SQLite cache inspector (pre-existing).

--- a/app/components/feedback/feedback-form.test.tsx
+++ b/app/components/feedback/feedback-form.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import type * as ReactRouter from 'react-router';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock the router hooks the form depends on so we can render it directly and
+// drive the fetcher's resolved state deterministically — no router context or
+// real network submission (which jsdom's fetch can't encode) required.
+const rootData: { user: unknown } = { user: null };
+const fetcherMock: { state: string; data: unknown; Form: React.ElementType } = {
+  state: 'idle',
+  data: undefined,
+  Form: ({ children, ...props }: React.ComponentProps<'form'>) => (
+    <form {...props}>{children}</form>
+  ),
+};
+
+vi.mock('react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof ReactRouter>();
+  return {
+    ...actual,
+    useFetcher: () => fetcherMock,
+    useLocation: () => ({
+      pathname: '/groups',
+      search: '',
+      hash: '',
+      state: null,
+      key: 'test',
+    }),
+    useRouteLoaderData: () => rootData,
+  };
+});
+
+import { FeedbackForm } from './feedback-form.tsx';
+
+beforeEach(() => {
+  rootData.user = null;
+  fetcherMock.state = 'idle';
+  fetcherMock.data = undefined;
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('FeedbackForm', () => {
+  it('renders the type options, message field, and submit button', () => {
+    render(<FeedbackForm />);
+    expect(screen.getByText('Bug')).toBeInTheDocument();
+    expect(screen.getByText('Idea')).toBeInTheDocument();
+    expect(screen.getByText('Question')).toBeInTheDocument();
+    expect(screen.getByLabelText('Your message')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /send feedback/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('shows the email field for anonymous visitors', () => {
+    rootData.user = null;
+    render(<FeedbackForm />);
+    // The label carries a required-asterisk, so match loosely.
+    expect(screen.getByLabelText(/your email/i)).toBeInTheDocument();
+  });
+
+  it('hides the email field for logged-in users', () => {
+    rootData.user = { id: 'u1', username: 'tester', name: 'Tester', roles: [] };
+    render(<FeedbackForm />);
+    expect(screen.queryByLabelText(/your email/i)).not.toBeInTheDocument();
+  });
+
+  it('renders the success state and fires onSuccess once submitted', () => {
+    const onSuccess = vi.fn();
+    fetcherMock.state = 'idle';
+    fetcherMock.data = { ok: true };
+
+    render(<FeedbackForm onSuccess={onSuccess} />);
+
+    expect(screen.getByText(/thanks for the feedback/i)).toBeInTheDocument();
+    // The form fields are replaced by the confirmation state.
+    expect(screen.queryByLabelText('Your message')).not.toBeInTheDocument();
+    expect(onSuccess).toHaveBeenCalled();
+  });
+});

--- a/app/components/feedback/feedback-form.tsx
+++ b/app/components/feedback/feedback-form.tsx
@@ -1,0 +1,177 @@
+import {
+  getFormProps,
+  getInputProps,
+  useForm,
+  type SubmissionResult,
+} from '@conform-to/react';
+import { getZodConstraint, parseWithZod } from '@conform-to/zod';
+import { useEffect, useId } from 'react';
+import { LuBug, LuCircleCheck, LuLightbulb, LuMessageCircle } from 'react-icons/lu';
+import { useFetcher, useLocation } from 'react-router';
+import { HoneypotInputs } from 'remix-utils/honeypot/react';
+import { ErrorList, Field, TextareaField } from '#app/components/forms.tsx';
+import { Label } from '#app/components/ui/label.tsx';
+import { StatusButton } from '#app/components/ui/status-button.tsx';
+import {
+  FEEDBACK_MESSAGE_MAX_LENGTH,
+  FeedbackSchema,
+  type FeedbackType,
+} from '#app/utils/feedback-validation.ts';
+import { cn } from '#app/utils/misc.tsx';
+import { useOptionalUser } from '#app/utils/user.ts';
+
+const TYPE_OPTIONS: Array<{
+  value: FeedbackType;
+  label: string;
+  icon: React.ReactNode;
+}> = [
+  { value: 'BUG', label: 'Bug', icon: <LuBug className="h-4 w-4" aria-hidden /> },
+  {
+    value: 'FEATURE',
+    label: 'Idea',
+    icon: <LuLightbulb className="h-4 w-4" aria-hidden />,
+  },
+  {
+    value: 'QUESTION',
+    label: 'Question',
+    icon: <LuMessageCircle className="h-4 w-4" aria-hidden />,
+  },
+];
+
+type FeedbackFetcherData = {
+  result?: SubmissionResult<string[]>;
+  ok?: boolean;
+};
+
+export const FeedbackForm = ({
+  defaultType = 'BUG',
+  onSuccess,
+  className,
+}: {
+  defaultType?: FeedbackType;
+  onSuccess?: () => void;
+  className?: string;
+}) => {
+  const user = useOptionalUser();
+  const location = useLocation();
+  const fetcher = useFetcher<FeedbackFetcherData>();
+  const formId = useId();
+  const isPending = fetcher.state !== 'idle';
+  const succeeded = fetcher.state === 'idle' && fetcher.data?.ok === true;
+
+  const [form, fields] = useForm({
+    id: `feedback-${formId}`,
+    constraint: getZodConstraint(FeedbackSchema),
+    lastResult: fetcher.data?.result,
+    defaultValue: { type: defaultType },
+    onValidate({ formData }) {
+      return parseWithZod(formData, { schema: FeedbackSchema });
+    },
+    shouldRevalidate: 'onBlur',
+  });
+
+  useEffect(() => {
+    if (succeeded) onSuccess?.();
+  }, [succeeded, onSuccess]);
+
+  if (succeeded) {
+    return (
+      <div
+        className={cn(
+          'flex flex-col items-center gap-3 py-8 text-center',
+          className,
+        )}
+        role="status"
+      >
+        <LuCircleCheck className="h-10 w-10 text-green-500" aria-hidden />
+        <p className="text-body-md font-semibold">Thanks for the feedback!</p>
+        <p className="text-sm text-muted-foreground">
+          We read every message. If you left an email, we&apos;ll be in touch.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <fetcher.Form
+      method="POST"
+      action="/api/feedback"
+      {...getFormProps(form)}
+      className={cn('flex flex-col gap-4', className)}
+    >
+      <HoneypotInputs />
+      <input type="hidden" name="pageUrl" value={location.pathname} />
+
+      <fieldset>
+        <legend className="mb-2 text-sm font-medium">
+          What&apos;s this about?
+        </legend>
+        <div className="grid grid-cols-3 gap-2" role="radiogroup">
+          {TYPE_OPTIONS.map((option) => {
+            const id = `${form.id}-type-${option.value}`;
+            return (
+              <div key={option.value}>
+                <input
+                  {...getInputProps(fields.type, { type: 'radio' })}
+                  id={id}
+                  value={option.value}
+                  defaultChecked={fields.type.initialValue === option.value}
+                  className="peer sr-only"
+                />
+                <Label
+                  htmlFor={id}
+                  className={cn(
+                    'flex cursor-pointer flex-col items-center gap-1 rounded-xl border border-input bg-background px-2 py-3 text-sm font-medium transition-colors',
+                    'hover:bg-accent hover:text-accent-foreground',
+                    'peer-checked:border-primary peer-checked:bg-primary/10 peer-checked:text-foreground',
+                    'peer-focus-visible:ring-2 peer-focus-visible:ring-ring',
+                  )}
+                >
+                  {option.icon}
+                  {option.label}
+                </Label>
+              </div>
+            );
+          })}
+        </div>
+        <ErrorList id={fields.type.errorId} errors={fields.type.errors} />
+      </fieldset>
+
+      <TextareaField
+        labelProps={{ children: 'Your message' }}
+        textareaProps={{
+          ...getInputProps(fields.message, { type: 'text' }),
+          rows: 5,
+          maxLength: FEEDBACK_MESSAGE_MAX_LENGTH,
+          placeholder:
+            'Tell us what happened, what you expected, or what you have in mind…',
+        }}
+        errors={fields.message.errors}
+      />
+
+      {user ? null : (
+        <Field
+          labelProps={{ children: 'Your email' }}
+          inputProps={{
+            ...getInputProps(fields.email, { type: 'email' }),
+            placeholder: 'you@example.com',
+            autoComplete: 'email',
+            required: true,
+          }}
+          errors={fields.email.errors}
+        />
+      )}
+
+      <ErrorList id={form.errorId} errors={form.errors} />
+
+      <StatusButton
+        type="submit"
+        status={isPending ? 'pending' : 'idle'}
+        disabled={isPending}
+        className="w-full"
+      >
+        Send feedback
+      </StatusButton>
+    </fetcher.Form>
+  );
+};

--- a/app/components/feedback/feedback-widget.test.tsx
+++ b/app/components/feedback/feedback-widget.test.tsx
@@ -1,0 +1,48 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+import { createRoutesStub } from 'react-router';
+import { describe, expect, it } from 'vitest';
+
+import { FeedbackWidget } from './feedback-widget.tsx';
+
+// No loaders → the stub renders synchronously. The embedded form (rendered only
+// once the dialog opens) reads optional root loader data, which is simply
+// undefined here, so it renders in its anonymous state.
+function renderAt(pathname: string) {
+  const Stub = createRoutesStub([
+    { id: 'root', path: '*', Component: () => <FeedbackWidget /> },
+  ]);
+  render(<Stub initialEntries={[pathname]} />);
+}
+
+describe('FeedbackWidget', () => {
+  it('renders the trigger button on a normal route', () => {
+    renderAt('/groups');
+    expect(
+      screen.getByRole('button', { name: 'Give feedback' }),
+    ).toBeInTheDocument();
+  });
+
+  it.each(['/support', '/login', '/signup', '/onboarding', '/verify'])(
+    'is suppressed on %s',
+    (pathname) => {
+      renderAt(pathname);
+      expect(
+        screen.queryByRole('button', { name: 'Give feedback' }),
+      ).not.toBeInTheDocument();
+    },
+  );
+
+  it('opens a dialog containing the feedback form when clicked', () => {
+    renderAt('/groups');
+    fireEvent.click(screen.getByRole('button', { name: 'Give feedback' }));
+
+    expect(screen.getByText('Send us feedback')).toBeInTheDocument();
+    // The embedded form renders its submit button once the dialog is open.
+    expect(
+      screen.getByRole('button', { name: /send feedback/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/app/components/feedback/feedback-widget.tsx
+++ b/app/components/feedback/feedback-widget.tsx
@@ -1,0 +1,52 @@
+import { useState } from 'react';
+import { LuMessageSquarePlus } from 'react-icons/lu';
+import { useLocation } from 'react-router';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '#app/components/ui/dialog.tsx';
+import { FeedbackForm } from './feedback-form.tsx';
+
+// Routes where a floating "give feedback" button would be redundant or get in
+// the way: the support page already embeds the form, and auth/onboarding flows
+// shouldn't have a button covering their primary action.
+const SUPPRESSED_PREFIXES = ['/support', '/login', '/signup', '/onboarding', '/verify', '/reset-password', '/forgot-password'];
+
+export const FeedbackWidget = () => {
+  const [open, setOpen] = useState(false);
+  const location = useLocation();
+
+  const suppressed = SUPPRESSED_PREFIXES.some((prefix) =>
+    location.pathname.startsWith(prefix),
+  );
+  if (suppressed) return null;
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <button
+          type="button"
+          aria-label="Give feedback"
+          className="fixed bottom-20 right-4 z-50 flex h-12 items-center gap-2 rounded-full bg-primary px-4 text-primary-foreground shadow-lg transition-transform hover:scale-105 active:scale-95 sm:bottom-6 sm:right-6"
+        >
+          <LuMessageSquarePlus className="h-5 w-5" aria-hidden />
+          <span className="hidden text-sm font-medium sm:inline">Feedback</span>
+        </button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Send us feedback</DialogTitle>
+          <DialogDescription>
+            Found a bug, have an idea, or a question? We&apos;d love to hear it.
+          </DialogDescription>
+        </DialogHeader>
+        {/* Remount the form per-open so each session starts clean. */}
+        {open ? <FeedbackForm /> : null}
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/app/emails/feedback-acknowledged.tsx
+++ b/app/emails/feedback-acknowledged.tsx
@@ -1,0 +1,49 @@
+import * as E from '@react-email/components';
+import {
+  FEEDBACK_TYPE_LABELS,
+  type FeedbackType,
+} from '#app/utils/feedback-validation.ts';
+
+export const FeedbackAcknowledgedEmail = ({
+  type,
+  message,
+  recipientName,
+}: {
+  type: FeedbackType;
+  message: string;
+  recipientName?: string | null;
+}) => {
+  const greeting = recipientName ? `Hi ${recipientName},` : 'Hi,';
+  return (
+    <E.Html lang="en" dir="ltr">
+      <E.Container>
+        <p>
+          <E.Text>{greeting}</E.Text>
+        </p>
+        <p>
+          <E.Text>
+            Thanks for sending us a {FEEDBACK_TYPE_LABELS[type].toLowerCase()}{' '}
+            on GiftPool — it came through and we read every message that lands
+            in our inbox. We&apos;ll get back to you if a reply makes sense.
+          </E.Text>
+        </p>
+        <p>
+          <E.Text>For reference, here&apos;s what you sent:</E.Text>
+        </p>
+        <E.Container
+          style={{
+            borderLeft: '3px solid #e5e7eb',
+            paddingLeft: '12px',
+            margin: '12px 0',
+            whiteSpace: 'pre-wrap',
+          }}
+        >
+          <E.Text>{message}</E.Text>
+        </E.Container>
+        <p>
+          <E.Text>— The GiftPool team</E.Text>
+        </p>
+      </E.Container>
+    </E.Html>
+  );
+};

--- a/app/emails/feedback-received.tsx
+++ b/app/emails/feedback-received.tsx
@@ -1,0 +1,48 @@
+import * as E from '@react-email/components';
+import {
+  FEEDBACK_TYPE_LABELS,
+  type FeedbackType,
+} from '#app/utils/feedback-validation.ts';
+
+export const FeedbackReceivedEmail = ({
+  type,
+  message,
+  fromEmail,
+  username,
+  pageUrl,
+  adminUrl,
+}: {
+  type: FeedbackType;
+  message: string;
+  fromEmail?: string;
+  username?: string;
+  pageUrl?: string;
+  adminUrl: string;
+}) => {
+  return (
+    <E.Html lang="en" dir="ltr">
+      <E.Container>
+        <h1>
+          <E.Text>New {FEEDBACK_TYPE_LABELS[type]} feedback</E.Text>
+        </h1>
+        <p>
+          <E.Text>
+            From: {username ? `@${username}` : 'Anonymous'}
+            {fromEmail ? ` (${fromEmail})` : ''}
+          </E.Text>
+        </p>
+        {pageUrl ? (
+          <p>
+            <E.Text>Submitted from: {pageUrl}</E.Text>
+          </p>
+        ) : null}
+        <hr />
+        <p>
+          <E.Text>{message}</E.Text>
+        </p>
+        <hr />
+        <E.Link href={adminUrl}>Open in admin →</E.Link>
+      </E.Container>
+    </E.Html>
+  );
+};

--- a/app/root.banner-height.test.tsx
+++ b/app/root.banner-height.test.tsx
@@ -52,6 +52,10 @@ vi.mock('./components/error-boundary.tsx', () => ({
   GeneralErrorBoundary: () => <div>error boundary</div>,
 }));
 
+vi.mock('./components/feedback/feedback-widget.tsx', () => ({
+  FeedbackWidget: () => null,
+}));
+
 vi.mock('./components/nav/bottom/bottom-nav.tsx', () => ({
   BottomNav: () => <div>bottom nav</div>,
 }));

--- a/app/root.test.tsx
+++ b/app/root.test.tsx
@@ -48,6 +48,10 @@ vi.mock('./components/error-boundary.tsx', () => ({
   GeneralErrorBoundary: () => <div>error boundary</div>,
 }));
 
+vi.mock('./components/feedback/feedback-widget.tsx', () => ({
+  FeedbackWidget: () => null,
+}));
+
 vi.mock('./components/nav/bottom/bottom-nav.tsx', () => ({
   BottomNav: () => <div>bottom nav</div>,
 }));

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -31,6 +31,7 @@ import { z } from 'zod';
 import appleTouchIconAssetUrl from './assets/favicons/apple-touch-icon.png';
 import faviconAssetUrl from './assets/favicons/favicon.svg';
 import { GeneralErrorBoundary } from './components/error-boundary.tsx';
+import { FeedbackWidget } from './components/feedback/feedback-widget.tsx';
 import { FriendsRouteSkeleton } from './components/friends/friends-route-skeleton.tsx';
 import { BottomNav } from './components/nav/bottom/bottom-nav.tsx';
 import { TopBar } from './components/nav/top-bar.tsx';
@@ -469,6 +470,7 @@ const App = () => {
 
             <Footer />
           </div>
+          <FeedbackWidget />
           <EpicProgress />
           <EpicToaster closeButton position="top-center" theme={theme} />
         </NotificationsProvider>

--- a/app/routes/_marketing+/support.test.tsx
+++ b/app/routes/_marketing+/support.test.tsx
@@ -2,25 +2,26 @@
  * @vitest-environment jsdom
  */
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+
+// The form requires a data router + root loader data; render a placeholder
+// here and assert on it. The form itself is covered by `api.feedback.test.ts`
+// and the `feedback` e2e test.
+vi.mock('#app/components/feedback/feedback-form.tsx', () => ({
+  FeedbackForm: () => <div data-testid="feedback-form" />,
+}));
+
 import SupportRoute from './support.tsx';
 
 describe('SupportRoute', () => {
-  it('renders contact channels and the FAQ', () => {
+  it('renders the feedback form, an email fallback link, and the FAQ', () => {
     render(<SupportRoute />);
 
     expect(
       screen.getByRole('heading', { level: 1, name: /support/i }),
     ).toBeInTheDocument();
-    expect(
-      screen.getByRole('heading', { level: 2, name: /email us/i }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('heading', { level: 2, name: /report a bug/i }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('heading', { level: 2, name: /suggest a feature/i }),
-    ).toBeInTheDocument();
+
+    expect(screen.getByTestId('feedback-form')).toBeInTheDocument();
 
     const emailLink = screen.getByRole('link', {
       name: 'support@giftpool.app',

--- a/app/routes/_marketing+/support.tsx
+++ b/app/routes/_marketing+/support.tsx
@@ -1,37 +1,9 @@
-import { LuBug, LuLightbulb, LuMail, LuMessageCircle } from 'react-icons/lu';
+import { LuMessageCircle } from 'react-icons/lu';
 import { type MetaFunction } from 'react-router';
+import { FeedbackForm } from '#app/components/feedback/feedback-form.tsx';
 import { Card, CardContent } from '#app/components/ui/card.tsx';
-import { cn } from '#app/utils/misc.tsx';
 
 export const meta: MetaFunction = () => [{ title: 'Support | GiftPool' }];
-
-const channels = [
-  {
-    icon: <LuMail className="h-5 w-5" aria-hidden />,
-    color: 'text-primary',
-    title: 'Email us',
-    description: 'For account issues, questions, or anything else.',
-    action: 'support@giftpool.app',
-    href: 'mailto:support@giftpool.app',
-  },
-  {
-    icon: <LuBug className="h-5 w-5" aria-hidden />,
-    color: 'text-yellow-500',
-    title: 'Report a bug',
-    description:
-      'Something broken? Let us know and we\u2019ll get it sorted.',
-    action: 'File a report',
-    href: 'mailto:support@giftpool.app?subject=Bug%20Report',
-  },
-  {
-    icon: <LuLightbulb className="h-5 w-5" aria-hidden />,
-    color: 'text-green-500',
-    title: 'Suggest a feature',
-    description: 'Got an idea that would make GiftPool better? We\u2019re all ears.',
-    action: 'Send a suggestion',
-    href: 'mailto:support@giftpool.app?subject=Feature%20Suggestion',
-  },
-];
 
 const faqs = [
   {
@@ -44,11 +16,11 @@ const faqs = [
   },
   {
     q: 'Does GiftPool handle payments?',
-    a: 'No. GiftPool coordinates who\u2019s contributing what, but actual money transfers happen directly between people however they prefer (Venmo, cash, etc.).',
+    a: 'No. GiftPool coordinates who’s contributing what, but actual money transfers happen directly between people however they prefer (Venmo, cash, etc.).',
   },
   {
     q: 'Can I delete my account?',
-    a: 'Yes. Head to Settings and you\u2019ll find the option to delete your account and all associated data.',
+    a: 'Yes. Head to Settings and you’ll find the option to delete your account and all associated data.',
   },
   {
     q: 'Who can see my wishlist?',
@@ -68,39 +40,27 @@ const SupportRoute = () => {
           />
         </h1>
         <p className="mx-auto mt-4 max-w-xl text-body-md leading-relaxed text-muted-foreground">
-          Need help or have feedback? Here&apos;s how to reach us.
+          Need help or have feedback? Send us a message and we&apos;ll get back
+          to you.
         </p>
       </section>
 
       <section className="mt-12">
-        <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
-          {channels.map((c) => (
-            <Card key={c.title} padding="lg" className="h-full">
-              <CardContent>
-                <div className="flex flex-col items-center gap-3 text-center">
-                  <div
-                    className={cn(
-                      'flex h-12 w-12 items-center justify-center rounded-full bg-accent',
-                      c.color,
-                    )}
-                  >
-                    {c.icon}
-                  </div>
-                  <h2 className="text-base font-bold md:text-lg">{c.title}</h2>
-                  <p className="text-sm text-muted-foreground">
-                    {c.description}
-                  </p>
-                  <a
-                    href={c.href}
-                    className="mt-1 text-sm font-medium text-foreground underline hover:no-underline"
-                  >
-                    {c.action}
-                  </a>
-                </div>
-              </CardContent>
-            </Card>
-          ))}
-        </div>
+        <Card padding="lg">
+          <CardContent>
+            <FeedbackForm className="mx-auto max-w-xl" />
+          </CardContent>
+        </Card>
+        <p className="mt-4 text-center text-sm text-muted-foreground">
+          Prefer email? Reach us directly at{' '}
+          <a
+            href="mailto:support@giftpool.app"
+            className="font-medium text-foreground underline hover:no-underline"
+          >
+            support@giftpool.app
+          </a>
+          .
+        </p>
       </section>
 
       <section className="mt-16">

--- a/app/routes/admin+/_layout.tsx
+++ b/app/routes/admin+/_layout.tsx
@@ -21,6 +21,7 @@ const TABS: ReadonlyArray<Tab> = [
   { to: '/admin', label: 'Overview', end: true },
   { to: '/admin/users', label: 'Users' },
   { to: '/admin/pools', label: 'Pools' },
+  { to: '/admin/feedback', label: 'Feedback' },
   { to: '/admin/ops', label: 'Ops' },
   { to: '/admin/analytics', label: 'Analytics' },
   { to: '/admin/cache', label: 'Cache' },
@@ -52,7 +53,7 @@ export default AdminLayout;
 
 const TabBar = () => {
   return (
-    <div className="grid w-full grid-cols-3 rounded-2xl bg-muted p-1 sm:grid-cols-6">
+    <div className="grid w-full grid-cols-3 rounded-2xl bg-muted p-1 sm:grid-cols-4 lg:grid-cols-7">
       {TABS.map((tab) => (
         <NavLink
           key={tab.to}

--- a/app/routes/admin+/feedback.render.test.tsx
+++ b/app/routes/admin+/feedback.render.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import { createRoutesStub } from 'react-router';
+import { describe, expect, it, vi } from 'vitest';
+
+// The route module imports server-only helpers at the top level. Stub them so
+// importing the component doesn't pull in Prisma; the render tests drive the
+// component through createRoutesStub's loader, not the module loader.
+vi.mock('#app/utils/admin.server.ts', () => ({
+  listAdminFeedback: vi.fn(),
+  getFeedbackStatusCounts: vi.fn(),
+  updateFeedbackStatus: vi.fn(),
+}));
+vi.mock('#app/utils/permissions.server.ts', () => ({
+  requireUserWithRole: vi.fn(),
+}));
+
+import FeedbackRoute from './feedback.tsx';
+
+type Item = {
+  id: string;
+  type: string;
+  message: string;
+  email: string | null;
+  user: { id: string; username: string } | null;
+  pageUrl: string | null;
+  createdAt: Date;
+  status: string;
+  adminNotes: string | null;
+};
+
+const baseCounts = {
+  all: 0,
+  NEW: 0,
+  IN_PROGRESS: 0,
+  RESOLVED: 0,
+  WONT_FIX: 0,
+};
+
+function renderRoute(
+  loaderData: Partial<{
+    items: Array<Item>;
+    total: number;
+    counts: typeof baseCounts;
+    statusParam: string;
+    page: number;
+    pageSize: number;
+  }>,
+) {
+  const data = {
+    items: [],
+    total: 0,
+    counts: baseCounts,
+    statusParam: 'NEW',
+    page: 1,
+    pageSize: 25,
+    ...loaderData,
+  };
+  const Stub = createRoutesStub([
+    { path: '/admin/feedback', Component: FeedbackRoute, loader: () => data },
+  ]);
+  render(<Stub initialEntries={['/admin/feedback']} />);
+}
+
+const userItem: Item = {
+  id: 'f1',
+  type: 'BUG',
+  message: 'Vote button is dead on mobile.',
+  email: 'tester@example.com',
+  user: { id: 'u1', username: 'tester' },
+  pageUrl: '/groups/123',
+  createdAt: new Date(),
+  status: 'NEW',
+  adminNotes: null,
+};
+
+const anonItem: Item = {
+  id: 'f2',
+  type: 'FEATURE',
+  message: 'Please add dark mode to the wishlist.',
+  email: 'guest@example.com',
+  user: null,
+  pageUrl: null,
+  createdAt: new Date(),
+  status: 'NEW',
+  adminNotes: null,
+};
+
+describe('admin FeedbackRoute', () => {
+  it('renders feedback rows with type, author, and message', async () => {
+    renderRoute({
+      items: [userItem, anonItem],
+      total: 2,
+      counts: { ...baseCounts, all: 2, NEW: 2 },
+    });
+
+    expect(
+      await screen.findByRole('heading', { level: 1, name: 'Feedback' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Vote button is dead on mobile.')).toBeInTheDocument();
+    expect(
+      screen.getByText('Please add dark mode to the wishlist.'),
+    ).toBeInTheDocument();
+
+    // Logged-in submitter links to the user detail page; anonymous shows email.
+    const userLink = screen.getByRole('link', { name: '@tester' });
+    expect(userLink).toHaveAttribute('href', '/admin/users/u1');
+    expect(screen.getByText('guest@example.com')).toBeInTheDocument();
+
+    // Each row exposes a Save button and a status select.
+    expect(screen.getAllByRole('button', { name: 'Save' })).toHaveLength(2);
+  });
+
+  it('renders the empty state when there is no feedback', async () => {
+    renderRoute({ items: [], total: 0 });
+    expect(
+      await screen.findByText('Nothing here. Inbox zero.'),
+    ).toBeInTheDocument();
+  });
+
+  it('renders pagination controls when results span multiple pages', async () => {
+    renderRoute({
+      items: [userItem],
+      total: 60,
+      counts: { ...baseCounts, all: 60, NEW: 60 },
+      page: 1,
+      pageSize: 25,
+    });
+    expect(await screen.findByText('Page 1 of 3')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /next/i })).toBeInTheDocument();
+  });
+});

--- a/app/routes/admin+/feedback.test.ts
+++ b/app/routes/admin+/feedback.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest';
+import { action, loader } from '#app/routes/admin+/feedback.tsx';
+import { prisma } from '#app/utils/db.server.ts';
+import { createUser } from '#tests/db-utils.ts';
+import {
+  getRouteResultData,
+  toActionArgs,
+  toLoaderArgs,
+} from '#tests/route-module-test-utils.ts';
+import { getSessionCookieHeader } from '#tests/utils.ts';
+
+const DAY_MS = 1000 * 60 * 60 * 24;
+
+async function seedAdminSession() {
+  await prisma.role.upsert({
+    where: { name: 'admin' },
+    update: {},
+    create: { name: 'admin', description: 'Admin role' },
+  });
+  const admin = await prisma.user.create({
+    data: { ...createUser(), roles: { connect: { name: 'admin' } } },
+    select: { id: true },
+  });
+  const session = await prisma.session.create({
+    data: { userId: admin.id, expirationDate: new Date(Date.now() + DAY_MS) },
+  });
+  return { admin, cookie: await getSessionCookieHeader(session) };
+}
+
+describe('/admin/feedback loader', () => {
+  it('rejects non-admin users', async () => {
+    const user = await prisma.user.create({ data: createUser() });
+    const session = await prisma.session.create({
+      data: { userId: user.id, expirationDate: new Date(Date.now() + DAY_MS) },
+    });
+    const cookie = await getSessionCookieHeader(session);
+    await expect(
+      loader(
+        toLoaderArgs({
+          request: new Request('http://localhost/admin/feedback', {
+            headers: { cookie },
+          }),
+          params: {},
+          context: {} as any,
+        }),
+      ),
+    ).rejects.toMatchObject({ init: { status: 403 } });
+  });
+
+  it('defaults to NEW and reports per-status counts', async () => {
+    const { cookie } = await seedAdminSession();
+    await prisma.feedback.createMany({
+      data: [
+        { type: 'BUG', message: 'one '.repeat(5), status: 'NEW' },
+        { type: 'FEATURE', message: 'two '.repeat(5), status: 'RESOLVED' },
+      ],
+    });
+    const result = await loader(
+      toLoaderArgs({
+        request: new Request('http://localhost/admin/feedback', {
+          headers: { cookie },
+        }),
+        params: {},
+        context: {} as any,
+      }),
+    );
+    const data = await getRouteResultData<{
+      items: Array<{ status: string }>;
+      counts: { NEW: number; RESOLVED: number; all: number };
+      statusParam: string;
+    }>(result);
+    expect(data.statusParam).toBe('NEW');
+    expect(data.items).toHaveLength(1);
+    expect(data.items[0]?.status).toBe('NEW');
+    expect(data.counts).toMatchObject({ NEW: 1, RESOLVED: 1, all: 2 });
+  });
+});
+
+describe('/admin/feedback action', () => {
+  it('updates status and admin notes', async () => {
+    const { cookie } = await seedAdminSession();
+    const feedback = await prisma.feedback.create({
+      data: { type: 'BUG', message: 'something is broken here' },
+      select: { id: true },
+    });
+    await action(
+      toActionArgs({
+        request: new Request('http://localhost/admin/feedback', {
+          method: 'POST',
+          headers: {
+            cookie,
+            'content-type': 'application/x-www-form-urlencoded',
+          },
+          body: new URLSearchParams({
+            feedbackId: feedback.id,
+            status: 'RESOLVED',
+            adminNotes: 'fixed in deploy 42',
+          }).toString(),
+        }),
+        params: {},
+        context: {} as any,
+      }),
+    );
+    const updated = await prisma.feedback.findUniqueOrThrow({
+      where: { id: feedback.id },
+    });
+    expect(updated.status).toBe('RESOLVED');
+    expect(updated.adminNotes).toBe('fixed in deploy 42');
+  });
+
+  it('rejects an invalid status', async () => {
+    const { cookie } = await seedAdminSession();
+    const feedback = await prisma.feedback.create({
+      data: { type: 'BUG', message: 'something is broken here' },
+      select: { id: true },
+    });
+    await expect(
+      action(
+        toActionArgs({
+          request: new Request('http://localhost/admin/feedback', {
+            method: 'POST',
+            headers: {
+              cookie,
+              'content-type': 'application/x-www-form-urlencoded',
+            },
+            body: new URLSearchParams({
+              feedbackId: feedback.id,
+              status: 'BOGUS',
+            }).toString(),
+          }),
+          params: {},
+          context: {} as any,
+        }),
+      ),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+});

--- a/app/routes/admin+/feedback.tsx
+++ b/app/routes/admin+/feedback.tsx
@@ -1,0 +1,284 @@
+import { invariantResponse } from '@epic-web/invariant';
+import {
+  Form,
+  Link,
+  NavLink,
+  data,
+  useLoaderData,
+  useNavigation,
+  type ActionFunctionArgs,
+  type LoaderFunctionArgs,
+} from 'react-router';
+import { EmptyRow, SectionCard } from '#app/components/admin-ui.tsx';
+import { GeneralErrorBoundary } from '#app/components/error-boundary.tsx';
+import { Button } from '#app/components/ui/button.tsx';
+import { Textarea } from '#app/components/ui/textarea.tsx';
+import {
+  getFeedbackStatusCounts,
+  listAdminFeedback,
+  updateFeedbackStatus,
+} from '#app/utils/admin.server.ts';
+import {
+  FEEDBACK_STATUS_LABELS,
+  FEEDBACK_STATUS_VALUES,
+  FEEDBACK_TYPE_LABELS,
+  FeedbackStatusSchema,
+  type FeedbackStatus,
+  type FeedbackType,
+} from '#app/utils/feedback-validation.ts';
+import { cn } from '#app/utils/misc.tsx';
+import { requireUserWithRole } from '#app/utils/permissions.server.ts';
+
+const PAGE_SIZE = 25;
+
+const STATUS_TABS: Array<{ value: string; label: string }> = [
+  { value: 'all', label: 'All' },
+  ...FEEDBACK_STATUS_VALUES.map((s) => ({
+    value: s,
+    label: FEEDBACK_STATUS_LABELS[s],
+  })),
+];
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  await requireUserWithRole(request, 'admin');
+  const url = new URL(request.url);
+  const statusParam = url.searchParams.get('status') ?? 'NEW';
+  const rawPage = Number.parseInt(url.searchParams.get('page') ?? '1', 10);
+  const page = Number.isFinite(rawPage) && rawPage > 0 ? rawPage : 1;
+
+  const status =
+    statusParam === 'all'
+      ? 'all'
+      : (FeedbackStatusSchema.safeParse(statusParam).data ?? 'NEW');
+
+  const [{ items, total }, counts] = await Promise.all([
+    listAdminFeedback({
+      status,
+      limit: PAGE_SIZE,
+      offset: (page - 1) * PAGE_SIZE,
+    }),
+    getFeedbackStatusCounts(),
+  ]);
+
+  return { items, total, counts, statusParam, page, pageSize: PAGE_SIZE };
+}
+
+export async function action({ request }: ActionFunctionArgs) {
+  await requireUserWithRole(request, 'admin');
+  const formData = await request.formData();
+
+  const feedbackId = formData.get('feedbackId');
+  invariantResponse(typeof feedbackId === 'string', 'feedbackId required', {
+    status: 400,
+  });
+
+  const statusResult = FeedbackStatusSchema.safeParse(formData.get('status'));
+  invariantResponse(statusResult.success, 'invalid status', { status: 400 });
+
+  const rawNotes = formData.get('adminNotes');
+  const adminNotes = typeof rawNotes === 'string' ? rawNotes : undefined;
+
+  await updateFeedbackStatus({
+    feedbackId,
+    status: statusResult.data,
+    adminNotes,
+  });
+
+  return data({ ok: true });
+}
+
+const formatRelative = (date: Date | string) => {
+  const d = typeof date === 'string' ? new Date(date) : date;
+  const days = Math.round((Date.now() - d.getTime()) / (1000 * 60 * 60 * 24));
+  if (days < 1) return 'today';
+  if (days === 1) return '1d ago';
+  return `${days}d ago`;
+};
+
+const FeedbackRoute = () => {
+  const { items, total, counts, statusParam, page, pageSize } =
+    useLoaderData<typeof loader>();
+  const totalPages = Math.ceil(total / pageSize);
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-1">
+        <h1 className="text-xl font-semibold">Feedback</h1>
+        <p className="text-muted-foreground">
+          User-submitted bugs, ideas, and questions. Triage by changing status
+          and leaving internal notes.
+        </p>
+      </div>
+
+      <div className="flex flex-wrap gap-1.5 rounded-xl bg-muted p-1">
+        {STATUS_TABS.map((tab) => {
+          const count =
+            tab.value === 'all'
+              ? counts.all
+              : counts[tab.value as FeedbackStatus];
+          return (
+            <NavLink
+              key={tab.value}
+              to={`/admin/feedback?status=${tab.value}`}
+              className={cn(
+                'px-3 py-1.5 text-sm font-medium text-muted-foreground',
+                'rounded-lg transition-colors',
+                statusParam === tab.value &&
+                  'bg-background text-foreground shadow',
+              )}
+            >
+              {tab.label}
+              <span className="ml-1.5 tabular-nums opacity-70">{count}</span>
+            </NavLink>
+          );
+        })}
+      </div>
+
+      <SectionCard
+        title={`${statusParam === 'all' ? 'All feedback' : FEEDBACK_STATUS_LABELS[statusParam as FeedbackStatus] ?? statusParam} (${total})`}
+      >
+        {items.length === 0 ? (
+          <EmptyRow>Nothing here. Inbox zero.</EmptyRow>
+        ) : (
+          <ul className="space-y-3">
+            {items.map((item) => (
+              <FeedbackCard key={item.id} item={item} />
+            ))}
+          </ul>
+        )}
+
+        {totalPages > 1 ? (
+          <div className="mt-4 flex items-center justify-between text-sm">
+            <span className="text-muted-foreground">
+              Page {page} of {totalPages}
+            </span>
+            <div className="flex gap-2">
+              {page > 1 ? (
+                <Link
+                  to={`/admin/feedback?status=${statusParam}&page=${page - 1}`}
+                  className="rounded-md bg-muted px-3 py-1 font-medium hover:bg-accent"
+                >
+                  ← Prev
+                </Link>
+              ) : null}
+              {page < totalPages ? (
+                <Link
+                  to={`/admin/feedback?status=${statusParam}&page=${page + 1}`}
+                  className="rounded-md bg-muted px-3 py-1 font-medium hover:bg-accent"
+                >
+                  Next →
+                </Link>
+              ) : null}
+            </div>
+          </div>
+        ) : null}
+      </SectionCard>
+    </div>
+  );
+};
+
+const TYPE_BADGE: Record<FeedbackType, string> = {
+  BUG: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300',
+  FEATURE:
+    'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300',
+  QUESTION: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300',
+};
+
+const FeedbackCard = ({
+  item,
+}: {
+  item: ReturnType<typeof useLoaderData<typeof loader>>['items'][number];
+}) => {
+  const navigation = useNavigation();
+  const isSaving =
+    navigation.state !== 'idle' &&
+    navigation.formData?.get('feedbackId') === item.id;
+
+  return (
+    <li className="rounded-lg border border-border/60 p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <span
+            className={cn(
+              'inline-block rounded-md px-2 py-0.5 text-xs font-semibold',
+              TYPE_BADGE[item.type as FeedbackType] ?? 'bg-muted',
+            )}
+          >
+            {FEEDBACK_TYPE_LABELS[item.type as FeedbackType] ?? item.type}
+          </span>
+          <span className="text-xs text-muted-foreground">
+            {item.user ? (
+              <Link
+                to={`/admin/users/${item.user.id}`}
+                className="font-medium hover:underline"
+              >
+                @{item.user.username}
+              </Link>
+            ) : (
+              (item.email ?? 'anonymous')
+            )}
+          </span>
+        </div>
+        <span className="shrink-0 text-xs text-muted-foreground">
+          {formatRelative(item.createdAt)}
+        </span>
+      </div>
+
+      <p className="mt-2 whitespace-pre-wrap text-sm">{item.message}</p>
+
+      {item.email && item.user ? (
+        <p className="mt-1 text-xs text-muted-foreground">
+          Reply-to: {item.email}
+        </p>
+      ) : null}
+      {item.pageUrl ? (
+        <p className="mt-1 text-xs text-muted-foreground">
+          From: {item.pageUrl}
+        </p>
+      ) : null}
+
+      <Form method="POST" className="mt-3 flex flex-col gap-2">
+        <input type="hidden" name="feedbackId" value={item.id} />
+        <Textarea
+          name="adminNotes"
+          rows={2}
+          defaultValue={item.adminNotes ?? ''}
+          placeholder="Internal notes (optional)…"
+          className="text-sm"
+        />
+        <div className="flex flex-wrap items-center gap-2">
+          <label className="text-xs text-muted-foreground" htmlFor={`status-${item.id}`}>
+            Status
+          </label>
+          <select
+            id={`status-${item.id}`}
+            name="status"
+            defaultValue={item.status}
+            className="rounded-md border border-input bg-background px-2 py-1 text-sm"
+          >
+            {FEEDBACK_STATUS_VALUES.map((s) => (
+              <option key={s} value={s}>
+                {FEEDBACK_STATUS_LABELS[s]}
+              </option>
+            ))}
+          </select>
+          <Button
+            type="submit"
+            size="sm"
+            variant="outline"
+            disabled={isSaving}
+            className="ml-auto"
+          >
+            {isSaving ? 'Saving…' : 'Save'}
+          </Button>
+        </div>
+      </Form>
+    </li>
+  );
+};
+
+export default FeedbackRoute;
+
+export const ErrorBoundary = () => {
+  return <GeneralErrorBoundary />;
+};

--- a/app/routes/api.feedback.test.ts
+++ b/app/routes/api.feedback.test.ts
@@ -14,13 +14,15 @@ import { getSessionCookieHeader } from '#tests/utils.ts';
 // Side effects fire off the action response; stub them so they don't perform
 // real network calls or race the test teardown. `vi.hoisted` ensures the mock
 // fns exist before any transitive import pulls in the mocked modules.
-const { sendEmail, queueLogEvent } = vi.hoisted(() => ({
+const { sendEmail, queueLogEvent, captureException } = vi.hoisted(() => ({
   sendEmail: vi.fn(async () => ({ status: 'success' as const })),
   queueLogEvent: vi.fn(() => ({ eventId: 'test-event' })),
+  captureException: vi.fn(),
 }));
 
 vi.mock('#app/utils/email.server.ts', () => ({ sendEmail }));
 vi.mock('#app/utils/analytics.server.ts', () => ({ queueLogEvent }));
+vi.mock('@sentry/react-router', () => ({ captureException }));
 
 import { action } from './api.feedback.tsx';
 
@@ -139,5 +141,35 @@ describe('/api/feedback action', () => {
     expect(row.userId).toBe(user.id);
     expect(row.email).toBe('real-user@example.com');
     expect(row.type).toBe('FEATURE');
+  });
+
+  it('reports to Sentry when sendEmail resolves with an error status', async () => {
+    // Resend returns a non-2xx → sendEmail RESOLVES { status: 'error' } rather
+    // than rejecting. The submission must still succeed, but the silent email
+    // failure must reach Sentry.
+    sendEmail.mockResolvedValue({
+      status: 'error',
+      error: { name: 'rate_limit', message: 'Too many requests', statusCode: 429 },
+    } as never);
+
+    const result = await action(
+      toActionArgs({
+        request: createRequest({ ...baseBody, email: 'guest@example.com' }),
+        params: {},
+        context: {} as any,
+      }),
+    );
+    // Action still succeeds — the side-effect failure never 500s the request.
+    await expect(getRouteResultData(result)).resolves.toMatchObject({ ok: true });
+
+    // Flush the fire-and-forget `.then` microtasks before asserting.
+    await new Promise((resolve) => setTimeout(resolve));
+
+    expect(captureException).toHaveBeenCalled();
+    const reported = (captureException.mock.calls as Array<[Error, unknown]>).map(
+      (call) => (call[0] as Error).message,
+    );
+    expect(reported.some((m) => /operator email failed/.test(m))).toBe(true);
+    expect(reported.some((m) => /acknowledgment email failed/.test(m))).toBe(true);
   });
 });

--- a/app/routes/api.feedback.test.ts
+++ b/app/routes/api.feedback.test.ts
@@ -1,0 +1,143 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { prisma } from '#app/utils/db.server.ts';
+import { createUser } from '#tests/db-utils.ts';
+import {
+  getRouteResultData,
+  getRouteResultStatus,
+  toActionArgs,
+} from '#tests/route-module-test-utils.ts';
+import { getSessionCookieHeader } from '#tests/utils.ts';
+
+// Side effects fire off the action response; stub them so they don't perform
+// real network calls or race the test teardown. `vi.hoisted` ensures the mock
+// fns exist before any transitive import pulls in the mocked modules.
+const { sendEmail, queueLogEvent } = vi.hoisted(() => ({
+  sendEmail: vi.fn(async () => ({ status: 'success' as const })),
+  queueLogEvent: vi.fn(() => ({ eventId: 'test-event' })),
+}));
+
+vi.mock('#app/utils/email.server.ts', () => ({ sendEmail }));
+vi.mock('#app/utils/analytics.server.ts', () => ({ queueLogEvent }));
+
+import { action } from './api.feedback.tsx';
+
+const DAY_MS = 1000 * 60 * 60 * 24;
+
+function createRequest(
+  body: Record<string, string>,
+  { cookie }: { cookie?: string } = {},
+) {
+  return new Request('https://giftpool.app/api/feedback', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/x-www-form-urlencoded',
+      'user-agent': 'vitest',
+      ...(cookie ? { cookie } : {}),
+    },
+    body: new URLSearchParams(body).toString(),
+  });
+}
+
+const baseBody = {
+  type: 'BUG',
+  message: 'The vote button does nothing when I tap it on mobile.',
+};
+
+describe('/api/feedback action', () => {
+  it('requires an email for anonymous submissions', async () => {
+    const result = await action(
+      toActionArgs({ request: createRequest(baseBody), params: {}, context: {} as any }),
+    );
+    expect(getRouteResultStatus(result)).toBe(400);
+    await expect(getRouteResultData(result)).resolves.toMatchObject({
+      result: { error: { email: expect.any(Array) } },
+    });
+    expect(await prisma.feedback.count()).toBe(0);
+    expect(sendEmail).not.toHaveBeenCalled();
+  });
+
+  it('persists an anonymous submission that includes an email', async () => {
+    const result = await action(
+      toActionArgs({
+        request: createRequest({ ...baseBody, email: 'Guest@Example.com' }),
+        params: {},
+        context: {} as any,
+      }),
+    );
+    await expect(getRouteResultData(result)).resolves.toMatchObject({ ok: true });
+
+    const rows = await prisma.feedback.findMany();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      type: 'BUG',
+      email: 'guest@example.com',
+      userId: null,
+      status: 'NEW',
+      userAgent: 'vitest',
+    });
+    expect(queueLogEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'feedback_submitted' }),
+    );
+    // One email to the operator inbox, one acknowledgment to the submitter.
+    expect(sendEmail).toHaveBeenCalledTimes(2);
+    const recipients = (
+      sendEmail.mock.calls as unknown as Array<[{ to: string }]>
+    ).map((call) => call[0].to);
+    expect(recipients).toContain('support@giftpool.app');
+    expect(recipients).toContain('guest@example.com');
+
+    // No FEEDBACK_CC_EMAIL set in tests → the operator email omits cc.
+    const operatorCall = (
+      sendEmail.mock.calls as unknown as Array<[{ to: string; cc?: string }]>
+    ).find((call) => call[0].to === 'support@giftpool.app');
+    expect(operatorCall?.[0].cc).toBeUndefined();
+  });
+
+  it('CCs the operator email to FEEDBACK_CC_EMAIL when configured', async () => {
+    vi.stubEnv('FEEDBACK_CC_EMAIL', 'owner@example.com');
+
+    const result = await action(
+      toActionArgs({
+        request: createRequest({ ...baseBody, email: 'guest@example.com' }),
+        params: {},
+        context: {} as any,
+      }),
+    );
+    await expect(getRouteResultData(result)).resolves.toMatchObject({ ok: true });
+
+    const operatorCall = (
+      sendEmail.mock.calls as unknown as Array<[{ to: string; cc?: string }]>
+    ).find((call) => call[0].to === 'support@giftpool.app');
+    expect(operatorCall?.[0].cc).toBe('owner@example.com');
+
+    vi.unstubAllEnvs();
+  });
+
+  it('uses the stored email for a logged-in submitter', async () => {
+    const user = await prisma.user.create({
+      data: { ...createUser(), email: 'real-user@example.com' },
+      select: { id: true },
+    });
+    const session = await prisma.session.create({
+      data: { userId: user.id, expirationDate: new Date(Date.now() + DAY_MS) },
+    });
+    const cookie = await getSessionCookieHeader(session);
+
+    const result = await action(
+      toActionArgs({
+        request: createRequest({ ...baseBody, type: 'FEATURE' }, { cookie }),
+        params: {},
+        context: {} as any,
+      }),
+    );
+    await expect(getRouteResultData(result)).resolves.toMatchObject({ ok: true });
+
+    const row = await prisma.feedback.findFirstOrThrow();
+    expect(row.userId).toBe(user.id);
+    expect(row.email).toBe('real-user@example.com');
+    expect(row.type).toBe('FEATURE');
+  });
+});

--- a/app/routes/api.feedback.tsx
+++ b/app/routes/api.feedback.tsx
@@ -81,46 +81,68 @@ export async function action({ request }: ActionFunctionArgs) {
     properties: { type, anonymous: !userId, feedbackId: feedback.id },
   });
 
+  // `sendEmail` resolves to `{ status: 'error' }` on a non-2xx Resend response
+  // rather than rejecting, so a bare `.catch` only sees network/render throws
+  // and would let API-level failures (bad address, rate limit, auth) drop
+  // silently. Inspect the resolved status AND catch throws — surfacing both to
+  // Sentry — without ever failing the already-committed action.
+  const dispatchEmail = (kind: string, send: ReturnType<typeof sendEmail>) => {
+    void send
+      .then((result) => {
+        if (result.status === 'error') {
+          captureException(
+            new Error(`Feedback ${kind} email failed: ${result.error.message}`),
+            { extra: { feedbackId: feedback.id, kind } },
+          );
+        }
+      })
+      .catch((error: unknown) => {
+        captureException(error, { extra: { feedbackId: feedback.id, kind } });
+      });
+  };
+
   const adminUrl = `${getDomainUrl(request)}/admin/feedback`;
   // CC a monitored inbox (e.g. a personal address) when configured, so
   // notifications reach someone even if support@ goes unwatched. Unset in
   // dev/test/CI, where it's simply omitted.
   const operatorCc = process.env.FEEDBACK_CC_EMAIL;
-  void sendEmail({
-    to: FEEDBACK_INBOX,
-    ...(operatorCc ? { cc: operatorCc } : {}),
-    subject: `[Feedback] ${type} from ${user?.username ?? contactEmail ?? 'anonymous'}`,
-    react: (
-      <FeedbackReceivedEmail
-        type={type as FeedbackType}
-        message={message}
-        fromEmail={contactEmail ?? undefined}
-        username={user?.username}
-        pageUrl={pageUrl}
-        adminUrl={adminUrl}
-      />
-    ),
-  }).catch((error: unknown) => {
-    captureException(error);
-  });
+  dispatchEmail(
+    'operator',
+    sendEmail({
+      to: FEEDBACK_INBOX,
+      ...(operatorCc ? { cc: operatorCc } : {}),
+      subject: `[Feedback] ${type} from ${user?.username ?? contactEmail ?? 'anonymous'}`,
+      react: (
+        <FeedbackReceivedEmail
+          type={type as FeedbackType}
+          message={message}
+          fromEmail={contactEmail ?? undefined}
+          username={user?.username}
+          pageUrl={pageUrl}
+          adminUrl={adminUrl}
+        />
+      ),
+    }),
+  );
 
   // Send a transactional acknowledgment back to the submitter when we know
   // their address. Fire-and-forget like the operator notification — a failure
   // here must never turn a successful submission into a 500.
   if (contactEmail) {
-    void sendEmail({
-      to: contactEmail,
-      subject: 'We got your feedback — thanks!',
-      react: (
-        <FeedbackAcknowledgedEmail
-          type={type as FeedbackType}
-          message={message}
-          recipientName={user?.name ?? user?.username ?? null}
-        />
-      ),
-    }).catch((error: unknown) => {
-      captureException(error);
-    });
+    dispatchEmail(
+      'acknowledgment',
+      sendEmail({
+        to: contactEmail,
+        subject: 'We got your feedback — thanks!',
+        react: (
+          <FeedbackAcknowledgedEmail
+            type={type as FeedbackType}
+            message={message}
+            recipientName={user?.name ?? user?.username ?? null}
+          />
+        ),
+      }),
+    );
   }
 
   return data({ result: submission.reply({ resetForm: true }), ok: true });

--- a/app/routes/api.feedback.tsx
+++ b/app/routes/api.feedback.tsx
@@ -1,0 +1,127 @@
+import { parseWithZod } from '@conform-to/zod';
+import { captureException } from '@sentry/react-router';
+import { data, type ActionFunctionArgs } from 'react-router';
+import { z } from 'zod';
+import { FeedbackAcknowledgedEmail } from '#app/emails/feedback-acknowledged.tsx';
+import { FeedbackReceivedEmail } from '#app/emails/feedback-received.tsx';
+import { queueLogEvent } from '#app/utils/analytics.server.ts';
+import { getUserId } from '#app/utils/auth.server.ts';
+import { prisma } from '#app/utils/db.server.ts';
+import { sendEmail } from '#app/utils/email.server.ts';
+import {
+  FeedbackSchema,
+  type FeedbackType,
+} from '#app/utils/feedback-validation.ts';
+import { checkHoneypot } from '#app/utils/honeypot.server.ts';
+import { getDomainUrl } from '#app/utils/misc.tsx';
+import { getRequestContext } from '#app/utils/request-context.server.ts';
+
+// Where operator notifications land. Mirrors the address the static support
+// page used to point its mailto links at.
+const FEEDBACK_INBOX = 'support@giftpool.app';
+
+export async function action({ request }: ActionFunctionArgs) {
+  const userId = await getUserId(request);
+  const formData = await request.formData();
+  await checkHoneypot(formData);
+
+  const submission = await parseWithZod(formData, {
+    schema: FeedbackSchema.superRefine((value, ctx) => {
+      // Anonymous submitters must give us a way to reply.
+      if (!userId && !value.email) {
+        ctx.addIssue({
+          path: ['email'],
+          code: z.ZodIssueCode.custom,
+          message: 'Please add an email so we can get back to you',
+        });
+      }
+    }),
+    async: true,
+  });
+
+  if (submission.status !== 'success') {
+    return data(
+      { result: submission.reply() },
+      { status: submission.status === 'error' ? 400 : 200 },
+    );
+  }
+
+  const { type, message, email, pageUrl } = submission.value;
+
+  // Prefer the authenticated user's stored email; fall back to the typed one.
+  const user = userId
+    ? await prisma.user.findUnique({
+        where: { id: userId },
+        select: { email: true, username: true, name: true },
+      })
+    : null;
+  const contactEmail = user?.email ?? email ?? null;
+
+  const feedback = await prisma.feedback.create({
+    data: {
+      type,
+      message,
+      email: contactEmail,
+      userId: userId ?? null,
+      pageUrl: pageUrl ?? null,
+      userAgent: request.headers.get('user-agent'),
+    },
+    select: { id: true },
+  });
+
+  // Primary change is committed. Everything below is best-effort and must
+  // never turn a successful submission into a 500 — fire without awaiting and
+  // tail rejections to Sentry. (See "Side effects off the action response".)
+  const { requestId } = await getRequestContext(request);
+  queueLogEvent({
+    name: 'feedback_submitted',
+    userId: userId ?? null,
+    source: 'server',
+    requestId,
+    properties: { type, anonymous: !userId, feedbackId: feedback.id },
+  });
+
+  const adminUrl = `${getDomainUrl(request)}/admin/feedback`;
+  // CC a monitored inbox (e.g. a personal address) when configured, so
+  // notifications reach someone even if support@ goes unwatched. Unset in
+  // dev/test/CI, where it's simply omitted.
+  const operatorCc = process.env.FEEDBACK_CC_EMAIL;
+  void sendEmail({
+    to: FEEDBACK_INBOX,
+    ...(operatorCc ? { cc: operatorCc } : {}),
+    subject: `[Feedback] ${type} from ${user?.username ?? contactEmail ?? 'anonymous'}`,
+    react: (
+      <FeedbackReceivedEmail
+        type={type as FeedbackType}
+        message={message}
+        fromEmail={contactEmail ?? undefined}
+        username={user?.username}
+        pageUrl={pageUrl}
+        adminUrl={adminUrl}
+      />
+    ),
+  }).catch((error: unknown) => {
+    captureException(error);
+  });
+
+  // Send a transactional acknowledgment back to the submitter when we know
+  // their address. Fire-and-forget like the operator notification — a failure
+  // here must never turn a successful submission into a 500.
+  if (contactEmail) {
+    void sendEmail({
+      to: contactEmail,
+      subject: 'We got your feedback — thanks!',
+      react: (
+        <FeedbackAcknowledgedEmail
+          type={type as FeedbackType}
+          message={message}
+          recipientName={user?.name ?? user?.username ?? null}
+        />
+      ),
+    }).catch((error: unknown) => {
+      captureException(error);
+    });
+  }
+
+  return data({ result: submission.reply({ resetForm: true }), ok: true });
+}

--- a/app/utils/admin.server.ts
+++ b/app/utils/admin.server.ts
@@ -1,6 +1,7 @@
 import { queueLogEvent } from './analytics.server.ts';
 import { cache, cachified, lruCache } from './cache.server.ts';
 import { prisma } from './db.server.ts';
+import { type FeedbackStatus } from './feedback-validation.ts';
 import { POOL_STATUS, type PoolStatus } from './pool-constants.ts';
 
 const SIXTY_SECONDS = 60 * 1000;
@@ -1439,5 +1440,92 @@ export async function getNotificationOptOutMatrix(): Promise<
       emailOptOutPercent: total > 0 ? Math.round((emailOff / total) * 100) : 0,
       total,
     };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Feedback triage — NOT cached. This is a live queue where an admin flips a
+// status and expects the change reflected on the next render, so stale reads
+// (lruCache or SQLite) would be a regression. Volume is low.
+// ---------------------------------------------------------------------------
+
+export type AdminFeedbackListItem = {
+  id: string;
+  type: string;
+  message: string;
+  email: string | null;
+  status: string;
+  adminNotes: string | null;
+  pageUrl: string | null;
+  createdAt: Date;
+  user: { id: string; username: string; name: string | null } | null;
+};
+
+export async function listAdminFeedback({
+  status,
+  limit = 25,
+  offset = 0,
+}: {
+  status?: FeedbackStatus | 'all';
+  limit?: number;
+  offset?: number;
+}): Promise<{ items: AdminFeedbackListItem[]; total: number }> {
+  const where = status && status !== 'all' ? { status } : {};
+  const [rows, total] = await Promise.all([
+    prisma.feedback.findMany({
+      where,
+      orderBy: { createdAt: 'desc' },
+      take: limit,
+      skip: offset,
+      select: {
+        id: true,
+        type: true,
+        message: true,
+        email: true,
+        status: true,
+        adminNotes: true,
+        pageUrl: true,
+        createdAt: true,
+        user: { select: { id: true, username: true, name: true } },
+      },
+    }),
+    prisma.feedback.count({ where }),
+  ]);
+  return { items: rows, total };
+}
+
+export async function getFeedbackStatusCounts(): Promise<
+  Record<FeedbackStatus, number> & { all: number }
+> {
+  const grouped = await prisma.feedback.groupBy({
+    by: ['status'],
+    _count: { _all: true },
+  });
+  const counts = { NEW: 0, IN_PROGRESS: 0, RESOLVED: 0, WONT_FIX: 0, all: 0 };
+  for (const row of grouped) {
+    const n = row._count._all;
+    counts.all += n;
+    if (row.status in counts) {
+      counts[row.status as FeedbackStatus] = n;
+    }
+  }
+  return counts;
+}
+
+export async function updateFeedbackStatus({
+  feedbackId,
+  status,
+  adminNotes,
+}: {
+  feedbackId: string;
+  status: FeedbackStatus;
+  adminNotes?: string | null;
+}): Promise<void> {
+  await prisma.feedback.update({
+    where: { id: feedbackId },
+    data: {
+      status,
+      ...(adminNotes !== undefined ? { adminNotes: adminNotes || null } : {}),
+    },
   });
 }

--- a/app/utils/analytics.ts
+++ b/app/utils/analytics.ts
@@ -20,6 +20,8 @@ export const ANALYTIC_EVENT_NAMES = [
   'admin_role_granted',
   'admin_role_revoked',
   'admin_sessions_revoked',
+  // Feedback — submitter may be anonymous, so this is NOT a user-required event.
+  'feedback_submitted',
 ] as const;
 
 export type AnalyticEventName = (typeof ANALYTIC_EVENT_NAMES)[number];

--- a/app/utils/email.server.ts
+++ b/app/utils/email.server.ts
@@ -26,6 +26,7 @@ export async function sendEmail({
   ...options
 }: {
   to: string;
+  cc?: string;
   subject: string;
 } & (
   | { html: string; text: string; react?: never }

--- a/app/utils/env.server.ts
+++ b/app/utils/env.server.ts
@@ -13,6 +13,9 @@ const schema = z.object({
   NOTIFICATION_TOKEN_SECRET: z.string().optional(),
   // If you plan to use Resend, uncomment this line
   // RESEND_API_KEY: z.string(),
+  // Optional: CC every feedback operator-notification to a monitored inbox.
+  // Set as a Fly secret in prod; left unset in dev/test/CI (no CC, no-op).
+  FEEDBACK_CC_EMAIL: z.string().email().optional(),
   // If you plan to use GitHub auth, remove the default:
   GITHUB_CLIENT_ID: z.string().default('MOCK_GITHUB_CLIENT_ID'),
   GITHUB_CLIENT_SECRET: z.string().default('MOCK_GITHUB_CLIENT_SECRET'),

--- a/app/utils/feedback-validation.test.ts
+++ b/app/utils/feedback-validation.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { FeedbackSchema } from './feedback-validation.ts';
+
+describe('FeedbackSchema', () => {
+  const valid = {
+    type: 'BUG',
+    message: 'The vote button does nothing when I click it.',
+  };
+
+  it('accepts a valid bug report without an email', () => {
+    const result = FeedbackSchema.safeParse(valid);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects an unknown type', () => {
+    const result = FeedbackSchema.safeParse({ ...valid, type: 'RANT' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a too-short message', () => {
+    const result = FeedbackSchema.safeParse({ ...valid, message: 'broken' });
+    expect(result.success).toBe(false);
+  });
+
+  it('treats a blank email as absent (undefined)', () => {
+    const result = FeedbackSchema.safeParse({ ...valid, email: '' });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.email).toBeUndefined();
+  });
+
+  it('rejects a malformed email when one is provided', () => {
+    const result = FeedbackSchema.safeParse({ ...valid, email: 'not-an-email' });
+    expect(result.success).toBe(false);
+  });
+
+  it('lowercases a valid email', () => {
+    const result = FeedbackSchema.safeParse({
+      ...valid,
+      email: 'Person@Example.COM',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.email).toBe('person@example.com');
+  });
+});

--- a/app/utils/feedback-validation.ts
+++ b/app/utils/feedback-validation.ts
@@ -1,0 +1,61 @@
+import { z } from 'zod';
+import { EmailSchema } from './user-validation.ts';
+
+// String fields in the DB (SQLite has no native enums); valid values are
+// enforced here at the app layer. See `prisma/schema.prisma` model `Feedback`.
+export const FEEDBACK_TYPE_VALUES = ['BUG', 'FEATURE', 'QUESTION'] as const;
+export type FeedbackType = (typeof FEEDBACK_TYPE_VALUES)[number];
+export const FeedbackTypeSchema = z.enum(FEEDBACK_TYPE_VALUES);
+
+export const FEEDBACK_STATUS_VALUES = [
+  'NEW',
+  'IN_PROGRESS',
+  'RESOLVED',
+  'WONT_FIX',
+] as const;
+export type FeedbackStatus = (typeof FEEDBACK_STATUS_VALUES)[number];
+export const FeedbackStatusSchema = z.enum(FEEDBACK_STATUS_VALUES);
+
+export const FEEDBACK_TYPE_LABELS: Record<FeedbackType, string> = {
+  BUG: 'Bug',
+  FEATURE: 'Suggestion',
+  QUESTION: 'Question',
+};
+
+export const FEEDBACK_STATUS_LABELS: Record<FeedbackStatus, string> = {
+  NEW: 'New',
+  IN_PROGRESS: 'In progress',
+  RESOLVED: 'Resolved',
+  WONT_FIX: "Won't fix",
+};
+
+export const FEEDBACK_MESSAGE_MIN_LENGTH = 10;
+export const FEEDBACK_MESSAGE_MAX_LENGTH = 2000;
+
+// Optional email field on the form: blank is allowed (the action requires it
+// only for anonymous submitters, via superRefine), but a non-blank value must
+// be a valid email. Empty string normalizes to undefined.
+const OptionalEmailSchema = z
+  .string()
+  .trim()
+  .optional()
+  .transform((value) => (value ? value : undefined))
+  .pipe(EmailSchema.optional());
+
+export const FeedbackSchema = z.object({
+  type: FeedbackTypeSchema,
+  message: z
+    .string({ required_error: 'Please tell us a little more' })
+    .trim()
+    .min(FEEDBACK_MESSAGE_MIN_LENGTH, {
+      message: `Please use at least ${FEEDBACK_MESSAGE_MIN_LENGTH} characters`,
+    })
+    .max(FEEDBACK_MESSAGE_MAX_LENGTH, {
+      message: `Please keep it under ${FEEDBACK_MESSAGE_MAX_LENGTH} characters`,
+    }),
+  email: OptionalEmailSchema,
+  // Captured client-side, best-effort context. Never trusted for auth.
+  pageUrl: z.string().max(500).optional(),
+});
+
+export type FeedbackInput = z.input<typeof FeedbackSchema>;

--- a/prisma/migrations/20260527044640_add_feedback/migration.sql
+++ b/prisma/migrations/20260527044640_add_feedback/migration.sql
@@ -1,0 +1,21 @@
+-- CreateTable
+CREATE TABLE "Feedback" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    "type" TEXT NOT NULL,
+    "message" TEXT NOT NULL,
+    "email" TEXT,
+    "userId" TEXT,
+    "pageUrl" TEXT,
+    "userAgent" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'NEW',
+    "adminNotes" TEXT,
+    CONSTRAINT "Feedback_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE INDEX "Feedback_status_createdAt_idx" ON "Feedback"("status", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "Feedback_createdAt_idx" ON "Feedback"("createdAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -60,6 +60,7 @@ model User {
   ideaVotesCast                IdeaVote[]
   poolActivities               PoolActivity[]                @relation("PoolActivity_Actor")
   poolMessages                 PoolMessage[]
+  feedback                     Feedback[]
 }
 
 model Friendship {
@@ -424,6 +425,43 @@ model PoolMessage {
   referencedIdea   GiftIdea? @relation("PoolMessage_ReferencedIdea", fields: [referencedIdeaId], references: [id], onDelete: SetNull)
 
   @@index([poolId, createdAt])
+}
+
+// -----------------------------------------------------------------------------
+// Feedback
+// -----------------------------------------------------------------------------
+
+model Feedback {
+  id        String   @id @default(cuid())
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  // String, not a true enum — SQLite doesn't support enums natively. Valid
+  // values enforced at the app layer via `FeedbackTypeSchema`
+  // (see `app/utils/feedback-validation.ts`): 'BUG' | 'FEATURE' | 'QUESTION'.
+  type    String
+  message String
+
+  // Contact-back address. Required for anonymous submissions, prefilled from
+  // the user record when logged in. Validated via `FeedbackSchema`.
+  email String?
+
+  // Submitter, when authenticated. SetNull so feedback survives account
+  // deletion — a deleted user's bug reports are still worth triaging.
+  userId String?
+  user   User?   @relation(fields: [userId], references: [id], onDelete: SetNull)
+
+  // Context captured automatically at submit time for triage/debugging.
+  pageUrl   String?
+  userAgent String?
+
+  // String, not a true enum — valid values enforced via `FeedbackStatusSchema`:
+  // 'NEW' | 'IN_PROGRESS' | 'RESOLVED' | 'WONT_FIX'.
+  status     String  @default("NEW")
+  adminNotes String?
+
+  @@index([status, createdAt])
+  @@index([createdAt])
 }
 
 // -----------------------------------------------------------------------------

--- a/tests/e2e/feedback.test.ts
+++ b/tests/e2e/feedback.test.ts
@@ -1,0 +1,74 @@
+import { type Page } from '@playwright/test';
+import { prisma } from '#app/utils/db.server.ts';
+import { expect, test, waitFor } from '#tests/playwright-utils.ts';
+
+const dismissInstallPrompt = async (page: Page) => {
+  const notNow = page.getByRole('button', { name: /not now/i });
+  if ((await notNow.count()) > 0) {
+    await notNow.click();
+  }
+};
+
+test('an anonymous visitor can submit feedback from the support page', async ({
+  page,
+}) => {
+  const message =
+    'The invite link 404s when I open it on Safari — playwright check.';
+
+  await page.goto('/support');
+  await dismissInstallPrompt(page);
+
+  // Default type is Bug; pick "Idea" to exercise the type control.
+  await page.getByText('Idea', { exact: true }).click();
+  await page.getByRole('textbox', { name: /your message/i }).fill(message);
+  await page
+    .getByRole('textbox', { name: /your email/i })
+    .fill('visitor@example.com');
+
+  await page.getByRole('button', { name: /send feedback/i }).click();
+
+  await expect(page.getByText(/thanks for the feedback/i)).toBeVisible();
+
+  await waitFor(async () => {
+    const row = await prisma.feedback.findFirst({ where: { message } });
+    expect(row).not.toBeNull();
+    expect(row?.type).toBe('FEATURE');
+    expect(row?.email).toBe('visitor@example.com');
+    expect(row?.userId).toBeNull();
+    return row;
+  });
+});
+
+test('a logged-in user can submit feedback from the global widget', async ({
+  page,
+  login,
+}) => {
+  const user = await login();
+  const message = 'Could we get dark mode on the pool page — playwright check.';
+
+  await page.goto('/');
+  await dismissInstallPrompt(page);
+
+  await page.getByRole('button', { name: /give feedback/i }).click();
+
+  // Widget dialog — no email field for authenticated users.
+  await expect(page.getByRole('dialog')).toBeVisible();
+  await expect(
+    page.getByRole('textbox', { name: /your email/i }),
+  ).toHaveCount(0);
+
+  await page.getByRole('textbox', { name: /your message/i }).fill(message);
+  await page
+    .getByRole('dialog')
+    .getByRole('button', { name: /send feedback/i })
+    .click();
+
+  await expect(page.getByText(/thanks for the feedback/i)).toBeVisible();
+
+  await waitFor(async () => {
+    const row = await prisma.feedback.findFirst({ where: { message } });
+    expect(row).not.toBeNull();
+    expect(row?.userId).toBe(user.id);
+    return row;
+  });
+});

--- a/tests/e2e/feedback.test.ts
+++ b/tests/e2e/feedback.test.ts
@@ -65,10 +65,18 @@ test('a logged-in user can submit feedback from the global widget', async ({
 
   await expect(page.getByText(/thanks for the feedback/i)).toBeVisible();
 
+  // Scope the lookup to this attempt's freshly-created user, NOT the shared
+  // message. On retry, the `login` fixture has deleted the prior attempt's
+  // user, and Feedback.userId is onDelete:SetNull — so a message-based query
+  // would match that prior row with its userId nulled out. Querying by userId
+  // matches only this attempt's row.
   await waitFor(async () => {
-    const row = await prisma.feedback.findFirst({ where: { message } });
+    const row = await prisma.feedback.findFirst({
+      where: { userId: user.id },
+      orderBy: { createdAt: 'desc' },
+    });
     expect(row).not.toBeNull();
-    expect(row?.userId).toBe(user.id);
+    expect(row?.message).toBe(message);
     return row;
   });
 });


### PR DESCRIPTION
## Summary

Adds an end-to-end feedback system so users can report bugs, request features, or ask questions — from both a dedicated `/support` form and a global floating widget available across the app.

Submissions are persisted, surfaced in an admin triage queue, and trigger two emails: an operator notification (with optional CC to a monitored inbox) and an acknowledgment back to the submitter.

## What's included

- **Data** — new `Feedback` model (`type`, `message`, `email`, `userId`, `pageUrl`, `userAgent`, `status`, `adminNotes`) + migration. `userId` is `SetNull` so feedback survives account deletion.
- **Validation** — `FeedbackSchema` (type enum, 10–2000 char message, optional email normalized to lowercase) + `feedback_submitted` analytics event (anonymous-allowed; not in `USER_REQUIRED_EVENTS`).
- **API** — `POST /api/feedback` action: honeypot-protected, requires an email for anonymous submitters, persists the row, fires analytics, then (off the response) sends:
  - operator notification → `support@giftpool.app`, **CC `FEEDBACK_CC_EMAIL` when set**
  - acknowledgment → the submitter, when an address is known
  - all email sends are fire-and-forget with `captureException`, so a mail failure never turns a successful submission into a 500.
- **UI** — shared `FeedbackForm` (Conform + Zod), a global `FeedbackWidget` (floating button → dialog, suppressed on auth/onboarding routes), and the `/support` page reworked from mailto cards to the form (mailto kept as a fallback link).
- **Admin** — 7th admin tab `/admin/feedback`: per-status triage queue (NEW default) with inline status + admin-notes mutations. Intentionally **not cached** — it's a live queue.

## Configuration

- `FEEDBACK_CC_EMAIL` (optional, server-only, validated as email) — CCs every operator notification to a monitored inbox. Set as a **Fly secret** in prod; unset in dev/test/CI (CC omitted, no-op).
  ```
  fly secrets set FEEDBACK_CC_EMAIL=<your-address>
  ```

## Test plan

- `feedback-validation.test.ts` — 6 tests (schema rules, email normalization)
- `api.feedback.test.ts` — 4 tests (anonymous-requires-email, anonymous persist + 2 emails, logged-in stored email, CC present/absent by env)
- `admin+/feedback.test.ts` — 4 tests (loader filter, status/notes mutation guards)
- `tests/e2e/feedback.test.ts` — 2 flows (anonymous support-page submit, logged-in widget submit)
- Typecheck clean; full validate green.

### Manual verification (mock email)

`npm run start:mocks` intercepts Resend and writes rendered emails to `tests/fixtures/email/<recipient>.json`. Submitting feedback produces an operator email + a submitter acknowledgment you can inspect, and the admin queue reflects the new rows.

## Notes / follow-ups

- Migration `20260527044640_add_feedback` runs as part of deploy.
- Inbound mail to `support@` (the mailto fallback + replies to the acknowledgment, which currently come from `hello@giftpool.app`) is **not** handled here — that's a separate Namecheap/Cloudflare forwarding task and doesn't block this PR.
