### PR TITLE
Unbury the mobile add-item FAB from under the feedback widget

### DIFF
--- a/app/components/feedback/feedback-widget.tsx
+++ b/app/components/feedback/feedback-widget.tsx
@@ -14,7 +14,15 @@ import { FeedbackForm } from './feedback-form.tsx';
 // Routes where a floating "give feedback" button would be redundant or get in
 // the way: the support page already embeds the form, and auth/onboarding flows
 // shouldn't have a button covering their primary action.
-const SUPPRESSED_PREFIXES = ['/support', '/login', '/signup', '/onboarding', '/verify', '/reset-password', '/forgot-password'];
+const SUPPRESSED_PREFIXES = [
+  '/support',
+  '/login',
+  '/signup',
+  '/onboarding',
+  '/verify',
+  '/reset-password',
+  '/forgot-password',
+];
 
 export const FeedbackWidget = () => {
   const [open, setOpen] = useState(false);
@@ -27,11 +35,15 @@ export const FeedbackWidget = () => {
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
+      {/* Trigger sits bottom-LEFT on mobile: the bottom-right thumb corner
+          belongs to page-level primary actions (the wishlist add-item FAB
+          rendered at the same spot and this widget covered it — June 2026
+          audit P0). */}
       <DialogTrigger asChild>
         <button
           type="button"
           aria-label="Give feedback"
-          className="fixed bottom-20 right-4 z-50 flex h-12 items-center gap-2 rounded-full bg-primary px-4 text-primary-foreground shadow-lg transition-transform hover:scale-105 active:scale-95 sm:bottom-6 sm:right-6"
+          className="fixed bottom-20 left-4 z-50 flex h-12 items-center gap-2 rounded-full bg-primary px-4 text-primary-foreground shadow-lg transition-transform hover:scale-105 active:scale-95 sm:bottom-6 sm:left-auto sm:right-6"
         >
           <LuMessageSquarePlus className="h-5 w-5" aria-hidden />
           <span className="hidden text-sm font-medium sm:inline">Feedback</span>

--- a/app/routes/wishlist+/__wishlist-item-editor.tsx
+++ b/app/routes/wishlist+/__wishlist-item-editor.tsx
@@ -534,7 +534,13 @@ function useWishlistItemEditorMode(
     if (trackedOpenRef.current) return;
     if (mode !== 'create' && mode !== 'edit') return;
     trackedOpenRef.current = true;
-    track('wishlist_editor_opened', { mode });
+    track('wishlist_editor_opened', {
+      mode,
+      // Distinguishes mobile from desktop opens — the June 2026 audit found
+      // the mobile FAB hidden behind the feedback widget, so mobile opens
+      // are the recovery signal to watch. 640px matches Tailwind's sm.
+      viewport: window.innerWidth < 640 ? 'mobile' : 'desktop',
+    });
   }, [open, mode]);
 
   return {


### PR DESCRIPTION
## Why

June 2026 friction audit P0: on mobile, the wishlist add-item FAB and the global Feedback widget both render fixed at the same bottom-right spot (`bottom: 5rem; right: 1rem`), and the Feedback widget's higher z-index (`z-50` vs `z-40`) covers the FAB completely. The page's primary action — and activation step #1 — was unreachable on phones.

## What

- Feedback widget trigger moves to **bottom-left on mobile**; desktop placement (`bottom-6 right-6`) unchanged. The bottom-right thumb corner now belongs to page-level primary actions.
- `wishlist_editor_opened` gains a `viewport: mobile|desktop` property (640px = Tailwind `sm`) so the mobile recovery is visible in the admin drop-off funnel.

## Verification

- Mobile (390px): both controls visible, FAB confirmed topmost at its center point via `elementFromPoint`
- Desktop: unchanged (header "+ Add Item" button, Feedback bottom-right, FAB hidden)
- 980 unit tests pass; typecheck clean

First PR of the friction fix cycle (workstream 0 of 0/A/B/C).