### PR TITLE
Activation surface: lead new users to their first wishlist item

### DIFF
--- a/app/components/forms.tsx
+++ b/app/components/forms.tsx
@@ -40,15 +40,19 @@ export const Field = ({
   inputProps,
   errors,
   className,
+  description,
 }: {
   labelProps: React.LabelHTMLAttributes<HTMLLabelElement>;
   inputProps: React.InputHTMLAttributes<HTMLInputElement>;
   errors?: ListOfErrors;
   className?: string;
+  /** Upfront requirements hint — show rules BEFORE the user fails them. */
+  description?: string;
 }) => {
   const fallbackId = useId();
   const id = inputProps.id ?? fallbackId;
   const errorId = errors?.length ? `${id}-error` : undefined;
+  const descriptionId = description ? `${id}-description` : undefined;
   return (
     <Stack gap={2} className={className}>
       <Label htmlFor={id} {...labelProps}>
@@ -62,9 +66,16 @@ export const Field = ({
       <Input
         id={id}
         aria-invalid={errorId ? true : undefined}
-        aria-describedby={errorId}
+        aria-describedby={
+          [errorId, descriptionId].filter(Boolean).join(' ') || undefined
+        }
         {...inputProps}
       />
+      {description && !errorId ? (
+        <p id={descriptionId} className="text-xs text-muted-foreground">
+          {description}
+        </p>
+      ) : null}
       {errorId && (
         <div className="px-4 pb-3 pt-1">
           <ErrorList id={errorId} errors={errors} />

--- a/app/components/home/HomeLoggedIn.tsx
+++ b/app/components/home/HomeLoggedIn.tsx
@@ -1,10 +1,5 @@
 import * as React from 'react';
-import {
-	LuActivity,
-	LuCalendar,
-	LuGift,
-	LuUsers,
-} from 'react-icons/lu';
+import { LuActivity, LuCalendar, LuGift, LuUsers } from 'react-icons/lu';
 import { Link, useFetcher } from 'react-router';
 import { Button } from '#app/components/ui/button.tsx';
 import { Card } from '#app/components/ui/card.tsx';
@@ -15,291 +10,328 @@ import { HOME_COPY } from './home-copy';
 // ── Types ────────────────────────────────────────────────────────────────────
 
 type ActivePool = {
-	id: string;
-	title: string;
-	status: string;
-	occasionType: string;
-	recipientName: string | null;
-	eventDate: string | null;
-	contributorCount: number;
+  id: string;
+  title: string;
+  status: string;
+  occasionType: string;
+  recipientName: string | null;
+  eventDate: string | null;
+  contributorCount: number;
 };
 
 type HomeLoggedInProps = {
-	activePools: ActivePool[];
-	wishlistCount: number;
-	groupCount: number;
-	mock?: 'empty' | 'data';
+  activePools: ActivePool[];
+  wishlistCount: number;
+  groupCount: number;
+  mock?: 'empty' | 'data';
 };
 
 type PanelsLoaderData = {
-	birthdays: UpcomingBirthday[];
-	activity: RecentActivityItem[];
+  birthdays: UpcomingBirthday[];
+  activity: RecentActivityItem[];
 };
 
 // ── Status styling ───────────────────────────────────────────────────────────
 
 const statusStyles: Record<string, string> = {
-	OPEN: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900 dark:text-emerald-200',
-	VOTING: 'bg-violet-100 text-violet-800 dark:bg-violet-900 dark:text-violet-200',
-	DECIDED: 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200',
-	PURCHASED: 'bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200',
+  OPEN: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900 dark:text-emerald-200',
+  VOTING:
+    'bg-violet-100 text-violet-800 dark:bg-violet-900 dark:text-violet-200',
+  DECIDED: 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200',
+  PURCHASED:
+    'bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200',
 };
 
 const statusLabels: Record<string, string> = {
-	OPEN: 'Open',
-	VOTING: 'Voting',
-	DECIDED: 'Decided',
-	PURCHASED: 'Purchased',
+  OPEN: 'Open',
+  VOTING: 'Voting',
+  DECIDED: 'Decided',
+  PURCHASED: 'Purchased',
 };
 
 const formatPoolEventDate = (eventDate: string) =>
-	new Intl.DateTimeFormat('en-US', {
-		month: 'short',
-		day: 'numeric',
-		timeZone: 'UTC',
-	}).format(new Date(eventDate));
+  new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    timeZone: 'UTC',
+  }).format(new Date(eventDate));
 
 // ── Pool card ────────────────────────────────────────────────────────────────
 
 const PoolCard = ({ pool }: { pool: ActivePool }) => {
-	const badge = statusStyles[pool.status] ?? 'bg-muted text-muted-foreground';
-	const label = statusLabels[pool.status] ?? pool.status;
+  const badge = statusStyles[pool.status] ?? 'bg-muted text-muted-foreground';
+  const label = statusLabels[pool.status] ?? pool.status;
 
-	return (
-		<Link
-			to={`/pools/${pool.id}`}
-			prefetch="intent"
-			data-testid="pool-card"
-			className="group block rounded-xl border bg-card px-4 py-3.5 transition-colors hover:bg-muted/40"
-		>
-			<div className="flex items-start justify-between gap-3">
-				<div className="min-w-0 flex-1">
-					<p className="truncate text-sm font-semibold group-hover:text-primary">
-						{pool.title}
-					</p>
-					{pool.recipientName && (
-						<p className="mt-0.5 truncate text-xs text-muted-foreground">
-							for{' '}
-							<span className="font-medium text-foreground">
-								{pool.recipientName}
-							</span>
-						</p>
-					)}
-				</div>
-				<span
-					className={`shrink-0 rounded-full px-2.5 py-0.5 text-xs font-semibold ${badge}`}
-				>
-					{label}
-				</span>
-			</div>
-			<div className="mt-2.5 flex items-center gap-3 text-xs text-muted-foreground">
-				<span className="flex items-center gap-1">
-					<LuUsers size={11} />
-					{pool.contributorCount}{' '}
-					{pool.contributorCount === 1 ? 'contributor' : 'contributors'}
-				</span>
-				{pool.eventDate && (
-					<>
-						<span>·</span>
-						<span className="flex items-center gap-1">
-							<LuCalendar size={11} />
-							{formatPoolEventDate(pool.eventDate)}
-						</span>
-					</>
-				)}
-			</div>
-		</Link>
-	);
+  return (
+    <Link
+      to={`/pools/${pool.id}`}
+      prefetch="intent"
+      data-testid="pool-card"
+      className="group block rounded-xl border bg-card px-4 py-3.5 transition-colors hover:bg-muted/40"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-semibold group-hover:text-primary">
+            {pool.title}
+          </p>
+          {pool.recipientName && (
+            <p className="mt-0.5 truncate text-xs text-muted-foreground">
+              for{' '}
+              <span className="font-medium text-foreground">
+                {pool.recipientName}
+              </span>
+            </p>
+          )}
+        </div>
+        <span
+          className={`shrink-0 rounded-full px-2.5 py-0.5 text-xs font-semibold ${badge}`}
+        >
+          {label}
+        </span>
+      </div>
+      <div className="mt-2.5 flex items-center gap-3 text-xs text-muted-foreground">
+        <span className="flex items-center gap-1">
+          <LuUsers size={11} />
+          {pool.contributorCount}{' '}
+          {pool.contributorCount === 1 ? 'contributor' : 'contributors'}
+        </span>
+        {pool.eventDate && (
+          <>
+            <span>·</span>
+            <span className="flex items-center gap-1">
+              <LuCalendar size={11} />
+              {formatPoolEventDate(pool.eventDate)}
+            </span>
+          </>
+        )}
+      </div>
+    </Link>
+  );
 };
 
 // ── Main component ───────────────────────────────────────────────────────────
 
 export const HomeLoggedIn: React.FC<HomeLoggedInProps> = ({
-	activePools,
-	wishlistCount,
-	groupCount,
-	mock,
+  activePools,
+  wishlistCount,
+  groupCount,
+  mock,
 }) => {
-	const fetcher = useFetcher<PanelsLoaderData>();
+  const fetcher = useFetcher<PanelsLoaderData>();
 
-	React.useEffect(() => {
-		if (fetcher.state !== 'idle' || fetcher.data) return;
-		const suffix = mock ? `?mock=${mock}` : '';
-		Promise.resolve(fetcher.load(`/resources/home/panels${suffix}`)).catch(
-			() => {},
-		);
-	}, [fetcher, mock]);
+  React.useEffect(() => {
+    if (fetcher.state !== 'idle' || fetcher.data) return;
+    const suffix = mock ? `?mock=${mock}` : '';
+    Promise.resolve(fetcher.load(`/resources/home/panels${suffix}`)).catch(
+      () => {},
+    );
+  }, [fetcher, mock]);
 
-	const birthdays = fetcher.data?.birthdays ?? [];
-	const activity = fetcher.data?.activity ?? [];
+  const birthdays = fetcher.data?.birthdays ?? [];
+  const activity = fetcher.data?.activity ?? [];
 
-	return (
-		<main role="main" className="container space-y-8 py-6 md:py-10">
-			{/* ── Active pools ───────────────────────────────────────── */}
-			<section aria-labelledby="dashboard-pools-heading">
-				<div className="flex items-center justify-between gap-3">
-					<h2
-						id="dashboard-pools-heading"
-						className="flex min-w-0 items-center gap-2 text-lg font-semibold"
-					>
-						<LuGift size={18} className="shrink-0 text-primary" />
-						<span className="truncate">Your pools</span>
-					</h2>
-					<Button asChild size="sm" className="shrink-0 whitespace-nowrap">
-						<Link to="/pools/new" prefetch="intent">
-							+ Start a Pool
-						</Link>
-					</Button>
-				</div>
+  // A brand-new user's natural first action is adding a wishlist item —
+  // pools need friends and groups first. Lead with the wishlist until it
+  // has something in it (June 2026 audit: the pools-first empty dashboard
+  // pointed new users at the hardest possible first step).
+  const isBrandNew = wishlistCount === 0;
 
-				{activePools.length > 0 ? (
-					<>
-						<div className="mt-3 flex flex-col gap-2">
-							{activePools.map(pool => (
-								<PoolCard key={pool.id} pool={pool} />
-							))}
-						</div>
-						<div className="mt-3 text-right">
-							<Link
-								to="/pools"
-								prefetch="intent"
-								className="text-xs text-muted-foreground hover:text-foreground hover:underline"
-							>
-								View all pools →
-							</Link>
-						</div>
-					</>
-				) : (
-					<Card className="mt-3 p-5 text-center">
-						<p className="text-sm font-medium">No active pools yet</p>
-						<p className="mt-1 text-xs text-muted-foreground">
-							Start one to coordinate a group gift with friends.
-						</p>
-						<Button asChild size="sm" className="mt-4">
-							<Link to="/pools/new" prefetch="intent">
-								Start a Pool
-							</Link>
-						</Button>
-					</Card>
-				)}
-			</section>
+  return (
+    <main role="main" className="container space-y-8 py-6 md:py-10">
+      {/* ── First-run: start the wishlist ──────────────────────── */}
+      {isBrandNew && (
+        <section aria-labelledby="dashboard-first-item-heading">
+          <Card className="p-6 text-center md:p-8">
+            <h2
+              id="dashboard-first-item-heading"
+              className="text-lg font-semibold"
+            >
+              Start your wishlist
+            </h2>
+            <p className="mx-auto mt-1 max-w-md text-sm text-muted-foreground">
+              Add the first thing you'd love to receive — paste a product link
+              and we'll fill in the details. Friends see your list when they
+              plan gifts.
+            </p>
+            <Button asChild className="mt-4">
+              <Link
+                to="/wishlist?add=1"
+                prefetch="intent"
+                data-testid="first-item-cta"
+              >
+                Add your first item
+              </Link>
+            </Button>
+          </Card>
+        </section>
+      )}
 
-			{/* ── Panels: birthdays + activity ───────────────────────── */}
-			<section
-				aria-labelledby="dashboard-panels-heading"
-				className="grid grid-cols-1 gap-4 md:grid-cols-2"
-			>
-				<h2 id="dashboard-panels-heading" className="sr-only">
-					Upcoming events and activity
-				</h2>
+      {/* ── Active pools ───────────────────────────────────────── */}
+      <section aria-labelledby="dashboard-pools-heading">
+        <div className="flex items-center justify-between gap-3">
+          <h2
+            id="dashboard-pools-heading"
+            className="flex min-w-0 items-center gap-2 text-lg font-semibold"
+          >
+            <LuGift size={18} className="shrink-0 text-primary" />
+            <span className="truncate">Your pools</span>
+          </h2>
+          <Button asChild size="sm" className="shrink-0 whitespace-nowrap">
+            <Link to="/pools/new" prefetch="intent">
+              + Start a Pool
+            </Link>
+          </Button>
+        </div>
 
-				{/* Upcoming birthdays */}
-				<Card className="p-5" data-testid="panel-birthdays">
-					<Flex gap={2} align="center">
-						<LuCalendar size={16} className="shrink-0 text-blue-500" />
-						<h3 className="text-sm font-semibold">
-							{HOME_COPY.panels.birthdaysHeading}
-						</h3>
-					</Flex>
-					<ul className="mt-3 space-y-2">
-						{birthdays.length > 0 ? (
-							birthdays.map(b => (
-								<li
-									key={b.id}
-									className="flex items-center justify-between gap-3"
-								>
-									<div>
-										<p className="text-sm font-medium">{b.name}</p>
-										<p className="text-xs text-muted-foreground">{b.dateLabel}</p>
-									</div>
-									{b.groupId ? (
-										<Button asChild size="sm" variant="secondary">
-											<Link to={`/groups/${b.groupId}`} prefetch="intent">
-												{HOME_COPY.panels.planGift}
-											</Link>
-										</Button>
-									) : null}
-								</li>
-							))
-						) : (
-							<li className="text-sm text-muted-foreground">
-								No upcoming birthdays.{' '}
-								<Link to="/friends" className="underline hover:text-foreground">
-									Add friends
-								</Link>{' '}
-								to see theirs.
-							</li>
-						)}
-					</ul>
-				</Card>
+        {activePools.length > 0 ? (
+          <>
+            <div className="mt-3 flex flex-col gap-2">
+              {activePools.map((pool) => (
+                <PoolCard key={pool.id} pool={pool} />
+              ))}
+            </div>
+            <div className="mt-3 text-right">
+              <Link
+                to="/pools"
+                prefetch="intent"
+                className="text-xs text-muted-foreground hover:text-foreground hover:underline"
+              >
+                View all pools →
+              </Link>
+            </div>
+          </>
+        ) : (
+          <Card className="mt-3 p-5 text-center">
+            <p className="text-sm font-medium">No active pools yet</p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Start one to coordinate a group gift with friends.
+            </p>
+            {/* Outline while the user is brand new — the wishlist hero
+						    above is the primary action at that stage. */}
+            <Button
+              asChild
+              size="sm"
+              variant={isBrandNew ? 'outline' : 'default'}
+              className="mt-4"
+            >
+              <Link to="/pools/new" prefetch="intent">
+                Start a Pool
+              </Link>
+            </Button>
+          </Card>
+        )}
+      </section>
 
-				{/* Recent activity */}
-				<Card className="p-5" data-testid="panel-activity">
-					<Flex gap={2} align="center">
-						<LuActivity size={16} className="shrink-0 text-green-500" />
-						<h3 className="text-sm font-semibold">
-							{HOME_COPY.panels.recentActivityHeading}
-						</h3>
-					</Flex>
-					<ul className="mt-3 space-y-2">
-						{activity.length > 0 ? (
-							activity.map(a => (
-								<li key={a.id} className="text-sm">
-									{a.description}
-								</li>
-							))
-						) : (
-							<li className="text-sm text-muted-foreground">
-								Nothing new yet.{' '}
-								<Link to="/pools/new" className="underline hover:text-foreground">
-									Start a pool
-								</Link>{' '}
-								to see activity here.
-							</li>
-						)}
-					</ul>
-				</Card>
-			</section>
+      {/* ── Panels: birthdays + activity ───────────────────────── */}
+      <section
+        aria-labelledby="dashboard-panels-heading"
+        className="grid grid-cols-1 gap-4 md:grid-cols-2"
+      >
+        <h2 id="dashboard-panels-heading" className="sr-only">
+          Upcoming events and activity
+        </h2>
 
-			{/* ── Onboarding nudges (only shown if setup is incomplete) ─ */}
-			{(wishlistCount === 0 || groupCount === 0) && (
-				<section
-					aria-labelledby="dashboard-setup-heading"
-					className="grid grid-cols-1 gap-4 md:grid-cols-2"
-				>
-					<h2 id="dashboard-setup-heading" className="sr-only">
-						Get started
-					</h2>
-					{wishlistCount === 0 && (
-						<Card className="border-dashed p-5">
-							<h3 className="text-sm font-medium">
-								{HOME_COPY.panels.emptyWishlistTitle}
-							</h3>
-							<div className="mt-3">
-								<Button asChild size="sm">
-									<Link to="/wishlist" prefetch="intent" data-testid="empty-wishlist-cta">
-										{HOME_COPY.panels.emptyWishlistCta}
-									</Link>
-								</Button>
-							</div>
-						</Card>
-					)}
-					{groupCount === 0 && (
-						<Card className="border-dashed p-5">
-							<h3 className="text-sm font-medium">
-								{HOME_COPY.panels.emptyGroupsTitle}
-							</h3>
-							<div className="mt-3">
-								<Button asChild size="sm" variant="outline">
-									<Link to="/groups/new" prefetch="intent" data-testid="empty-groups-cta">
-										{HOME_COPY.panels.emptyGroupsCta}
-									</Link>
-								</Button>
-							</div>
-						</Card>
-					)}
-				</section>
-			)}
-		</main>
-	);
+        {/* Upcoming birthdays */}
+        <Card className="p-5" data-testid="panel-birthdays">
+          <Flex gap={2} align="center">
+            <LuCalendar size={16} className="shrink-0 text-blue-500" />
+            <h3 className="text-sm font-semibold">
+              {HOME_COPY.panels.birthdaysHeading}
+            </h3>
+          </Flex>
+          <ul className="mt-3 space-y-2">
+            {birthdays.length > 0 ? (
+              birthdays.map((b) => (
+                <li
+                  key={b.id}
+                  className="flex items-center justify-between gap-3"
+                >
+                  <div>
+                    <p className="text-sm font-medium">{b.name}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {b.dateLabel}
+                    </p>
+                  </div>
+                  {b.groupId ? (
+                    <Button asChild size="sm" variant="secondary">
+                      <Link to={`/groups/${b.groupId}`} prefetch="intent">
+                        {HOME_COPY.panels.planGift}
+                      </Link>
+                    </Button>
+                  ) : null}
+                </li>
+              ))
+            ) : (
+              <li className="text-sm text-muted-foreground">
+                No upcoming birthdays.{' '}
+                <Link to="/friends" className="underline hover:text-foreground">
+                  Add friends
+                </Link>{' '}
+                to see theirs.
+              </li>
+            )}
+          </ul>
+        </Card>
+
+        {/* Recent activity */}
+        <Card className="p-5" data-testid="panel-activity">
+          <Flex gap={2} align="center">
+            <LuActivity size={16} className="shrink-0 text-green-500" />
+            <h3 className="text-sm font-semibold">
+              {HOME_COPY.panels.recentActivityHeading}
+            </h3>
+          </Flex>
+          <ul className="mt-3 space-y-2">
+            {activity.length > 0 ? (
+              activity.map((a) => (
+                <li key={a.id} className="text-sm">
+                  {a.description}
+                </li>
+              ))
+            ) : (
+              <li className="text-sm text-muted-foreground">
+                Nothing new yet.{' '}
+                <Link
+                  to="/pools/new"
+                  className="underline hover:text-foreground"
+                >
+                  Start a pool
+                </Link>{' '}
+                to see activity here.
+              </li>
+            )}
+          </ul>
+        </Card>
+      </section>
+
+      {/* ── Onboarding nudge — groups only: the empty-wishlist nudge
+			    is the first-run hero at the top of the page now. */}
+      {groupCount === 0 && (
+        <section
+          aria-labelledby="dashboard-setup-heading"
+          className="grid grid-cols-1 gap-4 md:grid-cols-2"
+        >
+          <h2 id="dashboard-setup-heading" className="sr-only">
+            Get started
+          </h2>
+          <Card className="border-dashed p-5">
+            <h3 className="text-sm font-medium">
+              {HOME_COPY.panels.emptyGroupsTitle}
+            </h3>
+            <div className="mt-3">
+              <Button asChild size="sm" variant="outline">
+                <Link
+                  to="/groups/new"
+                  prefetch="intent"
+                  data-testid="empty-groups-cta"
+                >
+                  {HOME_COPY.panels.emptyGroupsCta}
+                </Link>
+              </Button>
+            </div>
+          </Card>
+        </section>
+      )}
+    </main>
+  );
 };

--- a/app/components/home/home-surfaces.test.tsx
+++ b/app/components/home/home-surfaces.test.tsx
@@ -11,7 +11,11 @@ const fetcherLoad = vi.fn();
 const fetcherSnapshot: {
   data:
     | {
-        activity: Array<{ description: string; id: string; timestampISO: string }>;
+        activity: Array<{
+          description: string;
+          id: string;
+          timestampISO: string;
+        }>;
         birthdays: Array<{
           dateISO: string;
           dateLabel: string;
@@ -29,9 +33,8 @@ const fetcherSnapshot: {
 };
 
 vi.mock('react-router', async () => {
-  const actual = await vi.importActual<typeof import('react-router')>(
-    'react-router',
-  );
+  const actual =
+    await vi.importActual<typeof import('react-router')>('react-router');
 
   return {
     ...actual,
@@ -278,10 +281,9 @@ describe('home surface components', () => {
       ],
     });
 
-    expect(screen.getByRole('link', { name: '+ Start a Pool' })).toHaveAttribute(
-      'href',
-      '/pools/new',
-    );
+    expect(
+      screen.getByRole('link', { name: '+ Start a Pool' }),
+    ).toHaveAttribute('href', '/pools/new');
   });
 
   it('"View all pools →" link is shown when activePools.length > 0', () => {
@@ -299,10 +301,9 @@ describe('home surface components', () => {
       ],
     });
 
-    expect(screen.getByRole('link', { name: 'View all pools →' })).toHaveAttribute(
-      'href',
-      '/pools',
-    );
+    expect(
+      screen.getByRole('link', { name: 'View all pools →' }),
+    ).toHaveAttribute('href', '/pools');
   });
 
   it('"View all pools →" link is NOT shown when activePools is empty', () => {
@@ -355,12 +356,24 @@ describe('home surface components', () => {
     );
   });
 
-  it('shows onboarding nudge card for wishlist when wishlistCount === 0', () => {
+  it('leads with the first-item hero when the wishlist is empty', () => {
     renderHomeLoggedIn({ wishlistCount: 0 });
 
+    expect(screen.getByText('Start your wishlist')).toBeInTheDocument();
+    expect(screen.getByTestId('first-item-cta')).toHaveAttribute(
+      'href',
+      '/wishlist?add=1',
+    );
+    // The first-run hero replaces the old bottom nudge card.
     expect(
-      screen.getByText(HOME_COPY.panels.emptyWishlistTitle),
-    ).toBeInTheDocument();
+      screen.queryByText(HOME_COPY.panels.emptyWishlistTitle),
+    ).not.toBeInTheDocument();
+  });
+
+  it('hides the first-item hero once the wishlist has items', () => {
+    renderHomeLoggedIn({ wishlistCount: 3 });
+
+    expect(screen.queryByText('Start your wishlist')).not.toBeInTheDocument();
   });
 
   it('shows onboarding nudge card for groups when groupCount === 0', () => {
@@ -371,12 +384,10 @@ describe('home surface components', () => {
     ).toBeInTheDocument();
   });
 
-  it('hides both nudge cards when wishlistCount > 0 AND groupCount > 0', () => {
+  it('hides hero and nudges when wishlistCount > 0 AND groupCount > 0', () => {
     renderHomeLoggedIn({ wishlistCount: 1, groupCount: 1 });
 
-    expect(
-      screen.queryByText(HOME_COPY.panels.emptyWishlistTitle),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText('Start your wishlist')).not.toBeInTheDocument();
     expect(
       screen.queryByText(HOME_COPY.panels.emptyGroupsTitle),
     ).not.toBeInTheDocument();

--- a/app/components/wishlist/wishlist.tsx
+++ b/app/components/wishlist/wishlist.tsx
@@ -1,15 +1,6 @@
-import {
-  DndContext,
-  closestCenter,
-} from '@dnd-kit/core';
-import {
-  SortableContext,
-  rectSortingStrategy,
-} from '@dnd-kit/sortable';
-import {
-  type UserImage,
-  type User,
-} from '@prisma/client';
+import { DndContext, closestCenter } from '@dnd-kit/core';
+import { SortableContext, rectSortingStrategy } from '@dnd-kit/sortable';
+import { type UserImage, type User } from '@prisma/client';
 import {
   type FormEvent,
   useCallback,
@@ -42,11 +33,8 @@ import { useWishlistItemMutations } from './hooks/use-wishlist-item-mutations';
 import { useWishlistReorder } from './hooks/use-wishlist-reorder';
 import { useWishlistStatusUpdate } from './hooks/use-wishlist-status-update';
 import { PastEducationCallout, PastWishlistItems } from './past-wishlist-items';
-import {
-  SortableShell,
-  WishlistCategoryCard,
-} from './wishlist-category-card';
-import  { type WishlistCategory } from './wishlist-category-state';
+import { SortableShell, WishlistCategoryCard } from './wishlist-category-card';
+import { type WishlistCategory } from './wishlist-category-state';
 import { WishlistHeader } from './wishlist-header';
 import {
   categoryKeyFromId,
@@ -129,10 +117,7 @@ type WishlistActiveViewProps = Readonly<{
   handleDragEnd: (event: any) => void;
   handleDragOver: (event: any) => void;
   handleDragStart: (event: any) => void;
-  handleStatusChange: (
-    itemId: string,
-    status: any,
-  ) => boolean | void;
+  handleStatusChange: (itemId: string, status: any) => boolean | void;
   isCategoryReorderMode: boolean;
   isItemReorderMode: boolean;
   isOwner: boolean;
@@ -190,7 +175,9 @@ type WishlistCategorySectionsProps = Readonly<{
   startItemReorderMode: () => void;
 }>;
 
-function isWishlistItem(value: WishlistItem | undefined): value is WishlistItem {
+function isWishlistItem(
+  value: WishlistItem | undefined,
+): value is WishlistItem {
   return Boolean(value);
 }
 
@@ -297,10 +284,7 @@ function useWishlistUiState(
   };
 }
 
-function WishlistViewToggle({
-  onChange,
-  view,
-}: WishlistViewToggleProps) {
+function WishlistViewToggle({ onChange, view }: WishlistViewToggleProps) {
   return (
     <div className="inline-flex w-full max-w-md rounded-full bg-muted p-1 text-sm">
       <button
@@ -346,7 +330,8 @@ function WishlistReorderBanner({
             Reorder mode
           </Text>
           <Text size="xs" className="text-emerald-800">
-            Drag handles to move {isCategoryReorderMode ? 'categories' : 'items'}.
+            Drag handles to move{' '}
+            {isCategoryReorderMode ? 'categories' : 'items'}.
           </Text>
         </div>
         <div className="flex items-center gap-2">
@@ -416,7 +401,9 @@ function CategoryReorderList({
         </div>
       ) : null}
       <SortableContext
-        items={customCategories.map((category) => toCategoryDragId(category.id))}
+        items={customCategories.map((category) =>
+          toCategoryDragId(category.id),
+        )}
         strategy={rectSortingStrategy}
       >
         {customCategories.map((category) => (
@@ -489,11 +476,14 @@ function WishlistEmptyState({
       {isOwner ? (
         <p className="text-center text-base text-slate-500">
           Looks like you don't have any items in your wishlist yet!
-          {archivedItemsCount ? ' Past items are available in the Past items tab.' : ''}
+          {archivedItemsCount
+            ? ' Past items are available in the Past items tab.'
+            : ''}
         </p>
       ) : (
         <p className="text-center text-base text-slate-500">
-          {displayName} doesn't have any active items in their wishlist right now!
+          {displayName} doesn't have any active items in their wishlist right
+          now!
           {archivedItemsCount
             ? ' Their past items are available in the Past items tab.'
             : ''}
@@ -510,10 +500,7 @@ function DeleteCategoryDialog({
   pendingDeleteCategory,
 }: DeleteCategoryDialogProps) {
   return (
-    <Dialog
-      open={pendingDeleteCategory !== null}
-      onOpenChange={onOpenChange}
-    >
+    <Dialog open={pendingDeleteCategory !== null} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-[425px]">
         <DialogHeader>
           <DialogTitle>Delete category</DialogTitle>
@@ -524,7 +511,11 @@ function DeleteCategoryDialog({
           </DialogDescription>
         </DialogHeader>
         <DialogFooter className="gap-2">
-          <Button type="button" variant="secondary" onClick={() => onOpenChange(false)}>
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={() => onOpenChange(false)}
+          >
             Cancel
           </Button>
           <Button
@@ -569,7 +560,9 @@ function WishlistCategorySections({
 }: WishlistCategorySectionsProps) {
   const renderCategoryCard = useCallback(
     (
-      category: { id: string; name: string; order: number } | { id: null; name: string; order: number },
+      category:
+        | { id: string; name: string; order: number }
+        | { id: null; name: string; order: number },
       categoryKey: string,
       isEditing: boolean,
     ) => (
@@ -581,7 +574,9 @@ function WishlistCategorySections({
         canReorder={canReorder}
         isItemReorderMode={isItemReorderMode}
         isCategoryReorderMode={isCategoryReorderMode}
-        isCollapsed={isItemReorderMode ? false : Boolean(collapsed[categoryKey])}
+        isCollapsed={
+          isItemReorderMode ? false : Boolean(collapsed[categoryKey])
+        }
         isEditing={isEditing && !isCategoryReorderMode && !isItemReorderMode}
         isCategoryDropHighlighted={
           isItemReorderMode &&
@@ -589,7 +584,11 @@ function WishlistCategorySections({
           activeItemCategoryKey !== categoryKey
         }
         dragState={dragState}
-        itemsForCategory={getItemsForCategory(category.id, itemById, itemIdsByCategoryKey)}
+        itemsForCategory={getItemsForCategory(
+          category.id,
+          itemById,
+          itemIdsByCategoryKey,
+        )}
         itemIds={itemIdsByCategoryKey[categoryKey] ?? []}
         optimisticCategories={optimisticCategories}
         actionFetcher={actionFetcher}
@@ -780,9 +779,14 @@ function getItemsForCategory(
     .filter(isWishlistItem);
 }
 
-function useWishlistViewParam(searchParams: URLSearchParams, setSearchParams: ReturnType<typeof useSearchParams>[1]) {
+function useWishlistViewParam(
+  searchParams: URLSearchParams,
+  setSearchParams: ReturnType<typeof useSearchParams>[1],
+) {
   const initialView =
-    searchParams.get('view') === 'past' ? ('past' as const) : ('wishlist' as const);
+    searchParams.get('view') === 'past'
+      ? ('past' as const)
+      : ('wishlist' as const);
   const [view, setView] = useState<WishlistView>(initialView);
 
   const handleViewChange = useCallback(
@@ -837,6 +841,18 @@ export const Wishlist = ({
     toggleCategoryCollapse,
   } = useWishlistUiState(quickAddEditorRef);
 
+  // Deep link from the dashboard: /wishlist?add=1 opens the add-item editor
+  // immediately instead of making the user find the Add button a second
+  // time (June 2026 audit). Param is consumed so refresh doesn't re-open.
+  useEffect(() => {
+    if (!isOwner || searchParams.get('add') !== '1') return;
+    openQuickAdd(null);
+    const params = new URLSearchParams(searchParams);
+    params.delete('add');
+    setSearchParams(params, { replace: true });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   // actionFetcher shared by rename form and delete dialog
   const actionFetcher = useFetcher();
   useWishlistActionFetcherReset(actionFetcher, setEditingId);
@@ -846,12 +862,17 @@ export const Wishlist = ({
 
   // --- Hooks ---
 
-  const { items, setItems, showEducation, markEducationSeen, handleStatusChange } =
-    useWishlistStatusUpdate({
-      serverItems: user.wishlistItems,
-      userId: user.id,
-      onViewChange: handleViewChange,
-    });
+  const {
+    items,
+    setItems,
+    showEducation,
+    markEducationSeen,
+    handleStatusChange,
+  } = useWishlistStatusUpdate({
+    serverItems: user.wishlistItems,
+    userId: user.id,
+    onViewChange: handleViewChange,
+  });
 
   const { optimisticCategories, handleCategoryMutationResult } =
     useWishlistCategoryMutations({
@@ -860,11 +881,10 @@ export const Wishlist = ({
       serverCategories: user.wishlistCategories,
     });
 
-  const { activeItems, archivedItems } =
-    useWishlistItemMutations({
-      items,
-      userId: user.id,
-    });
+  const { activeItems, archivedItems } = useWishlistItemMutations({
+    items,
+    userId: user.id,
+  });
 
   // --- Derived values ---
 
@@ -939,9 +959,7 @@ export const Wishlist = ({
   const isReorderMode = canReorder && reorderMode !== 'off';
 
   const activeItemId =
-    dragging?.type === 'item'
-      ? dragging.dragId.replace(/^item:/, '')
-      : null;
+    dragging?.type === 'item' ? dragging.dragId.replace(/^item:/, '') : null;
   const activeItemCategoryKey = activeItemId
     ? categoryKeyFromId(itemById.get(activeItemId)?.categoryId ?? null)
     : null;
@@ -952,11 +970,14 @@ export const Wishlist = ({
     (category): category is { id: string; name: string; order: number } =>
       category.id !== null,
   );
-  const handleDeleteDialogOpenChange = useCallback((open: boolean) => {
-    if (!open) {
-      setPendingDeleteCategory(null);
-    }
-  }, [setPendingDeleteCategory]);
+  const handleDeleteDialogOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open) {
+        setPendingDeleteCategory(null);
+      }
+    },
+    [setPendingDeleteCategory],
+  );
 
   return (
     <div className="flex h-full min-h-0 flex-col overflow-x-clip">

--- a/app/i18n/dictionaries/en.ts
+++ b/app/i18n/dictionaries/en.ts
@@ -53,8 +53,8 @@ export const en = {
     listDescription: 'See the people you have connected with across GiftPool.',
     emptyTitle: 'No friends yet',
     emptyDescription:
-      'Find people in your groups and send them a friend request.',
-    emptyCta: 'Browse groups',
+      'Friends can see your wishlist and chip in on group gifts. Share an invite link or search by username.',
+    emptyCta: 'Add friend',
     incomingRequests: 'Incoming requests',
     outgoingRequests: 'Outgoing requests',
     removeSuccess: '{{name}} removed from friends.',
@@ -85,7 +85,7 @@ export const en = {
     gateIncomingDescriptionProfile:
       'Accept their request to view their profile and activity.',
     gateIncomingDescriptionWishlist:
-      "Accept their request to view their wishlist.",
+      'Accept their request to view their wishlist.',
   },
   time: {
     justNow: 'just now',

--- a/app/routes/_auth+/onboarding.tsx
+++ b/app/routes/_auth+/onboarding.tsx
@@ -219,6 +219,7 @@ const OnboardingRoute = () => {
               className: 'lowercase',
             }}
             errors={fields.username.errors}
+            description="Letters, numbers, and underscores only."
           />
           <Field
             labelProps={{
@@ -245,6 +246,7 @@ const OnboardingRoute = () => {
               autoComplete: 'new-password',
             }}
             errors={fields.password.errors}
+            description="At least 6 characters."
           />
 
           <Field
@@ -285,12 +287,15 @@ const OnboardingRoute = () => {
                 </>
               ),
             }}
-            buttonProps={getInputProps(
-              fields.agreeToTermsOfServiceAndPrivacyPolicy,
-              {
+            buttonProps={{
+              ...getInputProps(fields.agreeToTermsOfServiceAndPrivacyPolicy, {
                 type: 'checkbox',
-              },
-            )}
+              }),
+              // The visual label's link text doesn't reach the accessible
+              // name (it reads "I agree to the and" to screen readers).
+              'aria-label':
+                'I agree to the Terms of Service and Privacy Policy',
+            }}
             errors={fields.agreeToTermsOfServiceAndPrivacyPolicy.errors}
           />
           <CheckboxField

--- a/app/routes/friends.tsx
+++ b/app/routes/friends.tsx
@@ -1,9 +1,14 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { LuCopy, LuLink, LuPlus, LuQrCode, LuUsers } from 'react-icons/lu';
-import { Link, Outlet, useLoaderData, useSearchParams,
+import {
+  Link,
+  Outlet,
+  useLoaderData,
+  useSearchParams,
   type ClientLoaderFunctionArgs,
   type LoaderFunctionArgs,
-  type MetaFunction } from 'react-router';
+  type MetaFunction,
+} from 'react-router';
 import { toast } from 'sonner';
 import {
   FriendActionButton,
@@ -91,19 +96,13 @@ type FriendRequestRowProps = Readonly<{
   user: RequestListEntryUser;
 }>;
 type SearchResultRowProps = Readonly<{
-  onOutgoingCreated?: (
-    requestId: string,
-    user: FriendEntry['user'],
-  ) => void;
+  onOutgoingCreated?: (requestId: string, user: FriendEntry['user']) => void;
   result: SearchResult;
 }>;
 type SearchResultsPanelProps = Readonly<{
   hasResults: boolean;
   isLoading: boolean;
-  onOutgoingCreated?: (
-    requestId: string,
-    user: FriendEntry['user'],
-  ) => void;
+  onOutgoingCreated?: (requestId: string, user: FriendEntry['user']) => void;
   query: string;
   results: SearchResult[];
   showEmpty: boolean;
@@ -142,10 +141,7 @@ export function getActiveTab(searchParams: URLSearchParams): FriendsTab {
     : 'friends';
 }
 
-export function addFriendIfMissing(
-  friends: FriendEntry[],
-  entry: FriendEntry,
-) {
+export function addFriendIfMissing(friends: FriendEntry[], entry: FriendEntry) {
   if (friends.some((item) => item.user.id === entry.user.id)) {
     return friends;
   }
@@ -223,7 +219,9 @@ export async function runBatchRequestMutation(
   return { failedIds, unreadCount };
 }
 
-export async function runOptimisticRequestBatch<TRequest extends { id: string }>(
+export async function runOptimisticRequestBatch<
+  TRequest extends { id: string },
+>(
   ids: string[],
   action: RequestMutationAction,
   requests: TRequest[],
@@ -274,10 +272,7 @@ export function getRequestMutationMessages(
   };
 }
 
-export function filterFriends(
-  friends: FriendEntry[],
-  term: string,
-) {
+export function filterFriends(friends: FriendEntry[], term: string) {
   const normalizedTerm = term.trim().toLowerCase();
   if (!normalizedTerm) return friends;
 
@@ -337,7 +332,11 @@ export function sortFriendsByUpcomingBirthday(
   return withMeta.map((entry) => entry.friend);
 }
 
-export function toggleSelection(set: Set<string>, id: string, selected: boolean) {
+export function toggleSelection(
+  set: Set<string>,
+  id: string,
+  selected: boolean,
+) {
   const next = new Set(set);
   if (selected) next.add(id);
   else next.delete(id);
@@ -367,7 +366,8 @@ export function applyOutgoingRelationshipTransition(
 }
 
 export function extractInviteUser(detail: FriendshipEventDetail) {
-  return (detail as FriendshipEventDetail & { user?: FriendEntry['user'] }).user;
+  return (detail as FriendshipEventDetail & { user?: FriendEntry['user'] })
+    .user;
 }
 
 export function toRelationshipSnapshot(
@@ -418,9 +418,7 @@ function FriendRequestRow({
   const username = user.username;
 
   return (
-    <li
-      className="flex items-center gap-4 rounded-xl border border-border bg-card p-4 shadow-sm"
-    >
+    <li className="flex items-center gap-4 rounded-xl border border-border bg-card p-4 shadow-sm">
       {selectMode ? (
         <input
           type="checkbox"
@@ -447,19 +445,13 @@ function FriendRequestRow({
   );
 }
 
-function SearchResultRow({
-  onOutgoingCreated,
-  result,
-}: SearchResultRowProps) {
+function SearchResultRow({ onOutgoingCreated, result }: SearchResultRowProps) {
   const { relationship, user } = result;
   const username = user.username;
 
   const handleStateChange = useCallback(
     (snapshot: RelationshipSnapshot) => {
-      if (
-        snapshot.state === 'PENDING_OUTGOING' &&
-        snapshot.outgoingRequestId
-      ) {
+      if (snapshot.state === 'PENDING_OUTGOING' && snapshot.outgoingRequestId) {
         onOutgoingCreated?.(snapshot.outgoingRequestId, user);
       }
     },
@@ -471,7 +463,9 @@ function SearchResultRow({
       <div className="flex items-center gap-4">
         <Avatar size="s" image={user.image} user={user} />
         <div className="min-w-0">
-          <div className="truncate font-medium text-foreground">@{username}</div>
+          <div className="truncate font-medium text-foreground">
+            @{username}
+          </div>
         </div>
       </div>
       <div className="sm:ml-auto">
@@ -665,7 +659,9 @@ export function syncIncomingForFriendshipEvent(
     const match = prev.find((request) => request.fromUser.id === detail.userId);
     if (!match) return prev;
     if (detail.state === 'FRIENDS') {
-      addFriendEntry(buildFriendEntry(match.id, match.fromUser, detail.friendshipId));
+      addFriendEntry(
+        buildFriendEntry(match.id, match.fromUser, detail.friendshipId),
+      );
     }
     return applyIncomingRelationshipTransition(
       prev,
@@ -684,7 +680,9 @@ export function syncOutgoingForFriendshipEvent(
     const match = prev.find((request) => request.toUser.id === detail.userId);
     if (!match) return prev;
     if (detail.state === 'FRIENDS') {
-      addFriendEntry(buildFriendEntry(match.id, match.toUser, detail.friendshipId));
+      addFriendEntry(
+        buildFriendEntry(match.id, match.toUser, detail.friendshipId),
+      );
     }
     return applyOutgoingRelationshipTransition(
       prev,
@@ -856,8 +854,14 @@ function FriendsListSection({
         title={t('friends.emptyTitle')}
         description={t('friends.emptyDescription')}
         action={
-          <Button asChild variant="ghost">
-            <Link to="/groups">{t('friends.emptyCta')}</Link>
+          // Opens the Add friend dialog directly — the old "Browse groups"
+          // CTA was circular for new users, whose groups page is empty too.
+          <Button
+            onClick={() =>
+              window.dispatchEvent(new Event('friends:add-friend-open'))
+            }
+          >
+            {t('friends.emptyCta')}
           </Button>
         }
       />
@@ -1014,8 +1018,12 @@ function useInviteLinkController() {
     if (!inviteUrl) return;
 
     try {
-      const qrCodeModule: { toDataURL: (value: string, options: { margin: number; scale: number }) => Promise<string> } =
-        await import('qrcode');
+      const qrCodeModule: {
+        toDataURL: (
+          value: string,
+          options: { margin: number; scale: number },
+        ) => Promise<string>;
+      } = await import('qrcode');
       const dataUrl = await qrCodeModule.toDataURL(inviteUrl, {
         margin: 1,
         scale: 6,
@@ -1127,12 +1135,17 @@ function AddFriendDialog({
 }: Readonly<{
   q: string;
   setQ: (next: string) => void;
-  onOutgoingCreated: (
-    requestId: string,
-    user: FriendEntry['user'],
-  ) => void;
+  onOutgoingCreated: (requestId: string, user: FriendEntry['user']) => void;
 }>) {
   const [open, setOpen] = useState(false);
+  // Lets the empty state (and anything else) open this dialog without
+  // prop-drilling — same pattern as the notification bell's
+  // 'notifications:open' event.
+  useEffect(() => {
+    const handler = () => setOpen(true);
+    window.addEventListener('friends:add-friend-open', handler);
+    return () => window.removeEventListener('friends:add-friend-open', handler);
+  }, []);
   return (
     <>
       <Button onClick={() => setOpen(true)}>
@@ -1234,7 +1247,12 @@ const FriendsRoute = () => {
   const handleOutgoingCreated = useCallback(
     (requestId: string, user: FriendEntry['user']) => {
       setOutgoingState((prev) => {
-        if (prev.some((request) => request.id === requestId || request.toUser.id === user.id)) {
+        if (
+          prev.some(
+            (request) =>
+              request.id === requestId || request.toUser.id === user.id,
+          )
+        ) {
           return prev;
         }
         return [createOutgoingEntry(requestId, user), ...prev];
@@ -1257,7 +1275,7 @@ const FriendsRoute = () => {
         />
       </PageHeader>
 
-      <div className="mx-auto w-full max-w-6xl min-h-0 flex-1 px-4 py-6 sm:px-6 sm:py-8">
+      <div className="mx-auto min-h-0 w-full max-w-6xl flex-1 px-4 py-6 sm:px-6 sm:py-8">
         <Stack gap={4}>
           <PendingRequestsCard
             incomingState={incomingState}
@@ -1389,10 +1407,7 @@ function AddFriendsPanel({
   query: controlledQuery,
   onQueryChange,
 }: {
-  onOutgoingCreated?: (
-    requestId: string,
-    user: FriendEntry['user'],
-  ) => void;
+  onOutgoingCreated?: (requestId: string, user: FriendEntry['user']) => void;
   query?: string;
   onQueryChange?: (q: string) => void;
 }) {

--- a/app/routes/wishlist+/__wishlist-item-editor.tsx
+++ b/app/routes/wishlist+/__wishlist-item-editor.tsx
@@ -222,7 +222,12 @@ function EditorTypeSelector({
           Links to an external collection (Amazon wishlist, Steam list, etc.).
           Friends can browse it — list links can&apos;t be claimed.
         </p>
-      ) : null}
+      ) : (
+        <p className="text-xs text-muted-foreground">
+          One specific thing you&apos;d like. Paste a product link below and
+          we&apos;ll fill in the details.
+        </p>
+      )}
     </div>
   );
 }
@@ -1513,24 +1518,14 @@ function EditorFormSection({
         resetImageChanges={resetImageChanges}
         setItemType={setItemType}
       />
-      <Field
-        className="w-full"
-        labelProps={{ children: fieldConfig.titleLabel }}
-        inputProps={{
-          placeholder: fieldConfig.titlePlaceholder,
-          autoFocus: true,
-          ...getInputProps(fields.title, {
-            type: 'text',
-            ariaAttributes: true,
-          }),
-          onInput: () => enrichment.markEdited('title'),
-        }}
-        errors={fields.title.errors}
-      />
+      {/* Link leads: "paste a link, get a complete item" is the fast path,
+          and Title-first framing buried it (June 2026 audit). The autofocused
+          link field invites the paste; Title prefills from the unfurl. */}
       <UrlFieldWithSuggestion
         errors={fields.url.errors}
         inputProps={{
           placeholder: fieldConfig.urlPlaceholder,
+          autoFocus: true,
           ...getInputProps(fields.url, {
             type: 'url',
             ariaAttributes: true,
@@ -1554,6 +1549,19 @@ function EditorFormSection({
       <EnrichmentStatusLine
         isUnfurling={enrichment.isUnfurling}
         showHint={enrichment.showHint}
+      />
+      <Field
+        className="w-full"
+        labelProps={{ children: fieldConfig.titleLabel }}
+        inputProps={{
+          placeholder: fieldConfig.titlePlaceholder,
+          ...getInputProps(fields.title, {
+            type: 'text',
+            ariaAttributes: true,
+          }),
+          onInput: () => enrichment.markEdited('title'),
+        }}
+        errors={fields.title.errors}
       />
       {isListLinkType ? null : (
         <Field
@@ -1762,11 +1770,15 @@ function EditorFormSection({
             {imageWarning}
           </Text>
         ) : null}
-        <div className="flex flex-wrap gap-2">
-          <Button type="button" variant="outline" onClick={resetImageChanges}>
-            Reset image changes
-          </Button>
-        </div>
+        {/* Only meaningful once there's an image (or one was removed) —
+            showing it on a pristine empty editor reads as clutter. */}
+        {imagePreview || wishlistItem?.hasImage ? (
+          <div className="flex flex-wrap gap-2">
+            <Button type="button" variant="outline" onClick={resetImageChanges}>
+              Reset image changes
+            </Button>
+          </div>
+        ) : null}
       </div>
 
       <DialogFooterComponent className="grid gap-3 sm:flex sm:justify-end sm:space-x-2">

--- a/app/utils/user-validation.ts
+++ b/app/utils/user-validation.ts
@@ -5,17 +5,24 @@ export const USERNAME_MAX_LENGTH = 20;
 
 export const UsernameSchema = z
   .string({ required_error: 'Username is required' })
-  .min(USERNAME_MIN_LENGTH, { message: 'Username is too short' })
+  .min(USERNAME_MIN_LENGTH, {
+    message: `Username is too short (minimum ${USERNAME_MIN_LENGTH} characters)`,
+  })
   .max(USERNAME_MAX_LENGTH, { message: 'Username is too long' })
   .regex(/^[a-zA-Z0-9_]+$/, {
-    message: 'Username can only include letters, numbers, and underscores',
+    message:
+      'Username can only include letters, numbers, and underscores — no spaces or hyphens',
   })
   // users can type the username in any case, but we store it in lowercase
   .transform((value) => value.toLowerCase());
 
+export const PASSWORD_MIN_LENGTH = 6;
+
 export const PasswordSchema = z
   .string({ required_error: 'Password is required' })
-  .min(6, { message: 'Password is too short' })
+  .min(PASSWORD_MIN_LENGTH, {
+    message: `Password is too short (minimum ${PASSWORD_MIN_LENGTH} characters)`,
+  })
   .max(100, { message: 'Password is too long' });
 export const NameSchema = z
   .string({ required_error: 'Name is required' })
@@ -44,19 +51,30 @@ export const PasswordAndConfirmPasswordSchema = z
 export const BIO_MAX_LENGTH = 160;
 export const BioSchema = z
   .string()
-  .max(BIO_MAX_LENGTH, { message: `Bio must be ${BIO_MAX_LENGTH} characters or fewer` })
+  .max(BIO_MAX_LENGTH, {
+    message: `Bio must be ${BIO_MAX_LENGTH} characters or fewer`,
+  })
   .transform((value) => value.trim());
 
 // SQLite doesn't support Prisma enums, so we store the value as a string and
 // enforce the union at the app layer. Keep these two in sync.
 // Ordered from most-visible to least-visible.
-export const BIRTHDAY_VISIBILITY_VALUES = ['EVERYONE', 'FRIENDS_OF_FRIENDS', 'FRIENDS', 'NOBODY'] as const;
+export const BIRTHDAY_VISIBILITY_VALUES = [
+  'EVERYONE',
+  'FRIENDS_OF_FRIENDS',
+  'FRIENDS',
+  'NOBODY',
+] as const;
 export type BirthdayVisibility = (typeof BIRTHDAY_VISIBILITY_VALUES)[number];
 export const BirthdayVisibilitySchema = z.enum(BIRTHDAY_VISIBILITY_VALUES);
 
 // Ordered from most-visible to least-visible. No 'NOBODY' — a hidden wishlist is
 // handled by not sharing the link rather than a visibility setting.
-export const WISHLIST_VISIBILITY_VALUES = ['EVERYONE', 'FRIENDS_OF_FRIENDS', 'FRIENDS'] as const;
+export const WISHLIST_VISIBILITY_VALUES = [
+  'EVERYONE',
+  'FRIENDS_OF_FRIENDS',
+  'FRIENDS',
+] as const;
 export type WishlistVisibility = (typeof WISHLIST_VISIBILITY_VALUES)[number];
 export const WishlistVisibilitySchema = z.enum(WISHLIST_VISIBILITY_VALUES);
 


### PR DESCRIPTION
## Why

Workstream B of the friction fix cycle (June 2026 audit findings 6, 8, 9, 13, 14). After signup, every surface pointed new users away from the one action that activates them — adding a wishlist item — or made them work for it.

## What

**Dashboard (new users)** — the empty dashboard led with "Start a Pool", the hardest possible first action. Users with an empty wishlist now get a wishlist-first hero whose CTA deep-links to `/wishlist?add=1`, which opens the add-item editor immediately (no second hunt for the Add button). The pools empty-state CTA demotes to outline at that stage; the old bottom wishlist nudge is replaced by the hero.

**Editor** — the Link field now leads (autofocused) so "paste a link, get a complete item" is the visible fast path; Title prefills from the unfurl. The Gift idea / List link toggle is explained in both states, and "Reset image changes" hides until an image exists.

**Onboarding** — username and password requirements show *before* the user fails them (`Field` gains a `description` prop wired to `aria-describedby`); error messages now state the minimums; the username error mentions no hyphens; the ToS checkbox gets a complete accessible label (was "I agree to the and").

**Friends empty state** — "Browse groups" was circular for new users (empty groups page). The CTA now opens the Add friend dialog directly.

## Funnel measures

`wishlist_editor_opened → wishlist_item_added` conversion and the activation funnel's "Added first wishlist item" step are the before/after for this PR.

## Validation

1007 unit tests, 86 e2e, typecheck + lint clean.