### PR TITLE
Conversion polish: convert the share page, fix the marketing hero/nav, OTP auto-submit + copy/a11y batch

### DIFF
--- a/app/components/home/HomepageMockup.tsx
+++ b/app/components/home/HomepageMockup.tsx
@@ -1,3 +1,4 @@
+import { Heart } from 'lucide-react';
 import * as React from 'react';
 
 type HomepageMockupProps = {
@@ -5,7 +6,9 @@ type HomepageMockupProps = {
   className?: string;
 };
 
-// Lightweight, responsive placeholder illustration with accessible alt text
+// Decorative product preview for the marketing hero. Real text instead of
+// skeleton bars — placeholder bars read as failed-to-load content. The whole
+// mockup is one labeled image; the content inside is hidden from AT.
 export const HomepageMockup: React.FC<HomepageMockupProps> = ({
   alt,
   className,
@@ -17,50 +20,51 @@ export const HomepageMockup: React.FC<HomepageMockupProps> = ({
         aria-label={alt}
         className="relative aspect-[4/3] w-full overflow-hidden rounded-xl border border-border bg-gradient-to-br from-muted to-background"
       >
-        <svg
-          viewBox="0 0 400 300"
-          xmlns="http://www.w3.org/2000/svg"
-          className="h-full w-full"
+        <div
           aria-hidden="true"
+          className="flex h-full w-full select-none flex-col justify-center gap-3 p-4 sm:p-6"
         >
-          <defs>
-            <linearGradient id="g1" x1="0" y1="0" x2="1" y2="1">
-              <stop offset="0%" stopColor="hsl(var(--muted))" />
-              <stop offset="100%" stopColor="hsl(var(--background))" />
-            </linearGradient>
-          </defs>
-          <rect width="400" height="300" fill="url(#g1)" />
+          <div className="rounded-lg border border-border bg-card p-3 shadow-sm sm:p-4">
+            <div className="flex items-center justify-between gap-2">
+              <p className="truncate text-sm font-semibold">
+                Dad&rsquo;s 60th Birthday
+              </p>
+              <span className="rounded-full bg-emerald-100 px-2.5 py-0.5 text-xs font-medium text-emerald-800 dark:bg-emerald-900 dark:text-emerald-200">
+                Open
+              </span>
+            </div>
+            <p className="mt-1 text-xs text-muted-foreground">
+              $135 of $180 · 5 chipping in
+            </p>
+            <div className="mt-2 h-1.5 w-full overflow-hidden rounded-full bg-muted">
+              <div className="h-full w-3/4 rounded-full bg-primary" />
+            </div>
+          </div>
 
-          {/* Pool card 1 — Open */}
-          <rect x="24" y="24" width="352" height="70" rx="10" fill="hsl(var(--card))" stroke="hsl(var(--border))" />
-          {/* Title text line */}
-          <rect x="44" y="40" width="140" height="10" rx="5" fill="hsl(var(--foreground))" opacity="0.75" />
-          {/* Sub text line */}
-          <rect x="44" y="57" width="90" height="7" rx="3.5" fill="hsl(var(--muted-foreground))" opacity="0.5" />
-          {/* Contributor count */}
-          <rect x="44" y="74" width="60" height="6" rx="3" fill="hsl(var(--muted-foreground))" opacity="0.35" />
-          {/* "Open" status badge */}
-          <rect x="292" y="36" width="60" height="20" rx="10" fill="#d1fae5" />
-          <rect x="304" y="42" width="36" height="8" rx="4" fill="#065f46" opacity="0.7" />
-
-          {/* Pool card 2 — Decided */}
-          <rect x="24" y="110" width="352" height="70" rx="10" fill="hsl(var(--card))" stroke="hsl(var(--border))" />
-          <rect x="44" y="126" width="120" height="10" rx="5" fill="hsl(var(--foreground))" opacity="0.75" />
-          <rect x="44" y="143" width="80" height="7" rx="3.5" fill="hsl(var(--muted-foreground))" opacity="0.5" />
-          <rect x="44" y="160" width="60" height="6" rx="3" fill="hsl(var(--muted-foreground))" opacity="0.35" />
-          {/* "Decided" status badge */}
-          <rect x="284" y="122" width="68" height="20" rx="10" fill="#dbeafe" />
-          <rect x="296" y="128" width="44" height="8" rx="4" fill="#1e40af" opacity="0.7" />
-
-          {/* Pool card 3 — Voting */}
-          <rect x="24" y="196" width="352" height="70" rx="10" fill="hsl(var(--card))" stroke="hsl(var(--border))" />
-          <rect x="44" y="212" width="160" height="10" rx="5" fill="hsl(var(--foreground))" opacity="0.75" />
-          <rect x="44" y="229" width="100" height="7" rx="3.5" fill="hsl(var(--muted-foreground))" opacity="0.5" />
-          <rect x="44" y="246" width="60" height="6" rx="3" fill="hsl(var(--muted-foreground))" opacity="0.35" />
-          {/* "Voting" status badge */}
-          <rect x="288" y="208" width="64" height="20" rx="10" fill="#ede9fe" />
-          <rect x="300" y="214" width="40" height="8" rx="4" fill="#5b21b6" opacity="0.7" />
-        </svg>
+          <div className="rounded-lg border border-border bg-card p-3 shadow-sm sm:p-4">
+            <div className="flex items-center justify-between gap-2">
+              <div className="flex min-w-0 items-center gap-2">
+                <Heart className="h-4 w-4 shrink-0 text-primary" />
+                <p className="truncate text-sm font-medium">
+                  Espresso grinder
+                </p>
+              </div>
+              <p className="text-sm text-muted-foreground">$89</p>
+            </div>
+            <div className="mt-3 flex items-center justify-between gap-2">
+              <div className="flex min-w-0 items-center gap-2">
+                <Heart className="h-4 w-4 shrink-0 text-primary" />
+                <p className="truncate text-sm font-medium">
+                  Trail running shoes
+                </p>
+              </div>
+              <p className="text-sm text-muted-foreground">$140</p>
+            </div>
+            <p className="ml-6 mt-1 text-xs text-muted-foreground">
+              Claimed by Sofia
+            </p>
+          </div>
+        </div>
       </div>
       <figcaption id="home-mockup-caption" className="sr-only">
         {alt}

--- a/app/components/nav/top/top-nav.test.tsx
+++ b/app/components/nav/top/top-nav.test.tsx
@@ -8,6 +8,11 @@ import { afterEach, describe, expect, test, vi } from 'vitest';
 
 const useOptionalUser = vi.fn();
 const useRequestInfo = vi.fn();
+const track = vi.fn();
+
+vi.mock('#app/utils/analytics.client.ts', () => ({
+  track: (...args: Array<unknown>) => track(...args),
+}));
 
 vi.mock('#app/components/logo', () => ({
   Logo: () => <div>GiftPool</div>,
@@ -72,6 +77,7 @@ describe('<TopNav />', () => {
   afterEach(() => {
     useOptionalUser.mockReset();
     useRequestInfo.mockReset();
+    track.mockReset();
   });
 
   test('renders all primary links for authenticated users', () => {
@@ -84,9 +90,10 @@ describe('<TopNav />', () => {
     expect(screen.getByText('Theme light')).toBeInTheDocument();
     expect(screen.getByText('User menu')).toBeInTheDocument();
     expect(screen.queryByRole('link', { name: 'Log In' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Sign up' })).not.toBeInTheDocument();
   });
 
-  test('renders logged-out navigation with a login link', () => {
+  test('renders logged-out navigation with signup and login links', () => {
     renderTopNav(null);
 
     expect(screen.getByRole('link', { name: 'Home' })).toBeInTheDocument();
@@ -94,8 +101,22 @@ describe('<TopNav />', () => {
       'href',
       '/login',
     );
+    expect(screen.getByRole('link', { name: 'Sign up' })).toHaveAttribute(
+      'href',
+      '/signup',
+    );
     expect(screen.queryByRole('link', { name: 'Pools' })).not.toBeInTheDocument();
     expect(screen.queryByText('Notifications')).not.toBeInTheDocument();
     expect(screen.queryByText('User menu')).not.toBeInTheDocument();
+  });
+
+  test('tracks the nav signup click', () => {
+    renderTopNav(null);
+
+    screen.getByRole('link', { name: 'Sign up' }).click();
+
+    expect(track).toHaveBeenCalledWith('home_cta_clicked', {
+      cta: 'nav_signup',
+    });
   });
 });

--- a/app/components/nav/top/top-nav.tsx
+++ b/app/components/nav/top/top-nav.tsx
@@ -6,6 +6,7 @@ import { Button } from '#app/components/ui/button';
 import { TopNavItem } from '#app/components/ui/topNavItem';
 import { UserDropdown } from '#app/components/user-dropdown';
 import { ThemeSwitch } from '#app/routes/resources+/theme-switch';
+import { track } from '#app/utils/analytics.client.ts';
 import { useRequestInfo } from '#app/utils/request-info';
 import { useOptionalUser } from '#app/utils/user';
 
@@ -51,9 +52,21 @@ export const TopNav = () => {
           {user ? (
             <UserDropdown />
           ) : (
-            <Button asChild size="lg">
-              <Link to="/login">Log In</Link>
-            </Button>
+            <>
+              <Button asChild size="lg" variant="ghost">
+                <Link to="/login">Log In</Link>
+              </Button>
+              <Button asChild size="lg">
+                <Link
+                  to="/signup"
+                  onClick={() =>
+                    track('home_cta_clicked', { cta: 'nav_signup' })
+                  }
+                >
+                  Sign up
+                </Link>
+              </Button>
+            </>
           )}
         </div>
       </div>

--- a/app/components/share-conversion.test.tsx
+++ b/app/components/share-conversion.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const useOptionalUser = vi.fn();
+const track = vi.fn();
+
+vi.mock('#app/utils/user.ts', () => ({
+  useOptionalUser: () => useOptionalUser(),
+}));
+
+vi.mock('#app/utils/analytics.client.ts', () => ({
+  track: (...args: unknown[]) => track(...args),
+}));
+
+import {
+  ShareConversionBanner,
+  ShareConversionCard,
+} from './share-conversion.tsx';
+
+describe('share conversion surfaces', () => {
+  beforeEach(() => {
+    useOptionalUser.mockReset();
+    useOptionalUser.mockReturnValue(undefined);
+    track.mockReset();
+  });
+
+  it('shows the banner with the owner name and a signup link carrying redirectTo', () => {
+    render(
+      <MemoryRouter>
+        <ShareConversionBanner ownerName="Maria" />
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.getByText(/made this wishlist on GiftPool/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Maria')).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: /create your own/i }),
+    ).toHaveAttribute('href', '/signup?redirectTo=%2Fwishlist');
+  });
+
+  it('tracks a banner CTA click with its placement', async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <ShareConversionBanner ownerName="Maria" />
+      </MemoryRouter>,
+    );
+
+    await user.click(screen.getByRole('link', { name: /create your own/i }));
+
+    expect(track).toHaveBeenCalledWith('share_cta_clicked', {
+      placement: 'banner',
+    });
+  });
+
+  it('shows the footer card with signup and login affordances', () => {
+    render(
+      <MemoryRouter>
+        <ShareConversionCard />
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.getByText(/want one of these for yourself/i),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /get started/i })).toHaveAttribute(
+      'href',
+      '/signup?redirectTo=%2Fwishlist',
+    );
+    expect(screen.getByRole('link', { name: /log in/i })).toHaveAttribute(
+      'href',
+      '/login?redirectTo=%2Fwishlist',
+    );
+  });
+
+  it('tracks a footer card CTA click with its placement', async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <ShareConversionCard />
+      </MemoryRouter>,
+    );
+
+    await user.click(screen.getByRole('link', { name: /get started/i }));
+
+    expect(track).toHaveBeenCalledWith('share_cta_clicked', {
+      placement: 'footer_card',
+    });
+  });
+
+  it('renders nothing for logged-in viewers', () => {
+    useOptionalUser.mockReturnValue({ id: 'user-1', username: 'maria' });
+
+    render(
+      <MemoryRouter>
+        <ShareConversionBanner ownerName="Maria" />
+        <ShareConversionCard />
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.queryByText(/made this wishlist on GiftPool/i),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/want one of these for yourself/i),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/app/components/share-conversion.tsx
+++ b/app/components/share-conversion.tsx
@@ -1,0 +1,78 @@
+import { Link } from 'react-router';
+
+import { Button } from '#app/components/ui/button.tsx';
+import { track } from '#app/utils/analytics.client.ts';
+import { useOptionalUser } from '#app/utils/user.ts';
+
+// The public share page is the app's most-shared surface, but visitors had no
+// way to learn what GiftPool is or sign up from it. Both CTAs carry
+// redirectTo=/wishlist so a converted visitor lands on their own wishlist.
+const SIGNUP_HREF = '/signup?redirectTo=%2Fwishlist';
+
+export const ShareConversionBanner = ({
+  ownerName,
+}: {
+  ownerName: string;
+}) => {
+  const user = useOptionalUser();
+  if (user) return null;
+
+  return (
+    <div className="border-b border-border bg-primary/10">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-3 px-4 py-3 text-sm text-foreground sm:flex-row sm:items-center sm:justify-between sm:gap-4">
+        <p>
+          <span className="font-medium">{ownerName}</span> made this wishlist
+          on GiftPool.
+        </p>
+        <Button asChild size="sm" className="whitespace-nowrap">
+          <Link
+            to={SIGNUP_HREF}
+            onClick={() =>
+              track('share_cta_clicked', { placement: 'banner' })
+            }
+          >
+            Create your own — free
+          </Link>
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export const ShareConversionCard = () => {
+  const user = useOptionalUser();
+  if (user) return null;
+
+  return (
+    <div className="container max-w-3xl pb-12">
+      <div className="flex flex-col items-start gap-4 rounded-xl border border-border bg-card p-6 shadow-sm sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <p className="text-base font-semibold">
+            Want one of these for yourself?
+          </p>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Share what you actually want — no more guessing games.
+          </p>
+        </div>
+        <div className="flex shrink-0 items-center gap-3">
+          <Button asChild>
+            <Link
+              to={SIGNUP_HREF}
+              onClick={() =>
+                track('share_cta_clicked', { placement: 'footer_card' })
+              }
+            >
+              Get started
+            </Link>
+          </Button>
+          <Link
+            to="/login?redirectTo=%2Fwishlist"
+            className="text-sm text-muted-foreground underline underline-offset-2 hover:text-foreground"
+          >
+            Log in
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/app/components/wishlist/wishlist-share-dialog.test.tsx
+++ b/app/components/wishlist/wishlist-share-dialog.test.tsx
@@ -137,11 +137,19 @@ describe('WishlistShareDialog', () => {
     await waitFor(() => {
       expect(screen.getByRole('button', { name: /revoke$/i })).toBeInTheDocument();
     });
+    // The "are you sure" warning is idle-state noise until the user actually
+    // starts revoking.
+    expect(
+      screen.queryByText(/revoking disables this link/i),
+    ).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: /revoke$/i }));
     await waitFor(() => {
       expect(
         screen.getByRole('button', { name: /revoke link/i }),
       ).toBeInTheDocument();
     });
+    expect(
+      screen.getByText(/revoking disables this link/i),
+    ).toBeInTheDocument();
   });
 });

--- a/app/components/wishlist/wishlist-share-dialog.tsx
+++ b/app/components/wishlist/wishlist-share-dialog.tsx
@@ -152,9 +152,11 @@ function PublicLinkCard({
             value={publicLink}
             onClick={(event) => event.currentTarget.select()}
           />
-          <p className="text-[11px] text-muted-foreground">
-            Revoking disables this link immediately. Are you sure?
-          </p>
+          {confirmingRevoke ? (
+            <p className="text-[11px] text-muted-foreground">
+              Revoking disables this link immediately. Are you sure?
+            </p>
+          ) : null}
         </div>
       ) : (
         <div className="mt-3 space-y-3">

--- a/app/emails/feedback-received.tsx
+++ b/app/emails/feedback-received.tsx
@@ -22,25 +22,17 @@ export const FeedbackReceivedEmail = ({
   return (
     <E.Html lang="en" dir="ltr">
       <E.Container>
-        <h1>
-          <E.Text>New {FEEDBACK_TYPE_LABELS[type]} feedback</E.Text>
-        </h1>
-        <p>
-          <E.Text>
-            From: {username ? `@${username}` : 'Anonymous'}
-            {fromEmail ? ` (${fromEmail})` : ''}
-          </E.Text>
-        </p>
-        {pageUrl ? (
-          <p>
-            <E.Text>Submitted from: {pageUrl}</E.Text>
-          </p>
-        ) : null}
-        <hr />
-        <p>
-          <E.Text>{message}</E.Text>
-        </p>
-        <hr />
+        <E.Heading as="h1">
+          New {FEEDBACK_TYPE_LABELS[type]} feedback
+        </E.Heading>
+        <E.Text>
+          From: {username ? `@${username}` : 'Anonymous'}
+          {fromEmail ? ` (${fromEmail})` : ''}
+        </E.Text>
+        {pageUrl ? <E.Text>Submitted from: {pageUrl}</E.Text> : null}
+        <E.Hr />
+        <E.Text>{message}</E.Text>
+        <E.Hr />
         <E.Link href={adminUrl}>Open in admin →</E.Link>
       </E.Container>
     </E.Html>

--- a/app/emails/signup-email.tsx
+++ b/app/emails/signup-email.tsx
@@ -10,17 +10,19 @@ export const SignupEmail = ({
   return (
     <E.Html lang="en" dir="ltr">
       <E.Container>
-        <h1>
-          <E.Text>Welcome to GiftPool!</E.Text>
-        </h1>
-        <p>
-          <E.Text>
-            Here's your verification code: <strong>{otp}</strong>
-          </E.Text>
-        </p>
-        <p>
-          <E.Text>Or click the link to get started:</E.Text>
-        </p>
+        <E.Heading as="h1">Welcome to GiftPool!</E.Heading>
+        <E.Text>Here&apos;s your verification code:</E.Text>
+        <E.Text
+          style={{
+            fontSize: '32px',
+            fontWeight: 700,
+            letterSpacing: '8px',
+            margin: '16px 0',
+          }}
+        >
+          {otp}
+        </E.Text>
+        <E.Text>Or click the link to get started:</E.Text>
         <E.Link href={onboardingUrl}>{onboardingUrl}</E.Link>
       </E.Container>
     </E.Html>

--- a/app/routes/_auth+/verify.dom.test.tsx
+++ b/app/routes/_auth+/verify.dom.test.tsx
@@ -1,7 +1,8 @@
 /**
  * @vitest-environment jsdom
  */
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { createRoutesStub } from 'react-router';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -82,6 +83,20 @@ describe('verify route UI', () => {
       target: 'x@example.com',
       redirectTo: '/wishlist',
     });
+  });
+
+  it('auto-submits once the sixth digit lands', async () => {
+    const requestSubmit = vi
+      .spyOn(HTMLFormElement.prototype, 'requestSubmit')
+      .mockImplementation(() => {});
+    try {
+      renderVerify({ search: '?type=onboarding&target=x%40example.com' });
+      const codeInput = await screen.findByRole('textbox', { name: /code/i });
+      await userEvent.type(codeInput, '123456');
+      await waitFor(() => expect(requestSubmit).toHaveBeenCalled());
+    } finally {
+      requestSubmit.mockRestore();
+    }
   });
 
   it('hides the recovery affordances for non-onboarding types', async () => {

--- a/app/routes/_auth+/verify.dom.test.tsx
+++ b/app/routes/_auth+/verify.dom.test.tsx
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createRoutesStub } from 'react-router';
 import { describe, expect, it, vi } from 'vitest';
@@ -89,11 +89,20 @@ describe('verify route UI', () => {
     const requestSubmit = vi
       .spyOn(HTMLFormElement.prototype, 'requestSubmit')
       .mockImplementation(() => {});
+    const { unmount } = renderVerify({
+      search: '?type=onboarding&target=x%40example.com',
+    });
     try {
-      renderVerify({ search: '?type=onboarding&target=x%40example.com' });
       const codeInput = await screen.findByRole('textbox', { name: /code/i });
       await userEvent.type(codeInput, '123456');
       await waitFor(() => expect(requestSubmit).toHaveBeenCalled());
+      // input-otp schedules selection-mirroring timers; unmount (clears them
+      // via its effect cleanup) and drain the queue while jsdom is still alive,
+      // so no stray timer fires post-teardown ("window is not defined").
+      unmount();
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
     } finally {
       requestSubmit.mockRestore();
     }

--- a/app/routes/_auth+/verify.dom.test.tsx
+++ b/app/routes/_auth+/verify.dom.test.tsx
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createRoutesStub } from 'react-router';
 import { describe, expect, it, vi } from 'vitest';
@@ -100,9 +100,7 @@ describe('verify route UI', () => {
       // via its effect cleanup) and drain the queue while jsdom is still alive,
       // so no stray timer fires post-teardown ("window is not defined").
       unmount();
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 0));
-      });
+      await new Promise((resolve) => setTimeout(resolve, 0));
     } finally {
       requestSubmit.mockRestore();
     }

--- a/app/routes/_auth+/verify.tsx
+++ b/app/routes/_auth+/verify.tsx
@@ -134,6 +134,15 @@ const VerifyRoute = () => {
                   ...getInputProps(fields[codeQueryParam], { type: 'text' }),
                   autoComplete: 'one-time-code',
                   autoFocus: true,
+                  // Submit as soon as the sixth digit lands (typed or
+                  // pasted) — the Submit button stays as a fallback.
+                  onComplete: () => {
+                    if (isPending) return;
+                    const formElement = document.getElementById(form.id);
+                    if (formElement instanceof HTMLFormElement) {
+                      formElement.requestSubmit();
+                    }
+                  },
                 }}
                 errors={fields[codeQueryParam].errors}
               />

--- a/app/routes/w.public.$token.tsx
+++ b/app/routes/w.public.$token.tsx
@@ -9,6 +9,10 @@ import {
   useLoaderData,
 } from 'react-router';
 import { GeneralErrorBoundary } from '#app/components/error-boundary.tsx';
+import {
+  ShareConversionBanner,
+  ShareConversionCard,
+} from '#app/components/share-conversion.tsx';
 import { Wishlist, type WishlistUser } from '#app/components/wishlist';
 import { queueLogEvent } from '#app/utils/analytics.server.ts';
 import { getUserId } from '#app/utils/auth.server.ts';
@@ -216,7 +220,14 @@ const PublicWishlistRoute = () => {
       updatedAt: new Date(item.updatedAt),
     })),
   };
-  return <Wishlist isOwner={false} user={user} isPublicView />;
+  const ownerName = user.name ?? user.username;
+  return (
+    <>
+      <ShareConversionBanner ownerName={ownerName} />
+      <Wishlist isOwner={false} user={user} isPublicView />
+      <ShareConversionCard />
+    </>
+  );
 };
 export default PublicWishlistRoute;
 export const ErrorBoundary = () => {

--- a/app/utils/analytics.ts
+++ b/app/utils/analytics.ts
@@ -64,6 +64,10 @@ export const ANALYTIC_EVENT_NAMES = [
   'group_joined',
   // Funnel entry for wishlist_item_added — measures open-then-abandon.
   'wishlist_editor_opened',
+  // Public share page CTA clicks (`placement: banner|footer_card`). Sits
+  // between wishlist_share_viewed and signup_submitted in the share-reach
+  // funnel; anonymous visitors fire it, so NOT user-required.
+  'share_cta_clicked',
 ] as const;
 
 export type AnalyticEventName = (typeof ANALYTIC_EVENT_NAMES)[number];

--- a/tests/e2e/2fa.test.ts
+++ b/tests/e2e/2fa.test.ts
@@ -41,11 +41,10 @@ test('Users can add 2FA to their account and use it when logging in', async ({
   await page.getByRole('textbox', { name: /password/i }).fill(password);
   await page.getByRole('button', { name: /log in/i }).click();
 
+  // The /verify 2FA challenge auto-submits once the sixth digit lands.
   await page
     .getByRole('textbox', { name: /code/i })
     .fill(generateTOTP(options).otp);
-
-  await page.getByRole('button', { name: /submit/i }).click();
 
   await expect(
     page.getByRole('link', { name: user.name ?? user.username }),
@@ -80,10 +79,10 @@ test('Users can disable 2FA after enabling it', async ({ page, login }) => {
   // verify doesn't count, so we get bounced to /verify first. Re-enter the
   // TOTP, then the disable page loads for real.
   await expect(page).toHaveURL(/\/verify\?type=2fa/);
+  // The /verify 2FA challenge auto-submits once the sixth digit lands.
   await page
     .getByRole('textbox', { name: /code/i })
     .fill(generateTOTP(options).otp);
-  await page.getByRole('button', { name: /submit/i }).click();
   await expect(page).toHaveURL(/\/settings\/profile\/two-factor\/disable$/);
 
   // ── useDoubleCheck gates the action button: first click flips the label

--- a/tests/e2e/onboarding.test.ts
+++ b/tests/e2e/onboarding.test.ts
@@ -5,7 +5,9 @@ import { readEmail } from '#tests/mocks/utils.ts';
 import { createUser, expect, test as base } from '#tests/playwright-utils.ts';
 
 const URL_REGEX = /(?<url>https?:\/\/[^\s$.?#].[^\s]*)/;
-const CODE_REGEX = /Here's your verification code: (?<code>\d+)/;
+// `\s*` so the code matches whether the email renders it inline (reset
+// password) or on its own line (signup's prominent code block).
+const CODE_REGEX = /Here's your verification code:\s*(?<code>\d+)/;
 function extractUrl(text: string) {
   const match = text.match(URL_REGEX);
   return match?.groups?.url;

--- a/tests/e2e/onboarding.test.ts
+++ b/tests/e2e/onboarding.test.ts
@@ -123,8 +123,8 @@ test('onboarding with a short code', async ({ page, getOnboardingData }) => {
   const codeMatch = email.text.match(CODE_REGEX);
   const code = codeMatch?.groups?.code;
   invariant(code, 'Onboarding code not found');
+  // The verify form auto-submits once the sixth digit lands — no Submit click.
   await page.getByRole('textbox', { name: /code/i }).fill(code);
-  await page.getByRole('button', { name: /submit/i }).click();
 
   await expect(page).toHaveURL(`/onboarding`);
 });
@@ -224,8 +224,8 @@ test('reset password with a short code', async ({ page, insertNewUser }) => {
   const codeMatch = email.text.match(CODE_REGEX);
   const code = codeMatch?.groups?.code;
   invariant(code, 'Reset Password code not found');
+  // The verify form auto-submits once the sixth digit lands — no Submit click.
   await page.getByRole('textbox', { name: /code/i }).fill(code);
-  await page.getByRole('button', { name: /submit/i }).click();
 
   await expect(page).toHaveURL(`/reset-password`);
 });

--- a/tests/e2e/settings-profile.test.ts
+++ b/tests/e2e/settings-profile.test.ts
@@ -139,8 +139,8 @@ test('Users can change their email address', async ({ page, login }) => {
   const codeMatch = email.text.match(CODE_REGEX);
   const code = codeMatch?.groups?.code;
   invariant(code, 'Onboarding code not found');
+  // The verify form auto-submits once the sixth digit lands — no Submit click.
   await page.getByRole('textbox', { name: /code/i }).fill(code);
-  await page.getByRole('button', { name: /submit/i }).click();
   await expect(page.getByText(/email changed/i)).toBeVisible();
 
   const updatedUser = await prisma.user.findUnique({

--- a/tests/e2e/settings-profile.test.ts
+++ b/tests/e2e/settings-profile.test.ts
@@ -6,7 +6,9 @@ import { prisma } from '#app/utils/db.server.ts';
 import { readEmail } from '#tests/mocks/utils.ts';
 import { expect, test, createUser, waitFor } from '#tests/playwright-utils.ts';
 
-const CODE_REGEX = /Here's your verification code: (?<code>\d+)/;
+// `\s*` so the code matches whether the email renders it inline or on its
+// own line (signup's prominent code block).
+const CODE_REGEX = /Here's your verification code:\s*(?<code>\d+)/;
 
 const dismissInstallPrompt = async (page: Page) => {
   const notNow = page.getByRole('button', { name: /not now/i });


### PR DESCRIPTION
## Workstream C — conversion polish

Final fix batch from the June 12 friction audit (findings 11, 15, 17). Workstreams 0 (mobile FAB, #408), A (invite landings, #409), and B (activation surface, #410) are merged; this is the last batch.

### What changed
- **Share-page conversion (finding 11):** the public wishlist (`/w/public/:token`) — our most-shared, lowest-converting surface — now shows anonymous visitors a top banner naming the owner and a closing card, both linking to `/signup?redirectTo=/wishlist`. New `share_cta_clicked` event (`placement: banner|footer_card`) sits between `wishlist_share_viewed` and `signup_submitted` in the share-reach funnel. Hidden for logged-in viewers/owner.
- **Marketing nav + hero (finding 17):** the nav now leads with a **Sign up** button (Log In demoted to ghost, signup click tracked via `home_cta_clicked` `cta:nav_signup`). The hero illustration — previously gray skeleton bars that read as failed-to-load content — is now an HTML/CSS mockup with real product content (a funded pool with progress + priced wishlist items), theme-token styled so dark mode works. Same accessible-image shell, so `HomeHero` is untouched.
- **OTP auto-submit (finding 15):** the verify form submits as soon as the sixth digit lands (`input-otp` `onComplete` → `requestSubmit()`), guarded by `isPending`, Submit button kept as fallback. Applies to every verify type (onboarding / reset-password / change-email / 2fa).
- **Revoke copy (finding 15):** "Revoking disables this link immediately. Are you sure?" now shows only during the two-step confirm, not as idle text below the public link.
- **Transactional emails (finding 15):** signup + feedback emails use `<E.Heading as="h1">` with bare `<E.Text>` instead of a nested `<h1><E.Text>` (matching `friend-request-received`); the signup verification code renders in a prominent letter-spaced block.

> Finding 9's ToS-checkbox `aria-label` already shipped in #410, so it's not repeated here.

### Tests
- New: `share-conversion.test.tsx`; extended `top-nav`, `verify.dom` (auto-submit), `wishlist-share-dialog` (revoke gating).
- E2E: verify-flow tests drop the now-redundant Submit click and assert the resulting URL (doubles as the auto-submit regression test); `CODE_REGEX` gained `\s*` since signup now renders the code on its own line.
- Unit **1014 passed**; full e2e **86 passed / 7 skipped / 0 failed**; typecheck + lint clean.