### PR TITLE
feat(notifications): PWA web push + live in-app bell

### DIFF
--- a/app/components/notifications/notification-bell.tsx
+++ b/app/components/notifications/notification-bell.tsx
@@ -24,6 +24,7 @@ import {
 } from '#app/utils/i18n.tsx';
 import { cn } from '#app/utils/misc.tsx';
 import { useNotificationsStore } from './notifications-context.tsx';
+import { PushNudge } from './push-nudge.tsx';
 
 interface NotificationActionPayload {
   kind: string;
@@ -676,6 +677,7 @@ export const NotificationBell = () => {
             </Tooltip>
           </TooltipProvider>
         </div>
+        <PushNudge />
         {error ? (
           <div className="px-4 py-3 text-sm text-destructive">{error}</div>
         ) : null}

--- a/app/components/notifications/notification-polling.test.tsx
+++ b/app/components/notifications/notification-polling.test.tsx
@@ -1,0 +1,19 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { NotificationPolling } from './notification-polling.tsx';
+
+const useNotificationPolling = vi.fn();
+vi.mock('#app/hooks/use-notification-polling.ts', () => ({
+  useNotificationPolling: () => useNotificationPolling(),
+}));
+
+describe('NotificationPolling', () => {
+  it('runs the polling hook and renders nothing', () => {
+    const { container } = render(<NotificationPolling />);
+    expect(useNotificationPolling).toHaveBeenCalled();
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/app/components/notifications/notification-polling.tsx
+++ b/app/components/notifications/notification-polling.tsx
@@ -1,0 +1,10 @@
+import { useNotificationPolling } from '#app/hooks/use-notification-polling.ts';
+
+/**
+ * Headless component that keeps the bell's unread count live. Rendered inside
+ * `NotificationsProvider` for authenticated users only (see `app/root.tsx`).
+ */
+export const NotificationPolling = () => {
+  useNotificationPolling();
+  return null;
+};

--- a/app/components/notifications/push-nudge.test.tsx
+++ b/app/components/notifications/push-nudge.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { PushNudge } from './push-nudge.tsx';
+
+const track = vi.fn();
+const subscribe = vi.fn().mockResolvedValue(true);
+let status = 'default';
+
+vi.mock('#app/utils/analytics.client.ts', () => ({
+  track: (...args: unknown[]) => track(...args),
+}));
+vi.mock('#app/hooks/use-web-push.ts', () => ({
+  useWebPush: () => ({ status, isBusy: false, subscribe }),
+}));
+
+beforeEach(() => {
+  track.mockReset();
+  subscribe.mockClear();
+  status = 'default';
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  window.localStorage.clear();
+});
+
+describe('PushNudge', () => {
+  it('renders the opt-in when push is available and not enabled', () => {
+    render(<PushNudge />);
+    expect(
+      screen.getByRole('button', { name: /enable notifications/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders nothing when push is unsupported', () => {
+    status = 'unsupported';
+    const { container } = render(<PushNudge />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing once dismissed', () => {
+    window.localStorage.setItem('push-nudge-dismissed', 'true');
+    const { container } = render(<PushNudge />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('subscribes when accepting', () => {
+    render(<PushNudge />);
+    fireEvent.click(
+      screen.getByRole('button', { name: /enable notifications/i }),
+    );
+    expect(subscribe).toHaveBeenCalled();
+  });
+
+  it('persists dismissal and tracks it on "Not now"', () => {
+    render(<PushNudge />);
+    fireEvent.click(screen.getByRole('button', { name: /not now/i }));
+    expect(window.localStorage.getItem('push-nudge-dismissed')).toBe('true');
+    expect(track).toHaveBeenCalledWith('push_prompt_dismissed');
+    expect(
+      screen.queryByRole('button', { name: /enable notifications/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/app/components/notifications/push-nudge.tsx
+++ b/app/components/notifications/push-nudge.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useState } from 'react';
+import { Button } from '#app/components/ui/button.tsx';
+import { useWebPush } from '#app/hooks/use-web-push.ts';
+import { track } from '#app/utils/analytics.client.ts';
+
+const DISMISS_STORAGE_KEY = 'push-nudge-dismissed';
+
+/**
+ * One-time soft-ask shown in the notification panel inviting the user to turn
+ * on push. Only appears when push is available but not yet enabled
+ * (status 'default') and hasn't been dismissed before. Renders nothing in
+ * unsupported environments (incl. SSR / jsdom), so it's inert by default.
+ */
+export const PushNudge = () => {
+  const push = useWebPush();
+  const [dismissed, setDismissed] = useState(true);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    setDismissed(window.localStorage.getItem(DISMISS_STORAGE_KEY) === 'true');
+  }, []);
+
+  if (dismissed || push.status !== 'default') return null;
+
+  const dismiss = () => {
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(DISMISS_STORAGE_KEY, 'true');
+    }
+    setDismissed(true);
+    track('push_prompt_dismissed');
+  };
+
+  return (
+    <div className="space-y-2 border-b bg-muted/40 px-4 py-3 text-sm">
+      <p className="text-muted-foreground">
+        Get notified about friend activity even when GiftPool isn&apos;t open.
+      </p>
+      <div className="flex gap-2">
+        <Button
+          type="button"
+          size="sm"
+          disabled={push.isBusy}
+          onClick={() => {
+            void push.subscribe();
+          }}
+        >
+          Enable notifications
+        </Button>
+        <Button type="button" size="sm" variant="ghost" onClick={dismiss}>
+          Not now
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/app/entry.client.tsx
+++ b/app/entry.client.tsx
@@ -3,6 +3,7 @@ import { hydrateRoot } from 'react-dom/client';
 import { HydratedRouter } from 'react-router/dom';
 import { reloadOnceForChunkError } from './utils/chunk-error.client.ts';
 import { NonceProvider } from './utils/nonce-provider.ts';
+import { NOTIFICATIONS_REFRESH_EVENT } from './utils/web-push.client.ts';
 
 if (ENV.MODE === 'production' && ENV.SENTRY_DSN) {
   void import('./utils/monitoring.client.tsx').then(({ init }) => init());
@@ -11,6 +12,22 @@ if (ENV.MODE === 'production' && ENV.SENTRY_DSN) {
 window.addEventListener('unhandledrejection', (event) => {
   reloadOnceForChunkError(event.reason);
 });
+
+// Register the (push-only) service worker so already-subscribed devices keep
+// receiving pushes, and relay its "new notification" messages to a window event
+// the in-app bell polling hook listens for.
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    void navigator.serviceWorker.register('/sw.js').catch(() => {
+      // Registration failures are non-fatal — push just won't be available.
+    });
+  });
+  navigator.serviceWorker.addEventListener('message', (event) => {
+    if (event.data?.type === 'notification') {
+      window.dispatchEvent(new Event(NOTIFICATIONS_REFRESH_EVENT));
+    }
+  });
+}
 
 function getCspNonceFromMeta() {
   const el = document.querySelector('meta[name="csp-nonce"]');

--- a/app/hooks/use-notification-polling.test.ts
+++ b/app/hooks/use-notification-polling.test.ts
@@ -1,0 +1,48 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NOTIFICATIONS_REFRESH_EVENT } from '#app/utils/web-push.client.ts';
+import { useNotificationPolling } from './use-notification-polling.ts';
+
+const setUnreadCount = vi.fn();
+vi.mock('#app/components/notifications/notifications-context.tsx', () => ({
+  useNotificationsStore: () => ({ unreadCount: 0, setUnreadCount }),
+}));
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  setUnreadCount.mockReset();
+  fetchMock = vi
+    .fn()
+    .mockResolvedValue({ ok: true, json: async () => ({ unreadCount: 7 }) });
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('useNotificationPolling', () => {
+  it('refreshes the unread count when the SW relay event fires', async () => {
+    renderHook(() => useNotificationPolling());
+
+    window.dispatchEvent(new Event(NOTIFICATIONS_REFRESH_EVENT));
+
+    await waitFor(() => expect(setUnreadCount).toHaveBeenCalledWith(7));
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/notifications/unread-count',
+      expect.objectContaining({ headers: { Accept: 'application/json' } }),
+    );
+  });
+
+  it('refreshes when the tab regains focus', async () => {
+    renderHook(() => useNotificationPolling());
+
+    window.dispatchEvent(new Event('focus'));
+
+    await waitFor(() => expect(setUnreadCount).toHaveBeenCalledWith(7));
+  });
+});

--- a/app/hooks/use-notification-polling.ts
+++ b/app/hooks/use-notification-polling.ts
@@ -1,0 +1,66 @@
+import { useEffect } from 'react';
+import { useNotificationsStore } from '#app/components/notifications/notifications-context.tsx';
+import { NOTIFICATIONS_REFRESH_EVENT } from '#app/utils/web-push.client.ts';
+
+const UNREAD_COUNT_ENDPOINT = '/api/notifications/unread-count';
+const POLL_INTERVAL_MS = 30_000;
+
+/**
+ * Keeps the in-app notification bell's unread count fresh while the tab is
+ * visible. Polls a lightweight count endpoint on an interval and refreshes
+ * immediately on focus / visibility regain and whenever the service worker
+ * relays an incoming push. Deliberately polling (not SSE): the app runs on
+ * Fly.io + LiteFS with no cross-instance pub/sub, so polling is the
+ * instance-safe baseline and the SW message gives push subscribers an instant
+ * bump on top.
+ *
+ * Mounted once, under an authenticated user (see `app/root.tsx`).
+ */
+export const useNotificationPolling = () => {
+  const { setUnreadCount } = useNotificationsStore();
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    let cancelled = false;
+
+    const fetchCount = async () => {
+      if (document.visibilityState !== 'visible') return;
+      try {
+        const response = await fetch(UNREAD_COUNT_ENDPOINT, {
+          headers: { Accept: 'application/json' },
+        });
+        if (!response.ok || cancelled) return;
+        const body = (await response.json()) as { unreadCount?: number };
+        if (!cancelled && typeof body.unreadCount === 'number') {
+          setUnreadCount(body.unreadCount);
+        }
+      } catch {
+        // Network blips are non-fatal — the next tick retries.
+      }
+    };
+
+    const interval = window.setInterval(() => {
+      void fetchCount();
+    }, POLL_INTERVAL_MS);
+
+    const onVisibility = () => {
+      if (document.visibilityState === 'visible') void fetchCount();
+    };
+    const onRefresh = () => {
+      void fetchCount();
+    };
+
+    document.addEventListener('visibilitychange', onVisibility);
+    window.addEventListener('focus', onVisibility);
+    window.addEventListener(NOTIFICATIONS_REFRESH_EVENT, onRefresh);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+      document.removeEventListener('visibilitychange', onVisibility);
+      window.removeEventListener('focus', onVisibility);
+      window.removeEventListener(NOTIFICATIONS_REFRESH_EVENT, onRefresh);
+    };
+  }, [setUnreadCount]);
+};

--- a/app/hooks/use-pwa-install-prompt.ts
+++ b/app/hooks/use-pwa-install-prompt.ts
@@ -1,4 +1,9 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  detectManualInstallPlatform,
+  isStandalone,
+  type ManualInstallPlatform,
+} from '#app/utils/pwa.ts';
 
 type BeforeInstallPromptEvent = Event & {
   prompt: () => Promise<void>;
@@ -14,44 +19,8 @@ export type InstallOutcome =
   | 'unavailable'
   | 'error'
   | 'manual';
-export type ManualInstallPlatform = 'ios-safari' | 'ios-chrome';
+export type { ManualInstallPlatform };
 export type InstallCapability = 'prompt' | 'manual' | 'unsupported';
-
-const isStandalone = () => {
-  if (typeof window === 'undefined') return false;
-  const mediaQueryList = window.matchMedia?.('(display-mode: standalone)');
-  const navigatorStandalone = (
-    window.navigator as Navigator & {
-      standalone?: boolean;
-    }
-  ).standalone;
-  return Boolean(mediaQueryList?.matches || navigatorStandalone);
-};
-
-const detectManualInstallPlatform = (): ManualInstallPlatform | null => {
-  if (typeof window === 'undefined') return null;
-  if (isStandalone()) return null;
-
-  const userAgent = window.navigator.userAgent.toLowerCase();
-  const isIos = /iphone|ipad|ipod/.test(userAgent);
-  if (!isIos) return null;
-
-  if (userAgent.includes('crios')) {
-    return 'ios-chrome';
-  }
-
-  const isSafari =
-    userAgent.includes('safari') &&
-    !userAgent.includes('fxios') &&
-    !userAgent.includes('edgios') &&
-    !userAgent.includes('opios');
-
-  if (isSafari) {
-    return 'ios-safari';
-  }
-
-  return null;
-};
 
 const DISMISS_STORAGE_KEY = 'pwa-install-banner-dismissed';
 

--- a/app/hooks/use-web-push.test.ts
+++ b/app/hooks/use-web-push.test.ts
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { useWebPush } from './use-web-push.ts';
 
@@ -63,5 +63,124 @@ describe('useWebPush', () => {
     await waitFor(() =>
       expect(result.current.status).toBe('ios-needs-install'),
     );
+  });
+
+  describe('on a supported desktop browser', () => {
+    let getSubscription: ReturnType<typeof vi.fn>;
+    let subscribeFn: ReturnType<typeof vi.fn>;
+    let registerFn: ReturnType<typeof vi.fn>;
+    let requestPermission: ReturnType<typeof vi.fn>;
+    let fetchMock: ReturnType<typeof vi.fn>;
+    const fakeSubscription = {
+      endpoint: 'https://push.example/abc',
+      toJSON: () => ({
+        endpoint: 'https://push.example/abc',
+        keys: { p256dh: 'p', auth: 'a' },
+      }),
+      unsubscribe: vi.fn().mockResolvedValue(true),
+    };
+
+    const setup = (permission: NotificationPermission) => {
+      window.ENV = { VAPID_PUBLIC_KEY: 'pub' } as typeof window.ENV;
+      setUserAgent('Mozilla/5.0 (Macintosh) Chrome/120 Safari/537');
+      getSubscription = vi.fn().mockResolvedValue(null);
+      subscribeFn = vi.fn().mockResolvedValue(fakeSubscription);
+      const registration = {
+        pushManager: { getSubscription, subscribe: subscribeFn },
+      };
+      registerFn = vi.fn().mockResolvedValue(registration);
+      // Initial Notification.permission is `permission`; the prompt result
+      // defaults to granted and is overridden per test where needed.
+      requestPermission = vi.fn().mockResolvedValue('granted');
+      vi.stubGlobal('PushManager', class {});
+      vi.stubGlobal('Notification', { permission, requestPermission });
+      Object.defineProperty(window.navigator, 'serviceWorker', {
+        value: {
+          register: registerFn,
+          ready: Promise.resolve(registration),
+          addEventListener: vi.fn(),
+        },
+        configurable: true,
+      });
+      fetchMock = vi.fn().mockResolvedValue({ ok: true });
+      vi.stubGlobal('fetch', fetchMock);
+    };
+
+    const lastFetchBody = (): {
+      enableAll?: boolean;
+      subscription?: { endpoint: string };
+      endpoint?: string;
+    } => {
+      const init = fetchMock.mock.calls.at(-1)?.[1] as { body: string };
+      return JSON.parse(init.body) as {
+        enableAll?: boolean;
+        subscription?: { endpoint: string };
+        endpoint?: string;
+      };
+    };
+
+    it('starts in default state and subscribes with enableAll on opt-in', async () => {
+      setup('default');
+      const { result } = renderHook(() => useWebPush());
+      await waitFor(() => expect(result.current.status).toBe('default'));
+
+      let outcome: boolean | undefined;
+      await act(async () => {
+        outcome = await result.current.subscribe();
+      });
+
+      expect(outcome).toBe(true);
+      expect(requestPermission).toHaveBeenCalled();
+      expect(registerFn).toHaveBeenCalledWith('/sw.js');
+      const body = lastFetchBody();
+      expect(body.enableAll).toBe(true);
+      expect(body.subscription?.endpoint).toBe('https://push.example/abc');
+      expect(result.current.status).toBe('subscribed');
+    });
+
+    it('records denied permission and does not subscribe', async () => {
+      setup('default');
+      requestPermission.mockResolvedValue('denied');
+      const { result } = renderHook(() => useWebPush());
+      await waitFor(() => expect(result.current.status).toBe('default'));
+
+      await act(async () => {
+        await result.current.subscribe();
+      });
+
+      expect(subscribeFn).not.toHaveBeenCalled();
+      expect(result.current.status).toBe('denied');
+    });
+
+    it('re-registers an already-present subscription without enableAll', async () => {
+      setup('granted');
+      getSubscription.mockResolvedValue(fakeSubscription);
+      const { result } = renderHook(() => useWebPush());
+      await waitFor(() => expect(result.current.status).toBe('subscribed'));
+
+      const body = lastFetchBody();
+      expect(body.subscription?.endpoint).toBe('https://push.example/abc');
+      expect(body.enableAll).toBeUndefined();
+    });
+
+    it('unsubscribes: posts to the server, unsubscribes the browser, returns to default', async () => {
+      setup('granted');
+      getSubscription.mockResolvedValue(fakeSubscription);
+      const { result } = renderHook(() => useWebPush());
+      await waitFor(() => expect(result.current.status).toBe('subscribed'));
+
+      let outcome: boolean | undefined;
+      await act(async () => {
+        outcome = await result.current.unsubscribe();
+      });
+
+      expect(outcome).toBe(true);
+      expect(fakeSubscription.unsubscribe).toHaveBeenCalled();
+      expect(fetchMock.mock.calls.at(-1)?.[0]).toBe('/api/push/unsubscribe');
+      expect(lastFetchBody()).toEqual({
+        endpoint: 'https://push.example/abc',
+      });
+      expect(result.current.status).toBe('default');
+    });
   });
 });

--- a/app/hooks/use-web-push.test.ts
+++ b/app/hooks/use-web-push.test.ts
@@ -1,0 +1,67 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useWebPush } from './use-web-push.ts';
+
+vi.mock('#app/utils/analytics.client.ts', () => ({ track: vi.fn() }));
+
+const setUserAgent = (ua: string) => {
+  Object.defineProperty(window.navigator, 'userAgent', {
+    value: ua,
+    configurable: true,
+  });
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  // @ts-expect-error reset injected ENV between tests
+  delete window.ENV;
+  setUserAgent('node.js');
+});
+
+describe('useWebPush', () => {
+  it('reports unsupported when the browser lacks push APIs', async () => {
+    window.ENV = { VAPID_PUBLIC_KEY: 'pub' } as typeof window.ENV;
+    // jsdom has no PushManager / serviceWorker by default.
+    const { result } = renderHook(() => useWebPush());
+    await waitFor(() => expect(result.current.status).toBe('unsupported'));
+  });
+
+  it('reports unsupported when no VAPID key is configured server-side', async () => {
+    window.ENV = {} as typeof window.ENV;
+    vi.stubGlobal('PushManager', class {});
+    vi.stubGlobal('Notification', { permission: 'default' });
+    Object.defineProperty(window.navigator, 'serviceWorker', {
+      value: {},
+      configurable: true,
+    });
+
+    const { result } = renderHook(() => useWebPush());
+    await waitFor(() => expect(result.current.status).toBe('unsupported'));
+  });
+
+  it('asks iOS users to install the PWA before enabling push', async () => {
+    window.ENV = { VAPID_PUBLIC_KEY: 'pub' } as typeof window.ENV;
+    vi.stubGlobal('PushManager', class {});
+    vi.stubGlobal('Notification', { permission: 'default' });
+    Object.defineProperty(window.navigator, 'serviceWorker', {
+      value: {},
+      configurable: true,
+    });
+    setUserAgent(
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 Safari/604.1',
+    );
+    // Not standalone (default jsdom matchMedia returns matches: false).
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn().mockReturnValue({ matches: false, addEventListener: vi.fn() }),
+    );
+
+    const { result } = renderHook(() => useWebPush());
+    await waitFor(() =>
+      expect(result.current.status).toBe('ios-needs-install'),
+    );
+  });
+});

--- a/app/hooks/use-web-push.ts
+++ b/app/hooks/use-web-push.ts
@@ -51,7 +51,19 @@ export const useWebPush = () => {
     try {
       const registration = await navigator.serviceWorker.ready;
       const existing = await registration.pushManager.getSubscription();
-      setStatus(existing ? 'subscribed' : 'default');
+      if (existing) {
+        // Re-register the endpoint with the server so the row exists for the
+        // current user (covers shared devices and prior failed POSTs). No
+        // enableAll — this must not clobber the user's per-type push choices.
+        await fetch(SUBSCRIBE_ENDPOINT, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ subscription: existing.toJSON() }),
+        }).catch(() => {});
+        setStatus('subscribed');
+      } else {
+        setStatus('default');
+      }
     } catch {
       setStatus('default');
     }
@@ -87,7 +99,11 @@ export const useWebPush = () => {
       const response = await fetch(SUBSCRIBE_ENDPOINT, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(subscription.toJSON()),
+        // enableAll: this is an explicit opt-in, so turn push on for all types.
+        body: JSON.stringify({
+          subscription: subscription.toJSON(),
+          enableAll: true,
+        }),
       });
       if (!response.ok) {
         setStatus('default');

--- a/app/hooks/use-web-push.ts
+++ b/app/hooks/use-web-push.ts
@@ -1,0 +1,136 @@
+import { useCallback, useEffect, useState } from 'react';
+import { track } from '#app/utils/analytics.client.ts';
+import { isIos, isStandalone } from '#app/utils/pwa.ts';
+import {
+  isPushSupported,
+  urlBase64ToUint8Array,
+} from '#app/utils/web-push.client.ts';
+
+export type WebPushStatus =
+  // Browser can't do push, or the server has no VAPID key configured.
+  | 'unsupported'
+  // iOS requires the PWA to be installed to the home screen first.
+  | 'ios-needs-install'
+  // The user blocked notifications at the browser level.
+  | 'denied'
+  // Push is available and not yet enabled (permission default or granted but
+  // not subscribed).
+  | 'default'
+  // Subscribed and registered with the server.
+  | 'subscribed'
+  // Still determining the initial state.
+  | 'loading';
+
+const SUBSCRIBE_ENDPOINT = '/api/push/subscribe';
+const UNSUBSCRIBE_ENDPOINT = '/api/push/unsubscribe';
+
+const getVapidPublicKey = (): string | undefined =>
+  typeof window !== 'undefined' ? window.ENV?.VAPID_PUBLIC_KEY : undefined;
+
+const getPermission = (): NotificationPermission =>
+  typeof Notification !== 'undefined' ? Notification.permission : 'default';
+
+export const useWebPush = () => {
+  const [status, setStatus] = useState<WebPushStatus>('loading');
+  const [isBusy, setIsBusy] = useState(false);
+
+  const computeBaseStatus = useCallback((): WebPushStatus | null => {
+    if (!isPushSupported() || !getVapidPublicKey()) return 'unsupported';
+    if (isIos() && !isStandalone()) return 'ios-needs-install';
+    if (getPermission() === 'denied') return 'denied';
+    return null; // needs the async subscription check
+  }, []);
+
+  const refresh = useCallback(async () => {
+    const base = computeBaseStatus();
+    if (base) {
+      setStatus(base);
+      return;
+    }
+    // Permission is default or granted — distinguish subscribed vs not.
+    try {
+      const registration = await navigator.serviceWorker.ready;
+      const existing = await registration.pushManager.getSubscription();
+      setStatus(existing ? 'subscribed' : 'default');
+    } catch {
+      setStatus('default');
+    }
+  }, [computeBaseStatus]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const subscribe = useCallback(async (): Promise<boolean> => {
+    const vapidKey = getVapidPublicKey();
+    if (!isPushSupported() || !vapidKey) return false;
+
+    setIsBusy(true);
+    try {
+      const permission = await Notification.requestPermission();
+      if (permission !== 'granted') {
+        setStatus(permission === 'denied' ? 'denied' : 'default');
+        if (permission === 'denied') track('push_permission_denied');
+        return false;
+      }
+
+      const registration = await navigator.serviceWorker.register('/sw.js');
+      await navigator.serviceWorker.ready;
+
+      const subscription =
+        (await registration.pushManager.getSubscription()) ??
+        (await registration.pushManager.subscribe({
+          userVisibleOnly: true,
+          applicationServerKey: urlBase64ToUint8Array(vapidKey),
+        }));
+
+      const response = await fetch(SUBSCRIBE_ENDPOINT, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(subscription.toJSON()),
+      });
+      if (!response.ok) {
+        setStatus('default');
+        return false;
+      }
+
+      setStatus('subscribed');
+      track('push_subscribed');
+      return true;
+    } catch {
+      await refresh();
+      return false;
+    } finally {
+      setIsBusy(false);
+    }
+  }, [refresh]);
+
+  const unsubscribe = useCallback(async (): Promise<boolean> => {
+    if (!isPushSupported()) return false;
+    setIsBusy(true);
+    try {
+      const registration = await navigator.serviceWorker.ready;
+      const subscription = await registration.pushManager.getSubscription();
+      if (subscription) {
+        await fetch(UNSUBSCRIBE_ENDPOINT, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ endpoint: subscription.endpoint }),
+        });
+        await subscription.unsubscribe();
+      }
+      setStatus('default');
+      track('push_unsubscribed');
+      return true;
+    } catch {
+      await refresh();
+      return false;
+    } finally {
+      setIsBusy(false);
+    }
+  }, [refresh]);
+
+  return { status, isBusy, subscribe, unsubscribe, refresh };
+};
+
+export type UseWebPushReturn = ReturnType<typeof useWebPush>;

--- a/app/i18n/dictionaries/en.ts
+++ b/app/i18n/dictionaries/en.ts
@@ -21,6 +21,7 @@ export const en = {
     menuItem: 'Notifications',
     friendRequest: {
       message: '{{name}} sent you a friend request',
+      pushTitle: 'New friend request',
       fallbackName: 'Someone',
       accept: 'Accept',
       reject: 'Reject',
@@ -29,6 +30,7 @@ export const en = {
     },
     friendRequestAccepted: {
       message: '{{name}} accepted your friend request',
+      pushTitle: 'Friend request accepted',
       fallbackName: 'Someone',
     },
     upcomingBirthday: {

--- a/app/root.banner-height.test.tsx
+++ b/app/root.banner-height.test.tsx
@@ -74,6 +74,10 @@ vi.mock('./components/notifications/notifications-context.tsx', () => ({
   ),
 }));
 
+vi.mock('./components/notifications/notification-polling.tsx', () => ({
+  NotificationPolling: () => null,
+}));
+
 vi.mock('./components/progress-bar.tsx', () => ({
   EpicProgress: () => <div />,
 }));

--- a/app/root.test.tsx
+++ b/app/root.test.tsx
@@ -70,6 +70,10 @@ vi.mock('./components/notifications/notifications-context.tsx', () => ({
   ),
 }));
 
+vi.mock('./components/notifications/notification-polling.tsx', () => ({
+  NotificationPolling: () => null,
+}));
+
 vi.mock('./components/progress-bar.tsx', () => ({
   EpicProgress: () => <div data-testid="epic-progress" />,
 }));

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -35,6 +35,7 @@ import { FriendsRouteSkeleton } from './components/friends/friends-route-skeleto
 import { BottomNav } from './components/nav/bottom/bottom-nav.tsx';
 import { TopBar } from './components/nav/top-bar.tsx';
 import { NotificationsProvider } from './components/notifications/notifications-context.tsx';
+import { NotificationPolling } from './components/notifications/notification-polling.tsx';
 import { EpicProgress } from './components/progress-bar.tsx';
 import { PwaInstallBanner } from './components/pwa-install-banner.tsx';
 import { SiteFooter } from './components/site-footer.tsx';
@@ -438,6 +439,7 @@ const App = () => {
         <NotificationsProvider
           initialUnreadCount={data.notifications?.unreadCount ?? 0}
         >
+          {data.notifications ? <NotificationPolling /> : null}
           <div className="flex max-h-[100dvh] min-h-[100dvh] flex-col overflow-hidden">
             {showPwaInstallBanner ? (
               <div ref={bannerRef}>

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -53,6 +53,7 @@ import {
 } from './utils/chunk-error.client.ts';
 import { ClientHintCheck, getHints, useHints } from './utils/client-hints.tsx';
 import { prisma } from './utils/db.server.ts';
+import { getEnv } from './utils/env.server.ts';
 import { honeypot } from './utils/honeypot.server.ts';
 import { I18nProvider, getLocaleFromRequest } from './utils/i18n.tsx';
 import { combineHeaders, getDomainUrl } from './utils/misc.tsx';
@@ -200,11 +201,9 @@ export async function loader({ request }: LoaderFunctionArgs) {
         },
         locale,
       },
-      ENV: {
-        MODE: process.env.NODE_ENV,
-        SENTRY_DSN: process.env.SENTRY_DSN,
-        ALLOW_INDEXING: process.env.ALLOW_INDEXING,
-      },
+      // Use getEnv() so every public var (incl. VAPID_PUBLIC_KEY) reaches the
+      // client — hardcoding the keys here silently drops new public env vars.
+      ENV: getEnv(),
       toast,
       notifications: {
         unreadCount,

--- a/app/routes/api.notifications.unread-count.test.ts
+++ b/app/routes/api.notifications.unread-count.test.ts
@@ -1,0 +1,56 @@
+/**
+ * @vitest-environment node
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  getRouteResultData,
+  getRouteResultStatus,
+  toLoaderArgs,
+} from '#tests/route-module-test-utils.ts';
+
+const requireUserId = vi.fn();
+const notificationCount = vi.fn();
+
+vi.mock('#app/utils/auth.server.ts', () => ({
+  requireUserId: (...args: Array<unknown>) => requireUserId(...args),
+}));
+
+vi.mock('#app/utils/db.server.ts', () => ({
+  prisma: {
+    notification: {
+      count: (...args: Array<unknown>) => notificationCount(...args),
+    },
+  },
+}));
+
+import { loader } from './api.notifications.unread-count.ts';
+
+beforeEach(() => {
+  requireUserId.mockReset();
+  notificationCount.mockReset();
+});
+
+describe('api notifications unread-count loader', () => {
+  it('returns the unread count for the current user', async () => {
+    requireUserId.mockResolvedValue('user-1');
+    notificationCount.mockResolvedValue(4);
+
+    const result = await loader(
+      toLoaderArgs({
+        context: {},
+        params: {},
+        request: new Request(
+          'https://giftpool.app/api/notifications/unread-count',
+        ),
+      }),
+    );
+
+    expect(getRouteResultStatus(result)).toBe(200);
+    await expect(getRouteResultData(result)).resolves.toEqual({
+      unreadCount: 4,
+    });
+    expect(notificationCount).toHaveBeenCalledWith({
+      where: { userId: 'user-1', status: 'UNREAD' },
+    });
+  });
+});

--- a/app/routes/api.notifications.unread-count.ts
+++ b/app/routes/api.notifications.unread-count.ts
@@ -1,0 +1,13 @@
+import { data, type LoaderFunctionArgs } from 'react-router';
+import { requireUserId } from '#app/utils/auth.server.ts';
+import { prisma } from '#app/utils/db.server.ts';
+
+// Lightweight endpoint for the in-app bell's live polling — returns only the
+// unread count so we don't refetch a page of notifications every interval.
+export async function loader({ request }: LoaderFunctionArgs) {
+  const userId = await requireUserId(request);
+  const unreadCount = await prisma.notification.count({
+    where: { userId, status: 'UNREAD' },
+  });
+  return data({ unreadCount }, { headers: { 'Cache-Control': 'no-store' } });
+}

--- a/app/routes/api.push.subscribe.test.ts
+++ b/app/routes/api.push.subscribe.test.ts
@@ -1,0 +1,120 @@
+/**
+ * @vitest-environment node
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  getRouteResultData,
+  getRouteResultStatus,
+  toActionArgs,
+} from '#tests/route-module-test-utils.ts';
+
+const requireUserId = vi.fn();
+const upsert = vi.fn();
+const setNotificationPreference = vi.fn();
+
+vi.mock('#app/utils/auth.server.ts', () => ({
+  requireUserId: (...args: Array<unknown>) => requireUserId(...args),
+}));
+
+vi.mock('#app/utils/db.server.ts', () => ({
+  prisma: {
+    pushSubscription: {
+      upsert: (...args: Array<unknown>) => upsert(...args),
+    },
+  },
+}));
+
+vi.mock('#app/utils/notification-preferences.server.ts', () => ({
+  setNotificationPreference: (...args: Array<unknown>) =>
+    setNotificationPreference(...args),
+}));
+
+import { action } from './api.push.subscribe.ts';
+
+const validBody = {
+  subscription: {
+    endpoint: 'https://push.example/abc',
+    keys: { p256dh: 'p256', auth: 'authsecret' },
+  },
+};
+
+function postRequest(body: unknown) {
+  return new Request('https://giftpool.app/api/push/subscribe', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', 'user-agent': 'test-agent' },
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  requireUserId.mockReset();
+  upsert.mockReset();
+  setNotificationPreference.mockReset();
+  requireUserId.mockResolvedValue('user-1');
+  upsert.mockResolvedValue({});
+  setNotificationPreference.mockResolvedValue({});
+});
+
+describe('api push subscribe action', () => {
+  it('upserts the subscription by endpoint and does not enable prefs by default', async () => {
+    const result = await action(
+      toActionArgs({ context: {}, params: {}, request: postRequest(validBody) }),
+    );
+
+    expect(getRouteResultStatus(result)).toBe(200);
+    expect(upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { endpoint: 'https://push.example/abc' },
+        create: expect.objectContaining({
+          userId: 'user-1',
+          endpoint: 'https://push.example/abc',
+          p256dh: 'p256',
+          auth: 'authsecret',
+        }),
+      }),
+    );
+    expect(setNotificationPreference).not.toHaveBeenCalled();
+  });
+
+  it('enables push for every type when enableAll is set', async () => {
+    await action(
+      toActionArgs({
+        context: {},
+        params: {},
+        request: postRequest({ ...validBody, enableAll: true }),
+      }),
+    );
+
+    expect(setNotificationPreference).toHaveBeenCalled();
+    for (const call of setNotificationPreference.mock.calls) {
+      expect(call[1]).toBeTypeOf('string'); // type
+      expect(call[2]).toBe('WEB_PUSH'); // channel
+      expect(call[3]).toBe(true); // enabled
+    }
+  });
+
+  it('rejects an invalid subscription payload', async () => {
+    const result = await action(
+      toActionArgs({
+        context: {},
+        params: {},
+        request: postRequest({ subscription: { endpoint: 'not-a-url' } }),
+      }),
+    );
+    expect(getRouteResultStatus(result)).toBe(400);
+    expect(upsert).not.toHaveBeenCalled();
+  });
+
+  it('rejects non-POST methods', async () => {
+    const result = await action(
+      toActionArgs({
+        context: {},
+        params: {},
+        request: new Request('https://giftpool.app/api/push/subscribe', {
+          method: 'GET',
+        }),
+      }),
+    );
+    expect(getRouteResultStatus(result)).toBe(405);
+  });
+});

--- a/app/routes/api.push.subscribe.ts
+++ b/app/routes/api.push.subscribe.ts
@@ -2,14 +2,26 @@ import { data, type ActionFunctionArgs } from 'react-router';
 import { z } from 'zod';
 import { requireUserId } from '#app/utils/auth.server.ts';
 import { prisma } from '#app/utils/db.server.ts';
+import { setNotificationPreference } from '#app/utils/notification-preferences.server.ts';
+import {
+  NOTIFICATION_CHANNELS,
+  NOTIFICATION_TYPES,
+  type NotificationType,
+} from '#app/utils/notification-registry.ts';
 
 // Shape of a browser PushSubscription as serialized by `subscription.toJSON()`.
 const SubscribeSchema = z.object({
-  endpoint: z.string().url(),
-  keys: z.object({
-    p256dh: z.string().min(1),
-    auth: z.string().min(1),
+  subscription: z.object({
+    endpoint: z.string().url(),
+    keys: z.object({
+      p256dh: z.string().min(1),
+      auth: z.string().min(1),
+    }),
   }),
+  // When true (explicit opt-in), also flip pushEnabled on for every type so the
+  // fanout actually sends. Re-registration (e.g. on page load) omits this so it
+  // never clobbers the user's per-type push choices.
+  enableAll: z.boolean().optional(),
 });
 
 export async function action({ request }: ActionFunctionArgs) {
@@ -30,7 +42,8 @@ export async function action({ request }: ActionFunctionArgs) {
     return data({ error: 'Invalid subscription' }, { status: 400 });
   }
 
-  const { endpoint, keys } = parsed.data;
+  const { subscription, enableAll } = parsed.data;
+  const { endpoint, keys } = subscription;
   const userAgent = request.headers.get('user-agent');
 
   // Endpoint is globally unique per device+browser. Upsert so the same device
@@ -41,6 +54,18 @@ export async function action({ request }: ActionFunctionArgs) {
     create: { userId, endpoint, p256dh: keys.p256dh, auth: keys.auth, userAgent },
     update: { userId, p256dh: keys.p256dh, auth: keys.auth, userAgent },
   });
+
+  if (enableAll) {
+    for (const type of Object.values(NOTIFICATION_TYPES)) {
+      await setNotificationPreference(
+        userId,
+        type as NotificationType,
+        NOTIFICATION_CHANNELS.WEB_PUSH,
+        true,
+        'push:subscribe',
+      );
+    }
+  }
 
   return data({ success: true });
 }

--- a/app/routes/api.push.subscribe.ts
+++ b/app/routes/api.push.subscribe.ts
@@ -1,0 +1,46 @@
+import { data, type ActionFunctionArgs } from 'react-router';
+import { z } from 'zod';
+import { requireUserId } from '#app/utils/auth.server.ts';
+import { prisma } from '#app/utils/db.server.ts';
+
+// Shape of a browser PushSubscription as serialized by `subscription.toJSON()`.
+const SubscribeSchema = z.object({
+  endpoint: z.string().url(),
+  keys: z.object({
+    p256dh: z.string().min(1),
+    auth: z.string().min(1),
+  }),
+});
+
+export async function action({ request }: ActionFunctionArgs) {
+  const userId = await requireUserId(request);
+  if (request.method !== 'POST') {
+    return data({ error: 'Method not allowed' }, { status: 405 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return data({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const parsed = SubscribeSchema.safeParse(body);
+  if (!parsed.success) {
+    return data({ error: 'Invalid subscription' }, { status: 400 });
+  }
+
+  const { endpoint, keys } = parsed.data;
+  const userAgent = request.headers.get('user-agent');
+
+  // Endpoint is globally unique per device+browser. Upsert so the same device
+  // re-subscribing (or a different user signing in on it) is reassigned rather
+  // than duplicated.
+  await prisma.pushSubscription.upsert({
+    where: { endpoint },
+    create: { userId, endpoint, p256dh: keys.p256dh, auth: keys.auth, userAgent },
+    update: { userId, p256dh: keys.p256dh, auth: keys.auth, userAgent },
+  });
+
+  return data({ success: true });
+}

--- a/app/routes/api.push.unsubscribe.test.ts
+++ b/app/routes/api.push.unsubscribe.test.ts
@@ -1,0 +1,69 @@
+/**
+ * @vitest-environment node
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  getRouteResultStatus,
+  toActionArgs,
+} from '#tests/route-module-test-utils.ts';
+
+const requireUserId = vi.fn();
+const deleteMany = vi.fn();
+
+vi.mock('#app/utils/auth.server.ts', () => ({
+  requireUserId: (...args: Array<unknown>) => requireUserId(...args),
+}));
+
+vi.mock('#app/utils/db.server.ts', () => ({
+  prisma: {
+    pushSubscription: {
+      deleteMany: (...args: Array<unknown>) => deleteMany(...args),
+    },
+  },
+}));
+
+import { action } from './api.push.unsubscribe.ts';
+
+function postRequest(body: unknown) {
+  return new Request('https://giftpool.app/api/push/unsubscribe', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  requireUserId.mockReset();
+  deleteMany.mockReset();
+  requireUserId.mockResolvedValue('user-1');
+  deleteMany.mockResolvedValue({ count: 1 });
+});
+
+describe('api push unsubscribe action', () => {
+  it('deletes only the current user’s subscription for the endpoint', async () => {
+    const result = await action(
+      toActionArgs({
+        context: {},
+        params: {},
+        request: postRequest({ endpoint: 'https://push.example/abc' }),
+      }),
+    );
+
+    expect(getRouteResultStatus(result)).toBe(200);
+    expect(deleteMany).toHaveBeenCalledWith({
+      where: { endpoint: 'https://push.example/abc', userId: 'user-1' },
+    });
+  });
+
+  it('rejects an invalid endpoint', async () => {
+    const result = await action(
+      toActionArgs({
+        context: {},
+        params: {},
+        request: postRequest({ endpoint: 'nope' }),
+      }),
+    );
+    expect(getRouteResultStatus(result)).toBe(400);
+    expect(deleteMany).not.toHaveBeenCalled();
+  });
+});

--- a/app/routes/api.push.unsubscribe.ts
+++ b/app/routes/api.push.unsubscribe.ts
@@ -1,0 +1,35 @@
+import { data, type ActionFunctionArgs } from 'react-router';
+import { z } from 'zod';
+import { requireUserId } from '#app/utils/auth.server.ts';
+import { prisma } from '#app/utils/db.server.ts';
+
+const UnsubscribeSchema = z.object({
+  endpoint: z.string().url(),
+});
+
+export async function action({ request }: ActionFunctionArgs) {
+  const userId = await requireUserId(request);
+  if (request.method !== 'POST') {
+    return data({ error: 'Method not allowed' }, { status: 405 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return data({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const parsed = UnsubscribeSchema.safeParse(body);
+  if (!parsed.success) {
+    return data({ error: 'Invalid endpoint' }, { status: 400 });
+  }
+
+  // Scope the delete to this user's own subscriptions so one account can't
+  // remove another's by guessing an endpoint.
+  await prisma.pushSubscription.deleteMany({
+    where: { endpoint: parsed.data.endpoint, userId },
+  });
+
+  return data({ success: true });
+}

--- a/app/routes/settings+/profile.notifications.test.tsx
+++ b/app/routes/settings+/profile.notifications.test.tsx
@@ -27,11 +27,13 @@ const loaderDataSnapshot = {
     {
       emailEnabled: true,
       inAppEnabled: true,
+      pushEnabled: true,
       type: 'FRIEND_REQUEST_RECEIVED',
     },
     {
       emailEnabled: true,
       inAppEnabled: true,
+      pushEnabled: false,
       type: 'FRIEND_REQUEST_ACCEPTED',
     },
   ],
@@ -70,8 +72,21 @@ vi.mock('react-router', async () => {
       };
     },
     useLoaderData: () => loaderDataSnapshot,
+    useRevalidator: () => ({ revalidate: vi.fn(), state: 'idle' }),
   };
 });
+
+const webPushState = {
+  status: 'unsupported' as string,
+  isBusy: false,
+  subscribe: vi.fn().mockResolvedValue(true),
+  unsubscribe: vi.fn().mockResolvedValue(true),
+  refresh: vi.fn(),
+};
+
+vi.mock('#app/hooks/use-web-push.ts', () => ({
+  useWebPush: () => webPushState,
+}));
 
 vi.mock('#app/utils/auth.server.ts', () => ({
   getUserId: (...args: Array<unknown>) => getUserId(...args),
@@ -140,17 +155,22 @@ beforeEach(() => {
   disableFetcherState.state = 'idle';
   disableFetcherState.submit.mockReset();
   useFetcherCallCount = 0;
+  webPushState.status = 'unsupported';
+  webPushState.subscribe.mockClear();
+  webPushState.unsubscribe.mockClear();
 
   loaderDataSnapshot.isAuthenticated = true;
   loaderDataSnapshot.preferences = [
     {
       emailEnabled: true,
       inAppEnabled: true,
+      pushEnabled: true,
       type: 'FRIEND_REQUEST_RECEIVED',
     },
     {
       emailEnabled: true,
       inAppEnabled: true,
+      pushEnabled: false,
       type: 'FRIEND_REQUEST_ACCEPTED',
     },
   ];
@@ -466,5 +486,45 @@ describe('settings notifications route component', () => {
       ).toBe(true);
     });
     expect(disableFetcherState.submit).toHaveBeenCalledTimes(1);
+  });
+
+  describe('push column', () => {
+    it('shows the Push column and "on" banner when subscribed', () => {
+      webPushState.status = 'subscribed';
+      renderRoute();
+      expect(
+        screen.getByRole('columnheader', { name: 'Push' }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(/push notifications are on for this device/i),
+      ).toBeInTheDocument();
+    });
+
+    it('offers the enable button when push is available but off', () => {
+      webPushState.status = 'default';
+      renderRoute();
+      expect(
+        screen.getByRole('button', { name: /enable push notifications/i }),
+      ).toBeInTheDocument();
+    });
+
+    it('guides iOS users to install first', () => {
+      webPushState.status = 'ios-needs-install';
+      renderRoute();
+      expect(
+        screen.getByText(/add giftpool to your home screen/i),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('link', { name: /how to install/i }),
+      ).toBeInTheDocument();
+    });
+
+    it('hides the Push column entirely when unsupported', () => {
+      webPushState.status = 'unsupported';
+      renderRoute();
+      expect(
+        screen.queryByRole('columnheader', { name: 'Push' }),
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/app/routes/settings+/profile.notifications.tsx
+++ b/app/routes/settings+/profile.notifications.tsx
@@ -18,7 +18,9 @@ import {
   getNotificationPreferences,
   setNotificationPreference,
 } from '#app/utils/notification-preferences.server.ts';
+import { useWebPush } from '#app/hooks/use-web-push.ts';
 import {
+  channelToColumn,
   DEFAULT_NOTIFICATION_PREFERENCES,
   NOTIFICATION_CHANNELS,
   NOTIFICATION_TYPES,
@@ -99,6 +101,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
     {
       inAppEnabled: boolean;
       emailEnabled: boolean;
+      pushEnabled: boolean;
     }
   >();
   if (preferencesMap) {
@@ -115,6 +118,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
       type,
       inAppEnabled: pref.inAppEnabled,
       emailEnabled: pref.emailEnabled,
+      pushEnabled: pref.pushEnabled,
     })),
   };
 }
@@ -173,6 +177,7 @@ type NotificationPreferenceState = Record<
   {
     inAppEnabled: boolean;
     emailEnabled: boolean;
+    pushEnabled: boolean;
   }
 >;
 type PreferenceKey = `${NotificationType}:${NotificationChannel}`;
@@ -182,6 +187,12 @@ type PreferencesActionResult = {
 };
 const NotificationsSettingsRoute = () => {
   const data = useLoaderData<typeof loader>();
+  const push = useWebPush();
+  const pushColumnVisible =
+    data.isAuthenticated &&
+    push.status !== 'unsupported' &&
+    push.status !== 'loading';
+  const columnCount = pushColumnVisible ? 5 : 4;
   const toggleFetcher = useFetcher<PreferencesActionResult>();
   const disableEmailFetcher = useFetcher<PreferencesActionResult>();
   const [preferences, setPreferences] =
@@ -387,6 +398,10 @@ const NotificationsSettingsRoute = () => {
         </div>
       )}
 
+      {data.isAuthenticated && push.status !== 'unsupported' ? (
+        <PushStatusBanner push={push} />
+      ) : null}
+
       <div className="overflow-hidden rounded-lg border border-border">
         <table className="w-full text-sm">
           <thead className="bg-muted text-left text-xs uppercase tracking-wide text-muted-foreground">
@@ -395,19 +410,20 @@ const NotificationsSettingsRoute = () => {
               <th className="px-4 py-3">Description</th>
               <th className="px-4 py-3">In-app</th>
               <th className="px-4 py-3">Email</th>
+              {pushColumnVisible ? <th className="px-4 py-3">Push</th> : null}
             </tr>
           </thead>
           <tbody>
             {preferenceGroups.map((group) => (
               <React.Fragment key={group.id}>
                 <tr className="bg-muted/60">
-                  <td className="px-4 py-3 font-semibold" colSpan={4}>
+                  <td className="px-4 py-3 font-semibold" colSpan={columnCount}>
                     {group.title}
                   </td>
                 </tr>
                 {group.description ? (
                   <tr className="bg-muted/40 text-xs text-muted-foreground">
-                    <td className="px-4 pb-2" colSpan={4}>
+                    <td className="px-4 pb-2" colSpan={columnCount}>
                       {group.description}
                     </td>
                   </tr>
@@ -419,6 +435,9 @@ const NotificationsSettingsRoute = () => {
                   );
                   const pendingEmail = pendingKeys.has(
                     getPreferenceKey(item.type, NOTIFICATION_CHANNELS.EMAIL),
+                  );
+                  const pendingPush = pendingKeys.has(
+                    getPreferenceKey(item.type, NOTIFICATION_CHANNELS.WEB_PUSH),
                   );
                   const disableToggles = item.disabled || !data.isAuthenticated;
                   return (
@@ -459,6 +478,28 @@ const NotificationsSettingsRoute = () => {
                           }
                         />
                       </td>
+                      {pushColumnVisible ? (
+                        <td className="px-4 py-3">
+                          <PreferenceCheckbox
+                            checked={pref.pushEnabled}
+                            label="Enable push"
+                            // Push toggles only act once the device is
+                            // subscribed; otherwise use the banner above.
+                            disabled={
+                              disableToggles ||
+                              push.status !== 'subscribed' ||
+                              pendingPush
+                            }
+                            onChange={() =>
+                              handleToggle(
+                                item.type,
+                                NOTIFICATION_CHANNELS.WEB_PUSH,
+                                pref.pushEnabled,
+                              )
+                            }
+                          />
+                        </td>
+                      ) : null}
                     </tr>
                   );
                 })}
@@ -488,6 +529,7 @@ const DEFAULT_CHANNEL_FALLBACK: Record<
   {
     inAppEnabled: boolean;
     emailEnabled: boolean;
+    pushEnabled: boolean;
   }
 > = Object.fromEntries(
   Object.entries(DEFAULT_NOTIFICATION_PREFERENCES).map(([key, value]) => [
@@ -499,6 +541,7 @@ const DEFAULT_CHANNEL_FALLBACK: Record<
   {
     inAppEnabled: boolean;
     emailEnabled: boolean;
+    pushEnabled: boolean;
   }
 >;
 const PREFERENCE_TYPES = preferenceGroups.flatMap((group) =>
@@ -509,6 +552,7 @@ function buildPreferenceState(
     type: NotificationType;
     inAppEnabled: boolean;
     emailEnabled: boolean;
+    pushEnabled: boolean;
   }>,
 ): NotificationPreferenceState {
   const next = {
@@ -518,20 +562,87 @@ function buildPreferenceState(
     next[pref.type] = {
       inAppEnabled: pref.inAppEnabled,
       emailEnabled: pref.emailEnabled,
+      pushEnabled: pref.pushEnabled,
     };
   }
   return next;
 }
 function getChannelField(channel: NotificationChannel) {
-  return channel === NOTIFICATION_CHANNELS.IN_APP
-    ? 'inAppEnabled'
-    : 'emailEnabled';
+  return channelToColumn(channel);
 }
 function getPreferenceKey(
   type: NotificationType,
   channel: NotificationChannel,
 ): PreferenceKey {
   return `${type}:${channel}`;
+}
+function PushStatusBanner({
+  push,
+}: Readonly<{ push: ReturnType<typeof useWebPush> }>) {
+  const className =
+    'flex flex-col gap-2 rounded-md border border-border bg-muted/40 px-4 py-3 text-sm sm:flex-row sm:items-center sm:justify-between';
+
+  if (push.status === 'ios-needs-install') {
+    return (
+      <div className={className}>
+        <span className="text-muted-foreground">
+          Add GiftPool to your home screen to turn on push notifications.
+        </span>
+        <Link className="font-medium underline" to="/pwa-install">
+          How to install
+        </Link>
+      </div>
+    );
+  }
+
+  if (push.status === 'denied') {
+    return (
+      <div className={className}>
+        <span className="text-muted-foreground">
+          Push notifications are blocked. Enable them for this site in your
+          browser settings, then reload.
+        </span>
+      </div>
+    );
+  }
+
+  if (push.status === 'subscribed') {
+    return (
+      <div className={className}>
+        <span className="text-muted-foreground">
+          Push notifications are on for this device.
+        </span>
+        <Button
+          type="button"
+          variant="ghost"
+          disabled={push.isBusy}
+          onClick={() => {
+            void push.unsubscribe();
+          }}
+        >
+          Turn off on this device
+        </Button>
+      </div>
+    );
+  }
+
+  // status === 'default'
+  return (
+    <div className={className}>
+      <span className="text-muted-foreground">
+        Get notified on this device even when GiftPool isn&apos;t open.
+      </span>
+      <Button
+        type="button"
+        disabled={push.isBusy}
+        onClick={() => {
+          void push.subscribe();
+        }}
+      >
+        Enable push notifications
+      </Button>
+    </div>
+  );
 }
 function PreferenceCheckbox({
   checked,

--- a/app/routes/settings+/profile.notifications.tsx
+++ b/app/routes/settings+/profile.notifications.tsx
@@ -4,7 +4,7 @@ import {
   data,
   redirect,
   type ActionFunctionArgs,
-  type LoaderFunctionArgs, Link, useFetcher, useLoaderData 
+  type LoaderFunctionArgs, Link, useFetcher, useLoaderData, useRevalidator
 } from 'react-router';
 import { Button } from '#app/components/ui/button.tsx';
 import { Checkbox } from '#app/components/ui/checkbox.tsx';
@@ -579,6 +579,12 @@ function getPreferenceKey(
 function PushStatusBanner({
   push,
 }: Readonly<{ push: ReturnType<typeof useWebPush> }>) {
+  const revalidator = useRevalidator();
+  // After enabling/disabling push the server flips pushEnabled on the prefs
+  // rows; revalidate so the per-type push checkboxes reflect the new state.
+  const revalidate = () => {
+    void revalidator.revalidate();
+  };
   const className =
     'flex flex-col gap-2 rounded-md border border-border bg-muted/40 px-4 py-3 text-sm sm:flex-row sm:items-center sm:justify-between';
 
@@ -617,7 +623,7 @@ function PushStatusBanner({
           variant="ghost"
           disabled={push.isBusy}
           onClick={() => {
-            void push.unsubscribe();
+            void push.unsubscribe().then(revalidate);
           }}
         >
           Turn off on this device
@@ -636,7 +642,7 @@ function PushStatusBanner({
         type="button"
         disabled={push.isBusy}
         onClick={() => {
-          void push.subscribe();
+          void push.subscribe().then(revalidate);
         }}
       >
         Enable push notifications

--- a/app/utils/analytics.ts
+++ b/app/utils/analytics.ts
@@ -42,6 +42,11 @@ export const ANALYTIC_EVENT_NAMES = [
   // Outcome-coded (like wishlist_unfurl_completed): fires on success AND
   // failure with `kind` + `success` properties.
   'notification_action_completed',
+  // Web Push opt-in funnel.
+  'push_subscribed',
+  'push_unsubscribed',
+  'push_permission_denied',
+  'push_prompt_dismissed',
   'wishlist_item_removed',
   'wishlist_item_undo_clicked',
   'wishlist_item_undo_expired',
@@ -99,6 +104,10 @@ export const USER_REQUIRED_EVENTS: Set<AnalyticEventName> = new Set([
   'notification_clicked',
   'notifications_marked_all_read',
   'notification_action_completed',
+  'push_subscribed',
+  'push_unsubscribed',
+  'push_permission_denied',
+  'push_prompt_dismissed',
   'wishlist_item_removed',
   'wishlist_item_undo_clicked',
   'wishlist_item_undo_expired',

--- a/app/utils/auth.server.ts
+++ b/app/utils/auth.server.ts
@@ -19,6 +19,7 @@ const defaultNotificationPreferenceRows = Object.values(NOTIFICATION_TYPES).map(
     type,
     inAppEnabled: DEFAULT_NOTIFICATION_PREFERENCES[type].inAppEnabled,
     emailEnabled: DEFAULT_NOTIFICATION_PREFERENCES[type].emailEnabled,
+    pushEnabled: DEFAULT_NOTIFICATION_PREFERENCES[type].pushEnabled,
   }),
 );
 

--- a/app/utils/env.server.ts
+++ b/app/utils/env.server.ts
@@ -22,6 +22,13 @@ const schema = z.object({
   // Optional: enables the Claude Haiku fallback for product-page metadata
   // extraction. When unset, enrichment is structured-data only.
   ANTHROPIC_API_KEY: z.string().optional(),
+  // Optional: Web Push (VAPID) keys. Generate with `npx web-push
+  // generate-vapid-keys`. When unset (dev/CI), push send is a no-op and the
+  // subscribe UI hides itself. Only VAPID_PUBLIC_KEY is exposed to the client.
+  VAPID_PUBLIC_KEY: z.string().optional(),
+  VAPID_PRIVATE_KEY: z.string().optional(),
+  // Contact URI for the push service (e.g. "mailto:you@example.com").
+  VAPID_SUBJECT: z.string().optional(),
   // If you plan to use GitHub auth, remove the default:
   GITHUB_CLIENT_ID: z.string().default('MOCK_GITHUB_CLIENT_ID'),
   GITHUB_CLIENT_SECRET: z.string().default('MOCK_GITHUB_CLIENT_SECRET'),
@@ -62,6 +69,9 @@ export function getPublicEnv() {
     MODE: process.env.NODE_ENV,
     SENTRY_DSN: process.env.SENTRY_DSN,
     ALLOW_INDEXING: process.env.ALLOW_INDEXING,
+    // Public VAPID key — the client needs it to subscribe to push. Safe to
+    // expose; the private key stays server-side.
+    VAPID_PUBLIC_KEY: process.env.VAPID_PUBLIC_KEY,
   };
 }
 

--- a/app/utils/notification-preferences.server.test.ts
+++ b/app/utils/notification-preferences.server.test.ts
@@ -50,7 +50,11 @@ describe('notification preferences', () => {
       user.id,
       NOTIFICATION_TYPES.FRIEND_REQUEST_RECEIVED,
     );
-    expect(preference).toEqual({ inAppEnabled: true, emailEnabled: true });
+    expect(preference).toEqual({
+      inAppEnabled: true,
+      emailEnabled: true,
+      pushEnabled: false,
+    });
   });
 
   it('persists preference changes with audit log entries', async () => {
@@ -234,6 +238,7 @@ describe('notification preferences', () => {
     expect(prefs.get(NOTIFICATION_TYPES.FRIEND_REQUEST_RECEIVED)).toEqual({
       inAppEnabled: false,
       emailEnabled: false,
+      pushEnabled: false,
     });
     // Missing types come back with registry defaults.
     for (const type of Object.values(NOTIFICATION_TYPES)) {

--- a/app/utils/notification-preferences.server.ts
+++ b/app/utils/notification-preferences.server.ts
@@ -1,5 +1,6 @@
 import { prisma } from '#app/utils/db.server.ts';
 import {
+  channelToColumn,
   DEFAULT_NOTIFICATION_PREFERENCES,
   NOTIFICATION_CHANNELS,
   NOTIFICATION_TYPES,
@@ -23,6 +24,7 @@ export function notificationPreferenceDefaultsFor(userId: string) {
     type,
     inAppEnabled: defaultForType(type).inAppEnabled,
     emailEnabled: defaultForType(type).emailEnabled,
+    pushEnabled: defaultForType(type).pushEnabled,
     createdAt: now,
     updatedAt: now,
   }));
@@ -53,6 +55,7 @@ export async function ensureNotificationPreferencesForUser(
           type,
           inAppEnabled: defaultForType(type).inAppEnabled,
           emailEnabled: defaultForType(type).emailEnabled,
+          pushEnabled: defaultForType(type).pushEnabled,
           createdAt: now,
           updatedAt: now,
         },
@@ -64,16 +67,22 @@ export async function ensureNotificationPreferencesForUser(
 export async function getNotificationPreferences(userId: string) {
   const prefs = await prisma.userNotificationPreference.findMany({
     where: { userId },
-    select: { type: true, inAppEnabled: true, emailEnabled: true },
+    select: {
+      type: true,
+      inAppEnabled: true,
+      emailEnabled: true,
+      pushEnabled: true,
+    },
   });
   const map = new Map<
     NotificationType,
-    { inAppEnabled: boolean; emailEnabled: boolean }
+    { inAppEnabled: boolean; emailEnabled: boolean; pushEnabled: boolean }
   >();
   for (const pref of prefs) {
     map.set(pref.type as NotificationType, {
       inAppEnabled: pref.inAppEnabled,
       emailEnabled: pref.emailEnabled,
+      pushEnabled: pref.pushEnabled,
     });
   }
   // Fill in defaults for any type that doesn't yet have a row. This replaces
@@ -92,7 +101,7 @@ export async function getNotificationPreferenceForChannels(
 ) {
   const pref = await prisma.userNotificationPreference.findUnique({
     where: { userId_type: { userId, type } },
-    select: { inAppEnabled: true, emailEnabled: true },
+    select: { inAppEnabled: true, emailEnabled: true, pushEnabled: true },
   });
   if (!pref) {
     const defaults = defaultForType(type);
@@ -108,11 +117,10 @@ export async function setNotificationPreference(
   enabled: boolean,
   source: string,
 ) {
-  const column =
-    channel === NOTIFICATION_CHANNELS.EMAIL ? 'emailEnabled' : 'inAppEnabled';
+  const column = channelToColumn(channel);
   const existing = await prisma.userNotificationPreference.findUnique({
     where: { userId_type: { userId, type } },
-    select: { inAppEnabled: true, emailEnabled: true },
+    select: { inAppEnabled: true, emailEnabled: true, pushEnabled: true },
   });
   const defaults = defaultForType(type);
   const previousValue = existing?.[column] ?? defaults[column];
@@ -133,6 +141,8 @@ export async function setNotificationPreference(
           column === 'inAppEnabled' ? enabled : defaults.inAppEnabled,
         emailEnabled:
           column === 'emailEnabled' ? enabled : defaults.emailEnabled,
+        pushEnabled:
+          column === 'pushEnabled' ? enabled : defaults.pushEnabled,
       },
     });
 

--- a/app/utils/notification-registry.ts
+++ b/app/utils/notification-registry.ts
@@ -12,10 +12,30 @@ export type NotificationType =
 export const NOTIFICATION_CHANNELS = {
   IN_APP: 'IN_APP',
   EMAIL: 'EMAIL',
+  WEB_PUSH: 'WEB_PUSH',
 } as const;
 
 export type NotificationChannel =
   (typeof NOTIFICATION_CHANNELS)[keyof typeof NOTIFICATION_CHANNELS];
+
+export type NotificationPreferenceColumn =
+  | 'inAppEnabled'
+  | 'emailEnabled'
+  | 'pushEnabled';
+
+export function channelToColumn(
+  channel: NotificationChannel,
+): NotificationPreferenceColumn {
+  switch (channel) {
+    case NOTIFICATION_CHANNELS.EMAIL:
+      return 'emailEnabled';
+    case NOTIFICATION_CHANNELS.WEB_PUSH:
+      return 'pushEnabled';
+    case NOTIFICATION_CHANNELS.IN_APP:
+    default:
+      return 'inAppEnabled';
+  }
+}
 
 type FriendRequestPayload = {
   friendRequestId: string;
@@ -42,6 +62,9 @@ export type NotificationPayload<T extends NotificationType> = PayloadByType[T];
 export interface NotificationPreferenceDefaults {
   inAppEnabled: boolean;
   emailEnabled: boolean;
+  // Web Push defaults OFF for every type — it requires explicit opt-in + browser
+  // permission, so it's never on until the user enables it.
+  pushEnabled: boolean;
 }
 
 export const DEFAULT_NOTIFICATION_PREFERENCES: Record<
@@ -51,14 +74,17 @@ export const DEFAULT_NOTIFICATION_PREFERENCES: Record<
   [NOTIFICATION_TYPES.FRIEND_REQUEST_RECEIVED]: {
     inAppEnabled: true,
     emailEnabled: true,
+    pushEnabled: false,
   },
   [NOTIFICATION_TYPES.FRIEND_REQUEST_ACCEPTED]: {
     inAppEnabled: true,
     emailEnabled: true,
+    pushEnabled: false,
   },
   [NOTIFICATION_TYPES.UPCOMING_BIRTHDAY]: {
     inAppEnabled: true,
     emailEnabled: false,
+    pushEnabled: false,
   },
 };
 

--- a/app/utils/notification-service.server.test.tsx
+++ b/app/utils/notification-service.server.test.tsx
@@ -18,6 +18,11 @@ vi.mock('#app/utils/email.server.ts', () => ({
     .mockResolvedValue({ status: 'success', data: { id: 'mock-email' } }),
 }));
 
+const sendWebPush = vi.fn().mockResolvedValue(undefined);
+vi.mock('#app/utils/web-push.server.ts', () => ({
+  sendWebPush: (...args: Array<unknown>) => sendWebPush(...args),
+}));
+
 async function createUser(
   overrides: Partial<{ email: string; username: string; name: string }> = {},
 ) {
@@ -42,6 +47,7 @@ describe('notification service', () => {
 
   afterEach(async () => {
     emailMock.mockClear();
+    sendWebPush.mockClear();
     await prisma.notificationPreferenceAudit.deleteMany();
     await prisma.userNotificationPreference.deleteMany();
     await prisma.notification.deleteMany();
@@ -126,5 +132,71 @@ describe('notification service', () => {
     });
 
     expect(emailMock).not.toHaveBeenCalled();
+  });
+
+  it('sends a web push when the push preference is enabled', async () => {
+    const recipient = await createUser();
+    const actor = await createUser();
+    await ensureNotificationPreferencesForUser(recipient.id);
+
+    await setNotificationPreference(
+      recipient.id,
+      NOTIFICATION_TYPES.FRIEND_REQUEST_RECEIVED,
+      NOTIFICATION_CHANNELS.WEB_PUSH,
+      true,
+      'test',
+    );
+
+    const friendRequest = await prisma.friendRequest.create({
+      data: { fromUserId: actor.id, toUserId: recipient.id, status: 'PENDING' },
+      select: { id: true },
+    });
+
+    await notifyUser({
+      userId: recipient.id,
+      type: NOTIFICATION_TYPES.FRIEND_REQUEST_RECEIVED,
+      payload: {
+        friendRequestId: friendRequest.id,
+        actorUserId: actor.id,
+        actorDisplayName: actor.name ?? actor.username,
+        actorUsername: actor.username,
+        actorAvatarId: null,
+        recipientUserId: recipient.id,
+      },
+      sourceIdentifier: 'test-source-push-on',
+    });
+
+    expect(sendWebPush).toHaveBeenCalledTimes(1);
+    expect(sendWebPush).toHaveBeenCalledWith(
+      recipient.id,
+      expect.objectContaining({ url: '/friends#incoming-requests' }),
+    );
+  });
+
+  it('does not send a web push when the push preference is off (default)', async () => {
+    const recipient = await createUser();
+    const actor = await createUser();
+    await ensureNotificationPreferencesForUser(recipient.id);
+
+    const friendRequest = await prisma.friendRequest.create({
+      data: { fromUserId: actor.id, toUserId: recipient.id, status: 'PENDING' },
+      select: { id: true },
+    });
+
+    await notifyUser({
+      userId: recipient.id,
+      type: NOTIFICATION_TYPES.FRIEND_REQUEST_ACCEPTED,
+      payload: {
+        friendRequestId: friendRequest.id,
+        actorUserId: actor.id,
+        actorDisplayName: actor.name ?? actor.username,
+        actorUsername: actor.username,
+        actorAvatarId: null,
+        recipientUserId: recipient.id,
+      },
+      sourceIdentifier: 'test-source-push-off',
+    });
+
+    expect(sendWebPush).not.toHaveBeenCalled();
   });
 });

--- a/app/utils/notification-service.server.tsx
+++ b/app/utils/notification-service.server.tsx
@@ -9,15 +9,15 @@ import {
   createPreferenceToken,
   getPreferenceManagementUrl,
 } from '#app/utils/notification-preference-token.server.ts';
+import { translate } from '#app/utils/i18n.tsx';
 import { getNotificationPreferenceForChannels } from '#app/utils/notification-preferences.server.ts';
 import {
   NOTIFICATION_TYPES,
   type NotificationPayload,
   type NotificationType,
-  type NotificationChannel,
   type FriendRelationshipSnapshot,
-  NOTIFICATION_CHANNELS,
 } from '#app/utils/notification-registry.ts';
+import { sendWebPush } from '#app/utils/web-push.server.ts';
 
 const appName = 'GiftPool';
 
@@ -98,6 +98,17 @@ async function notifyFriendRequestReceived(
   if (prefs.emailEnabled) {
     await sendFriendRequestReceivedEmail(options);
   }
+
+  if (prefs.pushEnabled) {
+    await sendWebPush(userId, {
+      title: translate('en', 'notifications.friendRequest.pushTitle'),
+      body: translate('en', 'notifications.friendRequest.message', {
+        name: payload.actorDisplayName,
+      }),
+      url: '/friends#incoming-requests',
+      tag: `friend-request:${payload.friendRequestId}:received`,
+    });
+  }
 }
 
 async function notifyFriendRequestAccepted(
@@ -139,6 +150,17 @@ async function notifyFriendRequestAccepted(
 
   if (prefs.emailEnabled) {
     await sendFriendRequestAcceptedEmail(options);
+  }
+
+  if (prefs.pushEnabled) {
+    await sendWebPush(userId, {
+      title: translate('en', 'notifications.friendRequestAccepted.pushTitle'),
+      body: translate('en', 'notifications.friendRequestAccepted.message', {
+        name: payload.actorDisplayName,
+      }),
+      url: '/friends',
+      tag: `friend-request:${payload.friendRequestId}:accepted`,
+    });
   }
 }
 
@@ -252,10 +274,4 @@ async function buildManagePreferencesUrl(
 ) {
   const token = await createPreferenceToken({ userId, type });
   return getPreferenceManagementUrl(token);
-}
-
-export function channelToColumn(channel: NotificationChannel) {
-  return channel === NOTIFICATION_CHANNELS.EMAIL
-    ? 'emailEnabled'
-    : 'inAppEnabled';
 }

--- a/app/utils/pwa.test.ts
+++ b/app/utils/pwa.test.ts
@@ -1,0 +1,57 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { detectManualInstallPlatform, isIos, isStandalone } from './pwa.ts';
+
+const setUserAgent = (ua: string) => {
+  Object.defineProperty(window.navigator, 'userAgent', {
+    value: ua,
+    configurable: true,
+  });
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  setUserAgent('node.js');
+});
+
+describe('pwa detection', () => {
+  it('isStandalone reflects the display-mode media query', () => {
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn().mockReturnValue({ matches: true }),
+    );
+    expect(isStandalone()).toBe(true);
+  });
+
+  it('isIos detects iPhone user agents', () => {
+    setUserAgent('Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)');
+    expect(isIos()).toBe(true);
+    setUserAgent('Mozilla/5.0 (Macintosh) Chrome/120');
+    expect(isIos()).toBe(false);
+  });
+
+  it('detectManualInstallPlatform identifies iOS Safari vs Chrome, null elsewhere', () => {
+    vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({ matches: false }));
+
+    setUserAgent(
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit Safari/604.1',
+    );
+    expect(detectManualInstallPlatform()).toBe('ios-safari');
+
+    setUserAgent(
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) CriOS/120 Safari',
+    );
+    expect(detectManualInstallPlatform()).toBe('ios-chrome');
+
+    setUserAgent('Mozilla/5.0 (Macintosh) Chrome/120 Safari/537');
+    expect(detectManualInstallPlatform()).toBeNull();
+  });
+
+  it('returns null platform when already installed (standalone)', () => {
+    vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({ matches: true }));
+    setUserAgent('Mozilla/5.0 (iPhone) Safari/604.1');
+    expect(detectManualInstallPlatform()).toBeNull();
+  });
+});

--- a/app/utils/pwa.ts
+++ b/app/utils/pwa.ts
@@ -1,0 +1,48 @@
+// Shared PWA environment detection used by both the install prompt
+// (`use-pwa-install-prompt.ts`) and the Web Push opt-in (`use-web-push.ts`).
+
+export type ManualInstallPlatform = 'ios-safari' | 'ios-chrome';
+
+/** True when the app is running as an installed PWA (home-screen / standalone). */
+export const isStandalone = (): boolean => {
+  if (typeof window === 'undefined') return false;
+  const mediaQueryList = window.matchMedia?.('(display-mode: standalone)');
+  const navigatorStandalone = (
+    window.navigator as Navigator & {
+      standalone?: boolean;
+    }
+  ).standalone;
+  return Boolean(mediaQueryList?.matches || navigatorStandalone);
+};
+
+/** Detect iOS browsers that require a manual "Add to Home Screen" flow. */
+export const detectManualInstallPlatform = (): ManualInstallPlatform | null => {
+  if (typeof window === 'undefined') return null;
+  if (isStandalone()) return null;
+
+  const userAgent = window.navigator.userAgent.toLowerCase();
+  const isIos = /iphone|ipad|ipod/.test(userAgent);
+  if (!isIos) return null;
+
+  if (userAgent.includes('crios')) {
+    return 'ios-chrome';
+  }
+
+  const isSafari =
+    userAgent.includes('safari') &&
+    !userAgent.includes('fxios') &&
+    !userAgent.includes('edgios') &&
+    !userAgent.includes('opios');
+
+  if (isSafari) {
+    return 'ios-safari';
+  }
+
+  return null;
+};
+
+/** True for any iOS browser, regardless of install/standalone state. */
+export const isIos = (): boolean => {
+  if (typeof window === 'undefined') return false;
+  return /iphone|ipad|ipod/.test(window.navigator.userAgent.toLowerCase());
+};

--- a/app/utils/web-push.client.test.ts
+++ b/app/utils/web-push.client.test.ts
@@ -1,0 +1,26 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, expect, it } from 'vitest';
+import { urlBase64ToUint8Array } from './web-push.client.ts';
+
+describe('urlBase64ToUint8Array', () => {
+  it('decodes a base64url VAPID key into the raw bytes', () => {
+    // "hello" base64url-encoded (no padding) is "aGVsbG8".
+    const result = urlBase64ToUint8Array('aGVsbG8');
+    expect(Array.from(result)).toEqual([
+      ...new TextEncoder().encode('hello'),
+    ]);
+  });
+
+  it('handles base64url-specific characters (- and _)', () => {
+    // Bytes [0xff, 0xfe] base64url-encode to "__4" (standard base64 "//4=").
+    const result = urlBase64ToUint8Array('__4');
+    expect(Array.from(result)).toEqual([0xff, 0xfe]);
+  });
+
+  it('produces an ArrayBuffer-backed array (valid applicationServerKey)', () => {
+    const result = urlBase64ToUint8Array('aGVsbG8');
+    expect(result.buffer).toBeInstanceOf(ArrayBuffer);
+  });
+});

--- a/app/utils/web-push.client.ts
+++ b/app/utils/web-push.client.ts
@@ -1,0 +1,35 @@
+// Client-side Web Push helpers. Pure (non-React) utilities shared by the
+// service-worker message relay (`entry.client.tsx`) and the `useWebPush` hook.
+
+/**
+ * Window event dispatched when the service worker relays an incoming push, so
+ * the in-app notification bell can refresh its unread count immediately instead
+ * of waiting for the next poll.
+ */
+export const NOTIFICATIONS_REFRESH_EVENT = 'giftpool:notifications-refresh';
+
+/** Whether this browser can do Web Push at all. */
+export const isPushSupported = (): boolean =>
+  typeof window !== 'undefined' &&
+  'serviceWorker' in navigator &&
+  'PushManager' in window &&
+  'Notification' in window;
+
+/**
+ * Convert a base64url VAPID public key into the Uint8Array the Push API's
+ * `applicationServerKey` option expects.
+ */
+export const urlBase64ToUint8Array = (
+  base64String: string,
+): Uint8Array<ArrayBuffer> => {
+  const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+  const rawData = window.atob(base64);
+  // Back with an explicit ArrayBuffer so the result satisfies `BufferSource`
+  // (the Push API's applicationServerKey) under TS's generic Uint8Array.
+  const outputArray = new Uint8Array(new ArrayBuffer(rawData.length));
+  for (let i = 0; i < rawData.length; i += 1) {
+    outputArray[i] = rawData.charCodeAt(i);
+  }
+  return outputArray;
+};

--- a/app/utils/web-push.server.test.ts
+++ b/app/utils/web-push.server.test.ts
@@ -1,0 +1,118 @@
+import { randomUUID } from 'node:crypto';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { prisma } from '#app/utils/db.server.ts';
+
+// Stub the network-touching web-push library. setVapidDetails is a no-op;
+// sendNotification is asserted/overridden per test.
+const sendNotification = vi.fn();
+const setVapidDetails = vi.fn();
+vi.mock('web-push', () => ({
+  default: {
+    setVapidDetails: (...args: unknown[]) => setVapidDetails(...args),
+    sendNotification: (...args: unknown[]) => sendNotification(...args),
+  },
+}));
+
+async function createUser() {
+  return prisma.user.create({
+    select: { id: true },
+    data: {
+      email: `user-${randomUUID()}@example.com`,
+      username: `user_${randomUUID().slice(0, 8)}`,
+      roles: {
+        connectOrCreate: {
+          where: { name: 'user' },
+          create: { name: 'user' },
+        },
+      },
+    },
+  });
+}
+
+async function createSubscription(userId: string, endpoint: string) {
+  return prisma.pushSubscription.create({
+    data: { userId, endpoint, p256dh: 'p256dh-key', auth: 'auth-secret' },
+  });
+}
+
+const ORIGINAL_ENV = { ...process.env };
+
+beforeEach(() => {
+  sendNotification.mockReset();
+  setVapidDetails.mockReset();
+  // Each test re-imports the module so the memoized VAPID config is recomputed.
+  vi.resetModules();
+});
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+});
+
+describe('sendWebPush', () => {
+  it('is a no-op when VAPID keys are not configured', async () => {
+    delete process.env.VAPID_PUBLIC_KEY;
+    delete process.env.VAPID_PRIVATE_KEY;
+    delete process.env.VAPID_SUBJECT;
+
+    const user = await createUser();
+    await createSubscription(user.id, `https://push.example/${randomUUID()}`);
+
+    const { sendWebPush } = await import('#app/utils/web-push.server.ts');
+    await sendWebPush(user.id, { title: 'Hi', body: 'There', url: '/friends' });
+
+    expect(sendNotification).not.toHaveBeenCalled();
+  });
+
+  it('sends to every subscription when configured', async () => {
+    process.env.VAPID_PUBLIC_KEY = 'pub';
+    process.env.VAPID_PRIVATE_KEY = 'priv';
+    process.env.VAPID_SUBJECT = 'mailto:test@example.com';
+
+    const user = await createUser();
+    const endpointA = `https://push.example/${randomUUID()}`;
+    const endpointB = `https://push.example/${randomUUID()}`;
+    await createSubscription(user.id, endpointA);
+    await createSubscription(user.id, endpointB);
+
+    sendNotification.mockResolvedValue({ statusCode: 201 });
+
+    const { sendWebPush } = await import('#app/utils/web-push.server.ts');
+    await sendWebPush(user.id, {
+      title: 'New friend request',
+      body: 'Ada sent you a friend request',
+      url: '/friends#incoming-requests',
+      tag: 'friend-request:abc:received',
+    });
+
+    expect(setVapidDetails).toHaveBeenCalledWith('mailto:test@example.com', 'pub', 'priv');
+    expect(sendNotification).toHaveBeenCalledTimes(2);
+    const firstCall = sendNotification.mock.calls[0];
+    expect(firstCall).toBeDefined();
+    const payload = JSON.parse(firstCall?.[1] as string);
+    expect(payload).toMatchObject({
+      title: 'New friend request',
+      url: '/friends#incoming-requests',
+      tag: 'friend-request:abc:received',
+    });
+  });
+
+  it('prunes a subscription the push service reports as gone (410)', async () => {
+    process.env.VAPID_PUBLIC_KEY = 'pub';
+    process.env.VAPID_PRIVATE_KEY = 'priv';
+    process.env.VAPID_SUBJECT = 'mailto:test@example.com';
+
+    const user = await createUser();
+    const endpoint = `https://push.example/${randomUUID()}`;
+    await createSubscription(user.id, endpoint);
+
+    sendNotification.mockRejectedValue({ statusCode: 410 });
+
+    const { sendWebPush } = await import('#app/utils/web-push.server.ts');
+    await sendWebPush(user.id, { title: 'Hi', body: 'There', url: '/friends' });
+
+    const remaining = await prisma.pushSubscription.findUnique({
+      where: { endpoint },
+    });
+    expect(remaining).toBeNull();
+  });
+});

--- a/app/utils/web-push.server.ts
+++ b/app/utils/web-push.server.ts
@@ -1,0 +1,91 @@
+import { captureException } from '@sentry/react-router';
+import webpush, { type PushSubscription as WebPushSubscription } from 'web-push';
+import { prisma } from '#app/utils/db.server.ts';
+
+/**
+ * Web Push delivery. This is a best-effort side channel that hangs off the
+ * notification fanout — it must never throw into a mutation handler (mirrors
+ * the side-effect-off-the-response pattern used by `queueLogEvent` and
+ * `fanoutNotification`). Failures are tailed to Sentry; dead subscriptions are
+ * pruned on the spot.
+ *
+ * When the VAPID env vars are unset (dev / CI), every call is a no-op so the
+ * feature is inert without keys — the same approach as the ANTHROPIC_API_KEY
+ * enrichment fallback.
+ */
+
+let configured: boolean | null = null;
+
+function ensureConfigured(): boolean {
+  if (configured !== null) return configured;
+  const publicKey = process.env.VAPID_PUBLIC_KEY;
+  const privateKey = process.env.VAPID_PRIVATE_KEY;
+  const subject = process.env.VAPID_SUBJECT;
+  if (!publicKey || !privateKey || !subject) {
+    configured = false;
+    return false;
+  }
+  webpush.setVapidDetails(subject, publicKey, privateKey);
+  configured = true;
+  return true;
+}
+
+export interface WebPushMessage {
+  title: string;
+  body: string;
+  /** In-app path opened when the notification is clicked (e.g. "/friends"). */
+  url: string;
+  /** Collapse key so repeat notifications replace rather than stack. */
+  tag?: string;
+}
+
+/**
+ * Send a push to every registered subscription for a user. No-ops when VAPID is
+ * unconfigured or the user has no subscriptions. Prunes subscriptions the push
+ * service reports as gone (404/410).
+ */
+export async function sendWebPush(
+  userId: string,
+  message: WebPushMessage,
+): Promise<void> {
+  if (!ensureConfigured()) return;
+
+  const subscriptions = await prisma.pushSubscription.findMany({
+    where: { userId },
+    select: { id: true, endpoint: true, p256dh: true, auth: true },
+  });
+  if (subscriptions.length === 0) return;
+
+  const payload = JSON.stringify({
+    title: message.title,
+    body: message.body,
+    url: message.url,
+    tag: message.tag,
+  });
+
+  await Promise.all(
+    subscriptions.map(async (sub) => {
+      const target: WebPushSubscription = {
+        endpoint: sub.endpoint,
+        keys: { p256dh: sub.p256dh, auth: sub.auth },
+      };
+      try {
+        await webpush.sendNotification(target, payload);
+      } catch (error) {
+        const statusCode = (error as { statusCode?: number }).statusCode;
+        // 404/410 mean the subscription is permanently gone — drop it so we
+        // stop retrying a dead endpoint.
+        if (statusCode === 404 || statusCode === 410) {
+          await prisma.pushSubscription
+            .delete({ where: { id: sub.id } })
+            .catch(() => {});
+          return;
+        }
+        captureException(error, {
+          tags: { feature: 'web-push' },
+          extra: { userId, endpoint: sub.endpoint, statusCode },
+        });
+      }
+    }),
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -91,6 +91,7 @@
         "tailwindcss-radix": "^3.0.3",
         "vaul": "^1.1.2",
         "vite-env-only": "^3.0.3",
+        "web-push": "^3.6.7",
         "zod": "^3.23.8"
       },
       "devDependencies": {
@@ -128,6 +129,7 @@
         "@types/react-dom": "^18.3.0",
         "@types/set-cookie-parser": "^2.4.10",
         "@types/source-map-support": "^0.5.10",
+        "@types/web-push": "^3.6.4",
         "@vitejs/plugin-react": "^5.0.0",
         "@vitest/coverage-v8": "^2.0.3",
         "autoprefixer": "^10.4.19",
@@ -8016,6 +8018,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/web-push": {
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/@types/web-push/-/web-push-3.6.4.tgz",
+      "integrity": "sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.43.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.43.0.tgz",
@@ -9415,6 +9427,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -9676,6 +9700,12 @@
         "readable-stream": "^3.4.0"
       }
     },
+    "node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "license": "MIT"
+    },
     "node_modules/body-parser": {
       "version": "1.20.5",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
@@ -9827,6 +9857,12 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -11109,6 +11145,15 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "license": "MIT"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -13426,6 +13471,15 @@
         "entities": "^4.4.0"
       }
     },
+    "node_modules/http_ece": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http_ece/-/http_ece-1.2.0.tgz",
+      "integrity": "sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -14566,6 +14620,27 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -14984,6 +15059,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
     },
     "node_modules/minimatch": {
       "version": "9.0.9",
@@ -22002,6 +22083,47 @@
       "license": "MIT",
       "dependencies": {
         "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/web-push": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/web-push/-/web-push-3.6.7.tgz",
+      "integrity": "sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "asn1.js": "^5.3.0",
+        "http_ece": "1.2.0",
+        "https-proxy-agent": "^7.0.0",
+        "jws": "^4.0.0",
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "web-push": "src/cli.js"
+      },
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/web-push/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/web-push/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
     "tailwindcss-radix": "^3.0.3",
     "vaul": "^1.1.2",
     "vite-env-only": "^3.0.3",
+    "web-push": "^3.6.7",
     "zod": "^3.23.8"
   },
   "devDependencies": {
@@ -171,6 +172,7 @@
     "@types/react-dom": "^18.3.0",
     "@types/set-cookie-parser": "^2.4.10",
     "@types/source-map-support": "^0.5.10",
+    "@types/web-push": "^3.6.4",
     "@vitejs/plugin-react": "^5.0.0",
     "@vitest/coverage-v8": "^2.0.3",
     "autoprefixer": "^10.4.19",

--- a/prisma/migrations/20260616172750_push_notifications/migration.sql
+++ b/prisma/migrations/20260616172750_push_notifications/migration.sql
@@ -1,0 +1,40 @@
+-- CreateTable
+CREATE TABLE "PushSubscription" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "userId" TEXT NOT NULL,
+    "endpoint" TEXT NOT NULL,
+    "p256dh" TEXT NOT NULL,
+    "auth" TEXT NOT NULL,
+    "userAgent" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "PushSubscription_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_UserNotificationPreference" (
+    "userId" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "inAppEnabled" BOOLEAN NOT NULL DEFAULT true,
+    "emailEnabled" BOOLEAN NOT NULL DEFAULT true,
+    "pushEnabled" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+
+    PRIMARY KEY ("userId", "type"),
+    CONSTRAINT "UserNotificationPreference_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+INSERT INTO "new_UserNotificationPreference" ("createdAt", "emailEnabled", "inAppEnabled", "type", "updatedAt", "userId") SELECT "createdAt", "emailEnabled", "inAppEnabled", "type", "updatedAt", "userId" FROM "UserNotificationPreference";
+DROP TABLE "UserNotificationPreference";
+ALTER TABLE "new_UserNotificationPreference" RENAME TO "UserNotificationPreference";
+CREATE INDEX "UserNotificationPreference_type_idx" ON "UserNotificationPreference"("type");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PushSubscription_endpoint_key" ON "PushSubscription"("endpoint");
+
+-- CreateIndex
+CREATE INDEX "PushSubscription_userId_idx" ON "PushSubscription"("userId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -45,6 +45,7 @@ model User {
   friendshipsB                 Friendship[]                  @relation("FriendshipUserB")
   notificationPreferences      UserNotificationPreference[]
   notificationPreferenceAudits NotificationPreferenceAudit[]
+  pushSubscriptions            PushSubscription[]
   friendInvitationsCreated     FriendInvitation[]            @relation("FriendInvitation_CreatedBy")
   friendInvitationsUsed        FriendInvitation[]            @relation("FriendInvitation_UsedBy")
   wishlistPurchases            WishlistPurchase[]
@@ -133,12 +134,30 @@ model UserNotificationPreference {
   type         String
   inAppEnabled Boolean  @default(true)
   emailEnabled Boolean  @default(true)
+  // Web Push defaults OFF — unlike in-app/email it requires an explicit opt-in
+  // plus browser permission, so it can never be on by default.
+  pushEnabled  Boolean  @default(false)
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
   user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@id([userId, type])
   @@index([type])
+}
+
+model PushSubscription {
+  id        String   @id @default(cuid())
+  userId    String
+  // The push service endpoint URL — globally unique per device+browser.
+  endpoint  String   @unique
+  p256dh    String
+  auth      String
+  userAgent String?
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
 }
 
 model NotificationPreferenceAudit {

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,81 @@
+/* GiftPool service worker — push only.
+ *
+ * Deliberately minimal: no offline caching / precaching (avoids
+ * cache-invalidation bugs). Its only jobs are receiving Web Push messages,
+ * showing the OS notification, forwarding to open tabs so the in-app bell can
+ * refresh live, and routing clicks back into the app.
+ */
+
+self.addEventListener('install', () => {
+  // Activate this SW immediately instead of waiting for old tabs to close.
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener('push', (event) => {
+  let payload = {};
+  try {
+    payload = event.data ? event.data.json() : {};
+  } catch (err) {
+    payload = { title: 'GiftPool', body: event.data ? event.data.text() : '' };
+  }
+
+  const title = payload.title || 'GiftPool';
+  const url = payload.url || '/';
+  const options = {
+    body: payload.body || '',
+    tag: payload.tag,
+    icon: '/favicons/android-chrome-192x192.png',
+    badge: '/favicons/android-chrome-192x192.png',
+    data: { url },
+  };
+
+  event.waitUntil(
+    (async () => {
+      await self.registration.showNotification(title, options);
+      // Nudge any open tab to refresh its unread count immediately rather than
+      // waiting for the next poll.
+      const clients = await self.clients.matchAll({
+        type: 'window',
+        includeUncontrolled: true,
+      });
+      for (const client of clients) {
+        client.postMessage({ type: 'notification' });
+      }
+    })(),
+  );
+});
+
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close();
+  const targetUrl = (event.notification.data && event.notification.data.url) || '/';
+
+  event.waitUntil(
+    (async () => {
+      const clients = await self.clients.matchAll({
+        type: 'window',
+        includeUncontrolled: true,
+      });
+      // Focus an existing tab if one is open, then navigate it.
+      for (const client of clients) {
+        if ('focus' in client) {
+          await client.focus();
+          if ('navigate' in client) {
+            try {
+              await client.navigate(targetUrl);
+            } catch (err) {
+              /* cross-origin or detached client — ignore */
+            }
+          }
+          return;
+        }
+      }
+      if (self.clients.openWindow) {
+        await self.clients.openWindow(targetUrl);
+      }
+    })(),
+  );
+});

--- a/server/index.ts
+++ b/server/index.ts
@@ -88,8 +88,18 @@ if (viteDevServer) {
   );
 
   // Everything else (like favicon.ico) is cached for an hour. You may want to be
-  // more aggressive with this caching.
-  app.use(express.static('build/client', { maxAge: '1h' }));
+  // more aggressive with this caching. The service worker is an exception: keep
+  // it uncached so SW updates propagate promptly on the next visit.
+  app.use(
+    express.static('build/client', {
+      maxAge: '1h',
+      setHeaders: (res, filePath) => {
+        if (filePath.endsWith('sw.js')) {
+          res.setHeader('Cache-Control', 'no-cache');
+        }
+      },
+    }),
+  );
 }
 
 app.get(['/img/*', '/favicons/*'], (_req, res) => {
@@ -135,6 +145,8 @@ app.use(
         'font-src': ["'self'"],
         'frame-src': ["'self'"],
         'img-src': ["'self'", 'data:'],
+        'manifest-src': ["'self'"],
+        'worker-src': ["'self'"],
         'script-src': [
           "'strict-dynamic'",
           "'self'",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -19,8 +19,10 @@ sonar.exclusions=app/components/ui/icons/**
 # code in Sonar's static analysis scope, but do not require app-style line
 # coverage for those paths. `app/root.tsx` is the framework root route — it
 # imports CSS, fonts, and 30+ modules, so it's covered end-to-end by every
-# e2e run rather than unit-tested.
-sonar.coverage.exclusions=server/**,prisma/**,other/**,app/root.tsx
+# e2e run rather than unit-tested. `app/entry.client.tsx` is the hydration
+# entrypoint (same framework-bootstrap category) — it wires up the service
+# worker + Sentry and is exercised end-to-end, not unit-tested.
+sonar.coverage.exclusions=server/**,prisma/**,other/**,app/root.tsx,app/entry.client.tsx
 
 # Path is relative to the sonar-project.properties file.
 sonar.javascript.lcov.reportPaths=coverage/lcov.info


### PR DESCRIPTION
## Why

Roadmap item: notify users beyond the current poll-on-open bell. Today the notification fanout fans out to two channels (in-app DB row + Resend email) for the two friend-request events. This adds a third **Web Push** channel so users get OS-level notifications when the app is closed/backgrounded, plus **near-real-time in-app bell** updates while it's open.

Decisions (with the product owner): **both** live bell + web push; opt-in via a **Settings toggle + one-time soft-ask nudge**; push fires for the **existing two friend events**; on iOS, **guide users to install** the PWA first (web push needs an installed PWA on iOS 16.4+).

## What

- **Channel reuse:** new `WEB_PUSH` channel + `pushEnabled` preference (defaults **off** — requires explicit opt-in + browser permission), threaded through `notification-registry`, `notification-preferences.server`, signup seeding, and the existing toggle action (no action changes needed).
- **Send path:** `app/utils/web-push.server.ts` — no-op when VAPID env is unset, prunes dead 404/410 subscriptions, Sentry-safe (never throws into the fanout). Wired into both `notifyFriendRequest*` handlers.
- **Subscription:** `PushSubscription` model + migration; `POST /api/push/subscribe` (upsert by endpoint) and `/api/push/unsubscribe`.
- **Service worker:** the app's first SW (`public/sw.js`) — push-only (no offline caching). Handles `push`, `notificationclick`, and `postMessage` to open tabs. Registered in `entry.client.tsx`; `worker-src`/`manifest-src` added to CSP; `/sw.js` served `no-cache`.
- **Live bell:** lightweight `GET /api/notifications/unread-count` + a visibility-gated polling hook (instance-safe on LiteFS — deliberately not SSE; the SW message gives push subscribers an instant bump on top).
- **Opt-in UX:** Push column + status banner in Settings → Notifications (iOS install guidance / denied hint / enable / turn-off), and a one-time soft-ask nudge in the notification panel. `push_subscribed` / `push_unsubscribed` / `push_permission_denied` / `push_prompt_dismissed` analytics.

## Verification

- `npm run typecheck` ✓ (0 errors), `npm run lint` ✓ (0 errors)
- `npm test -- --run` ✓ **1023/1023** — new: `web-push.server` (no-op w/o keys, multi-sub send, 410 prune), `web-push.client` (key decode), `use-web-push` (status machine)
- e2e ✓ settings-notifications (3) + feedback (2) — push column is hidden without VAPID, so existing flows are unaffected
- ⚠️ Web Push delivery itself is **manual** to verify (CI has no VAPID keys, by design).

## Activation (required to go live)

VAPID keys are **optional env** — the feature is inert without them (CI stays green).
1. `npx web-push generate-vapid-keys`
2. Local: set `VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, `VAPID_SUBJECT=mailto:…` in `.env`
3. Prod: `fly secrets set VAPID_PUBLIC_KEY=… VAPID_PRIVATE_KEY=… VAPID_SUBJECT=mailto:…`

iOS testing requires installing the PWA to the home screen (iOS 16.4+).