### PR TITLE
fix(mobile): checkbox checkmark, notifications table, feedback sheet, date input

### DIFF
--- a/app/components/feedback/feedback-widget.tsx
+++ b/app/components/feedback/feedback-widget.tsx
@@ -2,13 +2,13 @@ import { useState } from 'react';
 import { LuMessageSquarePlus } from 'react-icons/lu';
 import { useLocation } from 'react-router';
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from '#app/components/ui/dialog.tsx';
+  MobileBottomSheet,
+  MobileBottomSheetContent,
+  MobileBottomSheetDescription,
+  MobileBottomSheetHeader,
+  MobileBottomSheetTitle,
+  MobileBottomSheetTrigger,
+} from '#app/components/ui/mobile-bottom-sheet.tsx';
 import { FeedbackForm } from './feedback-form.tsx';
 
 // Routes where a floating "give feedback" button would be redundant or get in
@@ -34,13 +34,15 @@ export const FeedbackWidget = () => {
   if (suppressed) return null;
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
+    // MobileBottomSheet renders a bottom sheet on mobile and a centered dialog
+    // on desktop — the preferred mobile pattern for transient content.
+    <MobileBottomSheet open={open} onOpenChange={setOpen}>
       {/* Lives in the top-bar cluster next to the bell/theme/avatar — a
           secondary-weight icon, not a floating FAB. A floating button at the
           bottom collided with the wishlist add-item FAB and overlapped the
           bottom nav on iOS (June 2026 audit). Styling mirrors NotificationBell
           so the cluster icons sit uniformly. */}
-      <DialogTrigger asChild>
+      <MobileBottomSheetTrigger asChild>
         <button
           type="button"
           aria-label="Give feedback"
@@ -48,17 +50,17 @@ export const FeedbackWidget = () => {
         >
           <LuMessageSquarePlus className="h-5 w-5" aria-hidden />
         </button>
-      </DialogTrigger>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>Send us feedback</DialogTitle>
-          <DialogDescription>
+      </MobileBottomSheetTrigger>
+      <MobileBottomSheetContent>
+        <MobileBottomSheetHeader>
+          <MobileBottomSheetTitle>Send us feedback</MobileBottomSheetTitle>
+          <MobileBottomSheetDescription>
             Found a bug, have an idea, or a question? We&apos;d love to hear it.
-          </DialogDescription>
-        </DialogHeader>
+          </MobileBottomSheetDescription>
+        </MobileBottomSheetHeader>
         {/* Remount the form per-open so each session starts clean. */}
         {open ? <FeedbackForm /> : null}
-      </DialogContent>
-    </Dialog>
+      </MobileBottomSheetContent>
+    </MobileBottomSheet>
   );
 };

--- a/app/components/ui/checkbox.test.tsx
+++ b/app/components/ui/checkbox.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { Checkbox } from './checkbox.tsx';
+
+describe('Checkbox', () => {
+  it('renders an unchecked checkbox with no visible checkmark', () => {
+    render(<Checkbox aria-label="Agree" />);
+
+    const box = screen.getByRole('checkbox', { name: 'Agree' });
+    expect(box).toHaveAttribute('data-state', 'unchecked');
+    // Radix only mounts the Indicator (and our SVG) once checked.
+    expect(box.querySelector('svg')).toBeNull();
+  });
+
+  it('renders the checkmark SVG when checked', () => {
+    render(<Checkbox aria-label="Agree" checked />);
+
+    const box = screen.getByRole('checkbox', { name: 'Agree' });
+    expect(box).toHaveAttribute('data-state', 'checked');
+
+    const svg = box.querySelector('svg');
+    expect(svg).not.toBeNull();
+    // Explicit size is what makes the check visible rather than a bare square.
+    expect(svg).toHaveClass('h-3', 'w-3');
+    expect(svg!.querySelector('path')).not.toBeNull();
+  });
+
+  it('merges a custom className onto the root', () => {
+    render(<Checkbox aria-label="Agree" className="custom-class" />);
+
+    expect(screen.getByRole('checkbox', { name: 'Agree' })).toHaveClass(
+      'custom-class',
+    );
+  });
+
+  it('toggles when clicked', async () => {
+    const onCheckedChange = vi.fn();
+    render(<Checkbox aria-label="Agree" onCheckedChange={onCheckedChange} />);
+
+    await userEvent.click(screen.getByRole('checkbox', { name: 'Agree' }));
+
+    expect(onCheckedChange).toHaveBeenCalledWith(true);
+  });
+
+  it('does not toggle when disabled', async () => {
+    const onCheckedChange = vi.fn();
+    render(
+      <Checkbox aria-label="Agree" disabled onCheckedChange={onCheckedChange} />,
+    );
+
+    const box = screen.getByRole('checkbox', { name: 'Agree' });
+    expect(box).toBeDisabled();
+    await userEvent.click(box);
+    expect(onCheckedChange).not.toHaveBeenCalled();
+  });
+});

--- a/app/components/ui/checkbox.tsx
+++ b/app/components/ui/checkbox.tsx
@@ -25,11 +25,15 @@ const Checkbox = React.forwardRef<
     <CheckboxPrimitive.Indicator
       className={cn('flex items-center justify-center text-current')}
     >
-      <svg viewBox="0 0 8 8">
+      {/* Explicit size — without it the SVG has no intrinsic dimensions and the
+          checkmark renders invisibly, leaving a bare filled square. */}
+      <svg viewBox="0 0 8 8" className="h-3 w-3" aria-hidden>
         <path
           d="M1,4 L3,6 L7,2"
-          stroke="currentcolor"
-          strokeWidth="1"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
           fill="none"
         />
       </svg>

--- a/app/routes/settings+/profile.notifications.tsx
+++ b/app/routes/settings+/profile.notifications.tsx
@@ -402,7 +402,7 @@ const NotificationsSettingsRoute = () => {
         <PushStatusBanner push={push} />
       ) : null}
 
-      <div className="overflow-hidden rounded-lg border border-border">
+      <div className="overflow-x-auto rounded-lg border border-border">
         <table className="w-full text-sm">
           <thead className="bg-muted text-left text-xs uppercase tracking-wide text-muted-foreground">
             <tr>
@@ -664,7 +664,7 @@ function PreferenceCheckbox({
   return (
     <label
       className={cn(
-        'flex items-center gap-2 text-sm',
+        'flex items-center justify-center text-sm',
         disabled && 'opacity-50',
       )}
     >
@@ -675,7 +675,9 @@ function PreferenceCheckbox({
           if (!disabled) onChange();
         }}
       />
-      <span>{label}</span>
+      {/* The column header already names the channel — keep the per-row label
+          for screen readers only so the table fits narrow viewports. */}
+      <span className="sr-only">{label}</span>
     </label>
   );
 }

--- a/app/styles/tailwind.css
+++ b/app/styles/tailwind.css
@@ -139,6 +139,18 @@
 
     --pool-badge-foreground: 0 0% 100%;
   }
+
+  /* iOS renders native date/time inputs at an intrinsic width that ignores
+     `width: 100%`, overflowing narrow containers, and centers the value.
+     Let them shrink and left-align so they match the other text inputs. */
+  input[type='date'],
+  input[type='datetime-local'],
+  input[type='time'] {
+    min-width: 0;
+  }
+  input::-webkit-date-and-time-value {
+    text-align: left;
+  }
 }
 
 @layer utilities {


### PR DESCRIPTION
Four mobile-polish fixes spotted on-device after the PWA push merge.

## Fixes
1. **Checkbox checkmark (app-wide)** — the indicator `<svg>` had no intrinsic size, so checkboxes rendered as bare coral squares (incl. login "Remember me"). Gave it explicit `h-3 w-3` + a `1.5` round-cap stroke so the check shows.
2. **Notifications settings table** — per-cell channel labels are now `sr-only` (headers already name each channel), so the In-app / Email / Push columns stay compact and all fit; container switched to `overflow-x-auto` as a safety net so no column is unreachable.
3. **Feedback → bottom sheet on mobile** — swapped `Dialog*` for the existing `MobileBottomSheet*` (bottom sheet on mobile, centered dialog on desktop, drag-to-dismiss).
4. **Birthday / date input** — `min-width:0` for native date/time inputs stops the iOS overflow-to-the-right, and `::-webkit-date-and-time-value { text-align:left }` matches the other left-aligned fields.

## Verification
- typecheck ✓, lint ✓ (0 errors)
- unit: feedback-widget ✓, profile.notifications ✓
- feedback e2e ✓ 2/2
- Live mobile screenshot not captured (Chrome extension wasn't connected); changes are deterministic CSS/markup.