### PR TITLE
Fix duplicate optimistic category render (red main after Playwright 1.61)

### DIFF
--- a/app/components/wishlist/hooks/use-wishlist-category-mutations.ts
+++ b/app/components/wishlist/hooks/use-wishlist-category-mutations.ts
@@ -105,8 +105,16 @@ export const useWishlistCategoryMutations = ({
           settledMutations: settledCategoryMutationList,
         }),
         pendingMutations: pendingCategoryMutations,
+        // A create whose result has already settled is represented by its real
+        // category; skip its optimistic placeholder so it doesn't render twice.
+        settledClientMutationIds: new Set(settledCategoryMutations.keys()),
       }),
-    [orderedCategories, pendingCategoryMutations, settledCategoryMutationList],
+    [
+      orderedCategories,
+      pendingCategoryMutations,
+      settledCategoryMutationList,
+      settledCategoryMutations,
+    ],
   );
 
   const handleCategoryMutationResult = useCallback(

--- a/app/components/wishlist/wishlist-category-state.test.ts
+++ b/app/components/wishlist/wishlist-category-state.test.ts
@@ -127,6 +127,39 @@ describe('wishlist category state', () => {
     ]);
   });
 
+  it('does not render a create twice while its settled result and pending fetcher overlap', () => {
+    // The create has returned a server result (settled adds the real category),
+    // but the in-flight fetcher's formData still produces a pending create with
+    // the same clientMutationId until loader revalidation. Without dedup this
+    // window renders the category twice. See wishlist.test.ts drag-reorder.
+    const settledCategories = applySettledCategoryMutations({
+      categories: [],
+      settledMutations: [
+        {
+          ok: true,
+          intent: 'create',
+          clientMutationId: 'create-books',
+          category: booksCategory,
+        },
+      ],
+    });
+
+    const categories = applyPendingCategoryMutations({
+      categories: settledCategories,
+      pendingMutations: [
+        {
+          type: 'create',
+          clientMutationId: 'create-books',
+          name: 'Books',
+          order: 0,
+        },
+      ],
+      settledClientMutationIds: new Set(['create-books']),
+    });
+
+    expect(categories.map((category) => category.name)).toEqual(['Books']);
+  });
+
   it('overlapping successful creates do not collapse to the earlier result', () => {
     const categories = applySettledCategoryMutations({
       categories: [],

--- a/app/components/wishlist/wishlist-category-state.ts
+++ b/app/components/wishlist/wishlist-category-state.ts
@@ -36,14 +36,21 @@ const sortAndRedensifyCategories = (categories: WishlistCategory[]) =>
 export const applyPendingCategoryMutations = ({
   categories,
   pendingMutations,
+  settledClientMutationIds,
 }: {
   categories: WishlistCategory[];
   pendingMutations: PendingCategoryMutation[];
+  // clientMutationIds of creates that already returned a server result. Their
+  // real category is present via applySettledCategoryMutations, so re-inserting
+  // the optimistic placeholder here would render the category twice during the
+  // window before loader revalidation prunes the settled mutation.
+  settledClientMutationIds?: ReadonlySet<string>;
 }) => {
   let next = [...categories];
 
   for (const mutation of pendingMutations) {
     if (mutation.type === 'create') {
+      if (settledClientMutationIds?.has(mutation.clientMutationId)) continue;
       const optimisticId = `optimistic-category:${mutation.clientMutationId}`;
       if (next.some((category) => category.id === optimisticId)) continue;
       next.push({


### PR DESCRIPTION
## Why main is red

`main` went red on the **Playwright 1.61.0 bump (#426)**, not on the audit-deps PR (#428, which was green on main). The failing test is `wishlist.test.ts:362 › owners can drag reorder categories and items across categories`, with a strict-mode violation:

```
getByRole('dialog').getByText('Books') resolved to 2 elements:
  1) <span class="flex-1">Books</span>
  2) <span class="flex-1">Books</span>
```

Both matches are real category-list spans — the dialog genuinely rendered the category **twice**. This test has been long-flaky for the same reason; the Playwright bump (and CI load) just made the window deterministic.

## Root cause

Optimistic category state composes pending fetcher mutations on top of settled server results (`use-wishlist-category-mutations.ts`). When a create returns:

1. `applySettledCategoryMutations` inserts the **real** category.
2. The in-flight fetcher's `formData` still yields a **pending** create (same `clientMutationId`) until loader revalidation.
3. `applyPendingCategoryMutations` only deduped against its own optimistic id, so it re-inserted the placeholder → real + placeholder both rendered.

Under CI load the loader revalidation was slow, holding the duplicate past the 5s assertion timeout.

## Fix

Thread the settled `clientMutationId`s into `applyPendingCategoryMutations` and skip the optimistic placeholder for any create already represented by a settled result. This closes the duplicate window entirely, independent of revalidation timing — no product behavior change, just no transient double-render.

## Test plan

- New regression unit test in `wishlist-category-state.test.ts` (settled + pending overlap with shared `clientMutationId` → single category).
- `npm test -- --run wishlist-category-state use-wishlist-category-mutations` → 10 passed.
- `npm run test:e2e:run -- wishlist.test.ts -g "drag reorder"` → **1 passed** locally (the exact failing test).
- Typecheck clean.