### PR TITLE
feat: persist legal consent and 13+ affirmation at signup

### DIFF
--- a/app/routes/_auth+/onboarding.action.test.ts
+++ b/app/routes/_auth+/onboarding.action.test.ts
@@ -1,0 +1,161 @@
+/**
+ * @vitest-environment node
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { CURRENT_LEGAL_VERSION } from '#app/utils/legal.ts';
+import {
+  getRouteResultStatus,
+  toActionArgs,
+} from '#tests/route-module-test-utils.ts';
+
+const requireAnonymous = vi.fn();
+const signup = vi.fn();
+const findUnique = vi.fn();
+const checkHoneypot = vi.fn();
+const getRequestContext = vi.fn();
+const queueLogEvent = vi.fn();
+const redirectWithToast = vi.fn();
+const authGetSession = vi.fn();
+const authCommitSession = vi.fn();
+const verifyGetSession = vi.fn();
+const verifyDestroySession = vi.fn();
+
+const onboardingEmail = 'new@example.com';
+
+vi.mock('#app/utils/auth.server.ts', () => ({
+  sessionKey: 'sessionId',
+  requireAnonymous: (...args: Array<unknown>) => requireAnonymous(...args),
+  signup: (...args: Array<unknown>) => signup(...args),
+}));
+
+vi.mock('#app/utils/db.server.ts', () => ({
+  prisma: {
+    user: {
+      findUnique: (...args: Array<unknown>) => findUnique(...args),
+    },
+  },
+}));
+
+vi.mock('#app/utils/honeypot.server.ts', () => ({
+  checkHoneypot: (...args: Array<unknown>) => checkHoneypot(...args),
+}));
+
+vi.mock('#app/utils/request-context.server.ts', () => ({
+  getRequestContext: (...args: Array<unknown>) => getRequestContext(...args),
+}));
+
+vi.mock('#app/utils/analytics.server.ts', () => ({
+  queueLogEvent: (...args: Array<unknown>) => queueLogEvent(...args),
+}));
+
+vi.mock('#app/utils/toast.server.ts', () => ({
+  redirectWithToast: (...args: Array<unknown>) => redirectWithToast(...args),
+}));
+
+vi.mock('#app/utils/session.server.ts', () => ({
+  authSessionStorage: {
+    getSession: (...args: Array<unknown>) => authGetSession(...args),
+    commitSession: (...args: Array<unknown>) => authCommitSession(...args),
+  },
+}));
+
+vi.mock('#app/utils/verification.server.ts', () => ({
+  verifySessionStorage: {
+    getSession: (...args: Array<unknown>) => verifyGetSession(...args),
+    destroySession: (...args: Array<unknown>) => verifyDestroySession(...args),
+  },
+}));
+
+import { action } from './onboarding.tsx';
+
+function createRequest(fields: Record<string, string>, ip?: string) {
+  const headers: Record<string, string> = {
+    'content-type': 'application/x-www-form-urlencoded',
+  };
+  if (ip) headers['fly-client-ip'] = ip;
+  return new Request('https://giftpool.app/onboarding', {
+    body: new URLSearchParams(fields).toString(),
+    headers,
+    method: 'POST',
+  });
+}
+
+const validFields = {
+  username: 'newbie',
+  name: 'New Bie',
+  password: 'correct horse battery staple',
+  confirmPassword: 'correct horse battery staple',
+  redirectTo: '/wishlist',
+};
+
+describe('app/routes/_auth+/onboarding.tsx action', () => {
+  beforeEach(() => {
+    requireAnonymous.mockResolvedValue(undefined);
+    checkHoneypot.mockResolvedValue(undefined);
+    findUnique.mockResolvedValue(null);
+    authGetSession.mockResolvedValue({ set: vi.fn() });
+    authCommitSession.mockResolvedValue('auth-cookie');
+    verifyGetSession.mockResolvedValue({
+      get: (key: string) =>
+        key === 'onboardingEmail' ? onboardingEmail : null,
+    });
+    verifyDestroySession.mockResolvedValue('destroyed-cookie');
+  });
+
+  it('persists consent with the current legal version, affirmation, and request IP', async () => {
+    getRequestContext.mockResolvedValue({
+      requestId: 'req-1',
+      visitorId: 'vis-1',
+    });
+    signup.mockResolvedValue({
+      id: 'session-1',
+      userId: 'user-1',
+      expirationDate: new Date(Date.now() + 1000 * 60 * 60),
+    });
+    redirectWithToast.mockResolvedValue(
+      new Response(null, { status: 302, headers: { Location: '/wishlist' } }),
+    );
+
+    const response = await action(
+      toActionArgs({
+        context: {},
+        params: {},
+        request: createRequest(
+          { ...validFields, agreeToTermsOfServiceAndPrivacyPolicy: 'on' },
+          '203.0.113.7',
+        ),
+      }),
+    );
+
+    expect(getRouteResultStatus(response)).toBe(302);
+    expect(signup).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: onboardingEmail,
+        username: 'newbie',
+        consent: {
+          version: CURRENT_LEGAL_VERSION,
+          ageAffirmed: true,
+          ipAddress: '203.0.113.7',
+        },
+      }),
+    );
+  });
+
+  it('rejects signup when the terms / 13+ affirmation is missing', async () => {
+    getRequestContext.mockResolvedValue({
+      requestId: 'req-2',
+      visitorId: 'vis-2',
+    });
+
+    const result = await action(
+      toActionArgs({
+        context: {},
+        params: {},
+        request: createRequest(validFields),
+      }),
+    );
+
+    expect(getRouteResultStatus(result)).toBe(400);
+    expect(signup).not.toHaveBeenCalled();
+  });
+});

--- a/app/routes/_auth+/onboarding.schema.test.ts
+++ b/app/routes/_auth+/onboarding.schema.test.ts
@@ -1,0 +1,41 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, expect, it } from 'vitest';
+import { SignupFormSchema } from './onboarding.tsx';
+
+const validBase = {
+  username: 'consent_user',
+  name: 'Consent User',
+  password: 'correct horse battery staple',
+  confirmPassword: 'correct horse battery staple',
+};
+
+describe('SignupFormSchema affirmation', () => {
+  it('accepts a submission when the terms / 13+ affirmation is checked', () => {
+    const result = SignupFormSchema.safeParse({
+      ...validBase,
+      agreeToTermsOfServiceAndPrivacyPolicy: true,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a submission when the affirmation is missing', () => {
+    const result = SignupFormSchema.safeParse({ ...validBase });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const affirmationError = result.error.issues.some((issue) =>
+        issue.path.includes('agreeToTermsOfServiceAndPrivacyPolicy'),
+      );
+      expect(affirmationError).toBe(true);
+    }
+  });
+
+  it('rejects a submission when the affirmation is explicitly false', () => {
+    const result = SignupFormSchema.safeParse({
+      ...validBase,
+      agreeToTermsOfServiceAndPrivacyPolicy: false,
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/app/routes/_auth+/onboarding.tsx
+++ b/app/routes/_auth+/onboarding.tsx
@@ -32,6 +32,7 @@ import {
 import { prisma } from '#app/utils/db.server.ts';
 import { checkHoneypot } from '#app/utils/honeypot.server.ts';
 import { useIsPending } from '#app/utils/misc.tsx';
+import { CURRENT_LEGAL_VERSION } from '#app/utils/legal.ts';
 import { getRequestContext } from '#app/utils/request-context.server.ts';
 import { authSessionStorage } from '#app/utils/session.server.ts';
 import { redirectWithToast } from '#app/utils/toast.server.ts';
@@ -42,14 +43,19 @@ import {
 } from '#app/utils/user-validation.ts';
 import { verifySessionStorage } from '#app/utils/verification.server.ts';
 export const onboardingEmailSessionKey = 'onboardingEmail';
-const SignupFormSchema = z
+export const SignupFormSchema = z
   .object({
     username: UsernameSchema,
     name: NameSchema,
-    agreeToTermsOfServiceAndPrivacyPolicy: z.boolean({
-      required_error:
-        'You must agree to the terms of service and privacy policy',
-    }),
+    agreeToTermsOfServiceAndPrivacyPolicy: z
+      .boolean({
+        required_error:
+          'You must agree to the terms of service and privacy policy, and confirm you are at least 13 years old',
+      })
+      .refine((val) => val === true, {
+        message:
+          'You must agree to the terms of service and privacy policy, and confirm you are at least 13 years old',
+      }),
     remember: z.boolean().optional(),
     redirectTo: z.string().optional(),
   })
@@ -74,6 +80,12 @@ export async function loader({ request }: LoaderFunctionArgs) {
 export async function action({ request }: ActionFunctionArgs) {
   const email = await requireOnboardingEmail(request);
   const { requestId, visitorId } = await getRequestContext(request);
+  // Captured for evidentiary strength on the consent record. Best-effort —
+  // null when no proxy header is present (e.g. local dev).
+  const ipAddress =
+    request.headers.get('fly-client-ip') ??
+    request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ??
+    null;
   const formData = await request.formData();
   await checkHoneypot(formData);
   const submission = await parseWithZod(formData, {
@@ -102,8 +114,18 @@ export async function action({ request }: ActionFunctionArgs) {
             session: null,
           };
         const session = await signup({
-          ...data,
           email,
+          username: data.username,
+          name: data.name,
+          password: data.password,
+          consent: {
+            version: CURRENT_LEGAL_VERSION,
+            // The single clickwrap checkbox covers both the legal agreement
+            // and the 13+ self-attestation, so a successful submission means
+            // both were affirmed.
+            ageAffirmed: data.agreeToTermsOfServiceAndPrivacyPolicy,
+            ipAddress,
+          },
         });
         return {
           ...data,
@@ -284,6 +306,7 @@ const OnboardingRoute = () => {
                   >
                     Privacy Policy
                   </Link>
+                  , and I confirm I am at least 13 years old
                 </>
               ),
             }}
@@ -294,7 +317,7 @@ const OnboardingRoute = () => {
               // The visual label's link text doesn't reach the accessible
               // name (it reads "I agree to the and" to screen readers).
               'aria-label':
-                'I agree to the Terms of Service and Privacy Policy',
+                'I agree to the Terms of Service and Privacy Policy, and I confirm I am at least 13 years old',
             }}
             errors={fields.agreeToTermsOfServiceAndPrivacyPolicy.errors}
           />

--- a/app/utils/auth.server.test.ts
+++ b/app/utils/auth.server.test.ts
@@ -2,7 +2,17 @@ import { randomUUID } from 'node:crypto';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { signup } from '#app/utils/auth.server.ts';
 import { prisma } from '#app/utils/db.server.ts';
+import {
+  CURRENT_LEGAL_VERSION,
+  LEGAL_DOCUMENT_TYPE,
+} from '#app/utils/legal.ts';
 import { NOTIFICATION_TYPES } from '#app/utils/notification-registry.ts';
+
+const testConsent = {
+  version: CURRENT_LEGAL_VERSION,
+  ageAffirmed: true,
+  ipAddress: '203.0.113.7',
+};
 
 describe('auth.server', () => {
   beforeEach(async () => {
@@ -30,6 +40,7 @@ describe('auth.server', () => {
       username,
       password: 'correct horse battery staple',
       name: 'Signup Test',
+      consent: testConsent,
     });
 
     const prefs = await prisma.userNotificationPreference.findMany({
@@ -41,5 +52,37 @@ describe('auth.server', () => {
     for (const type of Object.values(NOTIFICATION_TYPES)) {
       expect(seededTypes.has(type)).toBe(true);
     }
+  });
+
+  it('signup writes a consent row with the current legal version and age affirmation', async () => {
+    await prisma.role.upsert({
+      where: { name: 'user' },
+      update: {},
+      create: { name: 'user' },
+    });
+
+    const username = `signup_${randomUUID().slice(0, 8)}`;
+    const email = `${username}@signup-test.com`;
+
+    const session = await signup({
+      email,
+      username,
+      password: 'correct horse battery staple',
+      name: 'Signup Test',
+      consent: testConsent,
+    });
+
+    const consents = await prisma.consent.findMany({
+      where: { userId: session.userId },
+    });
+
+    expect(consents).toHaveLength(1);
+    expect(consents[0]).toMatchObject({
+      documentType: LEGAL_DOCUMENT_TYPE,
+      version: CURRENT_LEGAL_VERSION,
+      ageAffirmed: true,
+      ipAddress: '203.0.113.7',
+    });
+    expect(consents[0]?.acceptedAt).toBeInstanceOf(Date);
   });
 });

--- a/app/utils/auth.server.ts
+++ b/app/utils/auth.server.ts
@@ -3,6 +3,7 @@ import bcrypt from 'bcryptjs';
 import { redirect } from 'react-router';
 import { safeRedirect } from 'remix-utils/safe-redirect';
 import { prisma } from './db.server.ts';
+import { LEGAL_DOCUMENT_TYPE } from './legal.ts';
 import { combineHeaders } from './misc.tsx';
 import {
   DEFAULT_NOTIFICATION_PREFERENCES,
@@ -120,14 +121,23 @@ export async function signup({
   username,
   password,
   name,
+  consent,
 }: {
   email: User['email'];
   username: User['username'];
   name: User['name'];
   password: string;
+  consent: {
+    version: string;
+    ageAffirmed: boolean;
+    ipAddress?: string | null;
+  };
 }) {
   const hashedPassword = await getPasswordHash(password);
 
+  // The consent row is created as a nested write under the user, so it lands in
+  // the same transaction as user creation — an account can never exist without
+  // its acceptance record.
   const session = await prisma.session.create({
     data: {
       expirationDate: getSessionExpirationDate(),
@@ -144,6 +154,14 @@ export async function signup({
           },
           notificationPreferences: {
             create: defaultNotificationPreferenceRows,
+          },
+          consents: {
+            create: {
+              documentType: LEGAL_DOCUMENT_TYPE,
+              version: consent.version,
+              ageAffirmed: consent.ageAffirmed,
+              ipAddress: consent.ipAddress ?? null,
+            },
           },
         },
       },

--- a/app/utils/legal.ts
+++ b/app/utils/legal.ts
@@ -1,0 +1,11 @@
+// Single source of truth for the version of the Terms of Service / Privacy
+// Policy a user accepts at onboarding. Date-based. Bump this whenever the legal
+// documents materially change — the new value is what gets written to
+// `Consent.version` on subsequent acceptances, so future re-acceptance flows
+// can detect who agreed to which version.
+export const CURRENT_LEGAL_VERSION = '2026-06-20';
+
+// Discriminator stored on `Consent.documentType`. The Terms of Service and
+// Privacy Policy are accepted together via a single clickwrap checkbox, so one
+// combined record covers both.
+export const LEGAL_DOCUMENT_TYPE = 'TOS_AND_PRIVACY';

--- a/prisma/migrations/20260620142117_add_consent/migration.sql
+++ b/prisma/migrations/20260620142117_add_consent/migration.sql
@@ -1,0 +1,14 @@
+-- CreateTable
+CREATE TABLE "Consent" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "userId" TEXT NOT NULL,
+    "documentType" TEXT NOT NULL,
+    "version" TEXT NOT NULL,
+    "ageAffirmed" BOOLEAN NOT NULL,
+    "acceptedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "ipAddress" TEXT,
+    CONSTRAINT "Consent_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE INDEX "Consent_userId_idx" ON "Consent"("userId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -62,6 +62,7 @@ model User {
   poolActivities               PoolActivity[]                @relation("PoolActivity_Actor")
   poolMessages                 PoolMessage[]
   feedback                     Feedback[]
+  consents                     Consent[]
 }
 
 model Friendship {
@@ -569,6 +570,29 @@ model AnalyticsEvent {
 // -----------------------------------------------------------------------------
 // Auth & identity
 // -----------------------------------------------------------------------------
+
+// Records a user's affirmative acceptance of the legal documents at signup.
+// One row is written per acceptance, in the same transaction as user creation,
+// so an account can never exist without its consent record. Additive only —
+// existing users predating this table simply have no row, and the app must not
+// gate them for its absence.
+model Consent {
+  id           String   @id @default(cuid())
+  userId       String
+  user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  // e.g. "TOS_AND_PRIVACY" (see LEGAL_DOCUMENT_TYPE in app/utils/legal.ts)
+  documentType String
+  // Policy version accepted (see CURRENT_LEGAL_VERSION in app/utils/legal.ts)
+  version      String
+  // User self-attested they are at least 13 years old. Self-attestation only —
+  // we never collect a date of birth.
+  ageAffirmed  Boolean
+  acceptedAt   DateTime @default(now())
+  // Optional, for evidentiary strength. Null when not readily available.
+  ipAddress    String?
+
+  @@index([userId])
+}
 
 model Address {
   id        String   @id @default(cuid())


### PR DESCRIPTION
## What

Persists the legal consent that's already collected at onboarding, and adds a 13+ age affirmation. Previously the clickwrap checkbox was Zod-validated but its value was dropped and never stored — an account could exist with no record of acceptance.

## Changes

- **Schema:** new additive `Consent` model (`documentType`, `version`, `ageAffirmed`, `acceptedAt`, `ipAddress?`) with a back-relation on `User`. Migration `add_consent` creates the table only — no destructive changes.
- **Version constant:** `CURRENT_LEGAL_VERSION = '2026-06-20'` + `LEGAL_DOCUMENT_TYPE` in `app/utils/legal.ts` as the single source of truth. Bump on policy change.
- **Persistence:** `signup()` writes the `Consent` row as a nested create in the **same transaction** as user creation, so an account can never exist without its acceptance record. Captures request IP (`fly-client-ip` / `x-forwarded-for`, null fallback).
- **Age affirmation:** the existing required ToS/Privacy checkbox now also affirms "I am at least 13 years old" (folded into one checkbox for cleaner UX). Enforced server-side via Zod (`must be true`). Stored as `Consent.ageAffirmed`. Self-attestation only — no DOB collected.

## Not in scope

Existing users predating this table have no `Consent` row and are **not** gated for its absence. No re-acceptance/versioning enforcement yet (the `version` column is stored so that future flow has what it needs). No changes to group-settings, the address model, `User.birthday`, or visibility logic.

## Tests

- `auth.server.test.ts`: asserts a single `Consent` row is created with the current version, `ageAffirmed: true`, and IP.
- `onboarding.schema.test.ts`: asserts the schema accepts when affirmed, and rejects when the affirmation is missing or explicitly `false`.
- `npm run validate` passes — lint, typecheck, unit, e2e (86 passed / 7 skipped).