### PR TITLE
refactor(ui): containment & surfaces (Design Rules Part 1)

### DIFF
--- a/app/components/admin-ui.tsx
+++ b/app/components/admin-ui.tsx
@@ -1,5 +1,6 @@
 import { type ReactNode } from 'react';
 import { Card } from '#app/components/ui/card.tsx';
+import { Section } from '#app/components/ui/section.tsx';
 import { cn } from '#app/utils/misc.tsx';
 
 export const SummaryCard = ({
@@ -23,12 +24,7 @@ export const SummaryCard = ({
   const toneClass = TONE_CLASSES[tone];
 
   return (
-    <Card
-      className={cn(
-        'flex flex-col gap-1.5 p-4 shadow-sm',
-        toneClass,
-      )}
-    >
+    <Card className={cn('flex flex-col gap-1.5 p-4 shadow-sm', toneClass)}>
       <span className="text-sm font-medium text-muted-foreground">{label}</span>
       <span className="text-3xl font-semibold tabular-nums tracking-tight">
         {typeof value === 'number' ? value.toLocaleString() : value}
@@ -47,6 +43,10 @@ export const SummaryCard = ({
   );
 };
 
+/**
+ * Admin section card. Thin alias over the shared {@link Section} primitive so
+ * admin and product screens share one containment rule (R1.2/R1.3).
+ */
 export const SectionCard = ({
   title,
   description,
@@ -60,18 +60,14 @@ export const SectionCard = ({
   children: ReactNode;
   className?: string;
 }) => (
-  <Card className={cn('border-border/60 bg-card p-4 shadow-sm', className)}>
-    <div className="mb-3 flex items-start justify-between gap-3">
-      <div>
-        <h2 className="text-lg font-semibold leading-tight">{title}</h2>
-        {description ? (
-          <p className="text-sm text-muted-foreground">{description}</p>
-        ) : null}
-      </div>
-      {action ? <div className="shrink-0">{action}</div> : null}
-    </div>
+  <Section
+    title={title}
+    description={description}
+    action={action}
+    className={className}
+  >
     {children}
-  </Card>
+  </Section>
 );
 
 export const EmptyRow = ({ children }: { children: ReactNode }) => (

--- a/app/components/ui/input.tsx
+++ b/app/components/ui/input.tsx
@@ -10,7 +10,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-base file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 aria-[invalid]:border-input-invalid sm:text-sm sm:file:text-sm',
+          'flex h-10 w-full rounded-md border border-input bg-input-bg px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-base file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 aria-[invalid]:border-input-invalid sm:text-sm sm:file:text-sm',
           className,
         )}
         ref={ref}

--- a/app/components/ui/section.test.tsx
+++ b/app/components/ui/section.test.tsx
@@ -1,0 +1,47 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { Section } from './section.tsx';
+
+describe('Section', () => {
+  it('renders title, description, action, and children', () => {
+    render(
+      <Section
+        title="Your preferences"
+        description="How GiftPool reaches out."
+        action={<button type="button">Edit</button>}
+      >
+        <p>Body content.</p>
+      </Section>,
+    );
+    expect(
+      screen.getByRole('heading', { name: 'Your preferences' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('How GiftPool reaches out.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument();
+    expect(screen.getByText('Body content.')).toBeInTheDocument();
+  });
+
+  it('renders children with no header when title/description/action are omitted', () => {
+    const { container } = render(
+      <Section>
+        <p>Body only.</p>
+      </Section>,
+    );
+    expect(screen.getByText('Body only.')).toBeInTheDocument();
+    // No heading element should be rendered when there is no title.
+    expect(container.querySelector('h2')).toBeNull();
+  });
+
+  it('honors a custom heading element and wires titleId for aria-labelledby', () => {
+    render(
+      <Section as="h3" titleId="prefs-title" title="Privacy">
+        <p>Body.</p>
+      </Section>,
+    );
+    const heading = screen.getByRole('heading', { name: 'Privacy', level: 3 });
+    expect(heading).toHaveAttribute('id', 'prefs-title');
+  });
+});

--- a/app/components/ui/section.tsx
+++ b/app/components/ui/section.tsx
@@ -1,0 +1,59 @@
+import { type ElementType, type ReactNode } from 'react';
+
+import { Card } from '#app/components/ui/card.tsx';
+import { cn } from '#app/utils/misc.tsx';
+
+export interface SectionProps {
+  /**
+   * The section's title. Per design rule R1.3 a *section* title belongs to its
+   * container — render it here, not loose on the page backdrop. (Only the
+   * page-level H1 may sit on the backdrop.)
+   */
+  title?: ReactNode;
+  description?: ReactNode;
+  /** Optional trailing control aligned to the title row (e.g. an Edit button). */
+  action?: ReactNode;
+  children: ReactNode;
+  className?: string;
+  /** Heading element for the title. Defaults to `h2`. */
+  as?: ElementType;
+  /** Id for the heading, for `aria-labelledby` wiring. */
+  titleId?: string;
+}
+
+/**
+ * A card-bounded section: the single containment primitive for content blocks
+ * (R1.2). Content lives in a `Section`/`Card`; the page background is the space
+ * *between* sections, never the surface content sits on.
+ */
+export const Section = ({
+  title,
+  description,
+  action,
+  children,
+  className,
+  as: Heading = 'h2',
+  titleId,
+}: SectionProps) => (
+  <Card className={cn('border-border/60 bg-card p-4 shadow-sm', className)}>
+    {title || description || action ? (
+      <div className="mb-3 flex items-start justify-between gap-3">
+        <div>
+          {title ? (
+            <Heading
+              id={titleId}
+              className="text-lg font-semibold leading-tight"
+            >
+              {title}
+            </Heading>
+          ) : null}
+          {description ? (
+            <p className="text-sm text-muted-foreground">{description}</p>
+          ) : null}
+        </div>
+        {action ? <div className="shrink-0">{action}</div> : null}
+      </div>
+    ) : null}
+    {children}
+  </Card>
+);

--- a/app/components/ui/select.tsx
+++ b/app/components/ui/select.tsx
@@ -17,7 +17,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      'flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 sm:text-sm [&>span]:line-clamp-1',
+      'flex h-10 w-full items-center justify-between rounded-md border border-input bg-input-bg px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 sm:text-sm [&>span]:line-clamp-1',
       className,
     )}
     {...props}

--- a/app/components/ui/textarea.tsx
+++ b/app/components/ui/textarea.tsx
@@ -9,7 +9,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     return (
       <textarea
         className={cn(
-          'flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 aria-[invalid]:border-input-invalid sm:text-sm',
+          'flex min-h-[80px] w-full rounded-md border border-input bg-input-bg px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 aria-[invalid]:border-input-invalid sm:text-sm',
           className,
         )}
         ref={ref}

--- a/app/routes/groups+/$giftGroupId_+/index.tsx
+++ b/app/routes/groups+/$giftGroupId_+/index.tsx
@@ -740,7 +740,7 @@ const InlineBudgetEditor = ({
               name="dollars"
               defaultValue={dollars}
               inputMode="decimal"
-              className="border-input bg-input pl-5 text-foreground"
+              className="border-input bg-input-bg pl-5 text-foreground"
               onFocus={handleFocusSelectAll}
               onMouseUp={handleMouseUpPreserve}
             />
@@ -820,7 +820,7 @@ const InlineBudgetEditor = ({
           name="dollars"
           defaultValue={dollars}
           inputMode="decimal"
-          className="w-28 border-input bg-input pl-5 text-foreground"
+          className="w-28 border-input bg-input-bg pl-5 text-foreground"
           aria-label="Your budget"
           onFocus={handleFocusSelectAll}
           onMouseUp={handleMouseUpPreserve}

--- a/app/routes/settings+/profile.notifications.tsx
+++ b/app/routes/settings+/profile.notifications.tsx
@@ -4,9 +4,14 @@ import {
   data,
   redirect,
   type ActionFunctionArgs,
-  type LoaderFunctionArgs, Link, useFetcher, useLoaderData, useRevalidator
+  type LoaderFunctionArgs,
+  Link,
+  useFetcher,
+  useLoaderData,
+  useRevalidator,
 } from 'react-router';
 import { Button } from '#app/components/ui/button.tsx';
+import { Card } from '#app/components/ui/card.tsx';
 import { Checkbox } from '#app/components/ui/checkbox.tsx';
 import { Heading } from '#app/components/ui/heading.tsx';
 import { getUserId, requireUserId } from '#app/utils/auth.server.ts';
@@ -82,8 +87,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
     throw redirect('/login?redirectTo=/settings/profile/notifications');
   }
   const canReadPreferences =
-    (userId && userId === targetUserId) ||
-    tokenPayload?.uid === targetUserId;
+    (userId && userId === targetUserId) || tokenPayload?.uid === targetUserId;
   // Settings page is the only place users directly manage their preferences.
   // Materialize rows here so downstream writes (`setNotificationPreference`,
   // `disableEmailForAll`) always see persisted rows, and so UI optimistic
@@ -126,8 +130,7 @@ export async function action({ request }: ActionFunctionArgs) {
   const formData = await request.formData();
   const intent = formData.get('intent');
   const requestIdValue = formData.get('requestId');
-  const requestId =
-    typeof requestIdValue === 'string' ? requestIdValue : null;
+  const requestId = typeof requestIdValue === 'string' ? requestIdValue : null;
   const userId = await requireUserId(request);
   if (intent === 'toggle') {
     const type = formData.get('type');
@@ -384,142 +387,153 @@ const NotificationsSettingsRoute = () => {
         </p>
       </div>
 
-      {data.isAuthenticated ? null : (
-        <div className="rounded-md border border-dashed border-muted-foreground/50 bg-muted px-4 py-3 text-sm text-muted-foreground">
-          <p>You are viewing notification preferences with a one-time link.</p>
-          <p>
-            <Link
-              className="underline"
-              to={`/login?redirectTo=/settings/profile/notifications`}
-            >
-              Sign in to update your preferences.
-            </Link>
-          </p>
-        </div>
-      )}
+      <Card padding="lg" className="space-y-6">
+        {data.isAuthenticated ? null : (
+          <div className="rounded-md border border-dashed border-muted-foreground/50 bg-muted px-4 py-3 text-sm text-muted-foreground">
+            <p>
+              You are viewing notification preferences with a one-time link.
+            </p>
+            <p>
+              <Link
+                className="underline"
+                to={`/login?redirectTo=/settings/profile/notifications`}
+              >
+                Sign in to update your preferences.
+              </Link>
+            </p>
+          </div>
+        )}
 
-      {data.isAuthenticated && push.status !== 'unsupported' ? (
-        <PushStatusBanner push={push} />
-      ) : null}
+        {data.isAuthenticated && push.status !== 'unsupported' ? (
+          <PushStatusBanner push={push} />
+        ) : null}
 
-      <div className="overflow-x-auto rounded-lg border border-border">
-        <table className="w-full text-sm">
-          <thead className="bg-muted text-left text-xs uppercase tracking-wide text-muted-foreground">
-            <tr>
-              <th className="px-4 py-3">Notification</th>
-              <th className="px-4 py-3">Description</th>
-              <th className="px-4 py-3">In-app</th>
-              <th className="px-4 py-3">Email</th>
-              {pushColumnVisible ? <th className="px-4 py-3">Push</th> : null}
-            </tr>
-          </thead>
-          <tbody>
-            {preferenceGroups.map((group) => (
-              <React.Fragment key={group.id}>
-                <tr className="bg-muted/60">
-                  <td className="px-4 py-3 font-semibold" colSpan={columnCount}>
-                    {group.title}
-                  </td>
-                </tr>
-                {group.description ? (
-                  <tr className="bg-muted/40 text-xs text-muted-foreground">
-                    <td className="px-4 pb-2" colSpan={columnCount}>
-                      {group.description}
+        <div className="overflow-x-auto rounded-lg border border-border">
+          <table className="w-full text-sm">
+            <thead className="bg-muted text-left text-xs uppercase tracking-wide text-muted-foreground">
+              <tr>
+                <th className="px-4 py-3">Notification</th>
+                <th className="px-4 py-3">Description</th>
+                <th className="px-4 py-3">In-app</th>
+                <th className="px-4 py-3">Email</th>
+                {pushColumnVisible ? <th className="px-4 py-3">Push</th> : null}
+              </tr>
+            </thead>
+            <tbody>
+              {preferenceGroups.map((group) => (
+                <React.Fragment key={group.id}>
+                  <tr className="bg-muted/60">
+                    <td
+                      className="px-4 py-3 font-semibold"
+                      colSpan={columnCount}
+                    >
+                      {group.title}
                     </td>
                   </tr>
-                ) : null}
-                {group.items.map((item) => {
-                  const pref = preferences[item.type];
-                  const pendingInApp = pendingKeys.has(
-                    getPreferenceKey(item.type, NOTIFICATION_CHANNELS.IN_APP),
-                  );
-                  const pendingEmail = pendingKeys.has(
-                    getPreferenceKey(item.type, NOTIFICATION_CHANNELS.EMAIL),
-                  );
-                  const pendingPush = pendingKeys.has(
-                    getPreferenceKey(item.type, NOTIFICATION_CHANNELS.WEB_PUSH),
-                  );
-                  const disableToggles = item.disabled || !data.isAuthenticated;
-                  return (
-                    <tr key={item.type} className="even:bg-muted/10">
-                      <td className="px-4 py-3 font-medium">{item.label}</td>
-                      <td className="px-4 py-3 text-muted-foreground">
-                        {item.description}
+                  {group.description ? (
+                    <tr className="bg-muted/40 text-xs text-muted-foreground">
+                      <td className="px-4 pb-2" colSpan={columnCount}>
+                        {group.description}
                       </td>
-                      <td className="px-4 py-3">
-                        <PreferenceCheckbox
-                          checked={pref.inAppEnabled}
-                          label="Enable in-app"
-                          disabled={disableToggles || pendingInApp}
-                          onChange={() =>
-                            handleToggle(
-                              item.type,
-                              NOTIFICATION_CHANNELS.IN_APP,
-                              pref.inAppEnabled,
-                            )
-                          }
-                        />
-                      </td>
-                      <td className="px-4 py-3">
-                        <PreferenceCheckbox
-                          checked={pref.emailEnabled}
-                          label="Enable email"
-                          disabled={
-                            disableToggles ||
-                            (!item.emailDefault && item.disabled) ||
-                            pendingEmail
-                          }
-                          onChange={() =>
-                            handleToggle(
-                              item.type,
-                              NOTIFICATION_CHANNELS.EMAIL,
-                              pref.emailEnabled,
-                            )
-                          }
-                        />
-                      </td>
-                      {pushColumnVisible ? (
+                    </tr>
+                  ) : null}
+                  {group.items.map((item) => {
+                    const pref = preferences[item.type];
+                    const pendingInApp = pendingKeys.has(
+                      getPreferenceKey(item.type, NOTIFICATION_CHANNELS.IN_APP),
+                    );
+                    const pendingEmail = pendingKeys.has(
+                      getPreferenceKey(item.type, NOTIFICATION_CHANNELS.EMAIL),
+                    );
+                    const pendingPush = pendingKeys.has(
+                      getPreferenceKey(
+                        item.type,
+                        NOTIFICATION_CHANNELS.WEB_PUSH,
+                      ),
+                    );
+                    const disableToggles =
+                      item.disabled || !data.isAuthenticated;
+                    return (
+                      <tr key={item.type} className="even:bg-muted/10">
+                        <td className="px-4 py-3 font-medium">{item.label}</td>
+                        <td className="px-4 py-3 text-muted-foreground">
+                          {item.description}
+                        </td>
                         <td className="px-4 py-3">
                           <PreferenceCheckbox
-                            checked={pref.pushEnabled}
-                            label="Enable push"
-                            // Push toggles only act once the device is
-                            // subscribed; otherwise use the banner above.
-                            disabled={
-                              disableToggles ||
-                              push.status !== 'subscribed' ||
-                              pendingPush
-                            }
+                            checked={pref.inAppEnabled}
+                            label="Enable in-app"
+                            disabled={disableToggles || pendingInApp}
                             onChange={() =>
                               handleToggle(
                                 item.type,
-                                NOTIFICATION_CHANNELS.WEB_PUSH,
-                                pref.pushEnabled,
+                                NOTIFICATION_CHANNELS.IN_APP,
+                                pref.inAppEnabled,
                               )
                             }
                           />
                         </td>
-                      ) : null}
-                    </tr>
-                  );
-                })}
-              </React.Fragment>
-            ))}
-          </tbody>
-        </table>
-      </div>
+                        <td className="px-4 py-3">
+                          <PreferenceCheckbox
+                            checked={pref.emailEnabled}
+                            label="Enable email"
+                            disabled={
+                              disableToggles ||
+                              (!item.emailDefault && item.disabled) ||
+                              pendingEmail
+                            }
+                            onChange={() =>
+                              handleToggle(
+                                item.type,
+                                NOTIFICATION_CHANNELS.EMAIL,
+                                pref.emailEnabled,
+                              )
+                            }
+                          />
+                        </td>
+                        {pushColumnVisible ? (
+                          <td className="px-4 py-3">
+                            <PreferenceCheckbox
+                              checked={pref.pushEnabled}
+                              label="Enable push"
+                              // Push toggles only act once the device is
+                              // subscribed; otherwise use the banner above.
+                              disabled={
+                                disableToggles ||
+                                push.status !== 'subscribed' ||
+                                pendingPush
+                              }
+                              onChange={() =>
+                                handleToggle(
+                                  item.type,
+                                  NOTIFICATION_CHANNELS.WEB_PUSH,
+                                  pref.pushEnabled,
+                                )
+                              }
+                            />
+                          </td>
+                        ) : null}
+                      </tr>
+                    );
+                  })}
+                </React.Fragment>
+              ))}
+            </tbody>
+          </table>
+        </div>
 
-      {data.isAuthenticated ? (
-        <Button
-          type="button"
-          variant="ghost"
-          className="text-sm"
-          disabled={disableEmailFetcher.state !== 'idle'}
-          onClick={handleDisableAllEmail}
-        >
-          Turn off all email notifications
-        </Button>
-      ) : null}
+        {data.isAuthenticated ? (
+          <Button
+            type="button"
+            variant="ghost"
+            className="text-sm"
+            disabled={disableEmailFetcher.state !== 'idle'}
+            onClick={handleDisableAllEmail}
+          >
+            Turn off all email notifications
+          </Button>
+        ) : null}
+      </Card>
     </div>
   );
 };

--- a/app/styles/tailwind.css
+++ b/app/styles/tailwind.css
@@ -26,6 +26,9 @@
     --border: 214.3 31.8% 91.4%;
     --input: 214.3 31.8% 91.4%;
     --input-invalid: 0 84.2% 60.2%;
+    /* Field fill — distinct from both --background (98%) and --card (100%)
+       so an input reads as a filled field on any surface (R1.1/R1.4). */
+    --input-bg: 210 40% 96%;
 
     --primary: 0 100% 68%;
     /* --primary: 222.2 47.4% 11.2%; */
@@ -103,6 +106,9 @@
     --border: 217.2 32.6% 17.5%;
     --input: 217.2 32.6% 17.5%;
     --input-invalid: 0 62.8% 30.6%;
+    /* Field fill — a hair lighter than --card (6.8%) so it reads as a raised,
+       fillable field rather than a hole on dark surfaces (R1.1/R1.4). */
+    --input-bg: 217.2 32.6% 14%;
 
     --primary: 0 100% 68%;
     --primary-foreground: 0 0% 100%;

--- a/app/utils/extended-theme.ts
+++ b/app/utils/extended-theme.ts
@@ -6,6 +6,7 @@ export const extendedTheme = {
     input: {
       DEFAULT: 'hsl(var(--input))',
       invalid: 'hsl(var(--input-invalid))',
+      bg: 'hsl(var(--input-bg))',
     },
     ring: {
       DEFAULT: 'hsl(var(--ring))',


### PR DESCRIPTION
## Context

Part 1 of the Giftpool Design Rules (Jun 26 2026 UX audit). The audit's most-repeated complaint — "it looks unintentional," "slapped on the backdrop" — traces to a missing containment rule. This PR fixes the rule at the system level so every screen benefits, then sweeps the audited screens.

This is **PR 1 of 3**. PR 2 (`fix/design-view-state`, Part 5) branches off fresh main after this merges; PR 3 (group settings rework) is a future, deferred pass.

## Changes

**System / primitives**
- Add `--input-bg` token (`:root` + `.dark`), a field fill distinct from both `--background` and `--card`, so an input never matches the surface behind it (R1.1/R1.4). `Input`/`Textarea`/`Select` adopt it.
- Extract a shared `Section` container primitive from the admin-only `SectionCard`; `SectionCard` now delegates to it so admin screens are unchanged (R1.2/R1.3).

**Audited-screen sweep**
- Wrap the notifications page body in a `Card` (the one settings page sitting bare on the backdrop; the others already use the `SettingsSubpage` card shell). Page H1 stays on the backdrop per R1.3.
- Group budget inputs move off `bg-input` (border-gray) onto the new `bg-input-bg` for consistency.
- profile, change-email/password, two-factor, group overview, and pool view were already card-per-section and simply inherit the improved field fill.

## Out of scope
- Deeper "still feels bare" reactions to group overview / pool view are **R6.4 (Part 6)** — content is already contained.
- View-state behavior (read→edit, confirmable privacy, danger-zone relocation) is **Part 5 / PR 2**.

## Testing
- `npm run typecheck` clean
- Full unit suite: **1067 passed** (incl. new `section.test.tsx`)
- Lint: only 2 pre-existing warnings, none introduced

https://claude.ai/code/session_01WxjmZST9sAs7K1UL45i5Vv