### PR TITLE
fix(view-state): read-mode-first, confirmable privacy, pool settings route (Design Rules Part 5)

### DIFF
--- a/app/components/editable-section.tsx
+++ b/app/components/editable-section.tsx
@@ -1,0 +1,112 @@
+import { type ReactNode, useEffect, useRef } from 'react';
+
+import { Button } from '#app/components/ui/button.tsx';
+import { Card } from '#app/components/ui/card.tsx';
+import { Text } from '#app/components/ui-kit/text.tsx';
+import { cn } from '#app/utils/misc.tsx';
+
+/**
+ * A card that opens in *read* mode and offers an explicit way into *edit* mode
+ * (R5.1). Showing current state first makes a screen feel intentional and stops
+ * accidental edits. The caller owns the `editing` state and supplies both the
+ * read view and the edit form (which keeps its own Save/Cancel controls).
+ */
+export function EditableSection({
+  title,
+  description,
+  editing,
+  onEdit,
+  editLabel = 'Edit',
+  read,
+  children,
+  className,
+}: {
+  title: string;
+  description?: string;
+  editing: boolean;
+  onEdit: () => void;
+  editLabel?: string;
+  /** Read-mode content (current values). */
+  read: ReactNode;
+  /** Edit-mode content (the form). */
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <Card padding="lg" className={cn('flex flex-col gap-5', className)}>
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex flex-col gap-0.5">
+          <Text as="h2" size="lg" weight="semibold" className="text-foreground">
+            {title}
+          </Text>
+          {description ? (
+            <Text size="xs" className="text-muted-foreground">
+              {description}
+            </Text>
+          ) : null}
+        </div>
+        {editing ? null : (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="shrink-0"
+            onClick={onEdit}
+          >
+            {editLabel}
+          </Button>
+        )}
+      </div>
+      {editing ? children : read}
+    </Card>
+  );
+}
+
+/** A labelled current value for read mode. */
+export function ReadField({
+  label,
+  value,
+  className,
+}: {
+  label: string;
+  value: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={cn('flex flex-col gap-0.5', className)}>
+      <Text size="xs" weight="medium" className="text-muted-foreground">
+        {label}
+      </Text>
+      <Text size="sm" className="text-foreground">
+        {value}
+      </Text>
+    </div>
+  );
+}
+
+/**
+ * Leaves edit mode once a submit completes successfully. Tracks the in-flight
+ * transition so a stale `success` from an earlier save can't immediately kick
+ * the user back out of a freshly reopened editor.
+ */
+export function useExitOnSubmitSuccess({
+  state,
+  success,
+  onExit,
+}: {
+  state: 'idle' | 'loading' | 'submitting';
+  success: boolean;
+  onExit: () => void;
+}) {
+  const wasSubmitting = useRef(false);
+  useEffect(() => {
+    if (state !== 'idle') {
+      wasSubmitting.current = true;
+      return;
+    }
+    if (wasSubmitting.current) {
+      wasSubmitting.current = false;
+      if (success) onExit();
+    }
+  }, [state, success, onExit]);
+}

--- a/app/components/ui/system-label.test.tsx
+++ b/app/components/ui/system-label.test.tsx
@@ -1,0 +1,25 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { SystemLabel } from './system-label.tsx';
+
+describe('SystemLabel', () => {
+  it('renders its children', () => {
+    render(<SystemLabel>you</SystemLabel>);
+    expect(screen.getByText('you')).toBeInTheDocument();
+  });
+
+  it('applies a muted, system-toned treatment distinct from user data', () => {
+    render(<SystemLabel>owner</SystemLabel>);
+    const label = screen.getByText('owner');
+    expect(label.className).toContain('bg-muted');
+    expect(label.className).toContain('text-muted-foreground');
+  });
+
+  it('merges a custom className', () => {
+    render(<SystemLabel className="ml-2">member</SystemLabel>);
+    expect(screen.getByText('member').className).toContain('ml-2');
+  });
+});

--- a/app/components/ui/system-label.tsx
+++ b/app/components/ui/system-label.tsx
@@ -1,0 +1,32 @@
+import { type ReactNode } from 'react';
+
+import { cn } from '#app/utils/misc.tsx';
+
+/**
+ * A system-supplied annotation (you, owner, "from wishlist", etc.) rendered so
+ * it reads as *system*, not as content the user typed (R5.4). The muted pill
+ * treatment deliberately differs from username/value styling so a label like
+ * "you" is never mistaken for part of a name.
+ *
+ * Baseline tone matches the existing pool contributor "you" pill. Role badges
+ * (`RoleBadge`) keep their own iconography — this is for lightweight inline
+ * markers.
+ */
+export function SystemLabel({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <span
+      className={cn(
+        'inline-flex shrink-0 items-center rounded bg-muted px-1.5 py-px text-[10px] font-medium text-muted-foreground',
+        className,
+      )}
+    >
+      {children}
+    </span>
+  );
+}

--- a/app/routes/groups+/$giftGroupId_+/members.component.test.tsx
+++ b/app/routes/groups+/$giftGroupId_+/members.component.test.tsx
@@ -149,10 +149,9 @@ describe('Members tab — PoolActionForMember per row', () => {
 
   it("hides the pool action on the viewer's own row", () => {
     render(<GroupMembersRoute />);
-    // Viewer's row shows "viewer (You)" — confirm presence by partial match.
-    expect(
-      screen.getByText((_, el) => el?.textContent === 'viewer (You)'),
-    ).toBeInTheDocument();
+    // Viewer's row shows the username plus a system "you" label.
+    expect(screen.getByText('viewer')).toBeInTheDocument();
+    expect(screen.getByText('you')).toBeInTheDocument();
     // Total pool action links = 1 (only Marco's "View pool").
     const allLinks = screen.getAllByRole('link');
     const poolLinks = allLinks.filter((link) =>

--- a/app/routes/groups+/$giftGroupId_+/members.tsx
+++ b/app/routes/groups+/$giftGroupId_+/members.tsx
@@ -15,6 +15,7 @@ import { Avatar } from '#app/components/ui/avatar.tsx';
 import { Button } from '#app/components/ui/button.tsx';
 import { Card } from '#app/components/ui/card.tsx';
 import { Icon } from '#app/components/ui/icon.tsx';
+import { SystemLabel } from '#app/components/ui/system-label.tsx';
 import { type loader as routeLoader } from './__route.server';
 import { applyPendingSettingsMemberMutations } from './__route.shared';
 
@@ -127,9 +128,9 @@ const GroupMembersRoute = () => {
               >
                 <Avatar size="s" image={m.user.image} user={m.user} />
                 <div>
-                  <div className="font-medium">
-                    {m.user.username}
-                    {isViewer ? ' (You)' : ''}
+                  <div className="flex items-center gap-1.5 font-medium">
+                    <span>{m.user.username}</span>
+                    {isViewer ? <SystemLabel>you</SystemLabel> : null}
                   </div>
                   <div className="text-xs text-muted-foreground">
                     {birthday

--- a/app/routes/groups+/$giftGroupId_+/settings.tsx
+++ b/app/routes/groups+/$giftGroupId_+/settings.tsx
@@ -32,6 +32,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '#app/components/ui/select.tsx';
+import { SystemLabel } from '#app/components/ui/system-label.tsx';
 // import { StatusButton } from '#app/components/ui/status-button.tsx';
 import { Textarea } from '#app/components/ui/textarea.tsx';
 import { prisma } from '#app/utils/db.server.ts';
@@ -567,9 +568,9 @@ const GroupSettingsRoute = () => {
                 <div className="flex min-w-0 flex-1 items-center gap-3">
                   <Avatar size="s" image={m.user.image} user={m.user} />
                   <div className="min-w-0">
-                    <div className="truncate font-medium">
-                      {m.user.username}
-                      {isViewer ? ' (You)' : ''}
+                    <div className="flex items-center gap-1.5 font-medium">
+                      <span className="truncate">{m.user.username}</span>
+                      {isViewer ? <SystemLabel>you</SystemLabel> : null}
                     </div>
                     <div className="mt-0.5 flex items-center gap-2 text-xs text-muted-foreground">
                       <RoleBadge role={m.role} />

--- a/app/routes/pools+/$poolId+/__route.server.test.ts
+++ b/app/routes/pools+/$poolId+/__route.server.test.ts
@@ -1035,9 +1035,10 @@ describe('pool detail route action — update-pool-details', () => {
     );
   });
 
-  it('ignores a gift-selection method change once the pool is past OPEN', async () => {
-    // createPool defaults to VOTING.
-    await action(
+  it('saves details for a past-OPEN pool even when decisionMode is omitted', async () => {
+    // createPool defaults to VOTING. The editor disables the method select past
+    // OPEN, so the browser omits decisionMode entirely — this must still save.
+    const result = await action(
       toActionArgs({
         context: {} as never,
         params: { poolId: 'pool-1' },
@@ -1046,11 +1047,11 @@ describe('pool detail route action — update-pool-details', () => {
           poolId: 'pool-1',
           title: 'Updated title',
           occasionType: 'BIRTHDAY',
-          decisionMode: 'VOTE',
         }),
       }),
     );
 
+    expect(getRouteResultStatus(result)).toBe(200);
     expect(updatePool).toHaveBeenCalledWith(
       'pool-1',
       'viewer-1',

--- a/app/routes/pools+/$poolId+/__route.server.test.ts
+++ b/app/routes/pools+/$poolId+/__route.server.test.ts
@@ -33,6 +33,7 @@ const proposeIdea = vi.fn();
 const removeContributor = vi.fn();
 const updateContribution = vi.fn();
 const updateFinalPrice = vi.fn();
+const updatePool = vi.fn();
 const poolFindUnique = vi.fn();
 const giftIdeaFindFirst = vi.fn();
 const ideaVoteFindUnique = vi.fn();
@@ -107,6 +108,7 @@ vi.mock('#app/utils/pool.server.ts', () => ({
   removeContributor: (...args: Array<unknown>) => removeContributor(...args),
   updateContribution: (...args: Array<unknown>) => updateContribution(...args),
   updateFinalPrice: (...args: Array<unknown>) => updateFinalPrice(...args),
+  updatePool: (...args: Array<unknown>) => updatePool(...args),
 }));
 
 vi.mock('#app/utils/toast.server.ts', () => ({
@@ -183,6 +185,7 @@ beforeEach(() => {
   removeContributor.mockReset().mockResolvedValue(undefined);
   updateContribution.mockReset().mockResolvedValue(undefined);
   updateFinalPrice.mockReset().mockResolvedValue(undefined);
+  updatePool.mockReset().mockResolvedValue({ id: 'pool-1' });
   giftIdeaFindFirst.mockReset();
   ideaVoteFindUnique.mockReset().mockResolvedValue(null);
   wishlistItemFindMany.mockReset().mockResolvedValue([]);
@@ -998,5 +1001,102 @@ describe('pool detail route action', () => {
       title: 'Pool deleted',
       type: 'success',
     });
+  });
+});
+
+describe('pool detail route action — update-pool-details', () => {
+  it('updates details and the gift-selection method while the pool is OPEN', async () => {
+    poolFindUnique.mockResolvedValue(createPool({ status: 'OPEN' }));
+
+    const result = await action(
+      toActionArgs({
+        context: {} as never,
+        params: { poolId: 'pool-1' },
+        request: createFormRequest({
+          intent: 'update-pool-details',
+          poolId: 'pool-1',
+          title: 'Updated title',
+          occasionType: 'WEDDING',
+          eventDate: '2026-05-01',
+          decisionMode: 'VOTE',
+        }),
+      }),
+    );
+
+    expect(getRouteResultStatus(result)).toBe(200);
+    expect(updatePool).toHaveBeenCalledWith(
+      'pool-1',
+      'viewer-1',
+      expect.objectContaining({
+        title: 'Updated title',
+        occasionType: 'WEDDING',
+        decisionMode: 'VOTE',
+      }),
+    );
+  });
+
+  it('ignores a gift-selection method change once the pool is past OPEN', async () => {
+    // createPool defaults to VOTING.
+    await action(
+      toActionArgs({
+        context: {} as never,
+        params: { poolId: 'pool-1' },
+        request: createFormRequest({
+          intent: 'update-pool-details',
+          poolId: 'pool-1',
+          title: 'Updated title',
+          occasionType: 'BIRTHDAY',
+          decisionMode: 'VOTE',
+        }),
+      }),
+    );
+
+    expect(updatePool).toHaveBeenCalledWith(
+      'pool-1',
+      'viewer-1',
+      expect.not.objectContaining({ decisionMode: expect.anything() }),
+    );
+  });
+
+  it('rejects detail edits from non-managers', async () => {
+    canManagePool.mockResolvedValue(false);
+
+    await expect(
+      action(
+        toActionArgs({
+          context: {} as never,
+          params: { poolId: 'pool-1' },
+          request: createFormRequest({
+            intent: 'update-pool-details',
+            poolId: 'pool-1',
+            title: 'Updated title',
+            occasionType: 'BIRTHDAY',
+            decisionMode: 'VOTE',
+          }),
+        }),
+      ),
+    ).rejects.toMatchObject({ init: { status: 403 } });
+    expect(updatePool).not.toHaveBeenCalled();
+  });
+
+  it('rejects detail edits once the pool is closed', async () => {
+    poolFindUnique.mockResolvedValue(createPool({ status: 'CANCELLED' }));
+
+    await expect(
+      action(
+        toActionArgs({
+          context: {} as never,
+          params: { poolId: 'pool-1' },
+          request: createFormRequest({
+            intent: 'update-pool-details',
+            poolId: 'pool-1',
+            title: 'Updated title',
+            occasionType: 'BIRTHDAY',
+            decisionMode: 'VOTE',
+          }),
+        }),
+      ),
+    ).rejects.toMatchObject({ init: { status: 400 } });
+    expect(updatePool).not.toHaveBeenCalled();
   });
 });

--- a/app/routes/pools+/$poolId+/__route.server.ts
+++ b/app/routes/pools+/$poolId+/__route.server.ts
@@ -276,7 +276,10 @@ const UpdateDetailsSchema = PoolIdSchema.extend({
 		Object.values(OCCASION_TYPE) as [OccasionType, ...OccasionType[]],
 	),
 	eventDate: z.string().optional(),
-	decisionMode: z.enum(['ORGANIZER_PICKS', 'VOTE']),
+	// Optional: the editor disables (and so omits) this control once the pool is
+	// past OPEN, and the handler only applies it while OPEN anyway. Requiring it
+	// would block title/occasion/date edits on VOTING/DECIDED/PURCHASED pools.
+	decisionMode: z.enum(['ORGANIZER_PICKS', 'VOTE']).optional(),
 })
 
 const ActionSchema = ProposeIdeaSchema.or(DeleteIdeaSchema)
@@ -577,7 +580,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
 			}
 			// The gift-selection method only changes cleanly before a vote is
 			// called — once VOTING/DECIDED, switching modes is ambiguous.
-			if (pool.status === POOL_STATUS.OPEN) {
+			if (pool.status === POOL_STATUS.OPEN && v.decisionMode) {
 				updates.decisionMode = v.decisionMode
 			}
 			await updatePool(poolId, userId, updates)

--- a/app/routes/pools+/$poolId+/__route.server.ts
+++ b/app/routes/pools+/$poolId+/__route.server.ts
@@ -6,7 +6,11 @@ import { requireUserId } from '#app/utils/auth.server.ts'
 import { prisma } from '#app/utils/db.server.ts'
 import { canViewWishlistOf } from '#app/utils/friends.server.ts'
 import { dollarsToCents } from '#app/utils/price.ts'
-import { POOL_STATUS } from '#app/utils/pool-constants.ts'
+import {
+	OCCASION_TYPE,
+	POOL_STATUS,
+	type OccasionType,
+} from '#app/utils/pool-constants.ts'
 import {
 	canManagePool,
 	isPoolOrganizer,
@@ -34,6 +38,8 @@ import {
 	removeContributor,
 	updateContribution,
 	updateFinalPrice,
+	updatePool,
+	type UpdatePoolInput,
 } from '#app/utils/pool.server.ts'
 import { getRequestContext } from '#app/utils/request-context.server.ts'
 import { redirectWithToast } from '#app/utils/toast.server.ts'
@@ -155,6 +161,7 @@ enum Intent {
 	LeavePool = 'leave-pool',
 	CancelPool = 'cancel-pool',
 	DeletePool = 'delete-pool',
+	UpdateDetails = 'update-pool-details',
 }
 
 // ─── Schemas ──────────────────────────────────────────────────────────────────
@@ -262,6 +269,16 @@ const DeletePoolSchema = PoolIdSchema.extend({
 	intent: z.literal(Intent.DeletePool),
 })
 
+const UpdateDetailsSchema = PoolIdSchema.extend({
+	intent: z.literal(Intent.UpdateDetails),
+	title: z.string().min(1, 'Give the pool a title').max(200),
+	occasionType: z.enum(
+		Object.values(OCCASION_TYPE) as [OccasionType, ...OccasionType[]],
+	),
+	eventDate: z.string().optional(),
+	decisionMode: z.enum(['ORGANIZER_PICKS', 'VOTE']),
+})
+
 const ActionSchema = ProposeIdeaSchema.or(DeleteIdeaSchema)
 	.or(CastVoteSchema)
 	.or(CallVoteSchema)
@@ -279,6 +296,7 @@ const ActionSchema = ProposeIdeaSchema.or(DeleteIdeaSchema)
 	.or(LeavePoolSchema)
 	.or(CancelPoolSchema)
 	.or(DeletePoolSchema)
+	.or(UpdateDetailsSchema)
 
 // ─── Action ───────────────────────────────────────────────────────────────────
 
@@ -539,6 +557,31 @@ export async function action({ request, params }: ActionFunctionArgs) {
 				title: 'Pool deleted',
 				description: 'The pool has been deleted.',
 			})
+		}
+
+		case Intent.UpdateDetails: {
+			if (!(await canManagePool(userId, poolForPerms))) {
+				throw data({ error: 'Not allowed.' }, { status: 403 })
+			}
+			// Pool details are editable until the pool closes out.
+			if (
+				pool.status === POOL_STATUS.DELIVERED ||
+				pool.status === POOL_STATUS.CANCELLED
+			) {
+				throw data({ error: 'This pool is closed.' }, { status: 400 })
+			}
+			const updates: UpdatePoolInput = {
+				title: v.title,
+				occasionType: v.occasionType,
+				eventDate: v.eventDate ? new Date(v.eventDate) : null,
+			}
+			// The gift-selection method only changes cleanly before a vote is
+			// called — once VOTING/DECIDED, switching modes is ambiguous.
+			if (pool.status === POOL_STATUS.OPEN) {
+				updates.decisionMode = v.decisionMode
+			}
+			await updatePool(poolId, userId, updates)
+			return data(submission.reply())
 		}
 	}
 }

--- a/app/routes/pools+/$poolId+/_layout.tsx
+++ b/app/routes/pools+/$poolId+/_layout.tsx
@@ -1,4 +1,4 @@
-import { LuGift, LuUsers } from 'react-icons/lu'
+import { LuGift, LuSettings, LuUsers } from 'react-icons/lu'
 import { Link, Outlet, useLoaderData } from 'react-router'
 import { PageHeader } from '#app/components/page-header.tsx'
 import { Stack, Text } from '#app/components/ui-kit'
@@ -22,7 +22,7 @@ const statusColors: Record<PoolStatus, string> = {
 }
 
 const PoolLayout = () => {
-	const { pool } = useLoaderData<typeof routeLoader>()
+	const { pool, canManage } = useLoaderData<typeof routeLoader>()
 
 	const status = pool.status as PoolStatus
 	const occasion = pool.occasionType as OccasionType
@@ -46,11 +46,22 @@ const PoolLayout = () => {
 				title={pool.title}
 				subtitle={`${OCCASION_TYPE_LABELS[occasion]} for ${recipientLabel}`}
 			>
-				<span
-					className={`shrink-0 rounded-full px-2.5 py-0.5 text-xs font-semibold ${statusColors[status]}`}
-				>
-					{POOL_STATUS_LABELS[status]}
-				</span>
+				<div className="flex shrink-0 items-center gap-2">
+					<span
+						className={`rounded-full px-2.5 py-0.5 text-xs font-semibold ${statusColors[status]}`}
+					>
+						{POOL_STATUS_LABELS[status]}
+					</span>
+					{canManage && (
+						<Link
+							to="settings"
+							aria-label="Pool settings"
+							className="text-muted-foreground hover:text-foreground"
+						>
+							<LuSettings className="h-5 w-5" />
+						</Link>
+					)}
+				</div>
 			</PageHeader>
 
 			{/* Content */}

--- a/app/routes/pools+/$poolId+/index.test.tsx
+++ b/app/routes/pools+/$poolId+/index.test.tsx
@@ -169,7 +169,7 @@ describe('app/routes/pools+/$poolId+/index.tsx', () => {
     );
   }
 
-  it('renders the active voting UI, contribution editor, and invite tools', async () => {
+  it('renders the active voting UI and contribution editor', async () => {
     renderRoute();
 
     expect(screen.getByText('Organizer controls')).toBeInTheDocument();
@@ -189,15 +189,16 @@ describe('app/routes/pools+/$poolId+/index.tsx', () => {
     await userEvent.clear(input);
     await userEvent.type(input, '45');
     expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+  });
 
-    await userEvent.click(screen.getByRole('button', { name: /copy/i }));
-    expect(clipboardWriteText).toHaveBeenCalledWith(
-      'https://giftpool.app/pools/join/invite-1',
-    );
-
-    expect(screen.getByText('Danger zone')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Cancel pool' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Delete pool' })).toBeInTheDocument();
+  it('moves invite tools and the danger zone off the main page (now on settings)', () => {
+    renderRoute();
+    // These live on /pools/:id/settings now, reached from the header gear.
+    expect(screen.queryByRole('button', { name: /copy/i })).not.toBeInTheDocument();
+    expect(screen.queryByText('Danger zone')).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Delete pool' }),
+    ).not.toBeInTheDocument();
   });
 
   it('prefills the propose form from a picked wishlist item', async () => {

--- a/app/routes/pools+/$poolId+/index.tsx
+++ b/app/routes/pools+/$poolId+/index.tsx
@@ -8,7 +8,6 @@ import { getFormProps, getInputProps, useForm } from '@conform-to/react'
 import { parseWithZod } from '@conform-to/zod'
 import {
 	LuCheck,
-	LuClipboard,
 	LuLink,
 	LuPackage,
 	LuThumbsUp,
@@ -26,6 +25,7 @@ import { Badge } from '#app/components/ui/badge.tsx'
 import { Button } from '#app/components/ui/button.tsx'
 import { Card } from '#app/components/ui/card.tsx'
 import { Input } from '#app/components/ui/input.tsx'
+import { SystemLabel } from '#app/components/ui/system-label.tsx'
 import { Textarea } from '#app/components/ui/textarea.tsx'
 import { Flex, Stack, Text } from '#app/components/ui-kit'
 import { formatCents } from '#app/utils/pool-contributions.ts'
@@ -630,11 +630,7 @@ const ContributorsList = ({
 											<span className={isMe ? 'font-semibold' : ''}>
 												{getUserDisplayName(c.user)}
 											</span>
-											{isMe && (
-												<span className="rounded bg-muted px-1.5 py-px text-[10px] font-medium text-muted-foreground">
-													you
-												</span>
-											)}
+											{isMe && <SystemLabel>you</SystemLabel>}
 										</div>
 										{(isOrganizer || isPurchaser || isDeliverer) && (
 											<div className="mt-0.5 flex flex-wrap gap-1">
@@ -780,76 +776,15 @@ const AssignRolesSection = ({
 	)
 }
 
-// Invite link section
-const InviteSection = ({
-	poolId,
-	inviteUrl,
-}: {
-	poolId: string
-	inviteUrl: string | null
-}) => {
-	const fetcher = useFetcher()
-	const freshUrl =
-		fetcher.data && 'inviteUrl' in (fetcher.data as object)
-			? (fetcher.data as { inviteUrl: string }).inviteUrl
-			: inviteUrl
-
-	const copyToClipboard = () => {
-		if (freshUrl) void navigator.clipboard.writeText(freshUrl)
-	}
-
-	return (
-		<Card className="p-4">
-			<Stack gap={3}>
-				<SectionHeading>Invite contributors</SectionHeading>
-				<p className="text-xs text-muted-foreground">
-					Anyone with this link can join as a contributor.
-				</p>
-				{freshUrl ? (
-					<Flex gap={2}>
-						<Input value={freshUrl} readOnly className="flex-1 text-xs" />
-						<Button
-							type="button"
-							size="sm"
-							variant="outline"
-							onClick={copyToClipboard}
-							className="gap-1.5 shrink-0"
-						>
-							<LuClipboard size={13} /> Copy
-						</Button>
-					</Flex>
-				) : (
-					<fetcher.Form method="post">
-						<input type="hidden" name="intent" value="generate-invite" />
-						<input type="hidden" name="poolId" value={poolId} />
-						<Button
-							type="submit"
-							size="sm"
-							variant="outline"
-							className="gap-1.5"
-							disabled={fetcher.state !== 'idle'}
-						>
-							<LuLink size={13} />
-							Generate invite link
-						</Button>
-					</fetcher.Form>
-				)}
-			</Stack>
-		</Card>
-	)
-}
-
 // ─── Main component ───────────────────────────────────────────────────────────
 
 const PoolIndex = () => {
 	const {
 		pool,
 		viewer,
-		isOrganizer,
 		canManage,
 		myVoteIdeaId,
 		contributionBreakdown,
-		inviteUrl,
 		recipientWishlistItems,
 	} = useRouteLoaderData<typeof routeLoader>(
 		'routes/pools+/$poolId+/_layout',
@@ -861,9 +796,7 @@ const PoolIndex = () => {
 	const isDecided = status === POOL_STATUS.DECIDED
 	const isPurchased = status === POOL_STATUS.PURCHASED
 	const isDelivered = status === POOL_STATUS.DELIVERED
-	const isCancelled = status === POOL_STATUS.CANCELLED
 	const isActive = isOpen || isVoting
-	const isCompleted = isDelivered || isCancelled
 
 	const chosenIdea = pool.ideas.find(i => i.id === pool.chosenIdeaId) ?? null
 	const isPurchaser = viewer?.userId === pool.purchaserId
@@ -1050,52 +983,8 @@ const PoolIndex = () => {
 				/>
 			)}
 
-			{/* ── Invite link (active pools, managers only) ── */}
-			{canManage && isActive && (
-				<InviteSection poolId={pool.id} inviteUrl={inviteUrl} />
-			)}
-
-			{/* ── Danger zone (organizer only) ── */}
-			{isOrganizer && !isCompleted && (
-				<Card className="border-destructive/40 bg-destructive/5 p-4">
-					<Stack gap={3}>
-						<SectionHeading>Danger zone</SectionHeading>
-						<Text size="sm" className="text-muted-foreground">
-							These actions are destructive. Double-check before proceeding.
-						</Text>
-						<Flex gap={2} wrap="wrap">
-							{/* Cancel pool lives here — less drastic than delete but still destructive */}
-							{isActive && (
-								<Form
-									method="post"
-									onSubmit={e => {
-										if (!confirm('Cancel this pool?')) e.preventDefault()
-									}}
-								>
-									<input type="hidden" name="intent" value="cancel-pool" />
-									<input type="hidden" name="poolId" value={pool.id} />
-									<Button type="submit" size="sm" variant="outline" className="border-destructive/40 text-destructive hover:bg-destructive/5">
-										Cancel pool
-									</Button>
-								</Form>
-							)}
-							<Form
-								method="post"
-								onSubmit={e => {
-									if (!confirm('Delete this pool? This cannot be undone.'))
-										e.preventDefault()
-								}}
-							>
-								<input type="hidden" name="intent" value="delete-pool" />
-								<input type="hidden" name="poolId" value={pool.id} />
-								<Button type="submit" variant="destructive" size="sm">
-									Delete pool
-								</Button>
-							</Form>
-						</Flex>
-					</Stack>
-				</Card>
-			)}
+			{/* Inviting contributors and the danger zone (cancel / delete) now
+			    live on the pool settings page, reached from the header. */}
 		</Stack>
 	)
 }

--- a/app/routes/pools+/$poolId+/settings.test.tsx
+++ b/app/routes/pools+/$poolId+/settings.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const loaderDataSnapshot = {
+  inviteUrl: 'https://giftpool.app/pools/join/invite-1' as string | null,
+  isOrganizer: true,
+  pool: {
+    id: 'pool-1',
+    title: 'Alex Birthday Pool',
+    occasionType: 'BIRTHDAY',
+    eventDate: '2026-05-01T00:00:00.000Z' as string | null,
+    decisionMode: 'ORGANIZER_PICKS',
+    status: 'OPEN',
+    recipientName: 'Alex',
+    recipientUser: null as { name: string | null; username: string } | null,
+  },
+};
+
+vi.mock('react-router', async () => {
+  const actual =
+    await vi.importActual<typeof import('react-router')>('react-router');
+  return {
+    ...actual,
+    useLoaderData: () => loaderDataSnapshot,
+    useFetcher: () => ({
+      Form: (props: React.ComponentProps<'form'>) => <form {...props} />,
+      data: undefined,
+      state: 'idle',
+      submit: vi.fn(),
+    }),
+  };
+});
+
+import PoolSettings from './settings.tsx';
+
+function renderRoute() {
+  return render(
+    <MemoryRouter initialEntries={['/pools/pool-1/settings']}>
+      <PoolSettings />
+    </MemoryRouter>,
+  );
+}
+
+describe('app/routes/pools+/$poolId+/settings.tsx', () => {
+  beforeEach(() => {
+    loaderDataSnapshot.pool.status = 'OPEN';
+    loaderDataSnapshot.isOrganizer = true;
+    loaderDataSnapshot.inviteUrl = 'https://giftpool.app/pools/join/invite-1';
+  });
+
+  it('opens pool details in read mode and surfaces invite + danger zone', () => {
+    renderRoute();
+
+    expect(
+      screen.getByRole('heading', { name: 'Pool settings' }),
+    ).toBeInTheDocument();
+    // Read mode: values shown, no title input yet.
+    expect(screen.getByText('Alex Birthday Pool')).toBeInTheDocument();
+    expect(screen.getByText('Organizer chooses')).toBeInTheDocument();
+    expect(
+      document.querySelector('input[name="title"]'),
+    ).not.toBeInTheDocument();
+
+    expect(screen.getByText('Invite contributors')).toBeInTheDocument();
+    expect(screen.getByText('Danger zone')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Delete pool' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Cancel pool' }),
+    ).toBeInTheDocument();
+  });
+
+  it('reveals the details form on Edit, with the method editable while OPEN', () => {
+    renderRoute();
+    fireEvent.click(screen.getByRole('button', { name: 'Edit details' }));
+
+    const title = document.querySelector(
+      'input[name="title"]',
+    ) as HTMLInputElement;
+    expect(title.value).toBe('Alex Birthday Pool');
+
+    const method = document.querySelector(
+      'select[name="decisionMode"]',
+    ) as HTMLSelectElement;
+    expect(method.disabled).toBe(false);
+  });
+
+  it('locks the gift-selection method once the pool is past OPEN', () => {
+    loaderDataSnapshot.pool.status = 'VOTING';
+    renderRoute();
+    fireEvent.click(screen.getByRole('button', { name: 'Edit details' }));
+
+    const method = document.querySelector(
+      'select[name="decisionMode"]',
+    ) as HTMLSelectElement;
+    expect(method.disabled).toBe(true);
+  });
+
+  it('hides the delete action from non-organizer managers', () => {
+    loaderDataSnapshot.isOrganizer = false;
+    renderRoute();
+    expect(
+      screen.queryByRole('button', { name: 'Delete pool' }),
+    ).not.toBeInTheDocument();
+    // Cancel (a manage-level action) is still available.
+    expect(
+      screen.getByRole('button', { name: 'Cancel pool' }),
+    ).toBeInTheDocument();
+  });
+});

--- a/app/routes/pools+/$poolId+/settings.tsx
+++ b/app/routes/pools+/$poolId+/settings.tsx
@@ -1,0 +1,443 @@
+import {
+	getFormProps,
+	getInputProps,
+	useForm,
+	type SubmissionResult,
+} from '@conform-to/react';
+import { getZodConstraint, parseWithZod } from '@conform-to/zod';
+import { useCallback, useEffect, useState } from 'react';
+import { LuClipboard, LuLink } from 'react-icons/lu';
+import {
+	useFetcher,
+	useLoaderData,
+	type LoaderFunctionArgs,
+} from 'react-router';
+import { z } from 'zod';
+import {
+	EditableSection,
+	ReadField,
+	useExitOnSubmitSuccess,
+} from '#app/components/editable-section.tsx';
+import { ErrorList, Field } from '#app/components/forms.tsx';
+import { Button } from '#app/components/ui/button.tsx';
+import { Card } from '#app/components/ui/card.tsx';
+import { ConfirmDialog } from '#app/components/ui/confirm-dialog.tsx';
+import { Input } from '#app/components/ui/input.tsx';
+import { Label } from '#app/components/ui/label.tsx';
+import { StatusButton } from '#app/components/ui/status-button.tsx';
+import { Flex, Stack, Text } from '#app/components/ui-kit';
+import { requireUserId } from '#app/utils/auth.server.ts';
+import { prisma } from '#app/utils/db.server.ts';
+import {
+	DECISION_MODE_LABELS,
+	OCCASION_TYPE,
+	OCCASION_TYPE_LABELS,
+	POOL_STATUS,
+	type DecisionMode,
+	type OccasionType,
+} from '#app/utils/pool-constants.ts';
+import {
+	canManagePool,
+	isPoolOrganizer,
+	type PoolForPermissions,
+} from '#app/utils/pool-permissions.server.ts';
+
+// Reuse the shared pool action so cancel/delete/generate-invite/update-details
+// all flow through one place.
+export { action } from './__route.server';
+
+export async function loader({ request, params }: LoaderFunctionArgs) {
+	const userId = await requireUserId(request);
+	const poolId = params.poolId!;
+
+	const pool = await prisma.pool.findUnique({
+		where: { id: poolId },
+		select: {
+			id: true,
+			title: true,
+			occasionType: true,
+			eventDate: true,
+			decisionMode: true,
+			status: true,
+			organizerId: true,
+			giftGroupId: true,
+			recipientUserId: true,
+			recipientName: true,
+			inviteCode: true,
+			recipientUser: { select: { name: true, username: true } },
+		},
+	});
+
+	// Privacy: the recipient must never confirm a pool exists (mirror the main
+	// pool loader). Anyone who can't manage the pool gets the same 404, so the
+	// settings surface never reveals itself to non-managers.
+	if (!pool || pool.recipientUserId === userId) {
+		throw new Response('Not Found', { status: 404 });
+	}
+
+	const poolForPerms: PoolForPermissions = {
+		id: pool.id,
+		organizerId: pool.organizerId,
+		giftGroupId: pool.giftGroupId,
+		status: pool.status,
+	};
+	if (!(await canManagePool(userId, poolForPerms))) {
+		throw new Response('Not Found', { status: 404 });
+	}
+
+	const inviteUrl = pool.inviteCode
+		? `${new URL(request.url).origin}/pools/join/${pool.inviteCode}`
+		: null;
+
+	return {
+		pool,
+		inviteUrl,
+		isOrganizer: isPoolOrganizer(userId, poolForPerms),
+	};
+}
+
+const PoolDetailsSchema = z.object({
+	title: z.string().min(1, 'Give the pool a title').max(200),
+	occasionType: z.enum(
+		Object.values(OCCASION_TYPE) as [OccasionType, ...OccasionType[]],
+	),
+	eventDate: z.string().optional(),
+	decisionMode: z.enum(['ORGANIZER_PICKS', 'VOTE']),
+});
+
+function toDateInputValue(value: Date | string | null | undefined) {
+	if (!value) return '';
+	const date = value instanceof Date ? value : new Date(value);
+	if (Number.isNaN(date.getTime())) return '';
+	return date.toISOString().slice(0, 10);
+}
+
+const PoolSettings = () => {
+	const { pool, inviteUrl, isOrganizer } = useLoaderData<typeof loader>();
+	const isClosed =
+		pool.status === POOL_STATUS.DELIVERED ||
+		pool.status === POOL_STATUS.CANCELLED;
+
+	return (
+		<Stack gap={6}>
+			<div className="flex flex-col gap-1">
+				<Text as="h1" size="xl" weight="bold">
+					Pool settings
+				</Text>
+				<Text size="sm" className="text-muted-foreground">
+					Everything about this pool as an entity — what it is, who it's for,
+					and how the gift gets chosen.
+				</Text>
+			</div>
+
+			<PoolDetailsCard pool={pool} isClosed={isClosed} />
+			<InviteSection poolId={pool.id} inviteUrl={inviteUrl} />
+			{!isClosed && (
+				<DangerZone
+					poolId={pool.id}
+					isOrganizer={isOrganizer}
+					canCancel={pool.status !== POOL_STATUS.DELIVERED}
+				/>
+			)}
+		</Stack>
+	);
+};
+export default PoolSettings;
+
+// ─── Pool details (read → edit) ────────────────────────────────────────────
+
+function PoolDetailsCard({
+	pool,
+	isClosed,
+}: {
+	pool: {
+		id: string;
+		title: string;
+		occasionType: string;
+		eventDate: string | Date | null;
+		decisionMode: string;
+		status: string;
+		recipientName: string | null;
+		recipientUser: { name: string | null; username: string } | null;
+	};
+	isClosed: boolean;
+}) {
+	const fetcher = useFetcher<{ status?: string }>();
+	const [editing, setEditing] = useState(false);
+	const stopEditing = useCallback(() => setEditing(false), []);
+	// The gift-selection method is only safe to switch before a vote is called.
+	const methodLocked = pool.status !== POOL_STATUS.OPEN;
+
+	const [form, fields] = useForm<z.input<typeof PoolDetailsSchema>>({
+		id: 'pool-details',
+		constraint: getZodConstraint(PoolDetailsSchema),
+		lastResult: fetcher.data as unknown as SubmissionResult<string[]>,
+		onValidate({ formData }) {
+			return parseWithZod(formData, { schema: PoolDetailsSchema }) as any;
+		},
+		defaultValue: {
+			title: pool.title,
+			occasionType: pool.occasionType as OccasionType,
+			eventDate: toDateInputValue(pool.eventDate),
+			decisionMode: pool.decisionMode as DecisionMode,
+		},
+	});
+
+	useExitOnSubmitSuccess({
+		state: fetcher.state,
+		success: form.status === 'success',
+		onExit: stopEditing,
+	});
+
+	const recipientLabel =
+		pool.recipientName ??
+		pool.recipientUser?.name ??
+		pool.recipientUser?.username ??
+		'Someone special';
+	const eventDateDisplay = pool.eventDate
+		? new Date(pool.eventDate).toLocaleDateString()
+		: 'Not set';
+
+	return (
+		<EditableSection
+			title="Pool details"
+			description="The basics of this pool."
+			editLabel="Edit details"
+			editing={editing && !isClosed}
+			onEdit={() => setEditing(true)}
+			read={
+				<div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+					<ReadField label="Title" value={pool.title} />
+					<ReadField label="For" value={recipientLabel} />
+					<ReadField
+						label="Occasion"
+						value={OCCASION_TYPE_LABELS[pool.occasionType as OccasionType]}
+					/>
+					<ReadField label="Date" value={eventDateDisplay} />
+					<ReadField
+						label="Gift-selection method"
+						value={DECISION_MODE_LABELS[pool.decisionMode as DecisionMode]}
+					/>
+				</div>
+			}
+		>
+			<fetcher.Form
+				method="post"
+				{...getFormProps(form)}
+				className="flex flex-col gap-4"
+			>
+				<input type="hidden" name="intent" value="update-pool-details" />
+				<input type="hidden" name="poolId" value={pool.id} />
+
+				<Field
+					labelProps={{ htmlFor: fields.title.id, children: 'Title' }}
+					inputProps={getInputProps(fields.title, { type: 'text' })}
+					errors={fields.title.errors}
+				/>
+
+				<div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+					<div className="flex flex-col gap-1.5">
+						<Label htmlFor={fields.occasionType.id}>Occasion</Label>
+						<select
+							id={fields.occasionType.id}
+							name={fields.occasionType.name}
+							defaultValue={pool.occasionType}
+							className="flex h-10 w-full rounded-md border border-input bg-input-bg px-3 py-2 text-base ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 sm:text-sm"
+						>
+							{Object.entries(OCCASION_TYPE_LABELS).map(([value, label]) => (
+								<option key={value} value={value}>
+									{label}
+								</option>
+							))}
+						</select>
+					</div>
+
+					<Field
+						labelProps={{ htmlFor: fields.eventDate.id, children: 'Date' }}
+						inputProps={{
+							...getInputProps(fields.eventDate, { type: 'date' }),
+							required: false,
+						}}
+						errors={fields.eventDate.errors}
+					/>
+				</div>
+
+				<div className="flex flex-col gap-1.5">
+					<Label htmlFor={fields.decisionMode.id}>Gift-selection method</Label>
+					<select
+						id={fields.decisionMode.id}
+						name={fields.decisionMode.name}
+						defaultValue={pool.decisionMode}
+						disabled={methodLocked}
+						className="flex h-10 w-full rounded-md border border-input bg-input-bg px-3 py-2 text-base ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 sm:text-sm"
+					>
+						{Object.entries(DECISION_MODE_LABELS).map(([value, label]) => (
+							<option key={value} value={value}>
+								{label}
+							</option>
+						))}
+					</select>
+					<Text size="xs" className="text-muted-foreground">
+						{methodLocked
+							? 'Locked once the pool moves past the open stage.'
+							: 'Organizer chooses, or the group votes on the gift.'}
+					</Text>
+				</div>
+
+				<ErrorList errors={form.errors} id={form.errorId} />
+				<div className="flex justify-end gap-2">
+					<Button type="button" variant="ghost" onClick={stopEditing}>
+						Cancel
+					</Button>
+					<StatusButton
+						type="submit"
+						status={
+							fetcher.state !== 'idle' ? 'pending' : (form.status ?? 'idle')
+						}
+					>
+						Save details
+					</StatusButton>
+				</div>
+			</fetcher.Form>
+		</EditableSection>
+	);
+}
+
+// ─── Invite contributors ───────────────────────────────────────────────────
+
+const InviteSection = ({
+	poolId,
+	inviteUrl,
+}: {
+	poolId: string;
+	inviteUrl: string | null;
+}) => {
+	const fetcher = useFetcher<{ inviteUrl?: string }>();
+	const freshUrl =
+		fetcher.data && 'inviteUrl' in (fetcher.data as object)
+			? (fetcher.data as { inviteUrl: string }).inviteUrl
+			: inviteUrl;
+
+	useEffect(() => {
+		if (
+			fetcher.state === 'idle' &&
+			fetcher.data &&
+			'inviteUrl' in (fetcher.data as object)
+		) {
+			const url = (fetcher.data as { inviteUrl: string }).inviteUrl;
+			if (url) void navigator.clipboard.writeText(url);
+		}
+	}, [fetcher.state, fetcher.data]);
+
+	return (
+		<Card className="p-4">
+			<Stack gap={3}>
+				<Text size="lg" weight="semibold">
+					Invite contributors
+				</Text>
+				<p className="text-xs text-muted-foreground">
+					Anyone with this link can join as a contributor.
+				</p>
+				{freshUrl ? (
+					<Flex gap={2}>
+						<Input value={freshUrl} readOnly className="flex-1 text-xs" />
+						<Button
+							type="button"
+							size="sm"
+							variant="outline"
+							onClick={() => navigator.clipboard.writeText(freshUrl)}
+							className="shrink-0 gap-1.5"
+						>
+							<LuClipboard size={13} /> Copy
+						</Button>
+					</Flex>
+				) : (
+					<fetcher.Form method="post">
+						<input type="hidden" name="intent" value="generate-invite" />
+						<input type="hidden" name="poolId" value={poolId} />
+						<Button
+							type="submit"
+							size="sm"
+							variant="outline"
+							className="gap-1.5"
+							disabled={fetcher.state !== 'idle'}
+						>
+							<LuLink size={13} />
+							Generate invite link
+						</Button>
+					</fetcher.Form>
+				)}
+			</Stack>
+		</Card>
+	);
+};
+
+// ─── Danger zone ───────────────────────────────────────────────────────────
+
+const DangerZone = ({
+	poolId,
+	isOrganizer,
+	canCancel,
+}: {
+	poolId: string;
+	isOrganizer: boolean;
+	canCancel: boolean;
+}) => {
+	const cancelFetcher = useFetcher();
+	const deleteFetcher = useFetcher();
+
+	const submitIntent = (
+		fetcher: ReturnType<typeof useFetcher>,
+		intent: string,
+	) => {
+		const fd = new FormData();
+		fd.set('intent', intent);
+		fd.set('poolId', poolId);
+		void fetcher.submit(fd, { method: 'post' });
+	};
+
+	return (
+		<Card className="border-destructive/40 bg-destructive/5 p-4">
+			<Stack gap={3}>
+				<Text size="lg" weight="semibold">
+					Danger zone
+				</Text>
+				<Text size="sm" className="text-muted-foreground">
+					These actions are destructive. Double-check before proceeding.
+				</Text>
+				<Flex gap={2} wrap="wrap">
+					{canCancel && (
+						<ConfirmDialog
+							title="Cancel this pool?"
+							description="Contributors will no longer be able to act on it. This can't be undone."
+							confirmText="Cancel pool"
+							onConfirm={() => submitIntent(cancelFetcher, 'cancel-pool')}
+						>
+							<Button
+								type="button"
+								size="sm"
+								variant="outline"
+								className="border-destructive/40 text-destructive hover:bg-destructive/5"
+							>
+								Cancel pool
+							</Button>
+						</ConfirmDialog>
+					)}
+					{isOrganizer && (
+						<ConfirmDialog
+							title="Delete this pool?"
+							description="This permanently deletes the pool and everything in it."
+							confirmText="Delete pool"
+							requireText="DELETE"
+							onConfirm={() => submitIntent(deleteFetcher, 'delete-pool')}
+						>
+							<Button type="button" variant="destructive" size="sm">
+								Delete pool
+							</Button>
+						</ConfirmDialog>
+					)}
+				</Flex>
+			</Stack>
+		</Card>
+	);
+};

--- a/app/routes/pools+/$poolId+/settings.tsx
+++ b/app/routes/pools+/$poolId+/settings.tsx
@@ -81,6 +81,10 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 		giftGroupId: pool.giftGroupId,
 		status: pool.status,
 	};
+	// Contributor access is already enforced by the parent `_layout` loader
+	// (non-contributors get 404 there), so anyone reaching this loader is a
+	// contributor — the same guard the shared action relies on. This narrows
+	// it further to managers (organizer / group admin).
 	if (!(await canManagePool(userId, poolForPerms))) {
 		throw new Response('Not Found', { status: 404 });
 	}
@@ -102,7 +106,9 @@ const PoolDetailsSchema = z.object({
 		Object.values(OCCASION_TYPE) as [OccasionType, ...OccasionType[]],
 	),
 	eventDate: z.string().optional(),
-	decisionMode: z.enum(['ORGANIZER_PICKS', 'VOTE']),
+	// Optional because the select is disabled (and omitted) once the pool is
+	// past OPEN — see the matching note on the server UpdateDetailsSchema.
+	decisionMode: z.enum(['ORGANIZER_PICKS', 'VOTE']).optional(),
 });
 
 function toDateInputValue(value: Date | string | null | undefined) {

--- a/app/routes/settings+/profile.index.test.tsx
+++ b/app/routes/settings+/profile.index.test.tsx
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router';
 import { describe, expect, it, vi } from 'vitest';
@@ -91,6 +91,15 @@ function renderHub() {
   );
 }
 
+// Screens open in read mode (R5.1); editing is a deliberate step. These helpers
+// reveal the underlying forms so the form-population assertions can run.
+function editProfile() {
+  fireEvent.click(screen.getByRole('button', { name: 'Edit profile' }));
+}
+function editPrivacy() {
+  fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+}
+
 describe('<SettingsProfileHub />', () => {
   it('renders the Settings header and all card sections', () => {
     renderHub();
@@ -118,8 +127,19 @@ describe('<SettingsProfileHub />', () => {
     ).toBeInTheDocument();
   });
 
+  it('opens the Profile card in read mode showing current values', () => {
+    renderHub();
+    // Read mode: values shown as text, no editable inputs yet.
+    expect(screen.getByText('wade')).toBeInTheDocument();
+    expect(screen.getByText('Mercenary with a mouth.')).toBeInTheDocument();
+    expect(
+      document.querySelector('input[name="username"]'),
+    ).not.toBeInTheDocument();
+  });
+
   it('populates the bio and birthday fields from loader data', () => {
     const { container } = renderHub();
+    editProfile();
     const bio = container.querySelector(
       'textarea[name="bio"]',
     ) as HTMLTextAreaElement;
@@ -133,6 +153,7 @@ describe('<SettingsProfileHub />', () => {
 
   it('renders all four birthday visibility options with FRIENDS selected by default', () => {
     const { container } = renderHub();
+    editPrivacy();
     const radios = container.querySelectorAll<HTMLInputElement>(
       'input[name="birthdayVisibility"]',
     );
@@ -148,6 +169,7 @@ describe('<SettingsProfileHub />', () => {
   it('reflects a non-default birthdayVisibility from loader data', () => {
     loaderDataSnapshot.user.birthdayVisibility = 'NOBODY';
     const { container } = renderHub();
+    editPrivacy();
     const radios = container.querySelectorAll<HTMLInputElement>(
       'input[name="birthdayVisibility"]',
     );
@@ -160,6 +182,7 @@ describe('<SettingsProfileHub />', () => {
 
   it('populates the username + name form from loader data', () => {
     const { container } = renderHub();
+    editProfile();
     const username = container.querySelector(
       'input[name="username"]',
     ) as HTMLInputElement;

--- a/app/routes/settings+/profile.index.tsx
+++ b/app/routes/settings+/profile.index.tsx
@@ -7,7 +7,7 @@ import {
 import { getZodConstraint, parseWithZod } from '@conform-to/zod';
 import { invariantResponse } from '@epic-web/invariant';
 import { type SEOHandle } from '@nasa-gcn/remix-seo';
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import {
   data as rrData,
   Link,
@@ -17,6 +17,11 @@ import {
   type LoaderFunctionArgs,
 } from 'react-router';
 import { z } from 'zod';
+import {
+  EditableSection,
+  ReadField,
+  useExitOnSubmitSuccess,
+} from '#app/components/editable-section.tsx';
 import { ErrorList, Field, TextareaField } from '#app/components/forms.tsx';
 import { Avatar } from '#app/components/ui/avatar.tsx';
 import { Button } from '#app/components/ui/button.tsx';
@@ -31,13 +36,11 @@ import { authSessionStorage } from '#app/utils/session.server.ts';
 import { redirectWithToast } from '#app/utils/toast.server.ts';
 import {
   BIO_MAX_LENGTH,
-  BIRTHDAY_VISIBILITY_VALUES,
   BioSchema,
   BirthdaySchema,
   BirthdayVisibilitySchema,
   NameSchema,
   UsernameSchema,
-  WISHLIST_VISIBILITY_VALUES,
   WishlistVisibilitySchema,
   type BirthdayVisibility,
   type WishlistVisibility,
@@ -190,9 +193,37 @@ function toDateInputValue(value: Date | string | null | undefined) {
   return date.toISOString().slice(0, 10);
 }
 
+function ProfilePhotoButton({
+  onOpenPhoto,
+}: Readonly<{ onOpenPhoto: () => void }>) {
+  const data = useLoaderData<typeof loader>();
+  return (
+    <button
+      type="button"
+      onClick={onOpenPhoto}
+      className="group relative rounded-full outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+      aria-label="Change profile photo"
+    >
+      <Avatar
+        size="l"
+        className="max-h-40 max-w-40 sm:max-h-52 sm:max-w-52"
+        image={
+          data.user.image ? { id: data.user.image.id, altText: null } : null
+        }
+        user={{ name: data.user.name, username: data.user.username }}
+      />
+      <span className="pointer-events-none absolute inset-0 flex items-center justify-center rounded-full bg-foreground/0 text-transparent transition group-hover:bg-foreground/40 group-hover:text-background group-focus-visible:bg-foreground/40 group-focus-visible:text-background">
+        <Icon name="camera" className="h-6 w-6" />
+      </span>
+    </button>
+  );
+}
+
 function ProfileCard({ onOpenPhoto }: Readonly<{ onOpenPhoto: () => void }>) {
   const data = useLoaderData<typeof loader>();
   const fetcher = useFetcher<typeof profileUpdateAction>();
+  const [editing, setEditing] = useState(false);
+  const stopEditing = useCallback(() => setEditing(false), []);
   const [form, fields] = useForm<z.input<typeof ProfileFormSchema>>({
     id: 'edit-profile',
     constraint: getZodConstraint(ProfileFormSchema),
@@ -208,34 +239,42 @@ function ProfileCard({ onOpenPhoto }: Readonly<{ onOpenPhoto: () => void }>) {
     },
   });
 
-  return (
-    <Card padding="lg" className="flex flex-col gap-5">
-      <SectionHeading
-        title="Profile"
-        description="How you appear to friends across GiftPool."
-      />
+  // Leave edit mode once the save lands so we drop back to the read view.
+  useExitOnSubmitSuccess({
+    state: fetcher.state,
+    success: form.status === 'success',
+    onExit: stopEditing,
+  });
 
+  const birthdayDisplay = data.user.birthday
+    ? new Date(data.user.birthday).toLocaleDateString()
+    : 'Not set';
+
+  return (
+    <EditableSection
+      title="Profile"
+      description="How you appear to friends across GiftPool."
+      editLabel="Edit profile"
+      editing={editing}
+      onEdit={() => setEditing(true)}
+      read={
+        <div className="flex flex-col items-center gap-3 sm:flex-row sm:items-start sm:gap-5">
+          <ProfilePhotoButton onOpenPhoto={onOpenPhoto} />
+          <div className="grid w-full flex-1 grid-cols-1 gap-4 sm:grid-cols-2">
+            <ReadField label="Username" value={data.user.username} />
+            <ReadField label="Name" value={data.user.name || 'Not set'} />
+            <ReadField
+              label="Bio"
+              value={data.user.bio || 'No bio yet'}
+              className="sm:col-span-2"
+            />
+            <ReadField label="Birthday" value={birthdayDisplay} />
+          </div>
+        </div>
+      }
+    >
       <div className="flex flex-col items-center gap-3 sm:flex-row sm:items-start sm:gap-5">
-        <button
-          type="button"
-          onClick={onOpenPhoto}
-          className="group relative rounded-full outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
-          aria-label="Change profile photo"
-        >
-          <Avatar
-            size="l"
-            className="max-h-40 max-w-40 sm:max-h-52 sm:max-w-52"
-            image={
-              data.user.image
-                ? { id: data.user.image.id, altText: null }
-                : null
-            }
-            user={{ name: data.user.name, username: data.user.username }}
-          />
-          <span className="pointer-events-none absolute inset-0 flex items-center justify-center rounded-full bg-foreground/0 text-transparent transition group-hover:bg-foreground/40 group-hover:text-background group-focus-visible:bg-foreground/40 group-focus-visible:text-background">
-            <Icon name="camera" className="h-6 w-6" />
-          </span>
-        </button>
+        <ProfilePhotoButton onOpenPhoto={onOpenPhoto} />
 
         <fetcher.Form
           method="POST"
@@ -286,7 +325,10 @@ function ProfileCard({ onOpenPhoto }: Readonly<{ onOpenPhoto: () => void }>) {
             errors={fields.birthday.errors}
           />
           <ErrorList errors={form.errors} id={form.errorId} />
-          <div className="flex justify-end">
+          <div className="flex justify-end gap-2">
+            <Button type="button" variant="ghost" onClick={stopEditing}>
+              Cancel
+            </Button>
             <StatusButton
               type="submit"
               name="intent"
@@ -300,7 +342,7 @@ function ProfileCard({ onOpenPhoto }: Readonly<{ onOpenPhoto: () => void }>) {
           </div>
         </fetcher.Form>
       </div>
-    </Card>
+    </EditableSection>
   );
 }
 
@@ -401,13 +443,13 @@ function VisibilityRadioGroup<T extends string>({
   name,
   options,
   selected,
-  onSubmit,
+  onChange,
 }: {
   legend: string;
   name: string;
   options: ReadonlyArray<{ value: T; label: string; description: string }>;
   selected: T;
-  onSubmit: (value: T) => void;
+  onChange: (value: T) => void;
 }) {
   return (
     <fieldset className="flex flex-col gap-3">
@@ -429,7 +471,7 @@ function VisibilityRadioGroup<T extends string>({
               name={name}
               value={option.value}
               checked={isSelected}
-              onChange={(event) => onSubmit(event.currentTarget.value as T)}
+              onChange={(event) => onChange(event.currentTarget.value as T)}
               className="h-4 w-4 shrink-0 accent-primary"
             />
             <span className="flex flex-col gap-0.5">
@@ -447,9 +489,18 @@ function VisibilityRadioGroup<T extends string>({
   );
 }
 
+function privacyLabel<T extends string>(
+  options: ReadonlyArray<{ value: T; label: string }>,
+  value: T,
+): string {
+  return options.find((option) => option.value === value)?.label ?? value;
+}
+
 function PrivacyCard() {
   const data = useLoaderData<typeof loader>();
   const fetcher = useFetcher<typeof privacyUpdateAction>();
+  const [editing, setEditing] = useState(false);
+  const stopEditing = useCallback(() => setEditing(false), []);
 
   const currentBirthday =
     (data.user.birthdayVisibility as BirthdayVisibility | undefined) ??
@@ -458,52 +509,82 @@ function PrivacyCard() {
     (data.user.wishlistVisibility as WishlistVisibility | undefined) ??
     'FRIENDS';
 
-  // Optimistic reflection: while the fetcher is in-flight we show the
-  // pending values from its formData instead of waiting for revalidation.
-  const pendingBirthday = fetcher.formData?.get('birthdayVisibility');
-  const pendingWishlist = fetcher.formData?.get('wishlistVisibility');
+  // Draft selections — changing a visibility setting is deliberate now (R5.2):
+  // radios update local state and nothing persists until Save is pressed.
+  const [draftBirthday, setDraftBirthday] =
+    useState<BirthdayVisibility>(currentBirthday);
+  const [draftWishlist, setDraftWishlist] =
+    useState<WishlistVisibility>(currentWishlist);
 
-  const selectedBirthday =
-    typeof pendingBirthday === 'string' &&
-    (BIRTHDAY_VISIBILITY_VALUES as readonly string[]).includes(pendingBirthday)
-      ? (pendingBirthday as BirthdayVisibility)
-      : currentBirthday;
+  const saved = Boolean((fetcher.data as { ok?: boolean } | undefined)?.ok);
+  useExitOnSubmitSuccess({
+    state: fetcher.state,
+    success: saved,
+    onExit: stopEditing,
+  });
 
-  const selectedWishlist =
-    typeof pendingWishlist === 'string' &&
-    (WISHLIST_VISIBILITY_VALUES as readonly string[]).includes(pendingWishlist)
-      ? (pendingWishlist as WishlistVisibility)
-      : currentWishlist;
+  function startEditing() {
+    setDraftBirthday(currentBirthday);
+    setDraftWishlist(currentWishlist);
+    setEditing(true);
+  }
 
-  function submitPrivacy(patch: Partial<{ birthdayVisibility: BirthdayVisibility; wishlistVisibility: WishlistVisibility }>) {
+  function savePrivacy() {
     const formData = new FormData();
     formData.set('intent', privacyUpdateActionIntent);
-    formData.set('birthdayVisibility', patch.birthdayVisibility ?? selectedBirthday);
-    formData.set('wishlistVisibility', patch.wishlistVisibility ?? selectedWishlist);
+    formData.set('birthdayVisibility', draftBirthday);
+    formData.set('wishlistVisibility', draftWishlist);
     void fetcher.submit(formData, { method: 'POST' });
   }
 
   return (
-    <Card padding="lg" className="flex flex-col gap-5">
-      <SectionHeading
-        title="Privacy"
-        description="Control who can see personal details on your profile."
-      />
-      <VisibilityRadioGroup
-        legend="Birthday visibility"
-        name="birthdayVisibility"
-        options={BIRTHDAY_PRIVACY_OPTIONS}
-        selected={selectedBirthday}
-        onSubmit={(value) => submitPrivacy({ birthdayVisibility: value })}
-      />
-      <VisibilityRadioGroup
-        legend="Wishlist visibility"
-        name="wishlistVisibility"
-        options={WISHLIST_PRIVACY_OPTIONS}
-        selected={selectedWishlist}
-        onSubmit={(value) => submitPrivacy({ wishlistVisibility: value })}
-      />
-    </Card>
+    <EditableSection
+      title="Privacy"
+      description="Control who can see personal details on your profile."
+      editing={editing}
+      onEdit={startEditing}
+      read={
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <ReadField
+            label="Birthday visibility"
+            value={privacyLabel(BIRTHDAY_PRIVACY_OPTIONS, currentBirthday)}
+          />
+          <ReadField
+            label="Wishlist visibility"
+            value={privacyLabel(WISHLIST_PRIVACY_OPTIONS, currentWishlist)}
+          />
+        </div>
+      }
+    >
+      <div className="flex flex-col gap-5">
+        <VisibilityRadioGroup
+          legend="Birthday visibility"
+          name="birthdayVisibility"
+          options={BIRTHDAY_PRIVACY_OPTIONS}
+          selected={draftBirthday}
+          onChange={setDraftBirthday}
+        />
+        <VisibilityRadioGroup
+          legend="Wishlist visibility"
+          name="wishlistVisibility"
+          options={WISHLIST_PRIVACY_OPTIONS}
+          selected={draftWishlist}
+          onChange={setDraftWishlist}
+        />
+        <div className="flex justify-end gap-2">
+          <Button type="button" variant="ghost" onClick={stopEditing}>
+            Cancel
+          </Button>
+          <StatusButton
+            type="button"
+            onClick={savePrivacy}
+            status={fetcher.state !== 'idle' ? 'pending' : 'idle'}
+          >
+            Save privacy
+          </StatusButton>
+        </div>
+      </div>
+    </EditableSection>
   );
 }
 
@@ -722,7 +803,7 @@ async function privacyUpdateAction({ userId, formData }: ProfileActionArgs) {
       wishlistVisibility: submission.value.wishlistVisibility,
     },
   });
-  return { result: submission.reply() };
+  return { result: submission.reply(), ok: true };
 }
 
 async function signOutOfSessionsAction({ request, userId }: ProfileActionArgs) {

--- a/tests/e2e/settings-profile.test.ts
+++ b/tests/e2e/settings-profile.test.ts
@@ -24,12 +24,15 @@ test('Users can update their basic info', async ({ page, login }) => {
 
   const newUserData = createUser();
 
+  // The Profile card opens in read mode (R5.1) — enter edit mode first.
+  await page.getByRole('button', { name: /edit profile/i }).click();
+
   await page.getByRole('textbox', { name: /^name/i }).fill(newUserData.name);
   await page
     .getByRole('textbox', { name: /^username/i })
     .fill(newUserData.username);
 
-  await page.getByRole('button', { name: /^save/i }).click();
+  await page.getByRole('button', { name: /^save changes/i }).click();
 });
 
 test('Users can update their password', async ({ page, login }) => {


### PR DESCRIPTION
## Context

Part 5 of the Giftpool Design Rules (Jun 26 2026 UX audit): **showing vs editing**. Screens opened already-editable, privacy radios saved on a stray tap, the pool danger zone sat in the main flow with raw `confirm()`, and "(You)" looked like user data. This is **PR 2 of 3** (follows #444; group-settings rework is the future PR 3).

## Changes

**R5.1 / R5.2 — Profile read→edit + confirmable privacy**
- Profile and Privacy cards open in read mode showing current values, with an explicit Edit step, via a new shared `EditableSection` (+ `ReadField`, `useExitOnSubmitSuccess`).
- Visibility radios no longer auto-submit on change — they update a draft and persist only on **Save**.

**R5.3 — Pool settings route**
- New `pools/:id/settings` route, reached from a **header gear link** (not a tab). Organizer/manager-gated loader; reuses the shared pool action.
- Hosts the pool *as an entity*: editable title/occasion/date, editable **gift-selection method** while `OPEN` (new `update-pool-details` intent → existing `updatePool`), the invite link, and the **danger zone** (cancel/delete) using the typed-confirm `ConfirmDialog` instead of raw `confirm()`.
- The main pool page keeps everything about *serving the gift*: ideas, voting, chosen gift, delivery, status, and contributions.

**R5.4 — System annotations**
- New `SystemLabel` primitive; the plain-text `" (You)"` suffix in group member/settings lists and the pool contributor pill now read as system markers, distinct from usernames.

## Scope note — group settings deferred
The original R5.1 target list included group settings forms, but per the post-review decision they're deferred to **PR 3** (they need the preferences/admin-conflation rework first, which will restructure those forms anyway). Group navigation is untouched here.

## Testing
- `npm run typecheck` clean; lint only pre-existing/convention warnings
- Unit: **1080 passed** (new `system-label`, `settings` route, and `update-pool-details` action tests; updated `profile.index` + pool `index` tests)
- E2E: `settings-profile` **5 passed** (covers the new read→edit flow)

https://claude.ai/code/session_01WxjmZST9sAs7K1UL45i5Vv