### PR TITLE
fix(groups): member-aware group settings — gear nav, read/edit, P7.5 (Design Rules PR 3)

### DIFF
--- a/app/routes/groups+/$giftGroupId_+/_layout.tsx
+++ b/app/routes/groups+/$giftGroupId_+/_layout.tsx
@@ -1,5 +1,5 @@
-import { LuUsers } from 'react-icons/lu';
-import { NavLink, Outlet, useLoaderData } from 'react-router';
+import { LuSettings, LuUsers } from 'react-icons/lu';
+import { Link, NavLink, Outlet, useLoaderData } from 'react-router';
 import { RoleBadge } from '#app/components/groups/RoleBadge.tsx';
 import { PageHeader } from '#app/components/page-header.tsx';
 import { Stack } from '#app/components/ui-kit/stack.tsx';
@@ -11,8 +11,7 @@ import { type loader as routeLoader } from './__route.server';
 export { loader, action } from './__route.server';
 
 const GroupLayout = () => {
-  const { giftGroup, viewer, canSettings } =
-    useLoaderData<typeof routeLoader>();
+  const { giftGroup, viewer } = useLoaderData<typeof routeLoader>();
 
   return (
     <div className="flex h-full min-h-0 flex-col">
@@ -23,12 +22,23 @@ const GroupLayout = () => {
         title={giftGroup.name}
         subtitle={`${giftGroup.groupMembers.length} ${giftGroup.groupMembers.length === 1 ? 'member' : 'members'}`}
       >
-        <RoleBadge role={viewer.role as GroupRole} />
+        <div className="flex shrink-0 items-center gap-2">
+          <RoleBadge role={viewer.role as GroupRole} />
+          {/* Settings is reachable by every member — it's where your own
+              group preferences live, not just admin controls (P7.5). */}
+          <Link
+            to={`/groups/${giftGroup.id}/settings`}
+            aria-label="Group settings"
+            className="text-muted-foreground hover:text-foreground"
+          >
+            <LuSettings className="h-5 w-5" />
+          </Link>
+        </div>
       </PageHeader>
       <main className="min-h-0 flex-1 overflow-y-auto">
         <div className="mx-auto max-w-6xl p-3 sm:p-6">
           <Stack gap={6}>
-            <TabBar giftGroupId={giftGroup.id} canSettings={canSettings} />
+            <TabBar giftGroupId={giftGroup.id} />
             <Outlet />
           </Stack>
         </div>
@@ -39,28 +49,16 @@ const GroupLayout = () => {
 
 export default GroupLayout;
 
-const TabBar = ({
-  giftGroupId,
-  canSettings,
-}: {
-  giftGroupId: string;
-  canSettings: boolean;
-}) => {
+const TabBar = ({ giftGroupId }: { giftGroupId: string }) => {
+  // Settings is intentionally NOT a tab — it's reached from the header gear.
   const tabs = [
     { to: `/groups/${giftGroupId}`, label: 'Overview', end: true },
     { to: `/groups/${giftGroupId}/members`, label: 'Members' },
-    ...(canSettings
-      ? ([
-          { to: `/groups/${giftGroupId}/settings`, label: 'Settings' },
-        ] as const)
-      : ([] as const)),
     { to: `/groups/${giftGroupId}/activity`, label: 'Activity' },
   ] as const;
 
-  const colsClass = canSettings ? 'grid-cols-4' : 'grid-cols-3';
-
   return (
-    <div className={`grid w-full ${colsClass} rounded-full bg-muted p-1`}>
+    <div className="grid w-full grid-cols-3 rounded-full bg-muted p-1">
       {tabs.map((t) => (
         <NavLink
           key={t.to}

--- a/app/routes/groups+/$giftGroupId_+/settings.component.test.tsx
+++ b/app/routes/groups+/$giftGroupId_+/settings.component.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const loaderDataSnapshot = {
+  canManageSettings: false,
+  canDelete: false,
+  canLeave: true,
+  viewerMember: {
+    userId: 'viewer-1',
+    role: 'MEMBER',
+    contributionCents: 3000,
+    budgetVisibilityOverride: null as string | null,
+    shareWishlist: true,
+    shareBirthday: true,
+  },
+  giftGroup: {
+    id: 'group-1',
+    name: 'The Crew',
+    description: 'Birthday pooling squad',
+    budgetVisibility: 'EVERYONE',
+    groupMembers: [] as Array<unknown>,
+    reminders: [] as Array<{ id: string; offsetDays: number }>,
+  },
+};
+
+vi.mock('react-router', async () => {
+  const actual =
+    await vi.importActual<typeof import('react-router')>('react-router');
+  return {
+    ...actual,
+    Form: (props: React.ComponentProps<'form'>) => <form {...props} />,
+    useLoaderData: () => loaderDataSnapshot,
+    useActionData: () => undefined,
+    useFetchers: () => [],
+    useFetcher: () => ({
+      Form: (props: React.ComponentProps<'form'>) => <form {...props} />,
+      data: undefined,
+      state: 'idle',
+      submit: vi.fn(),
+    }),
+  };
+});
+
+import GroupSettingsRoute from './settings.tsx';
+
+function renderRoute() {
+  return render(
+    <MemoryRouter initialEntries={['/groups/group-1/settings']}>
+      <GroupSettingsRoute />
+    </MemoryRouter>,
+  );
+}
+
+describe('group settings route', () => {
+  beforeEach(() => {
+    loaderDataSnapshot.canManageSettings = false;
+    loaderDataSnapshot.canDelete = false;
+    loaderDataSnapshot.canLeave = true;
+    loaderDataSnapshot.viewerMember.role = 'MEMBER';
+    loaderDataSnapshot.viewerMember.shareWishlist = true;
+    loaderDataSnapshot.viewerMember.shareBirthday = true;
+    loaderDataSnapshot.giftGroup.groupMembers = [];
+  });
+
+  it('shows a plain member their preferences but no admin sections (P7.5)', () => {
+    renderRoute();
+    expect(
+      screen.getByRole('heading', { name: 'Your preferences' }),
+    ).toBeInTheDocument();
+    // Admin-only surfaces must not render for a member.
+    expect(
+      screen.queryByRole('heading', { name: 'Group settings' }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText('Member Actions')).not.toBeInTheDocument();
+    expect(screen.queryByText('Danger Zone')).not.toBeInTheDocument();
+    // Leaving is a member action — still available.
+    expect(
+      screen.getByRole('button', { name: /leave group/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('shows managers the admin sections alongside their preferences', () => {
+    loaderDataSnapshot.canManageSettings = true;
+    loaderDataSnapshot.canDelete = true;
+    loaderDataSnapshot.viewerMember.role = 'OWNER';
+    renderRoute();
+    expect(
+      screen.getByRole('heading', { name: 'Your preferences' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Group settings' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Member Actions')).toBeInTheDocument();
+    expect(screen.getByText('Danger Zone')).toBeInTheDocument();
+  });
+
+  it('opens preferences in read mode and reveals the form on Edit', () => {
+    renderRoute();
+    // Read mode shows current sharing state, no checkboxes yet.
+    expect(screen.getAllByText('Shared with group').length).toBeGreaterThan(0);
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    expect(
+      screen.getByRole('checkbox', { name: /share my wishlist/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('lets a member turn sharing OFF — unchecking persists false', () => {
+    renderRoute();
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+
+    const readHidden = () =>
+      (
+        document.querySelector(
+          'input[type="hidden"][name="shareWishlist"]',
+        ) as HTMLInputElement
+      ).value;
+    expect(readHidden()).toBe('true');
+
+    const checkbox = screen.getByRole('checkbox', {
+      name: /share my wishlist/i,
+    }) as HTMLInputElement;
+    fireEvent.click(checkbox);
+    expect(checkbox).not.toBeChecked();
+    expect(readHidden()).toBe('false');
+  });
+});

--- a/app/routes/groups+/$giftGroupId_+/settings.tsx
+++ b/app/routes/groups+/$giftGroupId_+/settings.tsx
@@ -14,9 +14,14 @@ import {
   useActionData,
   useFetcher,
   useFetchers,
-  useLoaderData
+  useLoaderData,
 } from 'react-router';
 import { z } from 'zod';
+import {
+  EditableSection,
+  ReadField,
+  useExitOnSubmitSuccess,
+} from '#app/components/editable-section.tsx';
 import { ErrorList } from '#app/components/forms.tsx';
 import { RoleBadge } from '#app/components/groups/RoleBadge.tsx';
 import { Avatar } from '#app/components/ui/avatar.tsx';
@@ -58,7 +63,6 @@ import {
   updateOwnPreferences,
   deleteGiftGroup,
 } from '#app/utils/groups.server.ts';
-import { cn } from '#app/utils/misc.tsx';
 import { createToastHeaders } from '#app/utils/toast.server.ts';
 import { applyPendingSettingsMemberMutations } from './__route.shared';
 export async function loader({ params, request }: LoaderFunctionArgs) {
@@ -141,65 +145,20 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
       url: getInviteLink(inv.code, request),
     })),
   };
-  const canManageInvites = await userHasGroupPermission(
-    userId,
-    groupId,
-    'manageInvites',
-  );
+  // Settings is reachable by every member (the gear links here for all roles),
+  // so these flags decide which admin sections render — not whether the page
+  // loads. A plain member sees only "Your preferences".
   const canManageSettings = await userHasGroupPermission(
     userId,
     groupId,
     'manageSettings',
   );
-  const canPromote = await userHasGroupPermission(
-    userId,
-    groupId,
-    'promoteAdmin',
-  );
-  const canDemote = await userHasGroupPermission(
-    userId,
-    groupId,
-    'demoteAdmin',
-  );
-  const canRemove = await userHasGroupPermission(
-    userId,
-    groupId,
-    'removeMember',
-  );
-  const canBan = await userHasGroupPermission(userId, groupId, 'banMember');
   const canLeave = await userHasGroupPermission(userId, groupId, 'leaveGroup');
-  const canTransfer = await userHasGroupPermission(
-    userId,
-    groupId,
-    'transferOwnership',
-  );
   const canDelete = await userHasGroupPermission(
     userId,
     groupId,
     'deleteGroup',
   );
-  const joinRequests = await prisma.joinRequest.findMany({
-    where: {
-      giftGroupId: groupId,
-      status: 'PENDING',
-    },
-    select: {
-      id: true,
-      user: {
-        select: {
-          id: true,
-          username: true,
-          name: true,
-          image: {
-            select: {
-              id: true,
-              altText: true,
-            },
-          },
-        },
-      },
-    },
-  });
   const viewerMemberRaw = await prisma.usersInGiftGroups.findUnique({
     where: {
       userId_giftGroupId: {
@@ -224,40 +183,18 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
         ) as GroupRole,
       } as const)
     : null;
-  const activities = await prisma.groupActivity.findMany({
-    where: {
-      giftGroupId: groupId,
-    },
-    orderBy: {
-      createdAt: 'desc',
-    },
-    take: 10,
-    select: {
-      id: true,
-      type: true,
-      payload: true,
-      createdAt: true,
-      actor: {
-        select: {
-          username: true,
-        },
-      },
-    },
-  });
+  // Non-managers must not receive other members' contribution / visibility /
+  // sharing settings or the admin roster — strip them so a member's payload
+  // carries only their own preferences (P7.5 privacy).
+  const giftGroupForViewer = canManageSettings
+    ? giftGroup
+    : { ...giftGroup, groupMembers: [], groupInvitations: [], reminders: [] };
   return {
-    giftGroup,
-    canManageInvites,
+    giftGroup: giftGroupForViewer,
     canManageSettings,
-    canPromote,
-    canDemote,
-    canRemove,
-    canBan,
-    canTransfer,
     canDelete,
     canLeave,
-    joinRequests,
     viewerMember,
-    activities,
   };
 }
 export enum SettingsIntent {
@@ -450,16 +387,26 @@ export async function action({ request }: ActionFunctionArgs) {
           : undefined,
         budgetVisibilityOverride: (v.budgetVisibilityOverride ??
           'INHERIT') as any,
-        shareWishlist: v.shareWishlist === 'on' ? true : undefined,
-        shareBirthday: v.shareBirthday === 'on' ? true : undefined,
+        // Explicit booleans so a member can turn sharing OFF, not just on.
+        shareWishlist:
+          v.shareWishlist === undefined
+            ? undefined
+            : v.shareWishlist === 'true',
+        shareBirthday:
+          v.shareBirthday === undefined
+            ? undefined
+            : v.shareBirthday === 'true',
       });
-      return data(submission.reply(), {
-        headers: await createToastHeaders({
-          type: 'success',
-          title: 'Saved',
-          description: 'Your preferences have been saved.',
-        }),
-      });
+      return data(
+        { ...submission.reply(), ok: true },
+        {
+          headers: await createToastHeaders({
+            type: 'success',
+            title: 'Saved',
+            description: 'Your preferences have been saved.',
+          }),
+        },
+      );
     }
     case SettingsIntent.DeleteGroup: {
       await deleteGiftGroup(request, {
@@ -482,7 +429,7 @@ export async function action({ request }: ActionFunctionArgs) {
   }
 }
 const GroupSettingsRoute = () => {
-  const { giftGroup, canDelete, canLeave, viewerMember } =
+  const { giftGroup, canManageSettings, canDelete, canLeave, viewerMember } =
     useLoaderData<typeof loader>();
   const actionData = useActionData<typeof action>();
   const fetchers = useFetchers();
@@ -513,179 +460,179 @@ const GroupSettingsRoute = () => {
     optimisticViewerRole === 'OWNER' || optimisticViewerRole === 'ADMIN';
   return (
     <div className="space-y-6">
-      <div className="rounded-2xl border bg-card p-4 sm:p-6">
-        <div className="mb-1 text-lg font-semibold">Group Settings</div>
-        <div className="mb-4 text-sm text-muted-foreground">
-          Configure how the group operates
-        </div>
-        <SettingsForm giftGroup={giftGroup} lastResult={actionData} />
-        <div className="my-4 h-px w-full bg-border" />
-        <RemindersSection giftGroup={giftGroup} />
-      </div>
-
-      {/* Member preferences (self) */}
+      {/* Your preferences — visible & editable by every member (P7.5) */}
       {viewerMember ? (
-        <div className="rounded-2xl border bg-card p-4 sm:p-6">
-          <div className="mb-1 text-lg font-semibold">Your Preferences</div>
-          <div className="mb-4 text-sm text-muted-foreground">
-            Control your budget visibility and sharing settings for this group
-          </div>
-          <MemberPreferencesForm
-            giftGroupId={giftGroup.id}
-            prefs={viewerMember}
-          />
-        </div>
+        <MemberPreferencesCard
+          giftGroupId={giftGroup.id}
+          prefs={viewerMember}
+        />
       ) : null}
 
-      {/* Transfer ownership */}
-      {canTransfer ? (
-        <div className="rounded-2xl border bg-card p-4 sm:p-6">
-          <div className="mb-1 text-lg font-semibold">Transfer Ownership</div>
-          <div className="mb-4 text-sm text-muted-foreground">
-            Make another admin the owner of this group
+      {/* Admin controls — a separate surface, only for managers */}
+      {canManageSettings ? (
+        <>
+          <SettingsCard giftGroup={giftGroup} lastResult={actionData} />
+          <div className="rounded-2xl border bg-card p-4 sm:p-6">
+            <RemindersSection giftGroup={giftGroup} />
           </div>
-          <TransferOwnershipForm
-            giftGroupId={giftGroup.id}
-            members={optimisticMembers}
-          />
-        </div>
-      ) : null}
 
-      {/* Member management */}
-      <div className="rounded-2xl border bg-card p-4 sm:p-6">
-        <div className="mb-1 text-lg font-semibold">Member Actions</div>
-        <div className="mb-4 text-sm text-muted-foreground">
-          Promote or demote admins, remove or ban members
-        </div>
-        <ul className="divide-y divide-border rounded-md border">
-          {optimisticMembers.map((m: any) => {
-            const isViewer = m.userId === viewerMember?.userId;
-            return (
-              <li
-                key={m.userId}
-                className="flex flex-wrap items-center gap-3 p-3 sm:flex-nowrap"
-              >
-                <div className="flex min-w-0 flex-1 items-center gap-3">
-                  <Avatar size="s" image={m.user.image} user={m.user} />
-                  <div className="min-w-0">
-                    <div className="flex items-center gap-1.5 font-medium">
-                      <span className="truncate">{m.user.username}</span>
-                      {isViewer ? <SystemLabel>you</SystemLabel> : null}
-                    </div>
-                    <div className="mt-0.5 flex items-center gap-2 text-xs text-muted-foreground">
-                      <RoleBadge role={m.role} />
-                      {m.bannedUntil ? (
-                        <span className="text-destructive">Banned</span>
-                      ) : null}
-                    </div>
-                  </div>
-                </div>
-                <div className="flex flex-wrap items-center gap-2">
-                  {/* Promote / Demote (owner only) */}
-                  {canPromote && m.role === 'MEMBER' && !isViewer ? (
-                    <memberActionFetcher.Form
-                      method="post"
-                      action={settingsAction}
-                    >
-                      <input
-                        type="hidden"
-                        name="giftGroupId"
-                        value={giftGroup.id}
-                      />
-                      <input
-                        type="hidden"
-                        name="memberUserId"
-                        value={m.userId}
-                      />
-                      <Button
-                        size="sm"
-                        variant="secondary"
-                        name="intent"
-                        value={SettingsIntent.MemberPromoteAdmin}
-                      >
-                        Promote to Admin
-                      </Button>
-                    </memberActionFetcher.Form>
-                  ) : null}
-                  {canDemote && m.role === 'ADMIN' && !isViewer ? (
-                    <memberActionFetcher.Form
-                      method="post"
-                      action={settingsAction}
-                    >
-                      <input
-                        type="hidden"
-                        name="giftGroupId"
-                        value={giftGroup.id}
-                      />
-                      <input
-                        type="hidden"
-                        name="memberUserId"
-                        value={m.userId}
-                      />
-                      <Button
-                        size="sm"
-                        variant="secondary"
-                        name="intent"
-                        value={SettingsIntent.MemberDemoteMember}
-                      >
-                        Demote to Member
-                      </Button>
-                    </memberActionFetcher.Form>
-                  ) : null}
-
-                  <MemberActions
-                    giftGroupId={giftGroup.id}
-                    memberUserId={m.userId}
-                    bannedUntil={m.bannedUntil}
-                    canRemove={canRemove && !isViewer}
-                    canBan={canBan && !isViewer}
-                  />
-                </div>
-              </li>
-            );
-          })}
-        </ul>
-      </div>
-
-      {canDelete ? (
-        <div className="rounded-2xl border bg-card p-4 sm:p-6">
-          <div className="rounded-md bg-destructive/10 p-4">
-            <div className="mb-1 font-semibold text-destructive">
-              Danger Zone
-            </div>
-            <div className="mb-3 text-sm text-destructive/80">
-              These actions cannot be undone. Please be careful. As the owner,
-              you can't leave directly — transfer ownership first or delete
-              the group.
-            </div>
-            <Form method="post" id="delete-group-form">
-              <input type="hidden" name="giftGroupId" value={giftGroup.id} />
-              <input
-                type="hidden"
-                name="intent"
-                value={SettingsIntent.DeleteGroup}
+          {/* Transfer ownership */}
+          {canTransfer ? (
+            <div className="rounded-2xl border bg-card p-4 sm:p-6">
+              <div className="mb-1 text-lg font-semibold">
+                Transfer Ownership
+              </div>
+              <div className="mb-4 text-sm text-muted-foreground">
+                Make another admin the owner of this group
+              </div>
+              <TransferOwnershipForm
+                giftGroupId={giftGroup.id}
+                members={optimisticMembers}
               />
-            </Form>
-            <ConfirmDialog
-              title="Delete Group"
-              description={
-                <div>Type DELETE to confirm. This cannot be undone.</div>
-              }
-              confirmText="Delete"
-              requireText="DELETE"
-              onConfirm={() => {
-                const form = document.getElementById(
-                  'delete-group-form',
-                ) as HTMLFormElement;
-                form?.requestSubmit();
-              }}
-            >
-              <Button variant="destructive">
-                <Icon name="trash" className="mr-2" /> Delete Group
-              </Button>
-            </ConfirmDialog>
+            </div>
+          ) : null}
+
+          {/* Member management */}
+          <div className="rounded-2xl border bg-card p-4 sm:p-6">
+            <div className="mb-1 text-lg font-semibold">Member Actions</div>
+            <div className="mb-4 text-sm text-muted-foreground">
+              Promote or demote admins, remove or ban members
+            </div>
+            <ul className="divide-y divide-border rounded-md border">
+              {optimisticMembers.map((m: any) => {
+                const isViewer = m.userId === viewerMember?.userId;
+                return (
+                  <li
+                    key={m.userId}
+                    className="flex flex-wrap items-center gap-3 p-3 sm:flex-nowrap"
+                  >
+                    <div className="flex min-w-0 flex-1 items-center gap-3">
+                      <Avatar size="s" image={m.user.image} user={m.user} />
+                      <div className="min-w-0">
+                        <div className="flex items-center gap-1.5 font-medium">
+                          <span className="truncate">{m.user.username}</span>
+                          {isViewer ? <SystemLabel>you</SystemLabel> : null}
+                        </div>
+                        <div className="mt-0.5 flex items-center gap-2 text-xs text-muted-foreground">
+                          <RoleBadge role={m.role} />
+                          {m.bannedUntil ? (
+                            <span className="text-destructive">Banned</span>
+                          ) : null}
+                        </div>
+                      </div>
+                    </div>
+                    <div className="flex flex-wrap items-center gap-2">
+                      {/* Promote / Demote (owner only) */}
+                      {canPromote && m.role === 'MEMBER' && !isViewer ? (
+                        <memberActionFetcher.Form
+                          method="post"
+                          action={settingsAction}
+                        >
+                          <input
+                            type="hidden"
+                            name="giftGroupId"
+                            value={giftGroup.id}
+                          />
+                          <input
+                            type="hidden"
+                            name="memberUserId"
+                            value={m.userId}
+                          />
+                          <Button
+                            size="sm"
+                            variant="secondary"
+                            name="intent"
+                            value={SettingsIntent.MemberPromoteAdmin}
+                          >
+                            Promote to Admin
+                          </Button>
+                        </memberActionFetcher.Form>
+                      ) : null}
+                      {canDemote && m.role === 'ADMIN' && !isViewer ? (
+                        <memberActionFetcher.Form
+                          method="post"
+                          action={settingsAction}
+                        >
+                          <input
+                            type="hidden"
+                            name="giftGroupId"
+                            value={giftGroup.id}
+                          />
+                          <input
+                            type="hidden"
+                            name="memberUserId"
+                            value={m.userId}
+                          />
+                          <Button
+                            size="sm"
+                            variant="secondary"
+                            name="intent"
+                            value={SettingsIntent.MemberDemoteMember}
+                          >
+                            Demote to Member
+                          </Button>
+                        </memberActionFetcher.Form>
+                      ) : null}
+
+                      <MemberActions
+                        giftGroupId={giftGroup.id}
+                        memberUserId={m.userId}
+                        bannedUntil={m.bannedUntil}
+                        canRemove={canRemove && !isViewer}
+                        canBan={canBan && !isViewer}
+                      />
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
           </div>
-        </div>
+
+          {canDelete ? (
+            <div className="rounded-2xl border bg-card p-4 sm:p-6">
+              <div className="rounded-md bg-destructive/10 p-4">
+                <div className="mb-1 font-semibold text-destructive">
+                  Danger Zone
+                </div>
+                <div className="mb-3 text-sm text-destructive/80">
+                  These actions cannot be undone. Please be careful. As the
+                  owner, you can't leave directly — transfer ownership first or
+                  delete the group.
+                </div>
+                <Form method="post" id="delete-group-form">
+                  <input
+                    type="hidden"
+                    name="giftGroupId"
+                    value={giftGroup.id}
+                  />
+                  <input
+                    type="hidden"
+                    name="intent"
+                    value={SettingsIntent.DeleteGroup}
+                  />
+                </Form>
+                <ConfirmDialog
+                  title="Delete Group"
+                  description={
+                    <div>Type DELETE to confirm. This cannot be undone.</div>
+                  }
+                  confirmText="Delete"
+                  requireText="DELETE"
+                  onConfirm={() => {
+                    const form = document.getElementById(
+                      'delete-group-form',
+                    ) as HTMLFormElement;
+                    form?.requestSubmit();
+                  }}
+                >
+                  <Button variant="destructive">
+                    <Icon name="trash" className="mr-2" /> Delete Group
+                  </Button>
+                </ConfirmDialog>
+              </div>
+            </div>
+          ) : null}
+        </>
       ) : null}
 
       {canLeave ? (
@@ -721,16 +668,21 @@ const GroupSettingsRoute = () => {
   );
 };
 export default GroupSettingsRoute;
-const SettingsForm = ({
+const SettingsCard = ({
   giftGroup,
   lastResult,
 }: {
   giftGroup: any;
   lastResult: any;
 }) => {
+  const fetcher = useFetcher<typeof action>();
+  const [editing, setEditing] = React.useState(false);
+  const stopEditing = React.useCallback(() => setEditing(false), []);
   const [form] = useForm<z.input<typeof UpdateSettingsSchema>>({
     id: 'settings-form',
-    lastResult: lastResult as unknown as SubmissionResult<string[]>,
+    lastResult: (fetcher.data ?? lastResult) as unknown as SubmissionResult<
+      string[]
+    >,
     constraint: getZodConstraint(UpdateSettingsSchema),
     onValidate({ formData }) {
       return parseWithZod(formData, {
@@ -743,30 +695,63 @@ const SettingsForm = ({
       budgetVisibility: giftGroup.budgetVisibility,
     },
   });
+  useExitOnSubmitSuccess({
+    state: fetcher.state,
+    success: form.status === 'success',
+    onExit: stopEditing,
+  });
   return (
-    <Form method="post" {...getFormProps(form)} className="grid gap-3">
-      <input type="hidden" name="giftGroupId" value={giftGroup.id} />
-      {/* keep budget visibility using hidden to satisfy schema */}
-      <input
-        type="hidden"
-        name="budgetVisibility"
-        value={giftGroup.budgetVisibility}
-      />
-      <Label htmlFor="name">Group Name</Label>
-      <Input name="name" defaultValue={giftGroup.name} />
-      <Label htmlFor="description">Description</Label>
-      <Textarea name="description" defaultValue={giftGroup.description ?? ''} />
-      <div className="flex items-center justify-end">
-        <Button
-          name="intent"
-          value={SettingsIntent.UpdateSettings}
-          type="submit"
-        >
-          Save
-        </Button>
-      </div>
-      <ErrorList errors={form.errors} id={form.errorId} />
-    </Form>
+    <EditableSection
+      title="Group settings"
+      description="Name and description for this group."
+      editing={editing}
+      onEdit={() => setEditing(true)}
+      read={
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <ReadField label="Name" value={giftGroup.name} />
+          <ReadField
+            label="Description"
+            value={giftGroup.description || 'No description'}
+            className="sm:col-span-2"
+          />
+        </div>
+      }
+    >
+      <fetcher.Form
+        method="post"
+        {...getFormProps(form)}
+        className="grid gap-3"
+      >
+        <input type="hidden" name="giftGroupId" value={giftGroup.id} />
+        {/* keep budget visibility using hidden to satisfy schema */}
+        <input
+          type="hidden"
+          name="budgetVisibility"
+          value={giftGroup.budgetVisibility}
+        />
+        <Label htmlFor="name">Group name</Label>
+        <Input id="name" name="name" defaultValue={giftGroup.name} />
+        <Label htmlFor="description">Description</Label>
+        <Textarea
+          id="description"
+          name="description"
+          defaultValue={giftGroup.description ?? ''}
+        />
+        <div className="flex items-center justify-end gap-2">
+          <Button type="button" variant="ghost" onClick={stopEditing}>
+            Cancel
+          </Button>
+          <Button
+            name="intent"
+            value={SettingsIntent.UpdateSettings}
+            type="submit"
+          >
+            Save
+          </Button>
+        </div>
+        <ErrorList errors={form.errors} id={form.errorId} />
+      </fetcher.Form>
+    </EditableSection>
   );
 };
 const MemberActions = ({
@@ -835,8 +820,6 @@ const MemberActions = ({
   );
 };
 const RemindersSection = ({ giftGroup }: { giftGroup: any }) => {
-  const [emailOn, setEmailOn] = React.useState<boolean>(true);
-  const [pushOn, setPushOn] = React.useState<boolean>(false);
   return (
     <div className="space-y-4">
       <div>
@@ -877,58 +860,6 @@ const RemindersSection = ({ giftGroup }: { giftGroup: any }) => {
           day thresholds
         </div>
       </div>
-      <div className="grid gap-4">
-        <div className="flex items-center justify-between">
-          <div>
-            <div className="font-medium">Email Reminders</div>
-            <div className="text-sm text-muted-foreground">
-              Send email notifications for upcoming birthdays
-            </div>
-          </div>
-          <button
-            type="button"
-            role="switch"
-            aria-checked={emailOn}
-            onClick={() => setEmailOn((v) => !v)}
-            className={cn(
-              'h-6 w-11 rounded-full p-0.5 transition-colors',
-              emailOn ? 'bg-primary' : 'bg-muted',
-            )}
-          >
-            <span
-              className={cn(
-                'block h-5 w-5 rounded-full bg-background transition-transform',
-                emailOn ? 'translate-x-5' : 'translate-x-0',
-              )}
-            />
-          </button>
-        </div>
-        <div className="flex items-center justify-between">
-          <div>
-            <div className="font-medium">Push Notifications</div>
-            <div className="text-sm text-muted-foreground">
-              Send push notifications for upcoming birthdays
-            </div>
-          </div>
-          <button
-            type="button"
-            role="switch"
-            aria-checked={pushOn}
-            onClick={() => setPushOn((v) => !v)}
-            className={cn(
-              'h-6 w-11 rounded-full p-0.5 transition-colors',
-              pushOn ? 'bg-primary' : 'bg-muted',
-            )}
-          >
-            <span
-              className={cn(
-                'block h-5 w-5 rounded-full bg-background transition-transform',
-                pushOn ? 'translate-x-5' : 'translate-x-0',
-              )}
-            />
-          </button>
-        </div>
-      </div>
       <ul className="space-y-1">
         {giftGroup.reminders.map((r: any) => (
           <li
@@ -957,74 +888,138 @@ const RemindersSection = ({ giftGroup }: { giftGroup: any }) => {
 
 // GiftPlansSection removed (unused)
 
-const MemberPreferencesForm = ({
+const BUDGET_VISIBILITY_LABELS: Record<string, string> = {
+  INHERIT: 'Inherit group setting',
+  EVERYONE: 'Everyone',
+  ADMINS: 'Admins',
+  ONLY_SELF: 'Only self',
+};
+
+// Every member can see and edit their own preferences here, regardless of role
+// (P7.5). Contribution stays on the group Overview's dollar editor; this card
+// owns budget visibility + what you share with the group.
+const MemberPreferencesCard = ({
   giftGroupId,
   prefs,
 }: {
   giftGroupId: string;
   prefs: any;
 }) => {
-  const [form] = useForm({
-    id: 'member-prefs',
-    defaultValue: {
-      contributionCents: String(prefs?.contributionCents ?? 0),
-      budgetVisibilityOverride: prefs?.budgetVisibilityOverride ?? 'INHERIT',
-      shareWishlist: prefs?.shareWishlist ? 'on' : '',
-      shareBirthday: prefs?.shareBirthday ? 'on' : '',
-    },
+  const fetcher = useFetcher<typeof action>();
+  const [editing, setEditing] = React.useState(false);
+  const stopEditing = React.useCallback(() => setEditing(false), []);
+  const currentVisibility = prefs?.budgetVisibilityOverride ?? 'INHERIT';
+  const [shareWishlist, setShareWishlist] = React.useState(
+    !!prefs?.shareWishlist,
+  );
+  const [shareBirthday, setShareBirthday] = React.useState(
+    !!prefs?.shareBirthday,
+  );
+
+  const startEditing = () => {
+    // Reset drafts to stored values each time we open the editor.
+    setShareWishlist(!!prefs?.shareWishlist);
+    setShareBirthday(!!prefs?.shareBirthday);
+    setEditing(true);
+  };
+
+  const saved = Boolean((fetcher.data as { ok?: boolean } | undefined)?.ok);
+  useExitOnSubmitSuccess({
+    state: fetcher.state,
+    success: saved,
+    onExit: stopEditing,
   });
+
   return (
-    <Form
-      method="post"
-      {...getFormProps(form)}
-      className="grid gap-2 rounded-md border p-3"
+    <EditableSection
+      title="Your preferences"
+      description="Your budget visibility and sharing settings for this group."
+      editing={editing}
+      onEdit={startEditing}
+      read={
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <ReadField
+            label="Budget visibility"
+            value={
+              BUDGET_VISIBILITY_LABELS[currentVisibility] ??
+              'Inherit group setting'
+            }
+          />
+          <ReadField
+            label="Share wishlist"
+            value={prefs?.shareWishlist ? 'Shared with group' : 'Hidden'}
+          />
+          <ReadField
+            label="Share birthday"
+            value={prefs?.shareBirthday ? 'Shared with group' : 'Hidden'}
+          />
+        </div>
+      }
     >
-      <input type="hidden" name="giftGroupId" value={giftGroupId} />
-      <input
-        type="hidden"
-        name="intent"
-        value={SettingsIntent.MemberUpdateSelf}
-      />
-      <Label>Contribution (USD cents)</Label>
-      <Input
-        name="contributionCents"
-        defaultValue={String(prefs?.contributionCents ?? 0)}
-      />
-      <Label>Budget visibility override</Label>
-      <Select
-        name="budgetVisibilityOverride"
-        defaultValue={prefs?.budgetVisibilityOverride ?? 'INHERIT'}
+      <fetcher.Form
+        method="post"
+        action={`/groups/${giftGroupId}/settings`}
+        className="grid gap-3"
       >
-        <SelectTrigger>
-          <SelectValue placeholder="Inherit group setting" />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value="INHERIT">Inherit group setting</SelectItem>
-          <SelectItem value="EVERYONE">Everyone</SelectItem>
-          <SelectItem value="ADMINS">Admins</SelectItem>
-          <SelectItem value="ONLY_SELF">Only self</SelectItem>
-        </SelectContent>
-      </Select>
-      <div className="flex items-center gap-2">
+        <input type="hidden" name="giftGroupId" value={giftGroupId} />
         <input
-          type="checkbox"
-          id="prefs-share-wishlist"
+          type="hidden"
+          name="intent"
+          value={SettingsIntent.MemberUpdateSelf}
+        />
+        {/* Controlled hidden inputs so unchecking persists `false` (the old
+            checkbox-only form could never turn sharing off). */}
+        <input
+          type="hidden"
           name="shareWishlist"
-          defaultChecked={!!prefs?.shareWishlist}
+          value={shareWishlist ? 'true' : 'false'}
         />
-        <Label htmlFor="prefs-share-wishlist">Share wishlist</Label>
-      </div>
-      <div className="flex items-center gap-2">
         <input
-          type="checkbox"
-          id="prefs-share-birthday"
+          type="hidden"
           name="shareBirthday"
-          defaultChecked={!!prefs?.shareBirthday}
+          value={shareBirthday ? 'true' : 'false'}
         />
-        <Label htmlFor="prefs-share-birthday">Share birthday</Label>
-      </div>
-      <Button type="submit">Save Preferences</Button>
-    </Form>
+        <div className="grid gap-1.5">
+          <Label htmlFor="budgetVisibilityOverride">Budget visibility</Label>
+          <Select
+            name="budgetVisibilityOverride"
+            defaultValue={currentVisibility}
+          >
+            <SelectTrigger id="budgetVisibilityOverride">
+              <SelectValue placeholder="Inherit group setting" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="INHERIT">Inherit group setting</SelectItem>
+              <SelectItem value="EVERYONE">Everyone</SelectItem>
+              <SelectItem value="ADMINS">Admins</SelectItem>
+              <SelectItem value="ONLY_SELF">Only self</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={shareWishlist}
+            onChange={(e) => setShareWishlist(e.currentTarget.checked)}
+          />
+          Share my wishlist with this group
+        </label>
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={shareBirthday}
+            onChange={(e) => setShareBirthday(e.currentTarget.checked)}
+          />
+          Share my birthday with this group
+        </label>
+        <div className="flex items-center justify-end gap-2">
+          <Button type="button" variant="ghost" onClick={stopEditing}>
+            Cancel
+          </Button>
+          <Button type="submit">Save</Button>
+        </div>
+      </fetcher.Form>
+    </EditableSection>
   );
 };
 const TransferOwnershipForm = ({


### PR DESCRIPTION
## Context

Third and final PR of the Design Rules initiative (Jun 2026 UX audit). PR 1 (containment, #444) and PR 2 (view-state, #445) shipped; PR 2 deferred the group-settings screen because it needed a real rework. This is it.

Core problem — **P7.5**: a member's own group preferences (budget visibility, share-wishlist, share-birthday) were unreachable to non-admins. The settings loader allowed any member, but the **Settings tab was hidden** unless you had `manageSettings` — so a plain member had no path to their own preferences.

## Changes

**Navigation** — Settings leaves the tab bar for a header **gear** shown to every member (`_layout.tsx`). It's where your own preferences live, not just admin controls.

**Member-aware settings** (`settings.tsx`):
- **Your preferences** renders first for every member, with an explicit read→edit step (`EditableSection`). Admin sections (group settings, members, reminders, transfer, danger zone) render **only for managers**.
- **Privacy**: the loader ships non-managers only their own preferences — no other members' contribution/visibility/sharing data or admin roster in the payload.
- **Group name/description** also gets read→edit.
- **Removed** the non-functional reminder email/push toggles (they were pure local state that never persisted).

**Bug fix** — the share-wishlist/share-birthday checkboxes could never be turned **off** (unchecked → `undefined` → no-op). The form now submits explicit `true`/`false` and the action maps them to booleans, so disabling sharing persists. (Contribution stays on the Overview's dollar editor; this card owns visibility + sharing.)

## Testing
- `npm run typecheck` clean; lint clean (only the repo-wide `import()`-in-test convention warning)
- Unit: **1084 passed**, incl. a new `settings.component.test.tsx` — a member sees only "Your preferences" (not admin sections); a manager sees both; preferences open in read mode; unchecking a share toggle persists `false`
- E2E: `groups-optimistic` (2) and `settings-profile` (5) pass

## Out of scope
Wiring real per-channel (email/push) reminder delivery — separate feature. Other Design-Rules parts (2, 3, 4, 6) remain unbuilt.

https://claude.ai/code/session_01WxjmZST9sAs7K1UL45i5Vv