### PR TITLE
Add first-party analytics insights

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 
 ## Analytics
 
-- Events are stored in the `AnalyticsEvent` table with `id` (uuid), `eventId` (unique), `name`, `userId`, `source`, `requestId`, `sessionId`, `properties` (JSON string for SQLite), and timestamps. IPs and full user agents are intentionally **not** collected.
+- Events are stored in the `AnalyticsEvent` table with `id` (uuid), `eventId` (unique), `name`, `userId`, `source`, `requestId`, `sessionId`, `properties` (JSON string for SQLite), and timestamps. IPs and full user agents are intentionally **not** collected; the environment dashboard stores normalized browser/device/viewport/OS/PWA fields only.
 - Dedupe: the server treats `eventId` as the primary key for correlation between client and server. If an `eventId` is missing, events are deduped by `(requestId, name, userId)` within a 5-minute window.
 - Client logging: use `track(name, properties?, { eventId?, requestId? })` from `app/utils/analytics.client.ts`; events post to `/api/analytics` and are best-effort with a single retry.
 - Server logging: use `logEvent` from `app/utils/analytics.server.ts` and pass `requestId/sessionId` from `getRequestContext(request)` when available.
-- Admin dashboard: `/admin/analytics` is protected by an allowlist (`ANALYTICS_ADMIN_EMAILS` or `ANALYTICS_ADMIN_USER_IDS`, comma-separated) or the `admin` role. It summarizes DAU/WAU/MAU, total users, daily actives (30d), and event counts (7d/30d).
+- Admin dashboard: `/admin/analytics` is protected by an allowlist (`ANALYTICS_ADMIN_EMAILS` or `ANALYTICS_ADMIN_USER_IDS`, comma-separated) or the `admin` role. It summarizes DAU/WAU/MAU, total users, daily actives (30d), event counts (7d/30d), and 30-day environment usage by browser, device, OS, viewport, display mode, and PWA install funnel.
 - Adding a new event: append the name to `ANALYTIC_EVENT_NAMES` in `app/utils/analytics.ts`, instrument server/client flows, and update admin dashboard tests if the new event should appear in summaries.

--- a/app/hooks/use-pwa-install-prompt.test.ts
+++ b/app/hooks/use-pwa-install-prompt.test.ts
@@ -1,0 +1,117 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const trackPwaLifecycleEvent = vi.hoisted(() => vi.fn());
+
+vi.mock('#app/utils/client-environment.ts', () => ({
+  trackPwaLifecycleEvent,
+}));
+
+import { usePwaInstallPrompt } from './use-pwa-install-prompt.ts';
+
+const setUserAgent = (ua: string) => {
+  Object.defineProperty(window.navigator, 'userAgent', {
+    value: ua,
+    configurable: true,
+  });
+};
+
+const makeBeforeInstallPromptEvent = (
+  outcome: 'accepted' | 'dismissed' = 'accepted',
+) => {
+  const event = new Event('beforeinstallprompt') as Event & {
+    prompt: ReturnType<typeof vi.fn>;
+    userChoice: Promise<{
+      outcome: 'accepted' | 'dismissed';
+      platform: string;
+    }>;
+  };
+  event.prompt = vi.fn().mockResolvedValue(undefined);
+  event.userChoice = Promise.resolve({ outcome, platform: 'web' });
+  return event;
+};
+
+beforeEach(() => {
+  window.localStorage.clear();
+  trackPwaLifecycleEvent.mockReset();
+  setUserAgent('Mozilla/5.0 (Macintosh) Chrome/120 Safari/537.36');
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn(() => ({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    })),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  window.localStorage.clear();
+  setUserAgent('node.js');
+});
+
+describe('usePwaInstallPrompt analytics', () => {
+  it('tracks when the browser install prompt becomes available', async () => {
+    const { result } = renderHook(() => usePwaInstallPrompt());
+    const event = makeBeforeInstallPromptEvent();
+
+    act(() => {
+      window.dispatchEvent(event);
+    });
+
+    await waitFor(() => expect(result.current.capability).toBe('prompt'));
+    expect(trackPwaLifecycleEvent).toHaveBeenCalledWith('pwa_prompt_available');
+  });
+
+  it('tracks accepted install prompt outcomes', async () => {
+    const { result } = renderHook(() => usePwaInstallPrompt());
+    const event = makeBeforeInstallPromptEvent('accepted');
+
+    act(() => {
+      window.dispatchEvent(event);
+    });
+    await waitFor(() => expect(result.current.capability).toBe('prompt'));
+
+    let outcome: string | undefined;
+    await act(async () => {
+      outcome = await result.current.promptInstall();
+    });
+
+    expect(outcome).toBe('accepted');
+    expect(event.prompt).toHaveBeenCalled();
+    expect(trackPwaLifecycleEvent).toHaveBeenCalledWith('pwa_install_clicked');
+    expect(trackPwaLifecycleEvent).toHaveBeenCalledWith('pwa_install_accepted');
+  });
+
+  it('tracks dismissed install prompt outcomes', async () => {
+    const { result } = renderHook(() => usePwaInstallPrompt());
+    const event = makeBeforeInstallPromptEvent('dismissed');
+
+    act(() => {
+      window.dispatchEvent(event);
+    });
+    await waitFor(() => expect(result.current.capability).toBe('prompt'));
+
+    await act(async () => {
+      await result.current.promptInstall();
+    });
+
+    expect(trackPwaLifecycleEvent).toHaveBeenCalledWith(
+      'pwa_install_dismissed',
+    );
+  });
+
+  it('tracks appinstalled events', () => {
+    renderHook(() => usePwaInstallPrompt());
+
+    act(() => {
+      window.dispatchEvent(new Event('appinstalled'));
+    });
+
+    expect(trackPwaLifecycleEvent).toHaveBeenCalledWith('pwa_appinstalled');
+  });
+});

--- a/app/hooks/use-pwa-install-prompt.ts
+++ b/app/hooks/use-pwa-install-prompt.ts
@@ -4,6 +4,7 @@ import {
   isStandalone,
   type ManualInstallPlatform,
 } from '#app/utils/pwa.ts';
+import { trackPwaLifecycleEvent } from '#app/utils/client-environment.ts';
 
 type BeforeInstallPromptEvent = Event & {
   prompt: () => Promise<void>;
@@ -65,10 +66,12 @@ export const usePwaInstallPrompt = () => {
       setInstallEvent(event as BeforeInstallPromptEvent);
       setIsDismissed(false);
       setManualPlatform(null);
+      trackPwaLifecycleEvent('pwa_prompt_available');
     };
 
     const handleAppInstalled = () => {
       updateInstallationState();
+      trackPwaLifecycleEvent('pwa_appinstalled');
     };
 
     window.addEventListener('beforeinstallprompt', handleBeforeInstallPrompt);
@@ -120,14 +123,17 @@ export const usePwaInstallPrompt = () => {
 
     setIsPrompting(true);
     try {
+      trackPwaLifecycleEvent('pwa_install_clicked');
       await installEvent.prompt();
       const choiceResult = await installEvent.userChoice;
       setInstallEvent(null);
       if (choiceResult.outcome === 'accepted') {
         setIsInstalled(true);
+        trackPwaLifecycleEvent('pwa_install_accepted');
         return 'accepted';
       }
       setIsDismissed(true);
+      trackPwaLifecycleEvent('pwa_install_dismissed');
       return 'dismissed';
     } catch (error) {
       console.error('Failed to prompt for PWA installation', error);

--- a/app/root.banner-height.test.tsx
+++ b/app/root.banner-height.test.tsx
@@ -21,6 +21,7 @@ const useHints = vi.fn();
 const usePwaInstallPrompt = vi.fn();
 const useToast = vi.fn();
 const setPrefetchCacheScope = vi.fn();
+const trackClientEnvironmentOncePerDay = vi.fn();
 
 vi.mock('react-router', async () => {
   const actual = await vi.importActual('react-router');
@@ -107,7 +108,8 @@ vi.mock('./components/wishlist/wishlist-route-skeleton.tsx', () => ({
 }));
 
 vi.mock('./hooks/use-pwa-install-prompt.ts', () => ({
-  usePwaInstallPrompt: (...args: Array<unknown>) => usePwaInstallPrompt(...args),
+  usePwaInstallPrompt: (...args: Array<unknown>) =>
+    usePwaInstallPrompt(...args),
 }));
 
 vi.mock('./utils/auth.server.ts', () => ({
@@ -126,6 +128,11 @@ vi.mock('./utils/client-hints.tsx', () => ({
   useHints: () => useHints(),
 }));
 
+vi.mock('./utils/client-environment.ts', () => ({
+  trackClientEnvironmentOncePerDay: (...args: Array<unknown>) =>
+    trackClientEnvironmentOncePerDay(...args),
+}));
+
 vi.mock('./utils/db.server.ts', () => ({
   prisma: { user: { findUniqueOrThrow: vi.fn() } },
 }));
@@ -133,7 +140,9 @@ vi.mock('./utils/db.server.ts', () => ({
 vi.mock('./utils/honeypot.server.ts', () => ({ honeypot: {} }));
 
 vi.mock('./utils/i18n.tsx', () => ({
-  I18nProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  I18nProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
   getLocaleFromRequest: vi.fn(),
 }));
 
@@ -212,6 +221,7 @@ function setupMocks(pwaOverrides = {}) {
   usePwaInstallPrompt.mockReturnValue(makePwaPrompt(pwaOverrides));
   useToast.mockReset();
   setPrefetchCacheScope.mockReset();
+  trackClientEnvironmentOncePerDay.mockReset();
 }
 
 // ─── Tests ───────────────────────────────────────────────────────────────────

--- a/app/root.test.tsx
+++ b/app/root.test.tsx
@@ -14,6 +14,7 @@ const useHints = vi.fn();
 const usePwaInstallPrompt = vi.fn();
 const useToast = vi.fn();
 const setPrefetchCacheScope = vi.fn();
+const trackClientEnvironmentOncePerDay = vi.fn();
 
 vi.mock('react-router', async () => {
   const actual = await vi.importActual('react-router');
@@ -33,7 +34,9 @@ vi.mock('react-router', async () => {
 });
 
 vi.mock('remix-utils/honeypot/react', () => ({
-  HoneypotProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  HoneypotProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
 }));
 
 vi.mock('sonner', () => ({
@@ -103,7 +106,8 @@ vi.mock('./components/wishlist/wishlist-route-skeleton.tsx', () => ({
 }));
 
 vi.mock('./hooks/use-pwa-install-prompt.ts', () => ({
-  usePwaInstallPrompt: (...args: Array<unknown>) => usePwaInstallPrompt(...args),
+  usePwaInstallPrompt: (...args: Array<unknown>) =>
+    usePwaInstallPrompt(...args),
 }));
 
 vi.mock('./utils/auth.server.ts', () => ({
@@ -122,6 +126,11 @@ vi.mock('./utils/client-hints.tsx', () => ({
   useHints: () => useHints(),
 }));
 
+vi.mock('./utils/client-environment.ts', () => ({
+  trackClientEnvironmentOncePerDay: (...args: Array<unknown>) =>
+    trackClientEnvironmentOncePerDay(...args),
+}));
+
 vi.mock('./utils/db.server.ts', () => ({
   prisma: {
     user: {
@@ -135,7 +144,9 @@ vi.mock('./utils/honeypot.server.ts', () => ({
 }));
 
 vi.mock('./utils/i18n.tsx', () => ({
-  I18nProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  I18nProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
   getLocaleFromRequest: vi.fn(),
 }));
 
@@ -149,7 +160,8 @@ vi.mock('./utils/nonce-provider.ts', () => ({
 }));
 
 vi.mock('./utils/prefetch-cache.client.ts', () => ({
-  setPrefetchCacheScope: (...args: Array<unknown>) => setPrefetchCacheScope(...args),
+  setPrefetchCacheScope: (...args: Array<unknown>) =>
+    setPrefetchCacheScope(...args),
 }));
 
 vi.mock('./utils/request-context.server.ts', () => ({
@@ -217,6 +229,7 @@ beforeEach(() => {
   });
   useToast.mockReset();
   setPrefetchCacheScope.mockReset();
+  trackClientEnvironmentOncePerDay.mockReset();
 });
 
 describe('app/root.tsx', () => {

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -52,6 +52,7 @@ import {
   reloadOnceForChunkError,
 } from './utils/chunk-error.client.ts';
 import { ClientHintCheck, getHints, useHints } from './utils/client-hints.tsx';
+import { trackClientEnvironmentOncePerDay } from './utils/client-environment.ts';
 import { prisma } from './utils/db.server.ts';
 import { getEnv } from './utils/env.server.ts';
 import { honeypot } from './utils/honeypot.server.ts';
@@ -299,6 +300,9 @@ const App = () => {
     promptInstall,
     shouldShowBanner: showPwaInstallBanner,
   } = usePwaInstallPrompt();
+  useEffect(() => {
+    void trackClientEnvironmentOncePerDay();
+  }, []);
   const handleInstallClick = useCallback(async () => {
     if (installCapability !== 'prompt') {
       return 'unavailable' as const;

--- a/app/routes/_marketing+/privacy.test.tsx
+++ b/app/routes/_marketing+/privacy.test.tsx
@@ -16,5 +16,8 @@ describe('PrivacyRoute', () => {
     expect(screen.getByText(/third-party services/i)).toBeInTheDocument();
     expect(screen.getByText(/cookies and sessions/i)).toBeInTheDocument();
     expect(screen.getByText(/data retention/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/normalized browser, device, viewport/i),
+    ).toBeInTheDocument();
   });
 });

--- a/app/routes/_marketing+/privacy.test.tsx
+++ b/app/routes/_marketing+/privacy.test.tsx
@@ -19,5 +19,8 @@ describe('PrivacyRoute', () => {
     expect(
       screen.getByText(/normalized browser, device, viewport/i),
     ).toBeInTheDocument();
+    expect(
+      screen.getByText(/browser notification permission state/i),
+    ).toBeInTheDocument();
   });
 });

--- a/app/routes/_marketing+/privacy.tsx
+++ b/app/routes/_marketing+/privacy.tsx
@@ -45,9 +45,10 @@ const PrivacyRoute = () => {
             invite link), these events are associated with a random first-party
             visitor identifier instead. We do not use third-party analytics or
             advertising trackers. We also collect normalized browser, device,
-            viewport, operating system, and PWA install/display-mode details so
-            we can understand how people access the app. We do not collect full
-            user-agent strings for this analytics view.
+            viewport, operating system, PWA install/display-mode, and browser
+            notification permission state details so we can understand how
+            people access the app. We do not collect full user-agent strings for
+            this analytics view.
           </p>
 
           <h3 className="mt-4 text-body-md font-semibold text-foreground">

--- a/app/routes/_marketing+/privacy.tsx
+++ b/app/routes/_marketing+/privacy.tsx
@@ -9,7 +9,7 @@ const PrivacyRoute = () => {
     <div className="container max-w-3xl pb-32 pt-20">
       <h1 className="text-h1">Privacy Policy</h1>
       <p className="mt-2 text-body-sm text-muted-foreground">
-        Last updated: June 12, 2026
+        Last updated: June 29, 2026
       </p>
 
       <div className="mt-10 space-y-8 text-body-md leading-relaxed text-muted-foreground">
@@ -44,7 +44,10 @@ const PrivacyRoute = () => {
             without an account (for example, opening a shared wishlist or an
             invite link), these events are associated with a random first-party
             visitor identifier instead. We do not use third-party analytics or
-            advertising trackers.
+            advertising trackers. We also collect normalized browser, device,
+            viewport, operating system, and PWA install/display-mode details so
+            we can understand how people access the app. We do not collect full
+            user-agent strings for this analytics view.
           </p>
 
           <h3 className="mt-4 text-body-md font-semibold text-foreground">

--- a/app/routes/admin+/analytics.dom.test.tsx
+++ b/app/routes/admin+/analytics.dom.test.tsx
@@ -98,6 +98,41 @@ const loaderDataSnapshot = {
     perDay: [{ day: '2026-03-13', clicks: 11, tagged: 7 }],
   },
   smartLinks: { proposed: 5, fromWishlist: 2, withPrice: 4 },
+  environment: {
+    totalObservations: 4,
+    uniqueVisitors: 3,
+    standaloneObservations: 1,
+    browserObservations: 3,
+    standalonePercent: 25,
+    browsers: [
+      { label: 'Chrome 120', count: 3, percent: 75 },
+      { label: 'Safari 17', count: 1, percent: 25 },
+    ],
+    operatingSystems: [
+      { label: 'macOS', count: 2, percent: 50 },
+      { label: 'iOS', count: 2, percent: 50 },
+    ],
+    deviceTypes: [
+      { label: 'desktop', count: 2, percent: 50 },
+      { label: 'mobile', count: 2, percent: 50 },
+    ],
+    viewportBuckets: [
+      { label: 'desktop', count: 2, percent: 50 },
+      { label: 'mobile', count: 2, percent: 50 },
+    ],
+    displayModes: [
+      { label: 'browser', count: 3, percent: 75 },
+      { label: 'standalone', count: 1, percent: 25 },
+    ],
+    pwaFunnel: [
+      { label: 'Prompt available', count: 2, percent: 0 },
+      { label: 'Install clicked', count: 1, percent: 0 },
+      { label: 'Install accepted', count: 1, percent: 0 },
+      { label: 'Install dismissed', count: 0, percent: 0 },
+      { label: 'App installed', count: 1, percent: 0 },
+      { label: 'Standalone launches', count: 1, percent: 0 },
+    ],
+  },
 };
 
 vi.mock('react-router', async () => {
@@ -114,6 +149,7 @@ vi.mock('#app/utils/permissions.server.ts', () => ({
 
 vi.mock('#app/utils/analytics.server.ts', () => ({
   getAnalyticsCounts: vi.fn(),
+  getEnvironmentAnalytics: vi.fn(),
 }));
 
 vi.mock('#app/utils/admin.server.ts', () => ({
@@ -142,6 +178,10 @@ describe('admin analytics page', () => {
     expect(
       screen.getByRole('heading', { name: 'Analytics' }),
     ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Open explorer' })).toHaveAttribute(
+      'href',
+      '/admin/analytics/explorer',
+    );
   });
 
   it('renders DAU/WAU/MAU summary cards', () => {
@@ -214,6 +254,20 @@ describe('admin analytics page', () => {
     ).toBeInTheDocument();
     expect(screen.getByText('friend request received')).toBeInTheDocument();
     expect(screen.getByText('upcoming birthday')).toBeInTheDocument();
+  });
+
+  it('renders the environment analytics section', () => {
+    renderAnalytics();
+    expect(
+      screen.getByRole('heading', { name: 'Environment' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Environment snapshots')).toBeInTheDocument();
+    expect(screen.getByText('Chrome 120')).toBeInTheDocument();
+    expect(screen.getByText('Safari 17')).toBeInTheDocument();
+    expect(screen.getByText('Prompt available')).toBeInTheDocument();
+    expect(screen.getAllByText('Standalone launches').length).toBeGreaterThan(
+      0,
+    );
   });
 
   it('renders the link enrichment & affiliate section', () => {

--- a/app/routes/admin+/analytics.test.ts
+++ b/app/routes/admin+/analytics.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import { loader } from '#app/routes/admin+/analytics.tsx';
-import { logEvent } from '#app/utils/analytics.server.ts';
+import {
+  logClientEnvironmentObservation,
+  logEvent,
+} from '#app/utils/analytics.server.ts';
 import { prisma } from '#app/utils/db.server.ts';
 import { createUser } from '#tests/db-utils.ts';
 import {
@@ -78,6 +81,24 @@ describe('/admin/analytics loader', () => {
       sessionId: null,
       createdAt: new Date(now.getTime() - 2 * DAY_MS),
     });
+    await logClientEnvironmentObservation({
+      visitorId: '11111111-1111-4111-8111-111111111111',
+      requestId: 'req-env',
+      sessionId: null,
+      properties: {
+        browserFamily: 'Chrome',
+        browserMajor: 120,
+        osFamily: 'macOS',
+        deviceType: 'desktop',
+        viewportBucket: 'desktop',
+        displayMode: 'browser',
+        isStandalone: false,
+        serviceWorkerSupported: true,
+        notificationPermission: 'default',
+        observedAt: now.toISOString(),
+      },
+      createdAt: now,
+    });
 
     const response = await loader(
       toLoaderArgs({
@@ -88,7 +109,10 @@ describe('/admin/analytics loader', () => {
     );
 
     expect(getRouteResultStatus(response)).toBe(200);
-    const data = await getRouteResultData<{ analytics: any }>(response);
+    const data = await getRouteResultData<{
+      analytics: any;
+      environment: any;
+    }>(response);
     expect(data.analytics.totalUsers).toBe(2);
     expect(data.analytics.dau).toBe(1);
     expect(data.analytics.wau).toBe(2);
@@ -111,5 +135,11 @@ describe('/admin/analytics loader', () => {
     );
     expect(event7?.count).toBe(1);
     expect(event30?.count).toBe(1);
+    expect(data.environment.totalObservations).toBe(1);
+    expect(data.environment.browsers[0]).toMatchObject({
+      label: 'Chrome 120',
+      count: 1,
+      percent: 100,
+    });
   });
 });

--- a/app/routes/admin+/analytics.tsx
+++ b/app/routes/admin+/analytics.tsx
@@ -1,4 +1,4 @@
-import { type LoaderFunctionArgs, useLoaderData } from 'react-router';
+import { Link, type LoaderFunctionArgs, useLoaderData } from 'react-router';
 import {
   EmptyRow,
   SectionCard,
@@ -8,7 +8,9 @@ import { GeneralErrorBoundary } from '#app/components/error-boundary.tsx';
 import { Card } from '#app/components/ui/card.tsx';
 import {
   type AnalyticsCounts,
+  type EnvironmentAnalytics,
   getAnalyticsCounts,
+  getEnvironmentAnalytics,
 } from '#app/utils/analytics.server.ts';
 import {
   type DropOffFunnels,
@@ -47,6 +49,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
     enrichmentFailures,
     linkClicks,
     smartLinks,
+    environment,
   ] = await Promise.all([
     getAnalyticsCounts(),
     getActivationFunnel({ cohortStart: thirtyDaysAgo, cohortEnd: now }),
@@ -57,6 +60,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
     getEnrichmentFailures({ days: 30 }),
     getLinkClickStats({ days: 30 }),
     getSmartLinkAdoption({ days: 30 }),
+    getEnvironmentAnalytics({ days: 30 }),
   ]);
 
   return {
@@ -69,6 +73,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
     enrichmentFailures,
     linkClicks,
     smartLinks,
+    environment,
   };
 }
 
@@ -190,15 +195,24 @@ const AnalyticsRoute = () => {
     enrichmentFailures,
     linkClicks,
     smartLinks,
+    environment,
   } = useLoaderData<typeof loader>();
   return (
     <div className="space-y-8">
-      <div className="space-y-1">
-        <h1 className="text-xl font-semibold">Analytics</h1>
-        <p className="text-muted-foreground">
-          Usage metrics, activation funnel, retention, and notification
-          opt-outs.
-        </p>
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="space-y-1">
+          <h1 className="text-xl font-semibold">Analytics</h1>
+          <p className="text-muted-foreground">
+            Usage metrics, activation funnel, retention, and notification
+            opt-outs.
+          </p>
+        </div>
+        <Link
+          to="/admin/analytics/explorer"
+          className="text-sm font-medium text-primary hover:underline"
+        >
+          Open explorer
+        </Link>
       </div>
 
       {/* --- DAU/WAU/MAU --- */}
@@ -263,6 +277,13 @@ const AnalyticsRoute = () => {
         )}
       </SectionCard>
 
+      <SectionCard
+        title="Environment"
+        description="Last 30 days. Daily visitor snapshots by browser, device, OS, and PWA launch mode."
+      >
+        <EnvironmentSection environment={environment} />
+      </SectionCard>
+
       {/* --- link enrichment & affiliate health --- */}
       <SectionCard
         title="Link enrichment & affiliate"
@@ -297,6 +318,112 @@ const AnalyticsRoute = () => {
 
 const pctOf = (count: number, total: number) =>
   total > 0 ? Math.round((count / total) * 100) : 0;
+
+// ---------------------------------------------------------------------------
+// Browser/device/PWA environment
+// ---------------------------------------------------------------------------
+
+const BreakdownTable = ({
+  title,
+  rows,
+  showPercent = true,
+}: {
+  title: string;
+  rows: EnvironmentAnalytics['browsers'];
+  showPercent?: boolean;
+}) => (
+  <div className="overflow-hidden rounded-md border border-border/50">
+    <div className="bg-muted/40 px-4 py-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+      {title}
+    </div>
+    <table className="min-w-full divide-y divide-border/60">
+      <tbody className="divide-y divide-border/60">
+        {rows.length === 0 ? (
+          <tr>
+            <td className="px-4 py-3 text-sm text-muted-foreground">
+              No observations yet.
+            </td>
+          </tr>
+        ) : (
+          rows.map((row) => (
+            <tr key={`${title}-${row.label}`}>
+              <td className="px-4 py-2 text-sm font-medium">{row.label}</td>
+              <td className="px-4 py-2 text-right text-sm tabular-nums">
+                {row.count.toLocaleString()}
+                {showPercent ? ` (${row.percent}%)` : null}
+              </td>
+            </tr>
+          ))
+        )}
+      </tbody>
+    </table>
+  </div>
+);
+
+const EnvironmentSection = ({
+  environment,
+}: {
+  environment: EnvironmentAnalytics;
+}) => {
+  const hasData =
+    environment.totalObservations > 0 ||
+    environment.pwaFunnel.some((row) => row.count > 0);
+
+  if (!hasData) {
+    return (
+      <EmptyRow>
+        No environment observations yet — they start recording from this deploy.
+      </EmptyRow>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <SummaryCard
+          label="Environment snapshots"
+          value={environment.totalObservations}
+          delta={`${environment.uniqueVisitors.toLocaleString()} unique visitors`}
+        />
+        <SummaryCard
+          label="Browser launches"
+          value={environment.browserObservations}
+          delta={`${100 - environment.standalonePercent}% of snapshots`}
+        />
+        <SummaryCard
+          label="Standalone launches"
+          value={environment.standaloneObservations}
+          delta={`${environment.standalonePercent}% of snapshots`}
+        />
+        <SummaryCard
+          label="Install funnel events"
+          value={environment.pwaFunnel
+            .reduce((sum, row) => sum + row.count, 0)
+            .toLocaleString()}
+        />
+      </section>
+
+      <section className="grid gap-4 lg:grid-cols-2">
+        <BreakdownTable title="Browsers" rows={environment.browsers} />
+        <BreakdownTable title="Devices" rows={environment.deviceTypes} />
+        <BreakdownTable
+          title="Operating systems"
+          rows={environment.operatingSystems}
+        />
+        <BreakdownTable title="Display modes" rows={environment.displayModes} />
+        <BreakdownTable
+          title="Viewport buckets"
+          rows={environment.viewportBuckets}
+        />
+        <BreakdownTable
+          title="PWA funnel"
+          rows={environment.pwaFunnel}
+          showPercent={false}
+        />
+      </section>
+    </div>
+  );
+};
 
 // ---------------------------------------------------------------------------
 // Drop-off funnels

--- a/app/routes/admin+/analytics_.explorer.dom.test.tsx
+++ b/app/routes/admin+/analytics_.explorer.dom.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import { type FormHTMLAttributes, type ReactNode } from 'react';
+import type * as ReactRouter from 'react-router';
+import { MemoryRouter } from 'react-router';
+import { describe, expect, it, vi } from 'vitest';
+
+const loaderDataSnapshot = {
+  chart: 'bar',
+  explorer: {
+    days: 30,
+    eventName: 'client_environment_observed',
+    groupBy: 'browser',
+    totalEvents: 3,
+    uniqueUsers: 1,
+    uniqueVisitors: 2,
+    series: [
+      { date: '2026-06-28', count: 1 },
+      { date: '2026-06-29', count: 2 },
+    ],
+    breakdown: [
+      { label: 'Chrome 126', count: 2, percent: 67 },
+      { label: 'Safari 17', count: 1, percent: 33 },
+    ],
+    recentEvents: [
+      {
+        id: 'event-1',
+        eventId: 'client-environment:v1',
+        name: 'client_environment_observed',
+        source: 'client',
+        createdAt: '2026-06-29T12:00:00.000Z',
+        userId: 'user-1234567890',
+        visitorId: 'visitor-1234567890',
+        propertiesPreview: '{"browserFamily":"Chrome"}',
+      },
+    ],
+  },
+};
+
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual<typeof ReactRouter>('react-router');
+  const MockForm = ({
+    children,
+    ...props
+  }: FormHTMLAttributes<HTMLFormElement> & {
+    children: ReactNode;
+  }) => <form {...props}>{children}</form>;
+  return {
+    ...actual,
+    Form: MockForm,
+    useLoaderData: () => loaderDataSnapshot,
+  };
+});
+
+vi.mock('#app/utils/analytics.server.ts', () => ({
+  ANALYTICS_EXPLORER_DAY_OPTIONS: [7, 30, 90],
+  ANALYTICS_EXPLORER_GROUP_BY_OPTIONS: [
+    'event',
+    'source',
+    'browser',
+    'os',
+    'device',
+    'viewport',
+    'displayMode',
+    'standalone',
+  ],
+  getAnalyticsExplorer: vi.fn(),
+}));
+
+vi.mock('#app/utils/permissions.server.ts', () => ({
+  requireUserWithRole: vi.fn(),
+}));
+
+import AnalyticsExplorerRoute from './analytics_.explorer.tsx';
+
+const renderExplorer = () =>
+  render(
+    <MemoryRouter initialEntries={['/admin/analytics/explorer']}>
+      <AnalyticsExplorerRoute />
+    </MemoryRouter>,
+  );
+
+describe('admin analytics explorer page', () => {
+  it('renders controls, trend, breakdown, and recent events', () => {
+    renderExplorer();
+
+    expect(
+      screen.getByRole('heading', { name: 'Analytics explorer' }),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText('Date range')).toBeInTheDocument();
+    expect(screen.getByLabelText('Event')).toBeInTheDocument();
+    expect(screen.getByLabelText('Group by')).toBeInTheDocument();
+    expect(screen.getByLabelText('Chart')).toBeInTheDocument();
+    expect(screen.getByText('Matching events')).toBeInTheDocument();
+    expect(screen.getByText('Chrome 126')).toBeInTheDocument();
+    expect(screen.getByText('Safari 17')).toBeInTheDocument();
+    expect(screen.getByText('Recent matching events')).toBeInTheDocument();
+    expect(screen.getByText(/browserFamily/)).toBeInTheDocument();
+  });
+});

--- a/app/routes/admin+/analytics_.explorer.test.ts
+++ b/app/routes/admin+/analytics_.explorer.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import { loader } from '#app/routes/admin+/analytics_.explorer.tsx';
+import { logEvent } from '#app/utils/analytics.server.ts';
+import { prisma } from '#app/utils/db.server.ts';
+import { createUser } from '#tests/db-utils.ts';
+import {
+  getRouteResultData,
+  getRouteResultStatus,
+  toLoaderArgs,
+} from '#tests/route-module-test-utils.ts';
+import { getSessionCookieHeader } from '#tests/utils.ts';
+
+const DAY_MS = 1000 * 60 * 60 * 24;
+
+const buildRequest = (cookie?: string, search = '') =>
+  new Request(`http://localhost/admin/analytics/explorer${search}`, {
+    headers: cookie ? { cookie } : undefined,
+  });
+
+async function seedAdminSession() {
+  await prisma.role.upsert({
+    where: { name: 'admin' },
+    update: {},
+    create: { name: 'admin', description: 'Admin role' },
+  });
+  const admin = await prisma.user.create({
+    data: {
+      ...createUser(),
+      roles: { connect: { name: 'admin' } },
+    },
+  });
+  const session = await prisma.session.create({
+    data: {
+      userId: admin.id,
+      expirationDate: new Date(Date.now() + DAY_MS),
+    },
+  });
+  return getSessionCookieHeader(session);
+}
+
+describe('/admin/analytics/explorer loader', () => {
+  it('rejects users without the admin role', async () => {
+    const user = await prisma.user.create({ data: createUser() });
+    const session = await prisma.session.create({
+      data: {
+        userId: user.id,
+        expirationDate: new Date(Date.now() + DAY_MS),
+      },
+    });
+    const cookie = await getSessionCookieHeader(session);
+
+    await expect(
+      loader(
+        toLoaderArgs({
+          request: buildRequest(cookie),
+          params: {},
+          context: {} as any,
+        }),
+      ),
+    ).rejects.toMatchObject({ init: { status: 403 } });
+  });
+
+  it('returns filtered explorer data for admin users', async () => {
+    const cookie = await seedAdminSession();
+    const user = await prisma.user.create({ data: createUser() });
+    await logEvent({
+      name: 'wishlist_viewed',
+      userId: user.id,
+      source: 'client',
+      visitorId: 'visitor-one',
+      createdAt: new Date(),
+    });
+
+    const response = await loader(
+      toLoaderArgs({
+        request: buildRequest(
+          cookie,
+          '?days=7&event=wishlist_viewed&groupBy=source&chart=bar',
+        ),
+        params: {},
+        context: {} as any,
+      }),
+    );
+
+    expect(getRouteResultStatus(response)).toBe(200);
+    const data = await getRouteResultData<{
+      chart: string;
+      explorer: {
+        days: number;
+        eventName: string;
+        groupBy: string;
+        totalEvents: number;
+        breakdown: Array<{ label: string; count: number }>;
+      };
+    }>(response);
+    expect(data.chart).toBe('bar');
+    expect(data.explorer.days).toBe(7);
+    expect(data.explorer.eventName).toBe('wishlist_viewed');
+    expect(data.explorer.groupBy).toBe('source');
+    expect(data.explorer.totalEvents).toBe(1);
+    expect(data.explorer.breakdown[0]).toMatchObject({
+      label: 'client',
+      count: 1,
+    });
+  });
+});

--- a/app/routes/admin+/analytics_.explorer.tsx
+++ b/app/routes/admin+/analytics_.explorer.tsx
@@ -1,0 +1,443 @@
+import {
+  type LoaderFunctionArgs,
+  Form,
+  Link,
+  useLoaderData,
+} from 'react-router';
+import {
+  EmptyRow,
+  SectionCard,
+  SummaryCard,
+} from '#app/components/admin-ui.tsx';
+import { GeneralErrorBoundary } from '#app/components/error-boundary.tsx';
+import { Button } from '#app/components/ui/button.tsx';
+import { Card } from '#app/components/ui/card.tsx';
+import {
+  ANALYTICS_EXPLORER_DAY_OPTIONS,
+  ANALYTICS_EXPLORER_GROUP_BY_OPTIONS,
+  ANALYTIC_EVENT_NAMES,
+  ANALYTIC_EVENT_SET,
+  type AnalyticsExplorerDays,
+  type AnalyticsExplorerEventFilter,
+  type AnalyticsExplorerGroupBy,
+  type AnalyticsExplorerResult,
+} from '#app/utils/analytics.ts';
+import { cn } from '#app/utils/misc.tsx';
+import { requireUserWithRole } from '#app/utils/permissions.server.ts';
+
+const CHART_MODES = ['line', 'bar', 'table'] as const;
+type ChartMode = (typeof CHART_MODES)[number];
+
+const GROUP_LABELS: Record<AnalyticsExplorerGroupBy, string> = {
+  event: 'Event',
+  source: 'Source',
+  browser: 'Browser',
+  os: 'Operating system',
+  device: 'Device',
+  viewport: 'Viewport',
+  displayMode: 'Display mode',
+  standalone: 'PWA standalone',
+};
+
+const CHART_LABELS: Record<ChartMode, string> = {
+  line: 'Line',
+  bar: 'Bar',
+  table: 'Table',
+};
+
+function parseDays(value: string | null): AnalyticsExplorerDays {
+  const parsed = Number(value);
+  return ANALYTICS_EXPLORER_DAY_OPTIONS.includes(
+    parsed as AnalyticsExplorerDays,
+  )
+    ? (parsed as AnalyticsExplorerDays)
+    : 30;
+}
+
+function parseEventName(value: string | null): AnalyticsExplorerEventFilter {
+  if (value && ANALYTIC_EVENT_SET.has(value)) {
+    return value as AnalyticsExplorerEventFilter;
+  }
+  return 'all';
+}
+
+function parseGroupBy(value: string | null): AnalyticsExplorerGroupBy {
+  return ANALYTICS_EXPLORER_GROUP_BY_OPTIONS.includes(
+    value as AnalyticsExplorerGroupBy,
+  )
+    ? (value as AnalyticsExplorerGroupBy)
+    : 'event';
+}
+
+function parseChart(value: string | null): ChartMode {
+  return CHART_MODES.includes(value as ChartMode)
+    ? (value as ChartMode)
+    : 'line';
+}
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  await requireUserWithRole(request, 'admin');
+
+  const searchParams = new URL(request.url).searchParams;
+  const days = parseDays(searchParams.get('days'));
+  const eventName = parseEventName(searchParams.get('event'));
+  const groupBy = parseGroupBy(searchParams.get('groupBy'));
+  const chart = parseChart(searchParams.get('chart'));
+  const { getAnalyticsExplorer } =
+    await import('#app/utils/analytics.server.ts');
+  const explorer = await getAnalyticsExplorer({ days, eventName, groupBy });
+
+  return { explorer, chart };
+}
+
+const formatEventName = (name: string) => name.replaceAll('_', ' ');
+
+const formatIdentifier = (id: string | null) =>
+  id ? `${id.slice(0, 10)}...` : '—';
+
+const AnalyticsExplorerRoute = () => {
+  const { explorer, chart } = useLoaderData<typeof loader>();
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="space-y-1">
+          <h1 className="text-xl font-semibold">Analytics explorer</h1>
+          <p className="text-muted-foreground">
+            Slice first-party analytics by event, source, environment, and time.
+          </p>
+        </div>
+        <Link
+          to="/admin/analytics"
+          className="text-sm font-medium text-primary hover:underline"
+        >
+          Back to dashboard
+        </Link>
+      </div>
+
+      <ExplorerControls explorer={explorer} chart={chart} />
+
+      <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <SummaryCard label="Matching events" value={explorer.totalEvents} />
+        <SummaryCard
+          label="Unique users"
+          value={explorer.uniqueUsers}
+          delta="events with a user id"
+        />
+        <SummaryCard
+          label="Unique visitors"
+          value={explorer.uniqueVisitors}
+          delta="events with a visitor id"
+        />
+        <SummaryCard
+          label="Groups"
+          value={explorer.breakdown.length}
+          delta={GROUP_LABELS[explorer.groupBy]}
+        />
+      </section>
+
+      <SectionCard
+        title="Trend"
+        description={`${explorer.days} days${
+          explorer.eventName === 'all'
+            ? ''
+            : `, ${formatEventName(explorer.eventName)}`
+        }`}
+      >
+        <TrendView mode={chart} explorer={explorer} />
+      </SectionCard>
+
+      <section className="grid gap-4 xl:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
+        <SectionCard
+          title={`${GROUP_LABELS[explorer.groupBy]} breakdown`}
+          description="Grouped event counts for the selected filter."
+        >
+          <BreakdownBars rows={explorer.breakdown} />
+        </SectionCard>
+
+        <SectionCard
+          title="Recent matching events"
+          description="Most recent rows, with truncated property previews."
+        >
+          <RecentEventsTable rows={explorer.recentEvents} />
+        </SectionCard>
+      </section>
+    </div>
+  );
+};
+
+export default AnalyticsExplorerRoute;
+
+const ExplorerControls = ({
+  explorer,
+  chart,
+}: {
+  explorer: AnalyticsExplorerResult;
+  chart: ChartMode;
+}) => (
+  <Card className="border-border/70 bg-card p-4 shadow-sm">
+    <Form method="get" className="grid gap-4 md:grid-cols-2 xl:grid-cols-5">
+      <label className="space-y-2">
+        <span className="text-sm font-medium">Date range</span>
+        <select
+          name="days"
+          defaultValue={explorer.days}
+          className="h-10 w-full rounded-md border border-input bg-input-bg px-3 py-2 text-sm"
+        >
+          {ANALYTICS_EXPLORER_DAY_OPTIONS.map((days) => (
+            <option key={days} value={days}>
+              Last {days} days
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label className="space-y-2 xl:col-span-2">
+        <span className="text-sm font-medium">Event</span>
+        <select
+          name="event"
+          defaultValue={explorer.eventName}
+          className="h-10 w-full rounded-md border border-input bg-input-bg px-3 py-2 text-sm"
+        >
+          <option value="all">All events</option>
+          {ANALYTIC_EVENT_NAMES.map((name) => (
+            <option key={name} value={name}>
+              {formatEventName(name)}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label className="space-y-2">
+        <span className="text-sm font-medium">Group by</span>
+        <select
+          name="groupBy"
+          defaultValue={explorer.groupBy}
+          className="h-10 w-full rounded-md border border-input bg-input-bg px-3 py-2 text-sm"
+        >
+          {ANALYTICS_EXPLORER_GROUP_BY_OPTIONS.map((groupBy) => (
+            <option key={groupBy} value={groupBy}>
+              {GROUP_LABELS[groupBy]}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label className="space-y-2">
+        <span className="text-sm font-medium">Chart</span>
+        <select
+          name="chart"
+          defaultValue={chart}
+          className="h-10 w-full rounded-md border border-input bg-input-bg px-3 py-2 text-sm"
+        >
+          {CHART_MODES.map((mode) => (
+            <option key={mode} value={mode}>
+              {CHART_LABELS[mode]}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <div className="md:col-span-2 xl:col-span-5">
+        <Button type="submit">Apply</Button>
+      </div>
+    </Form>
+  </Card>
+);
+
+const TrendView = ({
+  mode,
+  explorer,
+}: {
+  mode: ChartMode;
+  explorer: AnalyticsExplorerResult;
+}) => {
+  if (explorer.series.every((row) => row.count === 0)) {
+    return <EmptyRow>No matching events in this date range.</EmptyRow>;
+  }
+  if (mode === 'table') return <TrendTable rows={explorer.series} />;
+  if (mode === 'bar') return <TrendBars rows={explorer.series} />;
+  return <TrendLine rows={explorer.series} />;
+};
+
+const TrendLine = ({ rows }: { rows: AnalyticsExplorerResult['series'] }) => {
+  const height = 220;
+  const width = Math.max(520, rows.length * 16);
+  const maxCount = Math.max(...rows.map((row) => row.count), 1);
+  const points = rows
+    .map((row, index) => {
+      const x = (index / Math.max(rows.length - 1, 1)) * (width - 24) + 12;
+      const y = height - (row.count / maxCount) * (height - 24) + 12;
+      return `${x},${y}`;
+    })
+    .join(' ');
+
+  return (
+    <div className="overflow-x-auto">
+      <svg
+        role="img"
+        aria-label="Analytics event trend"
+        width={width}
+        height={height + 28}
+        className="text-muted-foreground"
+      >
+        <polyline
+          fill="none"
+          stroke="hsl(var(--primary))"
+          strokeWidth={3}
+          points={points}
+        />
+        <g className="fill-current text-[10px]">
+          <text x="12" y={height + 20}>
+            {rows[0]?.date}
+          </text>
+          <text x={width - 12} y={height + 20} textAnchor="end">
+            {rows.at(-1)?.date}
+          </text>
+        </g>
+      </svg>
+    </div>
+  );
+};
+
+const TrendBars = ({ rows }: { rows: AnalyticsExplorerResult['series'] }) => {
+  const maxCount = Math.max(...rows.map((row) => row.count), 1);
+  return (
+    <div className="space-y-2">
+      {rows.map((row) => (
+        <div
+          key={row.date}
+          className="grid grid-cols-[96px_minmax(0,1fr)_56px] items-center gap-3 text-sm"
+        >
+          <span className="font-mono text-xs text-muted-foreground">
+            {row.date}
+          </span>
+          <div className="h-5 overflow-hidden rounded bg-muted/50">
+            <div
+              className="h-full rounded bg-primary/30"
+              style={{ width: `${(row.count / maxCount) * 100}%` }}
+            />
+          </div>
+          <span className="text-right tabular-nums">
+            {row.count.toLocaleString()}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+const TrendTable = ({ rows }: { rows: AnalyticsExplorerResult['series'] }) => (
+  <div className="max-h-80 overflow-auto rounded-md border border-border/60">
+    <table className="min-w-full divide-y divide-border/60 text-sm">
+      <thead className="bg-muted/40">
+        <tr>
+          <th className="px-4 py-2 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Date
+          </th>
+          <th className="px-4 py-2 text-right text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Events
+          </th>
+        </tr>
+      </thead>
+      <tbody className="divide-y divide-border/60">
+        {rows.map((row) => (
+          <tr key={row.date}>
+            <td className="px-4 py-2 font-mono text-xs">{row.date}</td>
+            <td className="px-4 py-2 text-right tabular-nums">
+              {row.count.toLocaleString()}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </div>
+);
+
+const BreakdownBars = ({
+  rows,
+}: {
+  rows: AnalyticsExplorerResult['breakdown'];
+}) => {
+  if (rows.length === 0) return <EmptyRow>No grouped data.</EmptyRow>;
+  const maxCount = Math.max(...rows.map((row) => row.count), 1);
+  return (
+    <div className="space-y-2">
+      {rows.slice(0, 20).map((row) => (
+        <div
+          key={row.label}
+          className="grid grid-cols-[minmax(120px,0.45fr)_minmax(0,1fr)_88px] items-center gap-3 text-sm"
+        >
+          <span className="truncate font-medium" title={row.label}>
+            {formatEventName(row.label)}
+          </span>
+          <div className="h-6 overflow-hidden rounded bg-muted/50">
+            <div
+              className={cn('h-full rounded bg-primary/25')}
+              style={{ width: `${(row.count / maxCount) * 100}%` }}
+            />
+          </div>
+          <span className="text-right tabular-nums">
+            {row.count.toLocaleString()} ({row.percent}%)
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+const RecentEventsTable = ({
+  rows,
+}: {
+  rows: AnalyticsExplorerResult['recentEvents'];
+}) => {
+  if (rows.length === 0) return <EmptyRow>No matching events.</EmptyRow>;
+  return (
+    <div className="max-h-[520px] overflow-auto rounded-md border border-border/60">
+      <table className="min-w-full divide-y divide-border/60 text-sm">
+        <thead className="bg-muted/40">
+          <tr>
+            <th className="px-4 py-2 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              Time
+            </th>
+            <th className="px-4 py-2 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              Event
+            </th>
+            <th className="px-4 py-2 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              Actor
+            </th>
+            <th className="px-4 py-2 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              Properties
+            </th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-border/60">
+          {rows.map((row) => (
+            <tr key={row.id}>
+              <td className="whitespace-nowrap px-4 py-2 font-mono text-xs">
+                {new Date(row.createdAt).toLocaleString()}
+              </td>
+              <td className="px-4 py-2">
+                <div className="font-medium">{formatEventName(row.name)}</div>
+                <div className="text-xs text-muted-foreground">
+                  {row.source}
+                </div>
+              </td>
+              <td className="px-4 py-2 font-mono text-xs">
+                <div>u: {formatIdentifier(row.userId)}</div>
+                <div>v: {formatIdentifier(row.visitorId)}</div>
+              </td>
+              <td className="max-w-[360px] truncate px-4 py-2 font-mono text-xs">
+                {row.propertiesPreview}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export const ErrorBoundary = () => {
+  return <GeneralErrorBoundary />;
+};

--- a/app/routes/admin+/cache.dom.test.tsx
+++ b/app/routes/admin+/cache.dom.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import { type FormHTMLAttributes, type ReactNode } from 'react';
+import type * as ReactRouter from 'react-router';
+import { MemoryRouter } from 'react-router';
+import { describe, expect, it, vi } from 'vitest';
+
+const loaderDataSnapshot = {
+  cacheKeys: {
+    lru: ['admin:overview:counts:v1', 'admin:analytics:environment:v1:30'],
+    sqlite: ['admin:dropoff:v1:30'],
+  },
+  instance: 'app-primary',
+  instances: {
+    'app-primary': 'iad',
+    'app-replica': 'sjc',
+  },
+  currentInstanceInfo: {
+    currentInstance: 'app-primary',
+    primaryInstance: 'app-primary',
+  },
+};
+
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual<typeof ReactRouter>('react-router');
+  const MockForm = ({
+    children,
+    ...props
+  }: FormHTMLAttributes<HTMLFormElement> & {
+    children: ReactNode;
+  }) => <form {...props}>{children}</form>;
+  return {
+    ...actual,
+    Form: MockForm,
+    useFetcher: () => ({
+      state: 'idle',
+      Form: MockForm,
+    }),
+    useLoaderData: () => loaderDataSnapshot,
+    useSearchParams: () => [new URLSearchParams(), vi.fn()],
+    useSubmit: () => vi.fn(),
+  };
+});
+
+vi.mock('#app/utils/cache.server.ts', () => ({
+  cache: { delete: vi.fn() },
+  getAllCacheKeys: vi.fn(),
+  lruCache: { delete: vi.fn() },
+  searchCacheKeys: vi.fn(),
+}));
+
+vi.mock('#app/utils/litefs.server.ts', () => ({
+  ensureInstance: vi.fn(),
+  getAllInstances: vi.fn(),
+  getInstanceInfo: vi.fn(),
+}));
+
+vi.mock('#app/utils/permissions.server.ts', () => ({
+  requireUserWithRole: vi.fn(),
+}));
+
+import CacheAdminRoute from './cache.tsx';
+
+const renderCache = () =>
+  render(
+    <MemoryRouter initialEntries={['/admin/cache']}>
+      <CacheAdminRoute />
+    </MemoryRouter>,
+  );
+
+describe('admin cache page', () => {
+  it('renders cache summary cards, filters, and grouped cache keys', () => {
+    renderCache();
+
+    expect(screen.getByRole('heading', { name: 'Cache' })).toBeInTheDocument();
+    expect(screen.getByText('Entries shown')).toBeInTheDocument();
+    expect(screen.getByText('LRU entries')).toBeInTheDocument();
+    expect(screen.getByText('SQLite entries')).toBeInTheDocument();
+    expect(screen.getByText('Selected instance')).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText('admin:analytics, user id, route...'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'LRU cache' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'SQLite cache' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('admin:overview:counts:v1')).toBeInTheDocument();
+    expect(screen.getByText('admin:dropoff:v1:30')).toBeInTheDocument();
+    expect(screen.getAllByRole('link', { name: 'View' })).toHaveLength(3);
+  });
+});

--- a/app/routes/admin+/cache.tsx
+++ b/app/routes/admin+/cache.tsx
@@ -1,20 +1,33 @@
 import { invariantResponse } from '@epic-web/invariant';
 import { type SEOHandle } from '@nasa-gcn/remix-seo';
+import { type ReactNode } from 'react';
 import {
-  redirect,
-  type LoaderFunctionArgs,
-  type ActionFunctionArgs,
+  LuDatabase,
+  LuExternalLink,
+  LuHardDrive,
+  LuSearch,
+  LuServer,
+  LuTrash2,
+} from 'react-icons/lu';
+import {
   Form,
   Link,
+  redirect,
+  type ActionFunctionArgs,
+  type LoaderFunctionArgs,
   useFetcher,
   useLoaderData,
   useSearchParams,
   useSubmit,
 } from 'react-router';
+import {
+  EmptyRow,
+  SectionCard,
+  SummaryCard,
+} from '#app/components/admin-ui.tsx';
 import { GeneralErrorBoundary } from '#app/components/error-boundary';
-import { Field } from '#app/components/forms.tsx';
-import { Spacer } from '#app/components/spacer.tsx';
 import { Button } from '#app/components/ui/button.tsx';
+import { Input } from '#app/components/ui/input.tsx';
 import {
   cache,
   getAllCacheKeys,
@@ -26,11 +39,13 @@ import {
   getAllInstances,
   getInstanceInfo,
 } from '#app/utils/litefs.server.ts';
-import { useDebounce, useDoubleCheck } from '#app/utils/misc.tsx';
+import { cn, useDebounce, useDoubleCheck } from '#app/utils/misc.tsx';
 import { requireUserWithRole } from '#app/utils/permissions.server.ts';
+
 export const handle: SEOHandle = {
   getSitemapEntries: () => null,
 };
+
 export async function loader({ request }: LoaderFunctionArgs) {
   await requireUserWithRole(request, 'admin');
   const searchParams = new URL(request.url).searchParams;
@@ -61,6 +76,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
     currentInstanceInfo,
   };
 }
+
 export async function action({ request }: ActionFunctionArgs) {
   await requireUserWithRole(request, 'admin');
   const formData = await request.formData();
@@ -89,6 +105,7 @@ export async function action({ request }: ActionFunctionArgs) {
     success: true,
   };
 }
+
 const CacheAdminRoute = () => {
   const data = useLoaderData<typeof loader>();
   const [searchParams] = useSearchParams();
@@ -96,146 +113,263 @@ const CacheAdminRoute = () => {
   const query = searchParams.get('query') ?? '';
   const limit = searchParams.get('limit') ?? '100';
   const instance = searchParams.get('instance') ?? data.instance;
+  const sqliteCount = data.cacheKeys.sqlite.length;
+  const lruCount = data.cacheKeys.lru.length;
+  const totalCount = sqliteCount + lruCount;
+  const selectedRegion = data.instances[instance] ?? 'unknown region';
+  const selectedIsPrimary =
+    instance === data.currentInstanceInfo.primaryInstance;
+  const selectedIsCurrent =
+    instance === data.currentInstanceInfo.currentInstance;
   const handleFormChange = useDebounce((form: HTMLFormElement) => {
     Promise.resolve(submit(form)).catch(() => {});
   }, 400);
+
   return (
-    <div className="space-y-4">
-      <h1 className="text-xl font-semibold">Cache Admin</h1>
-      <Spacer size="2xs" />
+    <div className="space-y-6">
+      <div className="space-y-1">
+        <h1 className="text-xl font-semibold">Cache</h1>
+        <p className="text-muted-foreground">
+          Inspect and clear instance-local LRU entries plus the
+          LiteFS-replicated SQLite cache.
+        </p>
+      </div>
+
+      <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <SummaryCard
+          label="Entries shown"
+          value={totalCount}
+          delta={query ? `matching "${query}"` : `limited to ${limit}`}
+        />
+        <SummaryCard
+          label="LRU entries"
+          value={lruCount}
+          delta="instance-local memory"
+        />
+        <SummaryCard
+          label="SQLite entries"
+          value={sqliteCount}
+          delta="replicated persistent cache"
+        />
+        <SummaryCard
+          label="Selected instance"
+          value={instance}
+          delta={[
+            selectedRegion,
+            selectedIsCurrent ? 'current' : null,
+            selectedIsPrimary ? 'primary' : null,
+          ]
+            .filter(Boolean)
+            .join(' · ')}
+        />
+      </section>
+
       <Form
         method="get"
-        className="flex flex-col gap-4"
-        onChange={(e) => handleFormChange(e.currentTarget)}
+        className="rounded-lg border border-border/70 bg-card p-4 shadow-sm"
+        onChange={(event) => handleFormChange(event.currentTarget)}
       >
-        <div className="flex-1">
-          <div className="flex flex-1 gap-4">
-            <button
-              type="submit"
-              className="flex h-16 items-center justify-center"
-            >
-              🔎
-            </button>
-            <Field
-              className="flex-1"
-              labelProps={{
-                children: 'Search',
-              }}
-              inputProps={{
-                type: 'search',
-                name: 'query',
-                defaultValue: query,
-              }}
-            />
-            <div className="flex h-16 w-14 items-center text-lg font-medium text-muted-foreground">
-              <span title="Total results shown">
-                {data.cacheKeys.sqlite.length + data.cacheKeys.lru.length}
-              </span>
+        <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_140px_minmax(220px,280px)_auto] lg:items-end">
+          <label className="space-y-2">
+            <span className="text-sm font-medium">Search key</span>
+            <div className="relative">
+              <LuSearch className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                className="pl-9"
+                type="search"
+                name="query"
+                defaultValue={query}
+                placeholder="admin:analytics, user id, route..."
+              />
             </div>
-          </div>
-        </div>
-        <div className="flex flex-wrap items-center gap-4">
-          <Field
-            labelProps={{
-              children: 'Limit',
-            }}
-            inputProps={{
-              name: 'limit',
-              defaultValue: limit,
-              type: 'number',
-              step: '1',
-              min: '1',
-              max: '10000',
-              placeholder: 'results limit',
-            }}
-          />
-          <select name="instance" defaultValue={instance}>
-            {Object.entries(data.instances).map(([inst, region]) => (
-              <option key={inst} value={inst}>
-                {[
-                  inst,
-                  `(${region})`,
-                  inst === data.currentInstanceInfo.currentInstance
-                    ? '(current)'
-                    : '',
-                  inst === data.currentInstanceInfo.primaryInstance
-                    ? ' (primary)'
-                    : '',
-                ]
-                  .filter(Boolean)
-                  .join(' ')}
-              </option>
-            ))}
-          </select>
+          </label>
+
+          <label className="space-y-2">
+            <span className="text-sm font-medium">Limit</span>
+            <Input
+              name="limit"
+              defaultValue={limit}
+              type="number"
+              step="1"
+              min="1"
+              max="10000"
+            />
+          </label>
+
+          <label className="space-y-2">
+            <span className="text-sm font-medium">Instance</span>
+            <select
+              name="instance"
+              defaultValue={instance}
+              className="flex h-10 w-full rounded-md border border-input bg-input-bg px-3 py-2 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+            >
+              {Object.entries(data.instances).map(([inst, region]) => (
+                <option key={inst} value={inst}>
+                  {[
+                    inst,
+                    `(${region})`,
+                    inst === data.currentInstanceInfo.currentInstance
+                      ? '(current)'
+                      : '',
+                    inst === data.currentInstanceInfo.primaryInstance
+                      ? '(primary)'
+                      : '',
+                  ]
+                    .filter(Boolean)
+                    .join(' ')}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <Button type="submit" className="gap-2">
+            <LuSearch className="h-4 w-4" />
+            Search
+          </Button>
         </div>
       </Form>
-      <Spacer size="2xs" />
-      <div className="flex flex-col gap-4">
-        <h2 className="text-h2">LRU Cache:</h2>
-        {data.cacheKeys.lru.map((key) => (
-          <CacheKeyRow
-            key={key}
-            cacheKey={key}
-            instance={instance}
-            type="lru"
-          />
-        ))}
-      </div>
-      <Spacer size="3xs" />
-      <div className="flex flex-col gap-4">
-        <h2 className="text-h2">SQLite Cache:</h2>
-        {data.cacheKeys.sqlite.map((key) => (
-          <CacheKeyRow
-            key={key}
-            cacheKey={key}
-            instance={instance}
-            type="sqlite"
-          />
-        ))}
-      </div>
+
+      <section className="grid gap-4 xl:grid-cols-2">
+        <CacheKeySection
+          title="LRU cache"
+          description="Fast in-memory entries. These are local to the selected app instance."
+          icon={<LuHardDrive className="h-4 w-4" />}
+          keys={data.cacheKeys.lru}
+          instance={instance}
+          type="lru"
+        />
+        <CacheKeySection
+          title="SQLite cache"
+          description="Persistent cache entries replicated by LiteFS."
+          icon={<LuDatabase className="h-4 w-4" />}
+          keys={data.cacheKeys.sqlite}
+          instance={instance}
+          type="sqlite"
+        />
+      </section>
     </div>
   );
 };
 export default CacheAdminRoute;
+
+const CacheKeySection = ({
+  title,
+  description,
+  icon,
+  keys,
+  instance,
+  type,
+}: {
+  title: string;
+  description: string;
+  icon: ReactNode;
+  keys: Array<string>;
+  instance: string;
+  type: 'sqlite' | 'lru';
+}) => (
+  <SectionCard
+    title={title}
+    description={description}
+    action={
+      <span className="inline-flex items-center gap-1 rounded-full bg-muted px-2.5 py-1 text-xs font-medium text-muted-foreground">
+        {icon}
+        {keys.length.toLocaleString()}
+      </span>
+    }
+  >
+    {keys.length === 0 ? (
+      <EmptyRow>No {title.toLowerCase()} entries match this filter.</EmptyRow>
+    ) : (
+      <div className="divide-y divide-border/60 overflow-hidden rounded-md border border-border/60">
+        {keys.map((key) => (
+          <CacheKeyRow
+            key={key}
+            cacheKey={key}
+            instance={instance}
+            type={type}
+          />
+        ))}
+      </div>
+    )}
+  </SectionCard>
+);
+
 const CacheKeyRow = ({
   cacheKey,
   instance,
   type,
 }: {
   cacheKey: string;
-  instance?: string;
+  instance: string;
   type: 'sqlite' | 'lru';
 }) => {
   const fetcher = useFetcher<typeof action>();
   const dc = useDoubleCheck();
   const encodedKey = encodeURIComponent(cacheKey);
-  const valuePage = `/admin/cache/${type}/${encodedKey}?instance=${instance}`;
+  const valuePage = `/admin/cache/${type}/${encodedKey}?instance=${encodeURIComponent(
+    instance,
+  )}`;
+  const isDeleting = fetcher.state !== 'idle';
+
   return (
-    <div className="flex items-center gap-2 font-mono">
-      <fetcher.Form method="POST">
-        <input type="hidden" name="cacheKey" value={cacheKey} />
-        <input type="hidden" name="instance" value={instance} />
-        <input type="hidden" name="type" value={type} />
-        <Button
-          size="sm"
-          variant="secondary"
-          {...dc.getButtonProps({
-            type: 'submit',
-          })}
+    <div className="grid gap-3 bg-card px-3 py-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center">
+      <div className="min-w-0 space-y-1">
+        <div className="flex flex-wrap items-center gap-2">
+          <span
+            className={cn(
+              'inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium',
+              type === 'sqlite'
+                ? 'bg-sky-100 text-sky-900 dark:bg-sky-950/40 dark:text-sky-200'
+                : 'bg-amber-100 text-amber-900 dark:bg-amber-950/40 dark:text-amber-200',
+            )}
+          >
+            {type === 'sqlite' ? (
+              <LuDatabase className="h-3.5 w-3.5" />
+            ) : (
+              <LuServer className="h-3.5 w-3.5" />
+            )}
+            {type.toUpperCase()}
+          </span>
+          <span className="text-xs text-muted-foreground">{instance}</span>
+        </div>
+        <Link
+          reloadDocument
+          to={valuePage}
+          className="block truncate font-mono text-sm font-medium hover:underline"
+          title={cacheKey}
         >
-          {fetcher.state === 'idle'
-            ? dc.doubleCheck
-              ? 'You sure?'
-              : 'Delete'
-            : 'Deleting...'}
+          {cacheKey}
+        </Link>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Button asChild variant="outline" size="sm" className="gap-2">
+          <Link reloadDocument to={valuePage}>
+            <LuExternalLink className="h-4 w-4" />
+            View
+          </Link>
         </Button>
-      </fetcher.Form>
-      <Link reloadDocument to={valuePage}>
-        {cacheKey}
-      </Link>
+        <fetcher.Form method="POST">
+          <input type="hidden" name="cacheKey" value={cacheKey} />
+          <input type="hidden" name="instance" value={instance} />
+          <input type="hidden" name="type" value={type} />
+          <Button
+            size="sm"
+            variant={dc.doubleCheck ? 'destructive' : 'secondary'}
+            className="gap-2"
+            {...dc.getButtonProps({
+              type: 'submit',
+            })}
+          >
+            <LuTrash2 className="h-4 w-4" />
+            {isDeleting ? 'Deleting...' : dc.doubleCheck ? 'Confirm' : 'Delete'}
+          </Button>
+        </fetcher.Form>
+      </div>
     </div>
   );
 };
+
 export const ErrorBoundary = () => {
   return (
     <GeneralErrorBoundary

--- a/app/routes/api.analytics.test.ts
+++ b/app/routes/api.analytics.test.ts
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { toActionArgs } from '#tests/route-module-test-utils.ts';
 
 const getUserId = vi.fn();
+const logClientEnvironmentObservation = vi.fn();
 const logEvent = vi.fn();
 
 vi.mock('#app/utils/auth.server.ts', () => ({
@@ -13,6 +14,8 @@ vi.mock('#app/utils/auth.server.ts', () => ({
 }));
 
 vi.mock('#app/utils/analytics.server.ts', () => ({
+  logClientEnvironmentObservation: (...args: Array<unknown>) =>
+    logClientEnvironmentObservation(...args),
   logEvent: (...args: Array<unknown>) => logEvent(...args),
 }));
 
@@ -44,6 +47,9 @@ function postEvent(body: Record<string, unknown>) {
 describe('/api/analytics', () => {
   beforeEach(() => {
     getUserId.mockReset().mockResolvedValue(null);
+    logClientEnvironmentObservation.mockReset().mockResolvedValue({
+      eventId: 'client-environment-1',
+    });
     logEvent.mockReset().mockResolvedValue({ eventId: 'evt-1' });
   });
 
@@ -95,5 +101,55 @@ describe('/api/analytics', () => {
         visitorId: 'visitor-1',
       }),
     );
+  });
+
+  it('accepts normalized client environment observations anonymously', async () => {
+    const result = await postEvent({
+      name: 'client_environment_observed',
+      properties: {
+        browserFamily: 'Safari',
+        browserMajor: 17,
+        osFamily: 'iOS',
+        deviceType: 'mobile',
+        viewportBucket: 'mobile',
+        displayMode: 'browser',
+        isStandalone: false,
+        serviceWorkerSupported: true,
+        notificationPermission: 'default',
+        observedAt: '2026-06-29T17:00:00.000Z',
+      },
+    });
+    expect(result.init?.status ?? 200).toBe(200);
+    expect(logClientEnvironmentObservation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: null,
+        requestId: 'req-1',
+        sessionId: null,
+        visitorId: 'visitor-1',
+      }),
+    );
+    expect(logEvent).not.toHaveBeenCalled();
+  });
+
+  it('rejects client environment observations with raw user-agent payloads', async () => {
+    const result = await postEvent({
+      name: 'client_environment_observed',
+      properties: {
+        browserFamily: 'Chrome',
+        browserMajor: 126,
+        osFamily: 'Windows',
+        deviceType: 'desktop',
+        viewportBucket: 'desktop',
+        displayMode: 'browser',
+        isStandalone: false,
+        serviceWorkerSupported: true,
+        notificationPermission: 'default',
+        observedAt: '2026-06-29T17:00:00.000Z',
+        userAgent: 'Mozilla/5.0',
+      },
+    });
+    expect(result.init?.status).toBe(400);
+    expect(logClientEnvironmentObservation).not.toHaveBeenCalled();
+    expect(logEvent).not.toHaveBeenCalled();
   });
 });

--- a/app/routes/api.analytics.ts
+++ b/app/routes/api.analytics.ts
@@ -1,10 +1,14 @@
 import { type Prisma } from '@prisma/client';
 import { data, type ActionFunctionArgs } from 'react-router';
 import { z } from 'zod';
-import { logEvent } from '#app/utils/analytics.server.ts';
+import {
+  logClientEnvironmentObservation,
+  logEvent,
+} from '#app/utils/analytics.server.ts';
 import {
   type AnalyticEventName,
   ANALYTIC_EVENT_NAMES,
+  CLIENT_ENVIRONMENT_EVENT_NAME,
   USER_REQUIRED_EVENTS,
 } from '#app/utils/analytics.ts';
 import { getUserId } from '#app/utils/auth.server.ts';
@@ -19,6 +23,32 @@ const AnalyticsEventSchema = z.object({
   sessionId: z.string().optional(),
   eventId: z.string().optional(),
 });
+
+const ClientEnvironmentPropertiesSchema = z
+  .object({
+    browserFamily: z.string().min(1).max(40),
+    browserMajor: z.number().int().min(0).max(999).nullable(),
+    osFamily: z.string().min(1).max(40),
+    deviceType: z.enum(['mobile', 'tablet', 'desktop', 'unknown']),
+    viewportBucket: z.enum(['mobile', 'tablet', 'desktop', 'unknown']),
+    displayMode: z.enum([
+      'browser',
+      'fullscreen',
+      'minimal-ui',
+      'standalone',
+      'window-controls-overlay',
+    ]),
+    isStandalone: z.boolean(),
+    serviceWorkerSupported: z.boolean(),
+    notificationPermission: z.enum([
+      'default',
+      'denied',
+      'granted',
+      'unsupported',
+    ]),
+    observedAt: z.string().datetime(),
+  })
+  .strict();
 export async function loader() {
   return data(
     {
@@ -85,6 +115,40 @@ export async function action({ request }: ActionFunctionArgs) {
       },
     );
   }
+
+  if (payload.name === CLIENT_ENVIRONMENT_EVENT_NAME) {
+    const properties = ClientEnvironmentPropertiesSchema.safeParse(
+      payload.properties,
+    );
+    if (!properties.success) {
+      return data(
+        {
+          error: 'Invalid environment payload',
+          details: properties.error.flatten(),
+        },
+        {
+          status: 400,
+        },
+      );
+    }
+    const event = await logClientEnvironmentObservation({
+      userId,
+      requestId: payload.requestId ?? contextRequestId,
+      sessionId: sessionId ?? payload.sessionId ?? null,
+      visitorId,
+      properties: properties.data as Prisma.InputJsonValue,
+    });
+    return data(
+      {
+        ok: true,
+        eventId: event.eventId,
+      },
+      {
+        headers: applyRequestIdHeader(null, contextRequestId),
+      },
+    );
+  }
+
   const event = await logEvent({
     name: payload.name as AnalyticEventName,
     userId,

--- a/app/utils/analytics.server.test.ts
+++ b/app/utils/analytics.server.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it, vi } from 'vitest';
 import { prisma } from '#app/utils/db.server.ts';
 import { createUser } from '#tests/db-utils.ts';
-import { logEvent, queueLogEvent } from './analytics.server.ts';
+import {
+  getAnalyticsExplorer,
+  getClientEnvironmentEventId,
+  getEnvironmentAnalytics,
+  logClientEnvironmentObservation,
+  logEvent,
+  queueLogEvent,
+} from './analytics.server.ts';
 
 describe('logEvent deduplication', () => {
   it('dedupes identical eventIds', async () => {
@@ -154,5 +161,228 @@ describe('logEvent deduplication', () => {
         eventId: 'event-fk',
       }),
     ).rejects.toThrow();
+  });
+});
+
+describe('client environment analytics', () => {
+  it('upserts one environment observation per visitor per day', async () => {
+    const user = await prisma.user.create({ data: createUser() });
+    const createdAt = new Date('2026-06-29T12:00:00.000Z');
+    const visitorId = '11111111-1111-4111-8111-111111111111';
+
+    const first = await logClientEnvironmentObservation({
+      visitorId,
+      requestId: 'req-anon',
+      sessionId: null,
+      properties: {
+        browserFamily: 'Safari',
+        browserMajor: 17,
+        osFamily: 'iOS',
+        deviceType: 'mobile',
+        viewportBucket: 'mobile',
+        displayMode: 'browser',
+        isStandalone: false,
+        serviceWorkerSupported: true,
+        notificationPermission: 'default',
+        observedAt: createdAt.toISOString(),
+      },
+      createdAt,
+    });
+
+    const second = await logClientEnvironmentObservation({
+      userId: user.id,
+      visitorId,
+      requestId: 'req-user',
+      sessionId: 'session-user',
+      properties: {
+        browserFamily: 'Safari',
+        browserMajor: 17,
+        osFamily: 'iOS',
+        deviceType: 'mobile',
+        viewportBucket: 'mobile',
+        displayMode: 'standalone',
+        isStandalone: true,
+        serviceWorkerSupported: true,
+        notificationPermission: 'granted',
+        observedAt: createdAt.toISOString(),
+      },
+      createdAt,
+    });
+
+    expect(second.id).toBe(first.id);
+    expect(second.userId).toBe(user.id);
+    expect(second.requestId).toBe('req-user');
+    expect(second.sessionId).toBe('session-user');
+    expect(
+      await prisma.analyticsEvent.count({
+        where: { eventId: getClientEnvironmentEventId(visitorId, createdAt) },
+      }),
+    ).toBe(1);
+    expect(JSON.parse(second.properties ?? '{}')).toMatchObject({
+      displayMode: 'standalone',
+      isStandalone: true,
+    });
+  });
+
+  it('aggregates environment observations and PWA funnel events', async () => {
+    const now = new Date('2026-06-29T12:00:00.000Z');
+    await Promise.all([
+      logClientEnvironmentObservation({
+        visitorId: '11111111-1111-4111-8111-111111111111',
+        properties: {
+          browserFamily: 'Chrome',
+          browserMajor: 126,
+          osFamily: 'Windows',
+          deviceType: 'desktop',
+          viewportBucket: 'desktop',
+          displayMode: 'browser',
+          isStandalone: false,
+          serviceWorkerSupported: true,
+          notificationPermission: 'default',
+          observedAt: now.toISOString(),
+        },
+        createdAt: now,
+      }),
+      logClientEnvironmentObservation({
+        visitorId: '22222222-2222-4222-8222-222222222222',
+        properties: {
+          browserFamily: 'Safari',
+          browserMajor: 17,
+          osFamily: 'iOS',
+          deviceType: 'mobile',
+          viewportBucket: 'mobile',
+          displayMode: 'standalone',
+          isStandalone: true,
+          serviceWorkerSupported: true,
+          notificationPermission: 'granted',
+          observedAt: now.toISOString(),
+        },
+        createdAt: now,
+      }),
+      logEvent({
+        name: 'pwa_prompt_available',
+        source: 'client',
+        visitorId: '11111111-1111-4111-8111-111111111111',
+        createdAt: now,
+      }),
+    ]);
+
+    const analytics = await getEnvironmentAnalytics({ now });
+
+    expect(analytics.totalObservations).toBe(2);
+    expect(analytics.uniqueVisitors).toBe(2);
+    expect(analytics.standaloneObservations).toBe(1);
+    expect(analytics.standalonePercent).toBe(50);
+    expect(analytics.browsers).toEqual(
+      expect.arrayContaining([
+        { label: 'Chrome 126', count: 1, percent: 50 },
+        { label: 'Safari 17', count: 1, percent: 50 },
+      ]),
+    );
+    expect(
+      analytics.pwaFunnel.find((row) => row.label === 'Prompt available')
+        ?.count,
+    ).toBe(1);
+  });
+});
+
+describe('analytics explorer', () => {
+  it('aggregates matching events by source and date', async () => {
+    const user = await prisma.user.create({ data: createUser() });
+    const now = new Date('2026-06-29T12:00:00.000Z');
+
+    await logEvent({
+      name: 'wishlist_viewed',
+      userId: user.id,
+      source: 'server',
+      visitorId: 'visitor-one',
+      createdAt: now,
+    });
+    await logEvent({
+      name: 'wishlist_viewed',
+      userId: user.id,
+      source: 'client',
+      visitorId: 'visitor-one',
+      createdAt: new Date(now.getTime() - 2 * 24 * 60 * 60 * 1000),
+    });
+    await logEvent({
+      name: 'wishlist_item_added',
+      userId: user.id,
+      source: 'client',
+      visitorId: 'visitor-two',
+      createdAt: now,
+    });
+
+    const explorer = await getAnalyticsExplorer({
+      now,
+      days: 7,
+      eventName: 'wishlist_viewed',
+      groupBy: 'source',
+    });
+
+    expect(explorer.totalEvents).toBe(2);
+    expect(explorer.uniqueUsers).toBe(1);
+    expect(explorer.uniqueVisitors).toBe(1);
+    expect(explorer.series).toHaveLength(7);
+    expect(explorer.breakdown).toEqual(
+      expect.arrayContaining([
+        { label: 'client', count: 1, percent: 50 },
+        { label: 'server', count: 1, percent: 50 },
+      ]),
+    );
+    expect(
+      explorer.series.find((row) => row.date === '2026-06-29')?.count,
+    ).toBe(1);
+  });
+
+  it('groups environment observations by browser and tolerates malformed JSON', async () => {
+    const now = new Date('2026-06-29T12:00:00.000Z');
+    await logClientEnvironmentObservation({
+      visitorId: '11111111-1111-4111-8111-111111111111',
+      properties: {
+        browserFamily: 'Chrome',
+        browserMajor: 126,
+        osFamily: 'Windows',
+        deviceType: 'desktop',
+        viewportBucket: 'desktop',
+        displayMode: 'browser',
+        isStandalone: false,
+        serviceWorkerSupported: true,
+        notificationPermission: 'default',
+        observedAt: now.toISOString(),
+      },
+      createdAt: now,
+    });
+    await prisma.analyticsEvent.create({
+      data: {
+        eventId: 'malformed-properties-event',
+        name: 'client_environment_observed',
+        source: 'client',
+        visitorId: '22222222-2222-4222-8222-222222222222',
+        properties: '{not-json',
+        createdAt: now,
+      },
+    });
+
+    const explorer = await getAnalyticsExplorer({
+      now,
+      days: 7,
+      eventName: 'client_environment_observed',
+      groupBy: 'browser',
+      limit: 5,
+    });
+
+    expect(explorer.totalEvents).toBe(2);
+    expect(explorer.breakdown).toEqual(
+      expect.arrayContaining([
+        { label: 'Chrome 126', count: 1, percent: 50 },
+        { label: 'Unknown', count: 1, percent: 50 },
+      ]),
+    );
+    expect(
+      explorer.recentEvents.some(
+        (event) => event.propertiesPreview === 'Invalid JSON',
+      ),
+    ).toBe(true);
   });
 });

--- a/app/utils/analytics.server.test.ts
+++ b/app/utils/analytics.server.test.ts
@@ -385,4 +385,41 @@ describe('analytics explorer', () => {
       ),
     ).toBe(true);
   });
+
+  it('limits recent rows without limiting aggregate counts', async () => {
+    const user = await prisma.user.create({ data: createUser() });
+    const now = new Date('2026-06-29T12:00:00.000Z');
+
+    await Promise.all(
+      Array.from({ length: 55 }, (_, index) =>
+        logEvent({
+          name: 'wishlist_viewed',
+          userId: user.id,
+          source: 'client',
+          visitorId: `visitor-${index}`,
+          createdAt: now,
+        }),
+      ),
+    );
+
+    const explorer = await getAnalyticsExplorer({
+      now,
+      days: 7,
+      eventName: 'wishlist_viewed',
+      groupBy: 'source',
+      limit: 3,
+    });
+
+    expect(explorer.totalEvents).toBe(55);
+    expect(explorer.uniqueVisitors).toBe(55);
+    expect(explorer.recentEvents).toHaveLength(3);
+    expect(explorer.breakdown).toContainEqual({
+      label: 'client',
+      count: 55,
+      percent: 100,
+    });
+    expect(
+      explorer.series.find((row) => row.date === '2026-06-29')?.count,
+    ).toBe(55);
+  });
 });

--- a/app/utils/analytics.server.ts
+++ b/app/utils/analytics.server.ts
@@ -4,7 +4,14 @@ import { captureException } from '@sentry/react-router';
 import {
   ANALYTIC_EVENT_SET,
   ANALYTIC_EVENT_NAMES,
+  CLIENT_ENVIRONMENT_EVENT_NAME,
   type AnalyticEventName,
+  type AnalyticsExplorerDays,
+  type AnalyticsExplorerEventFilter,
+  type AnalyticsExplorerGroupBy,
+  type AnalyticsExplorerResult,
+  type AnalyticsExplorerSeriesRow,
+  PWA_ANALYTIC_EVENT_NAMES,
   USER_REQUIRED_EVENTS,
 } from './analytics.ts';
 import { prisma } from './db.server.ts';
@@ -25,6 +32,15 @@ type LogEventInput = {
   createdAt?: Date;
 };
 
+type LogClientEnvironmentInput = {
+  userId?: string | null;
+  requestId?: string | null;
+  sessionId?: string | null;
+  visitorId: string;
+  properties: Prisma.InputJsonValue;
+  createdAt?: Date;
+};
+
 function serializeProperties(properties?: Prisma.InputJsonValue | null) {
   if (typeof properties === 'undefined' || properties === null) return null;
   try {
@@ -39,6 +55,13 @@ function assertValidEventName(name: string): asserts name is AnalyticEventName {
   if (!ANALYTIC_EVENT_SET.has(name)) {
     throw new Error(`Invalid analytics event name: ${name}`);
   }
+}
+
+export function getClientEnvironmentEventId(
+  visitorId: string,
+  date = new Date(),
+) {
+  return `client-environment:${visitorId}:${formatDateKey(date)}`;
 }
 
 function isUniqueEventIdError(error: unknown) {
@@ -159,6 +182,60 @@ export async function logEvent({
   }
 }
 
+export async function logClientEnvironmentObservation({
+  userId,
+  requestId,
+  sessionId,
+  visitorId,
+  properties,
+  createdAt,
+}: LogClientEnvironmentInput) {
+  const resolvedCreatedAt = createdAt ?? new Date();
+  const eventId = getClientEnvironmentEventId(visitorId, resolvedCreatedAt);
+  const serializedProperties = serializeProperties(properties);
+
+  const updateExisting = async () => {
+    const existing = await prisma.analyticsEvent.findUnique({
+      where: { eventId },
+    });
+    if (!existing) return null;
+    return prisma.analyticsEvent.update({
+      where: { eventId },
+      data: {
+        userId: userId ?? existing.userId,
+        requestId: requestId ?? existing.requestId,
+        sessionId: sessionId ?? existing.sessionId,
+        visitorId,
+        properties: serializedProperties ?? existing.properties,
+      },
+    });
+  };
+
+  const updated = await updateExisting();
+  if (updated) return updated;
+
+  try {
+    return await prisma.analyticsEvent.create({
+      data: {
+        eventId,
+        name: CLIENT_ENVIRONMENT_EVENT_NAME,
+        userId: userId ?? null,
+        source: 'client',
+        requestId: requestId ?? null,
+        sessionId: sessionId ?? null,
+        visitorId,
+        properties: serializedProperties,
+        createdAt: resolvedCreatedAt,
+      },
+    });
+  } catch (error) {
+    if (!isUniqueEventIdError(error)) throw error;
+    const recovered = await updateExisting();
+    if (recovered) return recovered;
+    throw error;
+  }
+}
+
 /**
  * Fire `logEvent` without awaiting the DB write. Pre-generates `eventId`
  * synchronously so action handlers and loaders can echo it back to the
@@ -192,10 +269,288 @@ export type AnalyticsCounts = {
   eventsLast30Days: Array<{ name: AnalyticEventName; count: number }>;
 };
 
+export type EnvironmentBreakdownRow = {
+  label: string;
+  count: number;
+  percent: number;
+};
+
+export type EnvironmentAnalytics = {
+  totalObservations: number;
+  uniqueVisitors: number;
+  standaloneObservations: number;
+  browserObservations: number;
+  standalonePercent: number;
+  browsers: EnvironmentBreakdownRow[];
+  operatingSystems: EnvironmentBreakdownRow[];
+  deviceTypes: EnvironmentBreakdownRow[];
+  viewportBuckets: EnvironmentBreakdownRow[];
+  displayModes: EnvironmentBreakdownRow[];
+  pwaFunnel: EnvironmentBreakdownRow[];
+};
+
 const DAY_MS = 1000 * 60 * 60 * 24;
 
 function formatDateKey(date: Date) {
   return date.toISOString().slice(0, 10);
+}
+
+function parseProperties(properties: string | null) {
+  if (!properties) return null;
+  try {
+    return JSON.parse(properties) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+function increment(map: Map<string, number>, value: unknown) {
+  const label =
+    typeof value === 'string' && value.length > 0 ? value : 'Unknown';
+  map.set(label, (map.get(label) ?? 0) + 1);
+}
+
+function getBrowserLabel(properties: Record<string, unknown> | null) {
+  const family =
+    typeof properties?.browserFamily === 'string' &&
+    properties.browserFamily.length > 0
+      ? properties.browserFamily
+      : 'Unknown';
+  const major =
+    typeof properties?.browserMajor === 'number' &&
+    Number.isFinite(properties.browserMajor)
+      ? Math.trunc(properties.browserMajor)
+      : null;
+  return major === null || family === 'Unknown' ? family : `${family} ${major}`;
+}
+
+function getExplorerGroupLabel(
+  groupBy: AnalyticsExplorerGroupBy,
+  event: {
+    name: string;
+    source: string;
+    properties: string | null;
+  },
+) {
+  const properties = parseProperties(event.properties);
+  switch (groupBy) {
+    case 'event':
+      return event.name;
+    case 'source':
+      return event.source;
+    case 'browser':
+      return getBrowserLabel(properties);
+    case 'os':
+      return properties?.osFamily;
+    case 'device':
+      return properties?.deviceType;
+    case 'viewport':
+      return properties?.viewportBucket;
+    case 'displayMode':
+      return properties?.displayMode;
+    case 'standalone':
+      if (properties?.isStandalone === true) return 'Standalone';
+      if (properties?.isStandalone === false) return 'Browser';
+      return 'Unknown';
+  }
+}
+
+function getPropertiesPreview(properties: string | null) {
+  if (!properties) return '—';
+  const parsed = parseProperties(properties);
+  if (!parsed) return 'Invalid JSON';
+  const preview = JSON.stringify(parsed);
+  return preview.length > 240 ? `${preview.slice(0, 240)}...` : preview;
+}
+
+function toBreakdownRows(
+  map: Map<string, number>,
+  total: number,
+): EnvironmentBreakdownRow[] {
+  return [...map.entries()]
+    .map(([label, count]) => ({
+      label,
+      count,
+      percent: total > 0 ? Math.round((count / total) * 100) : 0,
+    }))
+    .sort((a, b) => b.count - a.count || a.label.localeCompare(b.label));
+}
+
+const PWA_FUNNEL_LABELS: Array<{
+  name: (typeof PWA_ANALYTIC_EVENT_NAMES)[number];
+  label: string;
+}> = [
+  { name: 'pwa_prompt_available', label: 'Prompt available' },
+  { name: 'pwa_install_clicked', label: 'Install clicked' },
+  { name: 'pwa_install_accepted', label: 'Install accepted' },
+  { name: 'pwa_install_dismissed', label: 'Install dismissed' },
+  { name: 'pwa_appinstalled', label: 'App installed' },
+  { name: 'pwa_launched_standalone', label: 'Standalone launches' },
+];
+
+export async function getEnvironmentAnalytics({
+  days = 30,
+  now = new Date(),
+}: {
+  days?: number;
+  now?: Date;
+} = {}): Promise<EnvironmentAnalytics> {
+  const startOfToday = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
+  );
+  const since = new Date(startOfToday.getTime() - DAY_MS * (days - 1));
+  const names = [
+    CLIENT_ENVIRONMENT_EVENT_NAME,
+    ...PWA_ANALYTIC_EVENT_NAMES,
+  ] as Array<AnalyticEventName>;
+
+  const events = await prisma.analyticsEvent.findMany({
+    where: {
+      name: { in: names },
+      createdAt: { gte: since },
+    },
+    select: {
+      eventId: true,
+      name: true,
+      userId: true,
+      visitorId: true,
+      properties: true,
+    },
+  });
+
+  const browserCounts = new Map<string, number>();
+  const osCounts = new Map<string, number>();
+  const deviceCounts = new Map<string, number>();
+  const viewportCounts = new Map<string, number>();
+  const displayModeCounts = new Map<string, number>();
+  const uniqueVisitors = new Set<string>();
+  const pwaCounts = new Map<AnalyticEventName, number>();
+  let totalObservations = 0;
+  let standaloneObservations = 0;
+
+  for (const event of events) {
+    if (event.name !== CLIENT_ENVIRONMENT_EVENT_NAME) {
+      const name = event.name as AnalyticEventName;
+      pwaCounts.set(name, (pwaCounts.get(name) ?? 0) + 1);
+      continue;
+    }
+
+    totalObservations += 1;
+    uniqueVisitors.add(event.visitorId ?? event.userId ?? event.eventId);
+    const properties = parseProperties(event.properties);
+    increment(browserCounts, getBrowserLabel(properties));
+    increment(osCounts, properties?.osFamily);
+    increment(deviceCounts, properties?.deviceType);
+    increment(viewportCounts, properties?.viewportBucket);
+    increment(displayModeCounts, properties?.displayMode);
+    if (properties?.isStandalone === true) {
+      standaloneObservations += 1;
+    }
+  }
+
+  const browserObservations = totalObservations - standaloneObservations;
+
+  return {
+    totalObservations,
+    uniqueVisitors: uniqueVisitors.size,
+    standaloneObservations,
+    browserObservations,
+    standalonePercent:
+      totalObservations > 0
+        ? Math.round((standaloneObservations / totalObservations) * 100)
+        : 0,
+    browsers: toBreakdownRows(browserCounts, totalObservations),
+    operatingSystems: toBreakdownRows(osCounts, totalObservations),
+    deviceTypes: toBreakdownRows(deviceCounts, totalObservations),
+    viewportBuckets: toBreakdownRows(viewportCounts, totalObservations),
+    displayModes: toBreakdownRows(displayModeCounts, totalObservations),
+    pwaFunnel: PWA_FUNNEL_LABELS.map(({ name, label }) => ({
+      label,
+      count: pwaCounts.get(name) ?? 0,
+      percent: 0,
+    })),
+  };
+}
+
+export async function getAnalyticsExplorer({
+  days = 30,
+  eventName = 'all',
+  groupBy = 'event',
+  now = new Date(),
+  limit = 50,
+}: {
+  days?: AnalyticsExplorerDays;
+  eventName?: AnalyticsExplorerEventFilter;
+  groupBy?: AnalyticsExplorerGroupBy;
+  now?: Date;
+  limit?: number;
+} = {}): Promise<AnalyticsExplorerResult> {
+  const startOfToday = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
+  );
+  const since = new Date(startOfToday.getTime() - DAY_MS * (days - 1));
+
+  const events = await prisma.analyticsEvent.findMany({
+    where: {
+      createdAt: { gte: since },
+      ...(eventName === 'all' ? {} : { name: eventName }),
+    },
+    orderBy: { createdAt: 'desc' },
+    select: {
+      id: true,
+      eventId: true,
+      name: true,
+      source: true,
+      userId: true,
+      visitorId: true,
+      properties: true,
+      createdAt: true,
+    },
+  });
+
+  const seriesCounts = new Map<string, number>();
+  const breakdownCounts = new Map<string, number>();
+  const uniqueUsers = new Set<string>();
+  const uniqueVisitors = new Set<string>();
+
+  for (const event of events) {
+    const dayKey = formatDateKey(event.createdAt);
+    seriesCounts.set(dayKey, (seriesCounts.get(dayKey) ?? 0) + 1);
+    increment(breakdownCounts, getExplorerGroupLabel(groupBy, event));
+    if (event.userId) uniqueUsers.add(event.userId);
+    if (event.visitorId) uniqueVisitors.add(event.visitorId);
+  }
+
+  const series: AnalyticsExplorerSeriesRow[] = [];
+  for (
+    let date = new Date(since);
+    date <= startOfToday;
+    date = new Date(date.getTime() + DAY_MS)
+  ) {
+    const key = formatDateKey(date);
+    series.push({ date: key, count: seriesCounts.get(key) ?? 0 });
+  }
+
+  return {
+    days,
+    eventName,
+    groupBy,
+    totalEvents: events.length,
+    uniqueUsers: uniqueUsers.size,
+    uniqueVisitors: uniqueVisitors.size,
+    series,
+    breakdown: toBreakdownRows(breakdownCounts, events.length),
+    recentEvents: events.slice(0, limit).map((event) => ({
+      id: event.id,
+      eventId: event.eventId,
+      name: event.name,
+      source: event.source,
+      createdAt: event.createdAt.toISOString(),
+      userId: event.userId,
+      visitorId: event.visitorId,
+      propertiesPreview: getPropertiesPreview(event.properties),
+    })),
+  };
 }
 
 export async function getAnalyticsCounts(

--- a/app/utils/analytics.server.ts
+++ b/app/utils/analytics.server.ts
@@ -324,34 +324,74 @@ function getBrowserLabel(properties: Record<string, unknown> | null) {
   return major === null || family === 'Unknown' ? family : `${family} ${major}`;
 }
 
-function getExplorerGroupLabel(
-  groupBy: AnalyticsExplorerGroupBy,
-  event: {
-    name: string;
-    source: string;
-    properties: string | null;
-  },
+function getAnalyticsExplorerWhereSql(
+  since: Date,
+  eventName: AnalyticsExplorerEventFilter,
 ) {
-  const properties = parseProperties(event.properties);
+  return Prisma.sql`
+    createdAt >= ${since.getTime()}
+    ${eventName === 'all' ? Prisma.empty : Prisma.sql`AND name = ${eventName}`}
+  `;
+}
+
+function getJsonTextGroupSql(path: string) {
+  return Prisma.sql`
+    CASE
+      WHEN json_valid(properties)
+        THEN COALESCE(NULLIF(json_extract(properties, ${path}), ''), 'Unknown')
+      ELSE 'Unknown'
+    END
+  `;
+}
+
+function getBrowserGroupSql() {
+  return Prisma.sql`
+    CASE
+      WHEN json_valid(properties) THEN
+        CASE
+          WHEN NULLIF(json_extract(properties, '$.browserFamily'), '') IS NULL
+            THEN 'Unknown'
+          WHEN json_extract(properties, '$.browserFamily') = 'Unknown'
+            THEN 'Unknown'
+          WHEN typeof(json_extract(properties, '$.browserMajor')) IN ('integer', 'real')
+            THEN json_extract(properties, '$.browserFamily') || ' ' || CAST(CAST(json_extract(properties, '$.browserMajor') AS INTEGER) AS TEXT)
+          ELSE json_extract(properties, '$.browserFamily')
+        END
+      ELSE 'Unknown'
+    END
+  `;
+}
+
+function getStandaloneGroupSql() {
+  return Prisma.sql`
+    CASE
+      WHEN json_valid(properties) AND json_extract(properties, '$.isStandalone') = 1
+        THEN 'Standalone'
+      WHEN json_valid(properties) AND json_extract(properties, '$.isStandalone') = 0
+        THEN 'Browser'
+      ELSE 'Unknown'
+    END
+  `;
+}
+
+function getExplorerGroupSql(groupBy: AnalyticsExplorerGroupBy) {
   switch (groupBy) {
     case 'event':
-      return event.name;
+      return Prisma.sql`COALESCE(NULLIF(name, ''), 'Unknown')`;
     case 'source':
-      return event.source;
+      return Prisma.sql`COALESCE(NULLIF(source, ''), 'Unknown')`;
     case 'browser':
-      return getBrowserLabel(properties);
+      return getBrowserGroupSql();
     case 'os':
-      return properties?.osFamily;
+      return getJsonTextGroupSql('$.osFamily');
     case 'device':
-      return properties?.deviceType;
+      return getJsonTextGroupSql('$.deviceType');
     case 'viewport':
-      return properties?.viewportBucket;
+      return getJsonTextGroupSql('$.viewportBucket');
     case 'displayMode':
-      return properties?.displayMode;
+      return getJsonTextGroupSql('$.displayMode');
     case 'standalone':
-      if (properties?.isStandalone === true) return 'Standalone';
-      if (properties?.isStandalone === false) return 'Browser';
-      return 'Unknown';
+      return getStandaloneGroupSql();
   }
 }
 
@@ -489,38 +529,74 @@ export async function getAnalyticsExplorer({
     Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
   );
   const since = new Date(startOfToday.getTime() - DAY_MS * (days - 1));
+  const requestedLimit = Number.isFinite(limit) ? Math.trunc(limit) : 50;
+  const safeLimit = Math.max(1, Math.min(requestedLimit, 100));
+  const whereSql = getAnalyticsExplorerWhereSql(since, eventName);
+  const groupSql = getExplorerGroupSql(groupBy);
 
-  const events = await prisma.analyticsEvent.findMany({
-    where: {
-      createdAt: { gte: since },
-      ...(eventName === 'all' ? {} : { name: eventName }),
-    },
-    orderBy: { createdAt: 'desc' },
-    select: {
-      id: true,
-      eventId: true,
-      name: true,
-      source: true,
-      userId: true,
-      visitorId: true,
-      properties: true,
-      createdAt: true,
-    },
-  });
+  const [totalRows, seriesRows, breakdownRows, recentEvents] =
+    await Promise.all([
+      prisma.$queryRaw<
+        Array<{
+          totalEvents: bigint | number | null;
+          uniqueUsers: bigint | number | null;
+          uniqueVisitors: bigint | number | null;
+        }>
+      >`
+        SELECT
+          COUNT(*) AS totalEvents,
+          COUNT(DISTINCT userId) AS uniqueUsers,
+          COUNT(DISTINCT visitorId) AS uniqueVisitors
+        FROM AnalyticsEvent
+        WHERE ${whereSql}
+      `,
+      prisma.$queryRaw<
+        Array<{ date: string | null; count: bigint | number | null }>
+      >`
+        SELECT date(createdAt / 1000, 'unixepoch') AS date, COUNT(*) AS count
+        FROM AnalyticsEvent
+        WHERE ${whereSql}
+        GROUP BY 1
+        ORDER BY 1 ASC
+      `,
+      prisma.$queryRaw<
+        Array<{ label: string | null; count: bigint | number | null }>
+      >`
+        SELECT ${groupSql} AS label, COUNT(*) AS count
+        FROM AnalyticsEvent
+        WHERE ${whereSql}
+        GROUP BY 1
+        ORDER BY count DESC, label ASC
+      `,
+      prisma.analyticsEvent.findMany({
+        where: {
+          createdAt: { gte: since },
+          ...(eventName === 'all' ? {} : { name: eventName }),
+        },
+        orderBy: { createdAt: 'desc' },
+        take: safeLimit,
+        select: {
+          id: true,
+          eventId: true,
+          name: true,
+          source: true,
+          userId: true,
+          visitorId: true,
+          properties: true,
+          createdAt: true,
+        },
+      }),
+    ]);
 
-  const seriesCounts = new Map<string, number>();
-  const breakdownCounts = new Map<string, number>();
-  const uniqueUsers = new Set<string>();
-  const uniqueVisitors = new Set<string>();
-
-  for (const event of events) {
-    const dayKey = formatDateKey(event.createdAt);
-    seriesCounts.set(dayKey, (seriesCounts.get(dayKey) ?? 0) + 1);
-    increment(breakdownCounts, getExplorerGroupLabel(groupBy, event));
-    if (event.userId) uniqueUsers.add(event.userId);
-    if (event.visitorId) uniqueVisitors.add(event.visitorId);
-  }
-
+  const totals = totalRows[0];
+  const totalEvents = Number(totals?.totalEvents ?? 0);
+  const seriesCounts = new Map(
+    seriesRows
+      .filter((row): row is { date: string; count: bigint | number | null } =>
+        Boolean(row.date),
+      )
+      .map((row) => [row.date, Number(row.count ?? 0)]),
+  );
   const series: AnalyticsExplorerSeriesRow[] = [];
   for (
     let date = new Date(since);
@@ -535,12 +611,19 @@ export async function getAnalyticsExplorer({
     days,
     eventName,
     groupBy,
-    totalEvents: events.length,
-    uniqueUsers: uniqueUsers.size,
-    uniqueVisitors: uniqueVisitors.size,
+    totalEvents,
+    uniqueUsers: Number(totals?.uniqueUsers ?? 0),
+    uniqueVisitors: Number(totals?.uniqueVisitors ?? 0),
     series,
-    breakdown: toBreakdownRows(breakdownCounts, events.length),
-    recentEvents: events.slice(0, limit).map((event) => ({
+    breakdown: breakdownRows.map((row) => {
+      const count = Number(row.count ?? 0);
+      return {
+        label: row.label ?? 'Unknown',
+        count,
+        percent: totalEvents > 0 ? Math.round((count / totalEvents) * 100) : 0,
+      };
+    }),
+    recentEvents: recentEvents.map((event) => ({
       id: event.id,
       eventId: event.eventId,
       name: event.name,

--- a/app/utils/analytics.ts
+++ b/app/utils/analytics.ts
@@ -1,3 +1,14 @@
+export const CLIENT_ENVIRONMENT_EVENT_NAME = 'client_environment_observed';
+
+export const PWA_ANALYTIC_EVENT_NAMES = [
+  'pwa_prompt_available',
+  'pwa_install_clicked',
+  'pwa_install_accepted',
+  'pwa_install_dismissed',
+  'pwa_appinstalled',
+  'pwa_launched_standalone',
+] as const;
+
 export const ANALYTIC_EVENT_NAMES = [
   'user_registered',
   'user_logged_in',
@@ -73,11 +84,67 @@ export const ANALYTIC_EVENT_NAMES = [
   // between wishlist_share_viewed and signup_submitted in the share-reach
   // funnel; anonymous visitors fire it, so NOT user-required.
   'share_cta_clicked',
+  // Browser/device/PWA environment snapshot. Anonymous-capable and deduped
+  // daily by visitor id in analytics.server.ts.
+  CLIENT_ENVIRONMENT_EVENT_NAME,
+  ...PWA_ANALYTIC_EVENT_NAMES,
 ] as const;
 
 export type AnalyticEventName = (typeof ANALYTIC_EVENT_NAMES)[number];
 
 export const ANALYTIC_EVENT_SET = new Set<string>(ANALYTIC_EVENT_NAMES);
+
+export const ANALYTICS_EXPLORER_DAY_OPTIONS = [7, 30, 90] as const;
+export type AnalyticsExplorerDays =
+  (typeof ANALYTICS_EXPLORER_DAY_OPTIONS)[number];
+
+export const ANALYTICS_EXPLORER_GROUP_BY_OPTIONS = [
+  'event',
+  'source',
+  'browser',
+  'os',
+  'device',
+  'viewport',
+  'displayMode',
+  'standalone',
+] as const;
+export type AnalyticsExplorerGroupBy =
+  (typeof ANALYTICS_EXPLORER_GROUP_BY_OPTIONS)[number];
+export type AnalyticsExplorerEventFilter = AnalyticEventName | 'all';
+
+export type AnalyticsExplorerSeriesRow = {
+  date: string;
+  count: number;
+};
+
+export type AnalyticsExplorerBreakdownRow = {
+  label: string;
+  count: number;
+  percent: number;
+};
+
+export type AnalyticsExplorerRecentEvent = {
+  id: string;
+  eventId: string;
+  name: string;
+  source: string;
+  createdAt: string;
+  userId: string | null;
+  visitorId: string | null;
+  propertiesPreview: string;
+};
+
+export type AnalyticsExplorerResult = {
+  days: AnalyticsExplorerDays;
+  eventName: AnalyticsExplorerEventFilter;
+  groupBy: AnalyticsExplorerGroupBy;
+  totalEvents: number;
+  uniqueUsers: number;
+  uniqueVisitors: number;
+  series: AnalyticsExplorerSeriesRow[];
+  breakdown: AnalyticsExplorerBreakdownRow[];
+  recentEvents: AnalyticsExplorerRecentEvent[];
+};
 
 export const USER_REQUIRED_EVENTS: Set<AnalyticEventName> = new Set([
   'user_registered',

--- a/app/utils/client-environment.test.ts
+++ b/app/utils/client-environment.test.ts
@@ -1,0 +1,194 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const track = vi.hoisted(() => vi.fn());
+
+vi.mock('./analytics.client.ts', () => ({ track }));
+
+import {
+  classifyBrowser,
+  classifyDeviceType,
+  classifyOperatingSystem,
+  collectClientEnvironment,
+  getViewportBucket,
+  trackClientEnvironmentOncePerDay,
+  trackPwaLifecycleEvent,
+} from './client-environment.ts';
+
+const setUserAgent = (ua: string) => {
+  Object.defineProperty(window.navigator, 'userAgent', {
+    value: ua,
+    configurable: true,
+  });
+};
+
+const setMaxTouchPoints = (maxTouchPoints: number) => {
+  Object.defineProperty(window.navigator, 'maxTouchPoints', {
+    value: maxTouchPoints,
+    configurable: true,
+  });
+};
+
+const setMatchMedia = (matchedMode: string | null) => {
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn((query: string) => ({
+      matches:
+        matchedMode === null
+          ? false
+          : query === `(display-mode: ${matchedMode})`,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    })),
+  );
+};
+
+const setViewportWidth = (width: number) => {
+  Object.defineProperty(window, 'innerWidth', {
+    value: width,
+    configurable: true,
+  });
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  window.localStorage.clear();
+  setUserAgent('node.js');
+  setMaxTouchPoints(0);
+  Reflect.deleteProperty(window.navigator, 'serviceWorker');
+});
+
+beforeEach(() => {
+  track.mockReset().mockReturnValue('event-id');
+  setMatchMedia(null);
+  setViewportWidth(1024);
+});
+
+describe('client environment classification', () => {
+  it('normalizes common browser families and major versions', () => {
+    expect(classifyBrowser('Mozilla/5.0 Edg/120.0')).toEqual({
+      browserFamily: 'Edge',
+      browserMajor: 120,
+    });
+    expect(classifyBrowser('Mozilla/5.0 Firefox/121.0')).toEqual({
+      browserFamily: 'Firefox',
+      browserMajor: 121,
+    });
+    expect(
+      classifyBrowser('Mozilla/5.0 Version/17.0 Mobile Safari/604.1'),
+    ).toEqual({
+      browserFamily: 'Safari',
+      browserMajor: 17,
+    });
+  });
+
+  it('classifies operating systems, devices, and viewport buckets', () => {
+    const ipadDesktopUa = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15)';
+
+    expect(classifyOperatingSystem(ipadDesktopUa, 5)).toBe('iOS');
+    expect(classifyDeviceType(ipadDesktopUa, 5)).toBe('tablet');
+    expect(classifyOperatingSystem('Mozilla/5.0 (Windows NT 10.0)', 0)).toBe(
+      'Windows',
+    );
+    expect(
+      classifyDeviceType('Mozilla/5.0 (iPhone; CPU iPhone OS 17_0)', 0),
+    ).toBe('mobile');
+    expect(getViewportBucket(390)).toBe('mobile');
+    expect(getViewportBucket(800)).toBe('tablet');
+    expect(getViewportBucket(1280)).toBe('desktop');
+  });
+
+  it('collects a normalized snapshot without raw user-agent data', () => {
+    const now = new Date('2026-06-29T12:00:00.000Z');
+    setUserAgent(
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) CriOS/120.0 Mobile Safari/604.1',
+    );
+    setViewportWidth(390);
+    setMatchMedia('standalone');
+    vi.stubGlobal('Notification', { permission: 'denied' });
+    Object.defineProperty(window.navigator, 'serviceWorker', {
+      value: {},
+      configurable: true,
+    });
+
+    const snapshot = collectClientEnvironment(now);
+
+    expect(snapshot).toEqual({
+      browserFamily: 'Chrome',
+      browserMajor: 120,
+      osFamily: 'iOS',
+      deviceType: 'mobile',
+      viewportBucket: 'mobile',
+      displayMode: 'standalone',
+      isStandalone: true,
+      serviceWorkerSupported: true,
+      notificationPermission: 'denied',
+      observedAt: '2026-06-29T12:00:00.000Z',
+    });
+    expect(snapshot).not.toHaveProperty('userAgent');
+  });
+});
+
+describe('client environment tracking', () => {
+  it('posts one normalized environment observation per day', async () => {
+    const now = new Date('2026-06-29T12:00:00.000Z');
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', fetchMock);
+    setUserAgent('Mozilla/5.0 (Macintosh) Chrome/120.0 Safari/537.36');
+
+    await trackClientEnvironmentOncePerDay(now);
+    await trackClientEnvironmentOncePerDay(now);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/analytics',
+      expect.objectContaining({
+        method: 'POST',
+        keepalive: true,
+      }),
+    );
+    const body = JSON.parse(fetchMock.mock.calls[0]![1].body as string) as {
+      name: string;
+      properties: Record<string, unknown>;
+    };
+    expect(body.name).toBe('client_environment_observed');
+    expect(body.properties.browserFamily).toBe('Chrome');
+    expect(body.properties).not.toHaveProperty('userAgent');
+  });
+
+  it('dedupes PWA lifecycle events per event name per day', () => {
+    const now = new Date('2026-06-29T12:00:00.000Z');
+
+    const first = trackPwaLifecycleEvent(
+      'pwa_prompt_available',
+      undefined,
+      now,
+    );
+    const second = trackPwaLifecycleEvent(
+      'pwa_prompt_available',
+      undefined,
+      now,
+    );
+
+    expect(first).toBe('event-id');
+    expect(second).toBeNull();
+    expect(track).toHaveBeenCalledTimes(1);
+    expect(track).toHaveBeenCalledWith('pwa_prompt_available', undefined);
+  });
+
+  it('tracks a standalone launch before posting the daily snapshot', async () => {
+    const now = new Date('2026-06-29T12:00:00.000Z');
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }));
+    setMatchMedia('standalone');
+    setUserAgent('Mozilla/5.0 (Macintosh) Chrome/120.0 Safari/537.36');
+
+    await trackClientEnvironmentOncePerDay(now);
+
+    expect(track).toHaveBeenCalledWith('pwa_launched_standalone', {
+      displayMode: 'standalone',
+    });
+  });
+});

--- a/app/utils/client-environment.ts
+++ b/app/utils/client-environment.ts
@@ -1,0 +1,190 @@
+import {
+  CLIENT_ENVIRONMENT_EVENT_NAME,
+  type AnalyticEventName,
+} from './analytics.ts';
+import { track } from './analytics.client.ts';
+import { getDisplayMode, isStandalone } from './pwa.ts';
+
+export type DeviceType = 'desktop' | 'mobile' | 'tablet' | 'unknown';
+export type ViewportBucket = 'desktop' | 'mobile' | 'tablet' | 'unknown';
+export type NotificationPermissionState =
+  | 'default'
+  | 'denied'
+  | 'granted'
+  | 'unsupported';
+
+export type ClientEnvironmentProperties = {
+  browserFamily: string;
+  browserMajor: number | null;
+  osFamily: string;
+  deviceType: DeviceType;
+  viewportBucket: ViewportBucket;
+  displayMode: ReturnType<typeof getDisplayMode>;
+  isStandalone: boolean;
+  serviceWorkerSupported: boolean;
+  notificationPermission: NotificationPermissionState;
+  observedAt: string;
+};
+
+const ENVIRONMENT_STORAGE_PREFIX = 'giftpool:client-environment-observed';
+const PWA_EVENT_STORAGE_PREFIX = 'giftpool:pwa-event';
+
+function todayKey(now = new Date()) {
+  return now.toISOString().slice(0, 10);
+}
+
+function parseMajor(value: string | undefined) {
+  if (!value) return null;
+  const major = Number.parseInt(value, 10);
+  return Number.isFinite(major) ? major : null;
+}
+
+function isIpadLike(userAgent: string, maxTouchPoints: number) {
+  return (
+    /ipad/i.test(userAgent) ||
+    (/macintosh/i.test(userAgent) && maxTouchPoints > 1)
+  );
+}
+
+export function classifyBrowser(userAgent: string) {
+  const checks: Array<[string, RegExp]> = [
+    ['Edge', /(?:Edg|EdgiOS|EdgA)\/(\d+)/i],
+    ['Samsung Internet', /SamsungBrowser\/(\d+)/i],
+    ['Opera', /(?:OPR|OPT)\/(\d+)/i],
+    ['Firefox', /(?:Firefox|FxiOS)\/(\d+)/i],
+    ['Chrome', /(?:Chrome|CriOS)\/(\d+)/i],
+    ['Safari', /Version\/(\d+).+Safari/i],
+  ];
+  for (const [browserFamily, regex] of checks) {
+    const match = regex.exec(userAgent);
+    if (match) {
+      return { browserFamily, browserMajor: parseMajor(match[1]) };
+    }
+  }
+  return { browserFamily: 'Unknown', browserMajor: null };
+}
+
+export function classifyOperatingSystem(userAgent: string, maxTouchPoints = 0) {
+  if (
+    /iphone|ipad|ipod/i.test(userAgent) ||
+    isIpadLike(userAgent, maxTouchPoints)
+  ) {
+    return 'iOS';
+  }
+  if (/android/i.test(userAgent)) return 'Android';
+  if (/windows/i.test(userAgent)) return 'Windows';
+  if (/cros/i.test(userAgent)) return 'ChromeOS';
+  if (/mac os x|macintosh/i.test(userAgent)) return 'macOS';
+  if (/linux/i.test(userAgent)) return 'Linux';
+  return 'Unknown';
+}
+
+export function classifyDeviceType(
+  userAgent: string,
+  maxTouchPoints = 0,
+): DeviceType {
+  if (isIpadLike(userAgent, maxTouchPoints)) return 'tablet';
+  if (/ipad|tablet/i.test(userAgent)) return 'tablet';
+  if (/iphone|ipod|android.+mobile|mobile/i.test(userAgent)) return 'mobile';
+  if (/android/i.test(userAgent)) return 'tablet';
+  if (!userAgent) return 'unknown';
+  return 'desktop';
+}
+
+export function getViewportBucket(width: number | undefined): ViewportBucket {
+  if (typeof width !== 'number' || !Number.isFinite(width)) return 'unknown';
+  if (width < 640) return 'mobile';
+  if (width < 1024) return 'tablet';
+  return 'desktop';
+}
+
+function getNotificationPermission(): NotificationPermissionState {
+  if (typeof Notification === 'undefined') return 'unsupported';
+  return Notification.permission;
+}
+
+export function collectClientEnvironment(
+  now = new Date(),
+): ClientEnvironmentProperties | null {
+  if (typeof window === 'undefined' || typeof navigator === 'undefined') {
+    return null;
+  }
+
+  const userAgent = navigator.userAgent;
+  const maxTouchPoints = navigator.maxTouchPoints ?? 0;
+  const browser = classifyBrowser(userAgent);
+
+  return {
+    ...browser,
+    osFamily: classifyOperatingSystem(userAgent, maxTouchPoints),
+    deviceType: classifyDeviceType(userAgent, maxTouchPoints),
+    viewportBucket: getViewportBucket(window.innerWidth),
+    displayMode: getDisplayMode(),
+    isStandalone: isStandalone(),
+    serviceWorkerSupported: 'serviceWorker' in navigator,
+    notificationPermission: getNotificationPermission(),
+    observedAt: now.toISOString(),
+  };
+}
+
+async function postEnvironment(properties: ClientEnvironmentProperties) {
+  if (typeof fetch === 'undefined') return false;
+  const response = await fetch('/api/analytics', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      name: CLIENT_ENVIRONMENT_EVENT_NAME,
+      properties,
+    }),
+    keepalive: true,
+  });
+  return response.ok;
+}
+
+export function trackPwaLifecycleEvent(
+  name: Extract<
+    AnalyticEventName,
+    | 'pwa_prompt_available'
+    | 'pwa_install_clicked'
+    | 'pwa_install_accepted'
+    | 'pwa_install_dismissed'
+    | 'pwa_appinstalled'
+    | 'pwa_launched_standalone'
+  >,
+  properties?: Record<string, unknown>,
+  now = new Date(),
+) {
+  if (typeof window === 'undefined') return null;
+  const key = `${PWA_EVENT_STORAGE_PREFIX}:${name}:${todayKey(now)}`;
+  if (window.localStorage.getItem(key)) return null;
+  const eventId = track(name, properties);
+  if (eventId) {
+    window.localStorage.setItem(key, '1');
+  }
+  return eventId;
+}
+
+export async function trackClientEnvironmentOncePerDay(now = new Date()) {
+  if (typeof window === 'undefined') return;
+  const key = `${ENVIRONMENT_STORAGE_PREFIX}:${todayKey(now)}`;
+  if (window.localStorage.getItem(key)) return;
+
+  const properties = collectClientEnvironment(now);
+  if (!properties) return;
+
+  if (properties.isStandalone) {
+    trackPwaLifecycleEvent(
+      'pwa_launched_standalone',
+      { displayMode: properties.displayMode },
+      now,
+    );
+  }
+
+  try {
+    if (await postEnvironment(properties)) {
+      window.localStorage.setItem(key, '1');
+    }
+  } catch {
+    // Best-effort analytics: failed observations are retried on a later page load.
+  }
+}

--- a/app/utils/pwa.test.ts
+++ b/app/utils/pwa.test.ts
@@ -2,7 +2,12 @@
  * @vitest-environment jsdom
  */
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { detectManualInstallPlatform, isIos, isStandalone } from './pwa.ts';
+import {
+  detectManualInstallPlatform,
+  getDisplayMode,
+  isIos,
+  isStandalone,
+} from './pwa.ts';
 
 const setUserAgent = (ua: string) => {
   Object.defineProperty(window.navigator, 'userAgent', {
@@ -17,10 +22,23 @@ afterEach(() => {
 });
 
 describe('pwa detection', () => {
+  it('returns the active PWA display mode', () => {
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn((query: string) => ({
+        matches: query === '(display-mode: minimal-ui)',
+      })),
+    );
+
+    expect(getDisplayMode()).toBe('minimal-ui');
+  });
+
   it('isStandalone reflects the display-mode media query', () => {
     vi.stubGlobal(
       'matchMedia',
-      vi.fn().mockReturnValue({ matches: true }),
+      vi.fn((query: string) => ({
+        matches: query === '(display-mode: standalone)',
+      })),
     );
     expect(isStandalone()).toBe(true);
   });
@@ -50,7 +68,12 @@ describe('pwa detection', () => {
   });
 
   it('returns null platform when already installed (standalone)', () => {
-    vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({ matches: true }));
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn((query: string) => ({
+        matches: query === '(display-mode: standalone)',
+      })),
+    );
     setUserAgent('Mozilla/5.0 (iPhone) Safari/604.1');
     expect(detectManualInstallPlatform()).toBeNull();
   });

--- a/app/utils/pwa.ts
+++ b/app/utils/pwa.ts
@@ -3,16 +3,39 @@
 
 export type ManualInstallPlatform = 'ios-safari' | 'ios-chrome';
 
+export type PwaDisplayMode =
+  | 'browser'
+  | 'fullscreen'
+  | 'minimal-ui'
+  | 'standalone'
+  | 'window-controls-overlay';
+
+const DISPLAY_MODES: Array<PwaDisplayMode> = [
+  'fullscreen',
+  'standalone',
+  'minimal-ui',
+  'window-controls-overlay',
+];
+
+export const getDisplayMode = (): PwaDisplayMode => {
+  if (typeof window === 'undefined') return 'browser';
+  for (const mode of DISPLAY_MODES) {
+    if (window.matchMedia?.(`(display-mode: ${mode})`).matches) {
+      return mode;
+    }
+  }
+  return 'browser';
+};
+
 /** True when the app is running as an installed PWA (home-screen / standalone). */
 export const isStandalone = (): boolean => {
   if (typeof window === 'undefined') return false;
-  const mediaQueryList = window.matchMedia?.('(display-mode: standalone)');
   const navigatorStandalone = (
     window.navigator as Navigator & {
       standalone?: boolean;
     }
   ).standalone;
-  return Boolean(mediaQueryList?.matches || navigatorStandalone);
+  return Boolean(getDisplayMode() === 'standalone' || navigatorStandalone);
 };
 
 /** Detect iOS browsers that require a manual "Add to Home Screen" flow. */


### PR DESCRIPTION
## Summary

- Add first-party client environment analytics for browser, OS, device class, viewport, display mode, standalone/PWA state, service worker support, and notification permission.
- Add admin analytics environment summaries plus an explorer route for slicing events by time, source, browser, OS, device, viewport, display mode, and standalone state.
- Refresh the admin cache inspector UI with clearer summary, filtering, grouping, and value actions.

## Why

This gives production operators an at-a-glance view of how people are using the app without adding a third-party analytics platform. It also keeps the collected payload intentionally narrow and documents the behavior in the privacy copy.

## Root Cause / Notes

Fly/app server logs cannot answer questions like PWA install state, viewport bucket, notification permission, or authenticated-vs-anonymous user behavior reliably. The app needs first-party client-side events for those dimensions, stored and summarized in the existing analytics tables.

The explorer route uses `analytics_.explorer.tsx` so `/admin/analytics/explorer` is a sibling of `/admin/analytics`, not a nested child requiring the dashboard route to render an outlet.

## Validation

- `npm run test -- --run app/routes/admin+/analytics_.explorer.test.ts app/routes/admin+/analytics_.explorer.dom.test.tsx app/routes/admin+/cache.dom.test.tsx app/routes/api.analytics.test.ts app/routes/admin+/analytics.test.ts app/routes/admin+/analytics.dom.test.tsx app/utils/client-environment.test.ts app/utils/analytics.server.test.ts`
- `npm run typecheck`
- `npm run lint -- --quiet`
- `npm run build`