### PR TITLE
feat(groups): group page rework — member menu, hover card, desktop dashboard

### DIFF
--- a/app/components/groups/group-avatar-cluster.tsx
+++ b/app/components/groups/group-avatar-cluster.tsx
@@ -1,0 +1,80 @@
+import { Link } from 'react-router';
+
+import { Avatar } from '#app/components/ui/avatar.tsx';
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from '#app/components/ui/hover-card.tsx';
+import { useHasHover } from '#app/hooks/use-has-hover.ts';
+import {
+  ProfilePreviewCard,
+  type ProfilePreviewMember,
+} from './profile-preview-card.tsx';
+
+type ClusterMember = ProfilePreviewMember & { user: { id: string } };
+
+const MAX_AVATARS = 5;
+
+export function GroupAvatarCluster({
+  members,
+  viewerId,
+}: Readonly<{
+  members: ReadonlyArray<ClusterMember>;
+  viewerId: string;
+}>) {
+  const hasHover = useHasHover();
+  const visible = members.slice(0, MAX_AVATARS);
+  const extra = members.length - visible.length;
+
+  return (
+    // Desktop-only adornment — the mobile header already shows the count.
+    <div className="hidden items-center sm:flex">
+      <div className="flex -space-x-2">
+        {visible.map((member) => {
+          const displayName = member.user.name ?? member.user.username;
+          const avatar = (
+            <Link
+              to={`/users/${member.user.username}`}
+              aria-label={`View ${displayName}'s profile`}
+              className="inline-flex rounded-full focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <Avatar
+                size="s"
+                className="ring-2 ring-background"
+                image={member.user.image}
+                user={member.user}
+              />
+            </Link>
+          );
+
+          if (!hasHover) {
+            return <span key={member.user.id}>{avatar}</span>;
+          }
+
+          return (
+            <HoverCard key={member.user.id} openDelay={200} closeDelay={100}>
+              <HoverCardTrigger asChild>{avatar}</HoverCardTrigger>
+              <HoverCardContent
+                side="bottom"
+                align="start"
+                sideOffset={-6}
+                className="w-72"
+              >
+                <ProfilePreviewCard
+                  member={member}
+                  isYou={member.user.id === viewerId}
+                />
+              </HoverCardContent>
+            </HoverCard>
+          );
+        })}
+      </div>
+      {extra > 0 ? (
+        <span className="ml-1.5 inline-flex h-8 items-center rounded-full bg-muted px-2 text-xs font-bold text-muted-foreground">
+          +{extra}
+        </span>
+      ) : null}
+    </div>
+  );
+}

--- a/app/components/groups/member-actions-menu.test.tsx
+++ b/app/components/groups/member-actions-menu.test.tsx
@@ -1,0 +1,224 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { type GroupRole } from '#app/utils/group-role.ts';
+
+const submit = vi.fn();
+
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual('react-router');
+  return {
+    ...actual,
+    useFetcher: () => ({
+      submit,
+      Form: (props: React.ComponentProps<'form'>) => <form {...props} />,
+      state: 'idle',
+      data: undefined,
+    }),
+  };
+});
+
+// Radix primitives are unreliable in jsdom — mock to plain elements so the
+// permission/confirmation logic is what's under test (mirrors the
+// friend-action-button test approach).
+vi.mock('#app/components/ui/dropdown-menu.tsx', () => ({
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuItem: ({
+    children,
+    onSelect,
+  }: {
+    children: React.ReactNode;
+    onSelect?: (e: { preventDefault: () => void }) => void;
+  }) => (
+    <button type="button" onClick={() => onSelect?.({ preventDefault() {} })}>
+      {children}
+    </button>
+  ),
+  DropdownMenuTrigger: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+// Render only the trigger for the mobile sheet so action buttons don't
+// duplicate the desktop dropdown items.
+vi.mock('#app/components/ui/mobile-bottom-sheet.tsx', () => ({
+  MobileBottomSheet: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  MobileBottomSheetTrigger: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  MobileBottomSheetContent: () => null,
+  MobileBottomSheetClose: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  MobileBottomSheetTitle: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  MobileBottomSheetDescription: ({
+    children,
+  }: {
+    children: React.ReactNode;
+  }) => <div>{children}</div>,
+}));
+
+vi.mock('#app/components/ui/dialog.tsx', () => ({
+  Dialog: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogContent: ({ children }: { children: React.ReactNode }) => (
+    <div role="dialog">{children}</div>
+  ),
+  DialogHeader: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogTitle: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogDescription: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogFooter: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogClose: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+import { MemberActionsMenu } from './member-actions-menu.tsx';
+
+function renderMenu({
+  viewerRole,
+  targetRole,
+  isViewer = false,
+}: {
+  viewerRole: GroupRole;
+  targetRole: GroupRole;
+  isViewer?: boolean;
+}) {
+  return render(
+    <MemberActionsMenu
+      giftGroupId="group-1"
+      viewerRole={viewerRole}
+      isViewer={isViewer}
+      member={{
+        user: { id: 'naomi', username: 'naomi', name: 'Naomi', image: null },
+        role: targetRole,
+      }}
+      birthdayLabel="Birthday Jul 19"
+    />,
+  );
+}
+
+const triggers = () => screen.queryAllByRole('button', { name: /actions for/i });
+
+describe('<MemberActionsMenu /> — permission matrix', () => {
+  beforeEach(() => submit.mockReset());
+
+  it('shows no menu to a member viewer', () => {
+    renderMenu({ viewerRole: 'MEMBER', targetRole: 'MEMBER' });
+    expect(triggers()).toHaveLength(0);
+    renderMenu({ viewerRole: 'MEMBER', targetRole: 'ADMIN' });
+    expect(triggers()).toHaveLength(0);
+  });
+
+  it('shows no menu on your own row or on the owner row', () => {
+    renderMenu({ viewerRole: 'OWNER', targetRole: 'OWNER', isViewer: true });
+    expect(triggers()).toHaveLength(0);
+    renderMenu({ viewerRole: 'ADMIN', targetRole: 'OWNER' });
+    expect(triggers()).toHaveLength(0);
+  });
+
+  it('lets an admin act on member rows only', () => {
+    renderMenu({ viewerRole: 'ADMIN', targetRole: 'MEMBER' });
+    expect(triggers().length).toBeGreaterThan(0);
+    expect(
+      screen.getByRole('button', { name: 'Remove from group' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Promote to admin' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows no menu to an admin on an admin row', () => {
+    renderMenu({ viewerRole: 'ADMIN', targetRole: 'ADMIN' });
+    expect(triggers()).toHaveLength(0);
+  });
+
+  it('offers promote+remove to the owner on a member row', () => {
+    renderMenu({ viewerRole: 'OWNER', targetRole: 'MEMBER' });
+    expect(
+      screen.getByRole('button', { name: 'Promote to admin' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Remove from group' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Demote to member' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('offers demote+remove to the owner on an admin row', () => {
+    renderMenu({ viewerRole: 'OWNER', targetRole: 'ADMIN' });
+    expect(
+      screen.getByRole('button', { name: 'Demote to member' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Remove from group' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Promote to admin' }),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe('<MemberActionsMenu /> — confirmation before firing', () => {
+  beforeEach(() => submit.mockReset());
+
+  it('requires a confirm step and posts the matching intent', async () => {
+    renderMenu({ viewerRole: 'OWNER', targetRole: 'MEMBER' });
+
+    // Choosing the action does not fire it — it opens a confirm step.
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Remove from group' }),
+    );
+    expect(submit).not.toHaveBeenCalled();
+    expect(
+      screen.getByText('Remove Naomi from the group?'),
+    ).toBeInTheDocument();
+
+    // Confirming posts the member-remove intent to the settings action.
+    await userEvent.click(screen.getByRole('button', { name: 'Remove' }));
+    expect(submit).toHaveBeenCalledTimes(1);
+    const [formData, options] = submit.mock.calls[0] as [
+      FormData,
+      { method: string; action: string },
+    ];
+    expect(formData.get('intent')).toBe('member-remove');
+    expect(formData.get('memberUserId')).toBe('naomi');
+    expect(formData.get('giftGroupId')).toBe('group-1');
+    expect(options).toMatchObject({
+      method: 'post',
+      action: '/groups/group-1/settings',
+    });
+  });
+
+  it('posts member-promote-admin when promoting is confirmed', async () => {
+    renderMenu({ viewerRole: 'OWNER', targetRole: 'MEMBER' });
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Promote to admin' }),
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'Promote' }));
+    const [formData] = submit.mock.calls[0] as [FormData];
+    expect(formData.get('intent')).toBe('member-promote-admin');
+  });
+});

--- a/app/components/groups/member-actions-menu.tsx
+++ b/app/components/groups/member-actions-menu.tsx
@@ -1,0 +1,282 @@
+import { type ReactNode, useState } from 'react';
+import {
+  LuEllipsisVertical,
+  LuShieldCheck,
+  LuShieldOff,
+  LuUserMinus,
+} from 'react-icons/lu';
+import { useFetcher } from 'react-router';
+
+import { Avatar } from '#app/components/ui/avatar.tsx';
+import { Button } from '#app/components/ui/button.tsx';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '#app/components/ui/dialog.tsx';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '#app/components/ui/dropdown-menu.tsx';
+import {
+  MobileBottomSheet,
+  MobileBottomSheetClose,
+  MobileBottomSheetContent,
+  MobileBottomSheetDescription,
+  MobileBottomSheetTitle,
+  MobileBottomSheetTrigger,
+} from '#app/components/ui/mobile-bottom-sheet.tsx';
+import {
+  type MemberMenuAction,
+  memberMenuActions,
+} from '#app/utils/group-member-menu.ts';
+import { type GroupRole } from '#app/utils/group-role.ts';
+import { cn } from '#app/utils/misc.tsx';
+import { RoleBadge } from './RoleBadge.tsx';
+
+type MenuMember = {
+  user: {
+    id: string;
+    username: string;
+    name: string | null;
+    image: { id: string; altText: string | null } | null;
+  };
+  role: GroupRole;
+};
+
+const ACTION_META: Record<
+  MemberMenuAction,
+  {
+    intent: string;
+    label: string;
+    icon: ReactNode;
+    destructive: boolean;
+    confirmTitle: (name: string) => string;
+    confirmBody: (name: string) => string;
+    confirmLabel: string;
+  }
+> = {
+  promote: {
+    intent: 'member-promote-admin',
+    label: 'Promote to admin',
+    icon: <LuShieldCheck className="h-4 w-4" aria-hidden />,
+    destructive: false,
+    confirmTitle: (name) => `Promote ${name} to admin?`,
+    confirmBody: (name) =>
+      `${name} will be able to manage members, invites, reminders, and group settings.`,
+    confirmLabel: 'Promote',
+  },
+  demote: {
+    intent: 'member-demote-member',
+    label: 'Demote to member',
+    icon: <LuShieldOff className="h-4 w-4" aria-hidden />,
+    destructive: false,
+    confirmTitle: (name) => `Demote ${name} to member?`,
+    confirmBody: (name) =>
+      `${name} will lose admin privileges and become a regular member.`,
+    confirmLabel: 'Demote',
+  },
+  remove: {
+    intent: 'member-remove',
+    label: 'Remove from group',
+    icon: <LuUserMinus className="h-4 w-4" aria-hidden />,
+    destructive: true,
+    confirmTitle: (name) => `Remove ${name} from the group?`,
+    confirmBody: (name) =>
+      `${name} will lose access to this group and its pools. You can invite them back later.`,
+    confirmLabel: 'Remove',
+  },
+};
+
+export function MemberActionsMenu({
+  giftGroupId,
+  viewerRole,
+  member,
+  isViewer,
+  birthdayLabel,
+}: Readonly<{
+  giftGroupId: string;
+  viewerRole: GroupRole;
+  member: MenuMember;
+  isViewer: boolean;
+  birthdayLabel?: string | null;
+}>) {
+  const actions = memberMenuActions(viewerRole, member.role, isViewer);
+  const fetcher = useFetcher();
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [sheetOpen, setSheetOpen] = useState(false);
+  const [pending, setPending] = useState<MemberMenuAction | null>(null);
+
+  if (actions.length === 0) return null;
+
+  const displayName = member.user.name ?? member.user.username;
+  const settingsAction = `/groups/${giftGroupId}/settings`;
+
+  const runAction = (action: MemberMenuAction) => {
+    const meta = ACTION_META[action];
+    const fd = new FormData();
+    fd.set('intent', meta.intent);
+    fd.set('giftGroupId', giftGroupId);
+    fd.set('memberUserId', member.user.id);
+    void fetcher.submit(fd, { method: 'post', action: settingsAction });
+  };
+
+  const pendingMeta = pending ? ACTION_META[pending] : null;
+
+  return (
+    <>
+      {/* Desktop: anchored dropdown */}
+      <div className="hidden sm:block">
+        <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
+          <DropdownMenuTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              aria-label={`Actions for ${displayName}`}
+              className="h-9 w-9 rounded-lg text-muted-foreground hover:bg-muted hover:text-foreground"
+            >
+              <LuEllipsisVertical className="h-4 w-4" aria-hidden />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" sideOffset={8} className="min-w-[12rem]">
+            {actions.map((action) => {
+              const meta = ACTION_META[action];
+              return (
+                <DropdownMenuItem
+                  key={action}
+                  className={cn(
+                    'gap-2 px-2 py-2 text-sm',
+                    meta.destructive && 'text-red-600 focus:text-red-700',
+                  )}
+                  onSelect={(event) => {
+                    // preventDefault stops Radix's own close+focus-restore from
+                    // racing the dialog; we close the menu ourselves so it
+                    // doesn't linger (and aria-hide the row) behind the dialog.
+                    event.preventDefault();
+                    setMenuOpen(false);
+                    setPending(action);
+                  }}
+                >
+                  {meta.icon}
+                  {meta.label}
+                </DropdownMenuItem>
+              );
+            })}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+
+      {/* Mobile: bottom sheet */}
+      <div className="sm:hidden">
+        <MobileBottomSheet open={sheetOpen} onOpenChange={setSheetOpen}>
+          <MobileBottomSheetTrigger asChild>
+            <button
+              type="button"
+              aria-label={`Actions for ${displayName}`}
+              className="flex h-11 w-11 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            >
+              <LuEllipsisVertical className="h-5 w-5" aria-hidden />
+            </button>
+          </MobileBottomSheetTrigger>
+          <MobileBottomSheetContent className="gap-0 p-0 pb-[calc(env(safe-area-inset-bottom)+12px)]">
+            <MobileBottomSheetTitle className="sr-only">
+              Manage {displayName}
+            </MobileBottomSheetTitle>
+            <MobileBottomSheetDescription className="sr-only">
+              Choose a manager action for {displayName}.
+            </MobileBottomSheetDescription>
+            <div className="flex items-center gap-3 px-5 pb-4 pt-2">
+              <Avatar size="s" image={member.user.image} user={member.user} />
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  <span className="truncate text-base font-bold text-foreground">
+                    {displayName}
+                  </span>
+                  <RoleBadge role={member.role} />
+                </div>
+                {birthdayLabel ? (
+                  <div className="mt-0.5 text-sm text-muted-foreground">
+                    {birthdayLabel}
+                  </div>
+                ) : null}
+              </div>
+            </div>
+            <div className="h-px bg-border" />
+            {actions.map((action) => {
+              const meta = ACTION_META[action];
+              return (
+                <button
+                  key={action}
+                  type="button"
+                  className={cn(
+                    'flex w-full items-center gap-3.5 px-5 py-4 text-left text-base font-medium transition-colors hover:bg-muted',
+                    meta.destructive ? 'text-red-600' : 'text-foreground',
+                  )}
+                  onClick={() => {
+                    setSheetOpen(false);
+                    setPending(action);
+                  }}
+                >
+                  {meta.icon}
+                  {meta.label}
+                </button>
+              );
+            })}
+            <div className="h-2 bg-muted/40" />
+            <MobileBottomSheetClose asChild>
+              <button
+                type="button"
+                className="w-full px-5 py-4 text-center text-base font-bold text-foreground transition-colors hover:bg-muted"
+              >
+                Cancel
+              </button>
+            </MobileBottomSheetClose>
+          </MobileBottomSheetContent>
+        </MobileBottomSheet>
+      </div>
+
+      {/* Shared confirmation step */}
+      <Dialog
+        open={pending !== null}
+        onOpenChange={(open) => {
+          if (!open) setPending(null);
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {pendingMeta ? pendingMeta.confirmTitle(displayName) : ''}
+            </DialogTitle>
+          </DialogHeader>
+          <DialogDescription>
+            {pendingMeta ? pendingMeta.confirmBody(displayName) : ''}
+          </DialogDescription>
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button type="button" variant="secondary">
+                Cancel
+              </Button>
+            </DialogClose>
+            <Button
+              type="button"
+              variant={pendingMeta?.destructive ? 'destructive' : 'default'}
+              onClick={() => {
+                if (pending) runAction(pending);
+                setPending(null);
+              }}
+            >
+              {pendingMeta?.confirmLabel ?? 'Confirm'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/app/components/groups/members-list.tsx
+++ b/app/components/groups/members-list.tsx
@@ -1,0 +1,115 @@
+import { LuCake } from 'react-icons/lu';
+import { Link } from 'react-router';
+
+import { Avatar } from '#app/components/ui/avatar.tsx';
+import { SystemLabel } from '#app/components/ui/system-label.tsx';
+import { type GroupRole } from '#app/utils/group-role.ts';
+import { MemberActionsMenu } from './member-actions-menu.tsx';
+import { RoleBadge } from './RoleBadge.tsx';
+
+export type MemberListEntry = {
+  user: {
+    id: string;
+    username: string;
+    name: string | null;
+    birthday: Date | string | null;
+    image: { id: string; altText: string | null } | null;
+  };
+  role: string;
+};
+
+function formatBirthday(birthday: Date | string | null): string {
+  if (!birthday) return 'Birthday not set';
+  const date = birthday instanceof Date ? birthday : new Date(birthday);
+  if (Number.isNaN(date.getTime())) return 'Birthday not set';
+  return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}
+
+function MemberRow({
+  giftGroupId,
+  viewerRole,
+  member,
+  isViewer,
+}: Readonly<{
+  giftGroupId: string;
+  viewerRole: GroupRole;
+  member: MemberListEntry;
+  isViewer: boolean;
+}>) {
+  const role = member.role as GroupRole;
+  const displayName = member.user.name ?? member.user.username;
+  const birthdayLabel = formatBirthday(member.user.birthday);
+
+  return (
+    <li className="relative flex items-center gap-3 px-2 py-2.5">
+      {/*
+       * Whole-row click target navigates to the profile. The menu cell
+       * below re-enables pointer events for itself (same isolation pattern
+       * as friend-row) so the three-dot is a separate 44x44 tap target.
+       */}
+      <Link
+        to={`/users/${member.user.username}`}
+        aria-label={`View ${displayName}'s profile`}
+        className="absolute inset-0 rounded-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+      />
+
+      <div className="pointer-events-none flex min-w-0 flex-1 items-center gap-3">
+        <Avatar
+          size="s"
+          className="!h-10 !w-10"
+          image={member.user.image}
+          user={member.user}
+        />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span className="truncate font-semibold text-foreground">
+              {displayName}
+            </span>
+            <RoleBadge role={role} />
+            {isViewer ? <SystemLabel>you</SystemLabel> : null}
+          </div>
+          <div className="mt-0.5 flex items-center gap-1.5 text-xs text-muted-foreground">
+            <LuCake className="h-3.5 w-3.5 shrink-0" aria-hidden />
+            <span className="truncate">{birthdayLabel}</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="pointer-events-auto relative flex-none">
+        <MemberActionsMenu
+          giftGroupId={giftGroupId}
+          viewerRole={viewerRole}
+          member={{ user: member.user, role }}
+          isViewer={isViewer}
+          birthdayLabel={birthdayLabel}
+        />
+      </div>
+    </li>
+  );
+}
+
+export function MembersList({
+  giftGroupId,
+  viewerRole,
+  viewerId,
+  members,
+}: Readonly<{
+  giftGroupId: string;
+  viewerRole: GroupRole;
+  viewerId: string;
+  members: ReadonlyArray<MemberListEntry>;
+}>) {
+  return (
+    <ul className="divide-y divide-border">
+      {members.map((member) => (
+        <MemberRow
+          key={member.user.id}
+          giftGroupId={giftGroupId}
+          viewerRole={viewerRole}
+          member={member}
+          isViewer={member.user.id === viewerId}
+        />
+      ))}
+    </ul>
+  );
+}

--- a/app/components/groups/profile-hover-card.test.tsx
+++ b/app/components/groups/profile-hover-card.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual('react-router');
+  return {
+    ...actual,
+    Link: ({
+      to,
+      children,
+      ...rest
+    }: {
+      to: string;
+      children?: React.ReactNode;
+    }) => (
+      <a href={to} {...rest}>
+        {children}
+      </a>
+    ),
+  };
+});
+
+// Force the non-hover (touch) branch so the cluster renders plain avatar
+// links we can count deterministically.
+vi.mock('#app/hooks/use-has-hover.ts', () => ({ useHasHover: () => false }));
+
+import { GroupAvatarCluster } from './group-avatar-cluster.tsx';
+import { ProfilePreviewCard } from './profile-preview-card.tsx';
+
+const member = (id: string, name: string, role = 'MEMBER') => ({
+  user: {
+    id,
+    username: name.toLowerCase(),
+    name,
+    birthday: new Date('1992-07-04'),
+    image: null,
+  },
+  role,
+});
+
+describe('<ProfilePreviewCard />', () => {
+  it('reads "View profile" for another member', () => {
+    render(
+      <ProfilePreviewCard member={member('marco', 'Marco')} isYou={false} />,
+    );
+    expect(screen.getByText('Marco')).toBeInTheDocument();
+    const link = screen.getByRole('link', { name: /view profile/i });
+    expect(link).toHaveAttribute('href', '/users/marco');
+    expect(screen.queryByText('you')).not.toBeInTheDocument();
+  });
+
+  it('reads "Your profile" for your own avatar', () => {
+    render(<ProfilePreviewCard member={member('you', 'Ada')} isYou={true} />);
+    expect(
+      screen.getByRole('link', { name: /your profile/i }),
+    ).toHaveAttribute('href', '/users/ada');
+    expect(screen.getByText('you')).toBeInTheDocument();
+  });
+});
+
+describe('<GroupAvatarCluster />', () => {
+  it('shows at most 5 avatars and a +N overflow chip', () => {
+    const members = [
+      member('a', 'Ada', 'OWNER'),
+      member('b', 'Bo'),
+      member('c', 'Cy'),
+      member('d', 'Di'),
+      member('e', 'Ed'),
+      member('f', 'Fi'),
+      member('g', 'Gus'),
+    ];
+    render(<GroupAvatarCluster members={members} viewerId="a" />);
+    expect(screen.getAllByRole('link')).toHaveLength(5);
+    expect(screen.getByText('+2')).toBeInTheDocument();
+  });
+
+  it('omits the chip when 5 or fewer members', () => {
+    const members = [member('a', 'Ada'), member('b', 'Bo')];
+    render(<GroupAvatarCluster members={members} viewerId="a" />);
+    expect(screen.getAllByRole('link')).toHaveLength(2);
+    expect(screen.queryByText(/^\+/)).not.toBeInTheDocument();
+  });
+});

--- a/app/components/groups/profile-preview-card.tsx
+++ b/app/components/groups/profile-preview-card.tsx
@@ -1,0 +1,83 @@
+import { LuCake, LuSettings, LuUser } from 'react-icons/lu';
+import { Link } from 'react-router';
+
+import { Avatar } from '#app/components/ui/avatar.tsx';
+import { SystemLabel } from '#app/components/ui/system-label.tsx';
+import { type GroupRole } from '#app/utils/group-role.ts';
+import { RoleBadge } from './RoleBadge.tsx';
+
+export type ProfilePreviewMember = {
+  user: {
+    username: string;
+    name: string | null;
+    birthday: Date | string | null;
+    image: { id: string; altText: string | null } | null;
+  };
+  role: string;
+};
+
+function formatBirthday(birthday: Date | string | null): string {
+  if (!birthday) return 'Not set';
+  const date = birthday instanceof Date ? birthday : new Date(birthday);
+  if (Number.isNaN(date.getTime())) return 'Not set';
+  return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}
+
+/**
+ * Inner content of the desktop profile hover-card. The popover surface
+ * (border, background, shadow, padding) comes from `HoverCardContent`.
+ */
+export function ProfilePreviewCard({
+  member,
+  isYou,
+}: Readonly<{ member: ProfilePreviewMember; isYou: boolean }>) {
+  const displayName = member.user.name ?? member.user.username;
+
+  return (
+    <div className="text-popover-foreground">
+      <div className="flex items-center gap-3.5">
+        <Avatar
+          size="m"
+          className="!h-14 !w-14 ring-2 ring-card"
+          image={member.user.image}
+          user={member.user}
+        />
+        <div className="flex min-w-0 flex-col gap-1.5">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-base font-extrabold leading-tight text-foreground">
+              {displayName}
+            </span>
+            {isYou ? <SystemLabel>you</SystemLabel> : null}
+          </div>
+          <RoleBadge role={member.role as GroupRole} />
+        </div>
+      </div>
+
+      <div className="mt-4 flex items-center gap-3 border-t pt-3.5">
+        <span className="inline-flex h-8 w-8 flex-none items-center justify-center rounded-full bg-muted text-muted-foreground">
+          <LuCake className="h-4 w-4" aria-hidden />
+        </span>
+        <div className="flex flex-col leading-tight">
+          <span className="text-[10px] font-extrabold uppercase tracking-wide text-muted-foreground">
+            Birthday
+          </span>
+          <span className="text-sm font-bold text-foreground">
+            {formatBirthday(member.user.birthday)}
+          </span>
+        </div>
+      </div>
+
+      <Link
+        to={`/users/${member.user.username}`}
+        className="mt-4 flex h-10 w-full items-center justify-center gap-2 rounded-full border border-input bg-card text-sm font-bold text-foreground transition-colors hover:border-accent hover:bg-accent hover:text-accent-foreground"
+      >
+        {isYou ? (
+          <LuSettings className="h-4 w-4" aria-hidden />
+        ) : (
+          <LuUser className="h-4 w-4" aria-hidden />
+        )}
+        {isYou ? 'Your profile' : 'View profile'}
+      </Link>
+    </div>
+  );
+}

--- a/app/components/ui/hover-card.tsx
+++ b/app/components/ui/hover-card.tsx
@@ -1,0 +1,28 @@
+import * as HoverCardPrimitive from '@radix-ui/react-hover-card';
+import * as React from 'react';
+import { cn } from '#app/utils/misc.tsx';
+
+const HoverCard = HoverCardPrimitive.Root;
+
+const HoverCardTrigger = HoverCardPrimitive.Trigger;
+
+const HoverCardContent = React.forwardRef<
+  React.ElementRef<typeof HoverCardPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof HoverCardPrimitive.Content>
+>(({ className, align = 'center', sideOffset = 4, ...props }, ref) => (
+  <HoverCardPrimitive.Portal>
+    <HoverCardPrimitive.Content
+      ref={ref}
+      align={align}
+      sideOffset={sideOffset}
+      className={cn(
+        'z-50 w-64 origin-[--radix-hover-card-content-transform-origin] rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        className,
+      )}
+      {...props}
+    />
+  </HoverCardPrimitive.Portal>
+));
+HoverCardContent.displayName = HoverCardPrimitive.Content.displayName;
+
+export { HoverCard, HoverCardTrigger, HoverCardContent };

--- a/app/hooks/use-has-hover.ts
+++ b/app/hooks/use-has-hover.ts
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react';
+
+const HOVER_QUERY = '(hover: hover) and (pointer: fine)';
+
+/**
+ * True only on devices with a real hover-capable pointer (mouse/trackpad).
+ * Used to gate hover-only affordances so they never render on touch.
+ *
+ * SSR-safe: starts `false` so the server and the first client paint agree,
+ * then upgrades after mount. Mirrors `useIsDesktop`.
+ */
+export const useHasHover = () => {
+  const [hasHover, setHasHover] = useState(false);
+
+  useEffect(() => {
+    if (
+      typeof window === 'undefined' ||
+      typeof window.matchMedia !== 'function'
+    ) {
+      return;
+    }
+
+    const mediaQuery = window.matchMedia(HOVER_QUERY);
+
+    const handleChange = (event: MediaQueryListEvent) => {
+      setHasHover(event.matches);
+    };
+
+    setHasHover(mediaQuery.matches);
+    mediaQuery.addEventListener('change', handleChange);
+    return () => mediaQuery.removeEventListener('change', handleChange);
+  }, []);
+
+  return hasHover;
+};

--- a/app/routes/groups+/$giftGroupId_+/_layout.tsx
+++ b/app/routes/groups+/$giftGroupId_+/_layout.tsx
@@ -1,5 +1,5 @@
-import { LuUsers } from 'react-icons/lu';
-import { NavLink, Outlet, useLoaderData } from 'react-router';
+import { LuSettings, LuUsers } from 'react-icons/lu';
+import { Link, NavLink, Outlet, useLoaderData } from 'react-router';
 import { RoleBadge } from '#app/components/groups/RoleBadge.tsx';
 import { PageHeader } from '#app/components/page-header.tsx';
 import { Stack } from '#app/components/ui-kit/stack.tsx';
@@ -11,8 +11,7 @@ import { type loader as routeLoader } from './__route.server';
 export { loader, action } from './__route.server';
 
 const GroupLayout = () => {
-  const { giftGroup, viewer, canSettings } =
-    useLoaderData<typeof routeLoader>();
+  const { giftGroup, viewer } = useLoaderData<typeof routeLoader>();
 
   return (
     <div className="flex h-full min-h-0 flex-col">
@@ -23,12 +22,23 @@ const GroupLayout = () => {
         title={giftGroup.name}
         subtitle={`${giftGroup.groupMembers.length} ${giftGroup.groupMembers.length === 1 ? 'member' : 'members'}`}
       >
-        <RoleBadge role={viewer.role as GroupRole} />
+        <div className="flex shrink-0 items-center gap-2">
+          <RoleBadge role={viewer.role as GroupRole} />
+          {/* Settings is reachable by every member — it's where your own
+              group preferences live, not just admin controls (P7.5). */}
+          <Link
+            to={`/groups/${giftGroup.id}/settings`}
+            aria-label="Group settings"
+            className="text-muted-foreground hover:text-foreground"
+          >
+            <LuSettings className="h-5 w-5" />
+          </Link>
+        </div>
       </PageHeader>
       <main className="min-h-0 flex-1 overflow-y-auto">
         <div className="mx-auto max-w-6xl p-3 sm:p-6">
           <Stack gap={6}>
-            <TabBar giftGroupId={giftGroup.id} canSettings={canSettings} />
+            <TabBar giftGroupId={giftGroup.id} />
             <Outlet />
           </Stack>
         </div>
@@ -39,28 +49,16 @@ const GroupLayout = () => {
 
 export default GroupLayout;
 
-const TabBar = ({
-  giftGroupId,
-  canSettings,
-}: {
-  giftGroupId: string;
-  canSettings: boolean;
-}) => {
+const TabBar = ({ giftGroupId }: { giftGroupId: string }) => {
+  // Settings is intentionally NOT a tab — it's reached from the header gear.
   const tabs = [
     { to: `/groups/${giftGroupId}`, label: 'Overview', end: true },
     { to: `/groups/${giftGroupId}/members`, label: 'Members' },
-    ...(canSettings
-      ? ([
-          { to: `/groups/${giftGroupId}/settings`, label: 'Settings' },
-        ] as const)
-      : ([] as const)),
     { to: `/groups/${giftGroupId}/activity`, label: 'Activity' },
   ] as const;
 
-  const colsClass = canSettings ? 'grid-cols-4' : 'grid-cols-3';
-
   return (
-    <div className={`grid w-full ${colsClass} rounded-full bg-muted p-1`}>
+    <div className="grid w-full grid-cols-3 rounded-full bg-muted p-1">
       {tabs.map((t) => (
         <NavLink
           key={t.to}

--- a/app/routes/groups+/$giftGroupId_+/_layout.tsx
+++ b/app/routes/groups+/$giftGroupId_+/_layout.tsx
@@ -43,7 +43,11 @@ const GroupLayout = () => {
       <main className="min-h-0 flex-1 overflow-y-auto">
         <div className="mx-auto max-w-6xl p-3 sm:p-6">
           <Stack gap={6}>
-            <TabBar giftGroupId={giftGroup.id} />
+            {/* Tabs are retained on mobile/tablet; desktop collapses them
+                into the single dashboard rendered by the index route. */}
+            <div className="lg:hidden">
+              <TabBar giftGroupId={giftGroup.id} />
+            </div>
             <Outlet />
           </Stack>
         </div>

--- a/app/routes/groups+/$giftGroupId_+/_layout.tsx
+++ b/app/routes/groups+/$giftGroupId_+/_layout.tsx
@@ -1,5 +1,6 @@
 import { LuSettings, LuUsers } from 'react-icons/lu';
 import { Link, NavLink, Outlet, useLoaderData } from 'react-router';
+import { GroupAvatarCluster } from '#app/components/groups/group-avatar-cluster.tsx';
 import { RoleBadge } from '#app/components/groups/RoleBadge.tsx';
 import { PageHeader } from '#app/components/page-header.tsx';
 import { Stack } from '#app/components/ui-kit/stack.tsx';
@@ -23,6 +24,10 @@ const GroupLayout = () => {
         subtitle={`${giftGroup.groupMembers.length} ${giftGroup.groupMembers.length === 1 ? 'member' : 'members'}`}
       >
         <div className="flex shrink-0 items-center gap-2">
+          <GroupAvatarCluster
+            members={giftGroup.groupMembers}
+            viewerId={viewer.userId}
+          />
           <RoleBadge role={viewer.role as GroupRole} />
           {/* Settings is reachable by every member — it's where your own
               group preferences live, not just admin controls (P7.5). */}

--- a/app/routes/groups+/$giftGroupId_+/index.test.tsx
+++ b/app/routes/groups+/$giftGroupId_+/index.test.tsx
@@ -16,9 +16,33 @@ const loaderDataSnapshot = {
     description: 'Birthday planning',
     id: 'group-1',
     name: 'Family',
+    groupMembers: [
+      {
+        user: {
+          id: 'viewer-1',
+          username: 'ada',
+          name: 'Ada',
+          birthday: new Date('1990-12-10'),
+          image: null,
+        },
+        role: 'OWNER' as const,
+      },
+      {
+        user: {
+          id: 'marco',
+          username: 'marco',
+          name: 'Marco',
+          birthday: new Date('1992-07-04'),
+          image: null,
+        },
+        role: 'MEMBER' as const,
+      },
+    ],
   },
   inviteLink: 'https://giftpool.app/groups/join/invite-1' as string | null,
   viewer: {
+    userId: 'viewer-1',
+    role: 'OWNER' as const,
     contributionCents: 1500,
   },
 };
@@ -87,6 +111,23 @@ vi.mock('#app/components/ui/dialog.tsx', () => ({
   DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   DialogTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   DialogTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+// The members rail's full row (Radix menu + confirm dialog) is covered by
+// member-actions-menu.test / members.component.test — stub it here so this
+// overview test stays focused on the dashboard layout.
+vi.mock('#app/components/groups/members-list.tsx', () => ({
+  MembersList: ({
+    members,
+  }: {
+    members: Array<{ user: { id: string; name: string | null; username: string } }>;
+  }) => (
+    <ul data-testid="members-rail-list">
+      {members.map((m) => (
+        <li key={m.user.id}>{m.user.name ?? m.user.username}</li>
+      ))}
+    </ul>
+  ),
 }));
 
 import GroupsDetailOverview from './index.tsx';
@@ -400,5 +441,32 @@ describe('group detail overview route', () => {
     ).toBeInTheDocument();
     // P0 urgency badge
     expect(screen.getByText(/in 3 days/i)).toBeInTheDocument();
+  });
+
+  it('renders the desktop members rail with every member', () => {
+    render(<GroupsDetailOverview />);
+    expect(screen.getByText('Members (2)')).toBeInTheDocument();
+    const rail = screen.getByTestId('members-rail-list');
+    expect(rail).toHaveTextContent('Ada');
+    expect(rail).toHaveTextContent('Marco');
+    expect(
+      screen.getByRole('link', { name: 'Manage' }),
+    ).toHaveAttribute('href', '/groups/group-1/members');
+  });
+
+  it('edits the per-gift cap inline — no modal for a single number', async () => {
+    render(<GroupsDetailOverview />);
+    // Read mode shows the current cap.
+    expect(screen.getByTestId('budget-amount')).toHaveTextContent('$15.00');
+
+    await userEvent.click(
+      screen.getByRole('button', { name: /edit your budget/i }),
+    );
+
+    // Edit reveals an inline input — not a dialog.
+    expect(
+      screen.getByRole('textbox', { name: /your budget/i }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
 });

--- a/app/routes/groups+/$giftGroupId_+/index.tsx
+++ b/app/routes/groups+/$giftGroupId_+/index.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import {
+  LuActivity,
   LuAlarmClock,
   LuTriangleAlert,
   LuCake,
@@ -22,20 +23,14 @@ import {
   useLoaderData,
   useRouteLoaderData,
 } from 'react-router';
+import {
+  MembersList,
+  type MemberListEntry,
+} from '#app/components/groups/members-list.tsx';
 import { Button } from '#app/components/ui/button.tsx';
 import { Card } from '#app/components/ui/card.tsx';
-import {
-  Dialog,
-  DialogTrigger,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogFooter,
-  DialogClose,
-} from '#app/components/ui/dialog.tsx';
 import { Icon } from '#app/components/ui/icon.tsx';
 import { Input } from '#app/components/ui/input.tsx';
-import { Label } from '#app/components/ui/label.tsx';
 import { Flex, Stack, Text } from '#app/components/ui-kit';
 import { track } from '#app/utils/analytics.client.ts';
 import {
@@ -46,6 +41,7 @@ import {
   type PoolSummary,
   type UpcomingOccasion,
 } from '#app/utils/group-overview.ts';
+import { type GroupRole } from '#app/utils/group-role.ts';
 import { cn, getUserImgSrc } from '#app/utils/misc.tsx';
 import {
   POOL_STATUS_LABELS,
@@ -110,29 +106,104 @@ const GiftGroupOverview = () => {
     typeof routeLoader
   >('routes/groups+/$giftGroupId_+/_layout')!;
 
+  const essentials = (
+    <GroupEssentialsCard
+      giftGroupId={giftGroup.id}
+      description={giftGroup.description}
+      contributionCents={viewer.contributionCents ?? 0}
+      inviteLink={inviteLink}
+      canInvite={canInvite}
+    />
+  );
+
   return (
-    <Stack gap={6}>
-      <ForYouSection
-        items={data.actionQueue}
-        nextOccasion={data.upcomingOccasions[0] ?? null}
-      />
-      <ActivePoolsSection
-        pools={data.activePools}
-        groupId={giftGroup.id}
-      />
-      <UpcomingOccasionsSection occasions={data.upcomingOccasions} />
-      <PastGiftsSection gifts={data.pastGifts} />
-      <GroupEssentialsCard
-        giftGroupId={giftGroup.id}
-        description={giftGroup.description}
-        contributionCents={viewer.contributionCents ?? 0}
-        inviteLink={inviteLink}
-        canInvite={canInvite}
-      />
-    </Stack>
+    // Desktop collapses the three tabs into one dashboard: a wide action
+    // feed on the left, a context rail (Members / Group info / Activity) on
+    // the right. Stays inside the existing max-w-6xl container — the page
+    // scrolls naturally, no independent-scroll columns. On mobile the rail
+    // simply flows under the feed and shows Group info only (Members and
+    // Activity remain their own tabs).
+    <div className="lg:grid lg:grid-cols-[minmax(0,1fr)_22rem] lg:items-start lg:gap-6">
+      <Stack gap={6}>
+        <ForYouSection
+          items={data.actionQueue}
+          nextOccasion={data.upcomingOccasions[0] ?? null}
+        />
+        <ActivePoolsSection pools={data.activePools} groupId={giftGroup.id} />
+        <UpcomingOccasionsSection occasions={data.upcomingOccasions} />
+        <PastGiftsSection gifts={data.pastGifts} />
+      </Stack>
+
+      <Stack gap={6} className="mt-6 lg:mt-0">
+        <div className="hidden lg:block">
+          <MembersRailCard
+            giftGroupId={giftGroup.id}
+            members={giftGroup.groupMembers}
+            viewerId={viewer.userId}
+            viewerRole={viewer.role as GroupRole}
+          />
+        </div>
+        {essentials}
+        <div className="hidden lg:block">
+          <ActivityRailCard />
+        </div>
+      </Stack>
+    </div>
   );
 };
 export default GiftGroupOverview;
+
+// ─── Desktop rail ────────────────────────────────────────────────────────────
+
+const MembersRailCard = ({
+  giftGroupId,
+  members,
+  viewerId,
+  viewerRole,
+}: {
+  giftGroupId: string;
+  members: ReadonlyArray<MemberListEntry>;
+  viewerId: string;
+  viewerRole: GroupRole;
+}) => (
+  <Card padding="lg">
+    <SectionHeader
+      title={`Members (${members.length})`}
+      trailing={
+        <Link
+          to={`/groups/${giftGroupId}/members`}
+          className="text-xs text-primary hover:underline"
+        >
+          Manage
+        </Link>
+      }
+    />
+    {/* Renders all members — no fixed-height scroll container. */}
+    <MembersList
+      giftGroupId={giftGroupId}
+      viewerRole={viewerRole}
+      viewerId={viewerId}
+      members={members}
+    />
+  </Card>
+);
+
+const ActivityRailCard = () => (
+  <Card padding="lg">
+    <SectionHeader title="Activity" />
+    <Stack gap={2} className="items-center px-2 py-4 text-center">
+      <span className="flex h-11 w-11 items-center justify-center rounded-full bg-muted text-muted-foreground">
+        <LuActivity size={20} />
+      </span>
+      <Text size="sm" weight="semibold">
+        No activity yet
+      </Text>
+      <Text size="xs" className="max-w-[14rem] text-muted-foreground">
+        New ideas, contributions and pool updates will show up here.
+      </Text>
+    </Stack>
+  </Card>
+);
 
 // ─── For You ─────────────────────────────────────────────────────────────────
 
@@ -697,97 +768,33 @@ const InlineBudgetEditor = ({
     e.preventDefault();
   };
 
-  const MobileEditor = (
-    <Dialog>
-      <DialogTrigger asChild>
-        {value > 0 ? (
-          <Button variant="ghost" size="sm">
-            ${dollars} <Icon name="pencil-1" className="ml-1" />
-          </Button>
-        ) : (
-          <Button size="sm">Set your budget</Button>
-        )}
-      </DialogTrigger>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>Set your budget</DialogTitle>
-        </DialogHeader>
-        <fetcher.Form
-          method="post"
-          action={`/groups/${giftGroupId}/settings`}
-          className="grid gap-3"
-          onSubmit={(e) => {
-            e.preventDefault();
-            const input = e.currentTarget.querySelector(
-              'input[name="dollars"]',
-            ) as HTMLInputElement;
-            const next = Math.max(
-              0,
-              Math.round(Number.parseFloat(input.value || '0') * 100),
-            );
-            submit(next);
-          }}
-        >
-          <input type="hidden" name="intent" value="member-update-self" />
-          <input type="hidden" name="giftGroupId" value={giftGroupId} />
-          <Label htmlFor="budget-mobile">Amount</Label>
-          <div className="relative">
-            <span className="pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 text-muted-foreground">
-              $
-            </span>
-            <Input
-              id="budget-mobile"
-              name="dollars"
-              defaultValue={dollars}
-              inputMode="decimal"
-              className="border-input bg-input-bg pl-5 text-foreground"
-              onFocus={handleFocusSelectAll}
-              onMouseUp={handleMouseUpPreserve}
-            />
-          </div>
-          <DialogFooter className="grid grid-cols-2 gap-3 sm:flex sm:justify-end">
-            <DialogClose asChild>
-              <Button type="button" variant="secondary">
-                Cancel
-              </Button>
-            </DialogClose>
-            <Button type="submit" disabled={pending}>
-              Save
-            </Button>
-          </DialogFooter>
-        </fetcher.Form>
-      </DialogContent>
-    </Dialog>
-  );
-
   if (!editing) {
+    // Read mode — a single inline affordance on all sizes (no modal for a
+    // single number; matches the PR 3 read→edit pattern).
     return (
       <div className="flex items-center gap-2">
-        <span className="sm:hidden">{MobileEditor}</span>
-        <span className="hidden items-center gap-2 sm:inline-flex">
-          {value > 0 ? (
-            <>
-              <span
-                className="text-base font-bold text-foreground"
-                data-testid="budget-amount"
-              >
-                ${dollars}
-              </span>
-              <Button
-                variant="ghost"
-                size="icon"
-                aria-label="Edit your budget"
-                onClick={() => setEditing(true)}
-              >
-                <Icon name="pencil-1" />
-              </Button>
-            </>
-          ) : (
-            <Button size="sm" onClick={() => setEditing(true)}>
-              Set your budget
+        {value > 0 ? (
+          <>
+            <span
+              className="text-base font-bold text-foreground"
+              data-testid="budget-amount"
+            >
+              ${dollars}
+            </span>
+            <Button
+              variant="ghost"
+              size="icon"
+              aria-label="Edit your budget"
+              onClick={() => setEditing(true)}
+            >
+              <Icon name="pencil-1" />
             </Button>
-          )}
-        </span>
+          </>
+        ) : (
+          <Button size="sm" onClick={() => setEditing(true)}>
+            Set your budget
+          </Button>
+        )}
       </div>
     );
   }
@@ -796,7 +803,7 @@ const InlineBudgetEditor = ({
     <fetcher.Form
       method="post"
       action={`/groups/${giftGroupId}/settings`}
-      className="hidden items-center gap-2 sm:flex"
+      className="flex items-center gap-2"
       onSubmit={(e) => {
         e.preventDefault();
         const input = e.currentTarget.querySelector(

--- a/app/routes/groups+/$giftGroupId_+/members.component.test.tsx
+++ b/app/routes/groups+/$giftGroupId_+/members.component.test.tsx
@@ -68,14 +68,6 @@ const layoutLoaderData = {
   viewer: { userId: 'viewer-1', role: 'OWNER' as const },
 };
 
-const overviewLoaderData: {
-  activePoolsByRecipient: Record<string, { id: string; title: string }>;
-} = {
-  activePoolsByRecipient: {
-    marco: { id: 'pool-1', title: "Marco's Birthday" },
-  },
-};
-
 vi.mock('react-router', async () => {
   const actual = await vi.importActual('react-router');
   return {
@@ -86,7 +78,7 @@ vi.mock('react-router', async () => {
       ...rest
     }: {
       to: string;
-      children: React.ReactNode;
+      children?: React.ReactNode;
     }) => (
       <a href={to} {...rest}>
         {children}
@@ -99,71 +91,57 @@ vi.mock('react-router', async () => {
       submit: vi.fn(),
     }),
     useFetchers: () => [],
-    useLoaderData: () => overviewLoaderData,
     useRouteLoaderData: () => layoutLoaderData,
   };
 });
 
-vi.mock('#app/components/friends/friend-action-button.tsx', () => ({
-  FriendActionButton: () => <div data-testid="friend-button" />,
-}));
-
 import GroupMembersRoute from './members.tsx';
 
-describe('Members tab — PoolActionForMember per row', () => {
-  it('shows "View pool" for members with an active pool', () => {
+describe('Members tab — reduced row', () => {
+  it('renders one row per member with name, role and birthday', () => {
     render(<GroupMembersRoute />);
-    const viewLink = screen.getByRole('link', { name: /^view pool$/i });
-    expect(viewLink).toHaveAttribute('href', '/pools/pool-1');
-    expect(viewLink).toHaveAttribute(
-      'title',
-      "View pool: Marco's Birthday",
-    );
-  });
-
-  it('omits the pool action for a member without a birthday and no active pool', () => {
-    render(<GroupMembersRoute />);
-    // Alex has no birthday and no active pool → no Start a pool link rendered.
-    // Marco's row provides the only "View pool" link — see other test.
-    const startLinks = screen.queryAllByRole('link', { name: /start a pool/i });
-    expect(startLinks).toHaveLength(0);
-  });
-
-  it('shows "Start a pool" for members with a birthday and no active pool', () => {
-    // Override the overview loader to remove the active pool entry — so
-    // Marco (who has a birthday) now needs a Start-a-pool CTA.
-    overviewLoaderData.activePoolsByRecipient = {};
-    try {
-      render(<GroupMembersRoute />);
-      const startLink = screen.getByRole('link', { name: /^start a pool$/i });
-      expect(startLink).toHaveAttribute(
-        'href',
-        '/pools/new?groupId=group-1&recipientId=marco',
-      );
-    } finally {
-      overviewLoaderData.activePoolsByRecipient = {
-        marco: { id: 'pool-1', title: "Marco's Birthday" },
-      };
-    }
-  });
-
-  it("hides the pool action on the viewer's own row", () => {
-    render(<GroupMembersRoute />);
-    // Viewer's row shows the username plus a system "you" label.
-    expect(screen.getByText('viewer')).toBeInTheDocument();
+    expect(screen.getByText('Group Members (3)')).toBeInTheDocument();
+    expect(screen.getByText('Marco')).toBeInTheDocument();
+    expect(screen.getByText('Alex')).toBeInTheDocument();
+    // Owner's own row carries a "you" system label.
     expect(screen.getByText('you')).toBeInTheDocument();
-    // Total pool action links = 1 (only Marco's "View pool").
-    const allLinks = screen.getAllByRole('link');
-    const poolLinks = allLinks.filter((link) =>
-      /^(start a pool|view pool)$/i.test((link.textContent ?? '').trim()),
-    );
-    expect(poolLinks).toHaveLength(1);
+    // Member with no birthday shows the empty state.
+    expect(screen.getByText('Birthday not set')).toBeInTheDocument();
   });
 
-  it('renders "gift budget" labels for non-viewer rows', () => {
+  it('links each row to the member profile', () => {
     render(<GroupMembersRoute />);
-    const labels = screen.getAllByText(/gift budget/i);
-    // 3 members → 3 rows → 3 labels
-    expect(labels.length).toBeGreaterThanOrEqual(3);
+    expect(
+      screen.getByRole('link', { name: /view marco's profile/i }),
+    ).toHaveAttribute('href', '/users/marco');
+  });
+
+  it('drops the budget, friend, pool and gift-history affordances', () => {
+    render(<GroupMembersRoute />);
+    expect(screen.queryByText(/gift budget/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: /start a pool/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: /view pool/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: /gift history/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /add friend|friends/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('exposes a manager menu for the owner on other members only', () => {
+    render(<GroupMembersRoute />);
+    // Owner sees a menu on marco + alex (member rows), but not on their own
+    // row. Both desktop and mobile triggers share the aria-label, so each
+    // actionable member contributes two trigger buttons.
+    const marco = screen.getAllByRole('button', { name: /actions for marco/i });
+    expect(marco.length).toBeGreaterThan(0);
+    expect(
+      screen.queryByRole('button', { name: /actions for viewer/i }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/app/routes/groups+/$giftGroupId_+/members.loader.test.ts
+++ b/app/routes/groups+/$giftGroupId_+/members.loader.test.ts
@@ -6,30 +6,20 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { toLoaderArgs } from '#tests/route-module-test-utils.ts';
 
 const requireUserIdInGroup = vi.fn();
-const poolFindMany = vi.fn();
 
 vi.mock('#app/utils/groups.server.ts', () => ({
   requireUserIdInGroup: (...args: Array<unknown>) =>
     requireUserIdInGroup(...args),
 }));
 
-vi.mock('#app/utils/db.server.ts', () => ({
-  prisma: {
-    pool: {
-      findMany: (...args: Array<unknown>) => poolFindMany(...args),
-    },
-  },
-}));
-
 import { loader } from './members.tsx';
 
 beforeEach(() => {
   requireUserIdInGroup.mockReset().mockResolvedValue('viewer-1');
-  poolFindMany.mockReset().mockResolvedValue([]);
 });
 
-describe('members tab loader — active pool cross-reference', () => {
-  it('returns an empty map when there are no active pools', async () => {
+describe('members tab loader — membership gate', () => {
+  it('requires the viewer to be a member of the group', async () => {
     const result = await loader(
       toLoaderArgs({
         context: {} as never,
@@ -38,83 +28,12 @@ describe('members tab loader — active pool cross-reference', () => {
       }),
     );
 
-    expect(result).toEqual({ activePoolsByRecipient: {} });
-  });
-
-  it('indexes active pools by recipient user id', async () => {
-    poolFindMany.mockResolvedValue([
-      { id: 'pool-1', title: "Marco's Birthday", recipientUserId: 'marco' },
-      { id: 'pool-2', title: "Leo's Graduation", recipientUserId: 'leo' },
-    ]);
-
-    const result = await loader(
-      toLoaderArgs({
-        context: {} as never,
-        params: { giftGroupId: 'group-1' },
-        request: new Request('https://giftpool.app/groups/group-1/members'),
-      }),
+    expect(requireUserIdInGroup).toHaveBeenCalledWith(
+      expect.any(Request),
+      'group-1',
     );
-
-    expect(result).toEqual({
-      activePoolsByRecipient: {
-        marco: { id: 'pool-1', title: "Marco's Birthday" },
-        leo: { id: 'pool-2', title: "Leo's Graduation" },
-      },
-    });
-  });
-
-  it('skips pools without a recipient user id (standalone / name-only recipients)', async () => {
-    poolFindMany.mockResolvedValue([
-      { id: 'pool-1', title: 'Name-only recipient', recipientUserId: null },
-      { id: 'pool-2', title: "Marco's Birthday", recipientUserId: 'marco' },
-    ]);
-
-    const result = await loader(
-      toLoaderArgs({
-        context: {} as never,
-        params: { giftGroupId: 'group-1' },
-        request: new Request('https://giftpool.app/groups/group-1/members'),
-      }),
-    );
-
-    expect(result.activePoolsByRecipient).toEqual({
-      marco: { id: 'pool-2', title: "Marco's Birthday" },
-    });
-  });
-
-  it('enforces the privacy filter in the query (recipient must not see their own pool)', async () => {
-    await loader(
-      toLoaderArgs({
-        context: {} as never,
-        params: { giftGroupId: 'group-1' },
-        request: new Request('https://giftpool.app/groups/group-1/members'),
-      }),
-    );
-
-    expect(poolFindMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: expect.objectContaining({
-          giftGroupId: 'group-1',
-          recipientUserId: { not: 'viewer-1' },
-        }),
-      }),
-    );
-  });
-
-  it('only queries non-terminal pools (not DELIVERED or CANCELLED)', async () => {
-    await loader(
-      toLoaderArgs({
-        context: {} as never,
-        params: { giftGroupId: 'group-1' },
-        request: new Request('https://giftpool.app/groups/group-1/members'),
-      }),
-    );
-
-    const call = poolFindMany.mock.calls[0]?.[0] as
-      | { where: { status: { notIn: string[] } } }
-      | undefined;
-    expect(call?.where.status.notIn).toEqual(
-      expect.arrayContaining(['DELIVERED', 'CANCELLED']),
-    );
+    // The roster itself comes from the layout loader, so this loader returns
+    // nothing of its own.
+    expect(result).toBeNull();
   });
 });

--- a/app/routes/groups+/$giftGroupId_+/members.tsx
+++ b/app/routes/groups+/$giftGroupId_+/members.tsx
@@ -3,18 +3,16 @@ import { LuGift, LuPlus } from 'react-icons/lu';
 import {
   type LoaderFunctionArgs,
   Link,
-  useFetcher,
   useFetchers,
   useLoaderData,
   useRouteLoaderData,
 } from 'react-router';
 
 import { FriendActionButton } from '#app/components/friends/friend-action-button.tsx';
+import { MemberActionsMenu } from '#app/components/groups/member-actions-menu.tsx';
 import { RoleBadge } from '#app/components/groups/RoleBadge.tsx';
 import { Avatar } from '#app/components/ui/avatar.tsx';
-import { Button } from '#app/components/ui/button.tsx';
 import { Card } from '#app/components/ui/card.tsx';
-import { Icon } from '#app/components/ui/icon.tsx';
 import { SystemLabel } from '#app/components/ui/system-label.tsx';
 import { type loader as routeLoader } from './__route.server';
 import { applyPendingSettingsMemberMutations } from './__route.shared';
@@ -69,7 +67,6 @@ const GroupMembersRoute = () => {
   const { giftGroup, viewer } = useRouteLoaderData<typeof routeLoader>(
     'routes/groups+/$giftGroupId_+/_layout',
   )!;
-  const fetcher = useFetcher();
   const fetchers = useFetchers();
   const settingsAction = `/groups/${giftGroup.id}/settings`;
   const optimisticMembers = useMemo(
@@ -93,10 +90,6 @@ const GroupMembersRoute = () => {
     optimisticMembers
       .filter((gm) => gm.user.id !== userId)
       .reduce((acc, gm) => acc + (gm.contributionCents ?? 0), 0);
-
-  const canOwner = optimisticViewerRole === 'OWNER';
-  const canAdmin =
-    optimisticViewerRole === 'OWNER' || optimisticViewerRole === 'ADMIN';
 
   return (
     <Card padding="lg">
@@ -151,138 +144,15 @@ const GroupMembersRoute = () => {
                 </div>
                 <RoleBadge role={m.role as any} />
 
-                {canOwner && !isViewer && (
-                  <div className="flex items-center gap-1">
-                    {m.role === 'MEMBER' ? (
-                      <fetcher.Form
-                        method="post"
-                        action={`/groups/${giftGroup.id}/settings`}
-                      >
-                        <input
-                          type="hidden"
-                          name="giftGroupId"
-                          value={giftGroup.id}
-                        />
-                        <input
-                          type="hidden"
-                          name="memberUserId"
-                          value={m.user.id}
-                        />
-                        <Button
-                          size="icon"
-                          variant="secondary"
-                          name="intent"
-                          value="member-promote-admin"
-                          aria-label="Promote to admin"
-                        >
-                          <Icon name="plus" />
-                        </Button>
-                      </fetcher.Form>
-                    ) : (
-                      <>
-                        <fetcher.Form
-                          method="post"
-                          action={`/groups/${giftGroup.id}/settings`}
-                        >
-                          <input
-                            type="hidden"
-                            name="giftGroupId"
-                            value={giftGroup.id}
-                          />
-                          <input
-                            type="hidden"
-                            name="memberUserId"
-                            value={m.user.id}
-                          />
-                          <Button
-                            size="icon"
-                            variant="secondary"
-                            name="intent"
-                            value="member-demote-member"
-                            aria-label="Demote to member"
-                          >
-                            <Icon name="reset" />
-                          </Button>
-                        </fetcher.Form>
-                        <fetcher.Form
-                          method="post"
-                          action={`/groups/${giftGroup.id}/settings`}
-                        >
-                          <input
-                            type="hidden"
-                            name="giftGroupId"
-                            value={giftGroup.id}
-                          />
-                          <input
-                            type="hidden"
-                            name="newOwnerUserId"
-                            value={m.user.id}
-                          />
-                          <Button
-                            size="icon"
-                            variant="secondary"
-                            name="intent"
-                            value="ownership-transfer"
-                            aria-label="Transfer ownership"
-                          >
-                            <Icon name="person" />
-                          </Button>
-                        </fetcher.Form>
-                      </>
-                    )}
-                    <fetcher.Form
-                      method="post"
-                      action={`/groups/${giftGroup.id}/settings`}
-                    >
-                      <input
-                        type="hidden"
-                        name="giftGroupId"
-                        value={giftGroup.id}
-                      />
-                      <input
-                        type="hidden"
-                        name="memberUserId"
-                        value={m.user.id}
-                      />
-                      <Button
-                        size="icon"
-                        variant="destructive"
-                        name="intent"
-                        value="member-remove"
-                        aria-label="Remove member"
-                      >
-                        <Icon name="trash" />
-                      </Button>
-                    </fetcher.Form>
-                  </div>
-                )}
-
-                {canAdmin && !canOwner && m.role === 'MEMBER' && !isViewer ? (
-                  <fetcher.Form
-                    method="post"
-                    action={`/groups/${giftGroup.id}/settings`}
-                  >
-                    <input
-                      type="hidden"
-                      name="giftGroupId"
-                      value={giftGroup.id}
-                    />
-                    <input
-                      type="hidden"
-                      name="memberUserId"
-                      value={m.user.id}
-                    />
-                    <Button
-                      size="icon"
-                      variant="destructive"
-                      name="intent"
-                      value="member-remove"
-                      aria-label="Remove member"
-                    >
-                      <Icon name="trash" />
-                    </Button>
-                  </fetcher.Form>
-                ) : null}
+                <MemberActionsMenu
+                  giftGroupId={giftGroup.id}
+                  viewerRole={optimisticViewerRole as GroupMemberRole}
+                  member={{ user: m.user, role: m.role as GroupMemberRole }}
+                  isViewer={isViewer}
+                  birthdayLabel={
+                    birthday ? `Birthday ${birthday.toLocaleDateString()}` : null
+                  }
+                />
 
                 {!isViewer ? (
                   <>

--- a/app/routes/groups+/$giftGroupId_+/members.tsx
+++ b/app/routes/groups+/$giftGroupId_+/members.tsx
@@ -1,19 +1,12 @@
 import { useMemo } from 'react';
-import { LuGift, LuPlus } from 'react-icons/lu';
 import {
   type LoaderFunctionArgs,
-  Link,
   useFetchers,
-  useLoaderData,
   useRouteLoaderData,
 } from 'react-router';
 
-import { FriendActionButton } from '#app/components/friends/friend-action-button.tsx';
-import { MemberActionsMenu } from '#app/components/groups/member-actions-menu.tsx';
-import { RoleBadge } from '#app/components/groups/RoleBadge.tsx';
-import { Avatar } from '#app/components/ui/avatar.tsx';
+import { MembersList } from '#app/components/groups/members-list.tsx';
 import { Card } from '#app/components/ui/card.tsx';
-import { SystemLabel } from '#app/components/ui/system-label.tsx';
 import { type loader as routeLoader } from './__route.server';
 import { applyPendingSettingsMemberMutations } from './__route.shared';
 
@@ -22,48 +15,14 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
   const { requireUserIdInGroup } = await import(
     '#app/utils/groups.server.ts'
   );
-  const { prisma } = await import('#app/utils/db.server.ts');
-  const { POOL_STATUS } = await import('#app/utils/pool-constants.ts');
-
-  const viewerId = await requireUserIdInGroup(request, groupId);
-
-  // Privacy: exclude pools where the viewer is the recipient — they must
-  // not be able to see a "View pool" link for their own gift pool.
-  const activePools = await prisma.pool.findMany({
-    where: {
-      giftGroupId: groupId,
-      status: {
-        notIn: [POOL_STATUS.DELIVERED, POOL_STATUS.CANCELLED],
-      },
-      recipientUserId: { not: viewerId },
-    },
-    select: {
-      id: true,
-      title: true,
-      recipientUserId: true,
-    },
-  });
-
-  const activePoolsByRecipient: Record<
-    string,
-    { id: string; title: string }
-  > = {};
-  for (const pool of activePools) {
-    if (pool.recipientUserId) {
-      activePoolsByRecipient[pool.recipientUserId] = {
-        id: pool.id,
-        title: pool.title,
-      };
-    }
-  }
-
-  return { activePoolsByRecipient };
+  // Membership gate — the roster itself comes from the layout loader.
+  await requireUserIdInGroup(request, groupId);
+  return null;
 }
 
 type GroupMemberRole = 'OWNER' | 'ADMIN' | 'MEMBER';
 
 const GroupMembersRoute = () => {
-  const { activePoolsByRecipient } = useLoaderData<typeof loader>();
   const { giftGroup, viewer } = useRouteLoaderData<typeof routeLoader>(
     'routes/groups+/$giftGroupId_+/_layout',
   )!;
@@ -86,144 +45,24 @@ const GroupMembersRoute = () => {
       ?.role ?? viewer.role;
   const totalMembers = optimisticMembers.length;
 
-  const sumBudgetForRecipient = (userId: string) =>
-    optimisticMembers
-      .filter((gm) => gm.user.id !== userId)
-      .reduce((acc, gm) => acc + (gm.contributionCents ?? 0), 0);
-
   return (
     <Card padding="lg">
       <div className="mb-1 text-lg font-semibold">
         Group Members ({totalMembers})
       </div>
       <div className="mb-4 text-sm text-muted-foreground">
-        Manage members and their gift budgets
+        Tap a member to view their profile
       </div>
-      <ul className="divide-y divide-border rounded-xl border bg-subcard">
-        {optimisticMembers.map((m) => {
-          const isViewer = m.user.id === viewer.userId;
-          const giftBudget = sumBudgetForRecipient(m.user.id);
-          const birthday = m.user.birthday
-            ? new Date(m.user.birthday as any)
-            : null;
-          const friendRelationship = m.friendRelationship ?? {
-            state: 'NONE',
-            friendshipId: null,
-            incomingRequestId: null,
-            outgoingRequestId: null,
-          };
-          const memberDisplayName = m.user.name ?? m.user.username;
-          return (
-            <li key={m.user.id} className="flex items-center gap-3 p-3">
-              <Link
-                to={`/users/${m.user.username}`}
-                className="flex items-center gap-3"
-              >
-                <Avatar size="s" image={m.user.image} user={m.user} />
-                <div>
-                  <div className="flex items-center gap-1.5 font-medium">
-                    <span>{m.user.username}</span>
-                    {isViewer ? <SystemLabel>you</SystemLabel> : null}
-                  </div>
-                  <div className="text-xs text-muted-foreground">
-                    {birthday
-                      ? `Birthday ${birthday.toLocaleDateString()}`
-                      : 'Birthday not set'}
-                  </div>
-                </div>
-              </Link>
-
-              <div className="ml-auto flex items-center gap-3">
-                <div className="text-right" title="Sum of everyone else's per-gift caps — what this person could receive">
-                  <div className="text-sm font-semibold">
-                    ${(giftBudget / 100).toFixed(2)}
-                  </div>
-                  <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
-                    gift budget
-                  </div>
-                </div>
-                <RoleBadge role={m.role as any} />
-
-                <MemberActionsMenu
-                  giftGroupId={giftGroup.id}
-                  viewerRole={optimisticViewerRole as GroupMemberRole}
-                  member={{ user: m.user, role: m.role as GroupMemberRole }}
-                  isViewer={isViewer}
-                  birthdayLabel={
-                    birthday ? `Birthday ${birthday.toLocaleDateString()}` : null
-                  }
-                />
-
-                {!isViewer ? (
-                  <>
-                    <PoolActionForMember
-                      groupId={giftGroup.id}
-                      memberId={m.user.id}
-                      memberHasBirthday={birthday !== null}
-                      activePool={activePoolsByRecipient[m.user.id] ?? null}
-                    />
-                    <Link
-                      to={`/groups/${giftGroup.id}/members/${m.user.id}/history`}
-                      aria-label={`View gift history for ${memberDisplayName}`}
-                      title={`Gifts for ${memberDisplayName}`}
-                      className="inline-flex h-8 w-8 items-center justify-center rounded-xl text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
-                    >
-                      <LuGift size={14} />
-                    </Link>
-                    <FriendActionButton
-                      targetUserId={m.user.id}
-                      targetUserName={memberDisplayName}
-                      relationship={friendRelationship}
-                      variant="compact"
-                    />
-                  </>
-                ) : null}
-              </div>
-            </li>
-          );
-        })}
-      </ul>
+      <div className="rounded-xl border bg-subcard p-1">
+        <MembersList
+          giftGroupId={giftGroup.id}
+          viewerRole={optimisticViewerRole as GroupMemberRole}
+          viewerId={viewer.userId}
+          members={optimisticMembers}
+        />
+      </div>
     </Card>
   );
 };
 
 export default GroupMembersRoute;
-
-type ActivePool = { id: string; title: string } | null;
-
-const PoolActionForMember = ({
-  groupId,
-  memberId,
-  memberHasBirthday,
-  activePool,
-}: {
-  groupId: string;
-  memberId: string;
-  memberHasBirthday: boolean;
-  activePool: ActivePool;
-}) => {
-  if (activePool) {
-    return (
-      <Link
-        to={`/pools/${activePool.id}`}
-        title={`View pool: ${activePool.title}`}
-        className="inline-flex h-8 items-center justify-center rounded-xl border border-input bg-background px-2.5 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
-      >
-        View pool
-      </Link>
-    );
-  }
-
-  if (!memberHasBirthday) return null;
-
-  return (
-    <Link
-      to={`/pools/new?groupId=${groupId}&recipientId=${memberId}`}
-      title="Start a pool for this member"
-      className="inline-flex h-8 items-center justify-center gap-1 rounded-xl border border-input bg-background px-2.5 text-xs text-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
-    >
-      <LuPlus size={12} />
-      Start a pool
-    </Link>
-  );
-};

--- a/app/routes/groups+/$giftGroupId_+/settings.action.test.ts
+++ b/app/routes/groups+/$giftGroupId_+/settings.action.test.ts
@@ -1,0 +1,81 @@
+/**
+ * @vitest-environment node
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const updateOwnPreferences = vi.fn();
+
+// settings.tsx imports the whole groups.server surface at module load — stub
+// every name so the module evaluates, and capture updateOwnPreferences.
+vi.mock('#app/utils/groups.server.ts', () => ({
+  updateOwnPreferences: (...args: Array<unknown>) =>
+    updateOwnPreferences(...args),
+  requireUserIdInGroup: vi.fn(),
+  addReminder: vi.fn(),
+  approveJoinRequest: vi.fn(),
+  banMember: vi.fn(),
+  rejectJoinRequest: vi.fn(),
+  removeMember: vi.fn(),
+  removeReminder: vi.fn(),
+  transferOwnership: vi.fn(),
+  updateGroupSettings: vi.fn(),
+  promoteToAdmin: vi.fn(),
+  demoteAdminToMember: vi.fn(),
+  deleteGiftGroup: vi.fn(),
+}));
+
+vi.mock('#app/utils/toast.server.ts', () => ({
+  createToastHeaders: vi.fn(async () => ({})),
+}));
+
+import { action } from './settings.tsx';
+
+function memberUpdateSelfRequest(fields: Record<string, string>) {
+  const formData = new FormData();
+  formData.set('intent', 'member-update-self');
+  formData.set('giftGroupId', 'group-1');
+  for (const [key, value] of Object.entries(fields)) {
+    formData.set(key, value);
+  }
+  return new Request('https://giftpool.app/groups/group-1/settings', {
+    method: 'POST',
+    body: formData,
+  });
+}
+
+describe('settings action — member-update-self is a partial update', () => {
+  beforeEach(() => updateOwnPreferences.mockReset());
+
+  it('does not reset budget visibility when only the cap is submitted', async () => {
+    // The Overview budget editor sends only contributionCents.
+    await action({
+      request: memberUpdateSelfRequest({ contributionCents: '2500' }),
+    } as never);
+
+    expect(updateOwnPreferences).toHaveBeenCalledWith(
+      expect.any(Request),
+      'group-1',
+      expect.objectContaining({
+        contributionCents: 2500,
+        // undefined => leave the stored override untouched (not 'INHERIT',
+        // which would clear an ADMINS / ONLY_SELF choice).
+        budgetVisibilityOverride: undefined,
+      }),
+    );
+  });
+
+  it('applies an explicit visibility choice from the preferences form', async () => {
+    await action({
+      request: memberUpdateSelfRequest({
+        contributionCents: '2500',
+        budgetVisibilityOverride: 'ADMINS',
+      }),
+    } as never);
+
+    expect(updateOwnPreferences).toHaveBeenCalledWith(
+      expect.any(Request),
+      'group-1',
+      expect.objectContaining({ budgetVisibilityOverride: 'ADMINS' }),
+    );
+  });
+});

--- a/app/routes/groups+/$giftGroupId_+/settings.component.test.tsx
+++ b/app/routes/groups+/$giftGroupId_+/settings.component.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const loaderDataSnapshot = {
+  canManageSettings: false,
+  canDelete: false,
+  canLeave: true,
+  viewerMember: {
+    userId: 'viewer-1',
+    role: 'MEMBER',
+    contributionCents: 3000,
+    budgetVisibilityOverride: null as string | null,
+    shareWishlist: true,
+    shareBirthday: true,
+  },
+  giftGroup: {
+    id: 'group-1',
+    name: 'The Crew',
+    description: 'Birthday pooling squad',
+    budgetVisibility: 'EVERYONE',
+    groupMembers: [] as Array<unknown>,
+    reminders: [] as Array<{ id: string; offsetDays: number }>,
+  },
+};
+
+vi.mock('react-router', async () => {
+  const actual =
+    await vi.importActual<typeof import('react-router')>('react-router');
+  return {
+    ...actual,
+    Form: (props: React.ComponentProps<'form'>) => <form {...props} />,
+    useLoaderData: () => loaderDataSnapshot,
+    useActionData: () => undefined,
+    useFetchers: () => [],
+    useFetcher: () => ({
+      Form: (props: React.ComponentProps<'form'>) => <form {...props} />,
+      data: undefined,
+      state: 'idle',
+      submit: vi.fn(),
+    }),
+  };
+});
+
+import GroupSettingsRoute from './settings.tsx';
+
+function renderRoute() {
+  return render(
+    <MemoryRouter initialEntries={['/groups/group-1/settings']}>
+      <GroupSettingsRoute />
+    </MemoryRouter>,
+  );
+}
+
+describe('group settings route', () => {
+  beforeEach(() => {
+    loaderDataSnapshot.canManageSettings = false;
+    loaderDataSnapshot.canDelete = false;
+    loaderDataSnapshot.canLeave = true;
+    loaderDataSnapshot.viewerMember.role = 'MEMBER';
+    loaderDataSnapshot.viewerMember.shareWishlist = true;
+    loaderDataSnapshot.viewerMember.shareBirthday = true;
+    loaderDataSnapshot.giftGroup.groupMembers = [];
+  });
+
+  it('shows a plain member their preferences but no admin sections (P7.5)', () => {
+    renderRoute();
+    expect(
+      screen.getByRole('heading', { name: 'Your preferences' }),
+    ).toBeInTheDocument();
+    // Admin-only surfaces must not render for a member.
+    expect(
+      screen.queryByRole('heading', { name: 'Group settings' }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText('Member Actions')).not.toBeInTheDocument();
+    expect(screen.queryByText('Danger Zone')).not.toBeInTheDocument();
+    // Leaving is a member action — still available.
+    expect(
+      screen.getByRole('button', { name: /leave group/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('shows managers the admin sections alongside their preferences', () => {
+    loaderDataSnapshot.canManageSettings = true;
+    loaderDataSnapshot.canDelete = true;
+    loaderDataSnapshot.viewerMember.role = 'OWNER';
+    renderRoute();
+    expect(
+      screen.getByRole('heading', { name: 'Your preferences' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Group settings' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Member Actions')).toBeInTheDocument();
+    expect(screen.getByText('Danger Zone')).toBeInTheDocument();
+  });
+
+  it('opens preferences in read mode and reveals the form on Edit', () => {
+    renderRoute();
+    // Read mode shows current sharing state, no checkboxes yet.
+    expect(screen.getAllByText('Shared with group').length).toBeGreaterThan(0);
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    expect(
+      screen.getByRole('checkbox', { name: /share my wishlist/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('lets a member turn sharing OFF — unchecking persists false', () => {
+    renderRoute();
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+
+    const readHidden = () =>
+      (
+        document.querySelector(
+          'input[type="hidden"][name="shareWishlist"]',
+        ) as HTMLInputElement
+      ).value;
+    expect(readHidden()).toBe('true');
+
+    const checkbox = screen.getByRole('checkbox', {
+      name: /share my wishlist/i,
+    }) as HTMLInputElement;
+    fireEvent.click(checkbox);
+    expect(checkbox).not.toBeChecked();
+    expect(readHidden()).toBe('false');
+  });
+});

--- a/app/routes/groups+/$giftGroupId_+/settings.tsx
+++ b/app/routes/groups+/$giftGroupId_+/settings.tsx
@@ -385,8 +385,11 @@ export async function action({ request }: ActionFunctionArgs) {
         contributionCents: v.contributionCents
           ? Number.parseInt(v.contributionCents, 10)
           : undefined,
-        budgetVisibilityOverride: (v.budgetVisibilityOverride ??
-          'INHERIT') as any,
+        // Pass through as-is so this stays a partial update: the Overview
+        // budget editor submits only contributionCents, and must NOT reset a
+        // member's chosen visibility (ADMINS / ONLY_SELF) to INHERIT. An
+        // explicit 'INHERIT' from the preferences form still clears it.
+        budgetVisibilityOverride: v.budgetVisibilityOverride as any,
         // Explicit booleans so a member can turn sharing OFF, not just on.
         shareWishlist:
           v.shareWishlist === undefined

--- a/app/routes/groups+/$giftGroupId_+/settings.tsx
+++ b/app/routes/groups+/$giftGroupId_+/settings.tsx
@@ -456,8 +456,6 @@ const GroupSettingsRoute = () => {
   const canDemote = optimisticViewerRole === 'OWNER';
   const canRemove =
     optimisticViewerRole === 'OWNER' || optimisticViewerRole === 'ADMIN';
-  const canBan =
-    optimisticViewerRole === 'OWNER' || optimisticViewerRole === 'ADMIN';
   return (
     <div className="space-y-6">
       {/* Your preferences — visible & editable by every member (P7.5) */}
@@ -496,7 +494,7 @@ const GroupSettingsRoute = () => {
           <div className="rounded-2xl border bg-card p-4 sm:p-6">
             <div className="mb-1 text-lg font-semibold">Member Actions</div>
             <div className="mb-4 text-sm text-muted-foreground">
-              Promote or demote admins, remove or ban members
+              Promote or demote admins, remove members
             </div>
             <ul className="divide-y divide-border rounded-md border">
               {optimisticMembers.map((m: any) => {
@@ -515,9 +513,6 @@ const GroupSettingsRoute = () => {
                         </div>
                         <div className="mt-0.5 flex items-center gap-2 text-xs text-muted-foreground">
                           <RoleBadge role={m.role} />
-                          {m.bannedUntil ? (
-                            <span className="text-destructive">Banned</span>
-                          ) : null}
                         </div>
                       </div>
                     </div>
@@ -577,9 +572,7 @@ const GroupSettingsRoute = () => {
                       <MemberActions
                         giftGroupId={giftGroup.id}
                         memberUserId={m.userId}
-                        bannedUntil={m.bannedUntil}
                         canRemove={canRemove && !isViewer}
-                        canBan={canBan && !isViewer}
                       />
                     </div>
                   </li>
@@ -757,15 +750,11 @@ const SettingsCard = ({
 const MemberActions = ({
   giftGroupId,
   memberUserId,
-  bannedUntil,
   canRemove,
-  canBan,
 }: {
   giftGroupId: string;
   memberUserId: string;
-  bannedUntil: string | null;
   canRemove: boolean;
-  canBan: boolean;
 }) => {
   const fetcher = useFetcher<typeof action>();
   const settingsAction = `/groups/${giftGroupId}/settings`;
@@ -782,38 +771,6 @@ const MemberActions = ({
           >
             Remove
           </Button>
-        </fetcher.Form>
-      )}
-      {canBan && (
-        <fetcher.Form method="post" action={settingsAction}>
-          <input type="hidden" name="giftGroupId" value={giftGroupId} />
-          <input type="hidden" name="memberUserId" value={memberUserId} />
-          {bannedUntil ? (
-            <Button
-              name="intent"
-              value={SettingsIntent.MemberBan}
-              variant="secondary"
-            >
-              Unban
-            </Button>
-          ) : (
-            <>
-              <input
-                type="hidden"
-                name="until"
-                value={new Date(
-                  Date.now() + 1000 * 60 * 60 * 24 * 7,
-                ).toISOString()}
-              />
-              <Button
-                name="intent"
-                value={SettingsIntent.MemberBan}
-                variant="secondary"
-              >
-                Ban 7 days
-              </Button>
-            </>
-          )}
         </fetcher.Form>
       )}
     </div>

--- a/app/routes/groups+/$giftGroupId_+/settings.tsx
+++ b/app/routes/groups+/$giftGroupId_+/settings.tsx
@@ -14,9 +14,14 @@ import {
   useActionData,
   useFetcher,
   useFetchers,
-  useLoaderData
+  useLoaderData,
 } from 'react-router';
 import { z } from 'zod';
+import {
+  EditableSection,
+  ReadField,
+  useExitOnSubmitSuccess,
+} from '#app/components/editable-section.tsx';
 import { ErrorList } from '#app/components/forms.tsx';
 import { RoleBadge } from '#app/components/groups/RoleBadge.tsx';
 import { Avatar } from '#app/components/ui/avatar.tsx';
@@ -58,7 +63,6 @@ import {
   updateOwnPreferences,
   deleteGiftGroup,
 } from '#app/utils/groups.server.ts';
-import { cn } from '#app/utils/misc.tsx';
 import { createToastHeaders } from '#app/utils/toast.server.ts';
 import { applyPendingSettingsMemberMutations } from './__route.shared';
 export async function loader({ params, request }: LoaderFunctionArgs) {
@@ -141,65 +145,20 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
       url: getInviteLink(inv.code, request),
     })),
   };
-  const canManageInvites = await userHasGroupPermission(
-    userId,
-    groupId,
-    'manageInvites',
-  );
+  // Settings is reachable by every member (the gear links here for all roles),
+  // so these flags decide which admin sections render — not whether the page
+  // loads. A plain member sees only "Your preferences".
   const canManageSettings = await userHasGroupPermission(
     userId,
     groupId,
     'manageSettings',
   );
-  const canPromote = await userHasGroupPermission(
-    userId,
-    groupId,
-    'promoteAdmin',
-  );
-  const canDemote = await userHasGroupPermission(
-    userId,
-    groupId,
-    'demoteAdmin',
-  );
-  const canRemove = await userHasGroupPermission(
-    userId,
-    groupId,
-    'removeMember',
-  );
-  const canBan = await userHasGroupPermission(userId, groupId, 'banMember');
   const canLeave = await userHasGroupPermission(userId, groupId, 'leaveGroup');
-  const canTransfer = await userHasGroupPermission(
-    userId,
-    groupId,
-    'transferOwnership',
-  );
   const canDelete = await userHasGroupPermission(
     userId,
     groupId,
     'deleteGroup',
   );
-  const joinRequests = await prisma.joinRequest.findMany({
-    where: {
-      giftGroupId: groupId,
-      status: 'PENDING',
-    },
-    select: {
-      id: true,
-      user: {
-        select: {
-          id: true,
-          username: true,
-          name: true,
-          image: {
-            select: {
-              id: true,
-              altText: true,
-            },
-          },
-        },
-      },
-    },
-  });
   const viewerMemberRaw = await prisma.usersInGiftGroups.findUnique({
     where: {
       userId_giftGroupId: {
@@ -224,40 +183,18 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
         ) as GroupRole,
       } as const)
     : null;
-  const activities = await prisma.groupActivity.findMany({
-    where: {
-      giftGroupId: groupId,
-    },
-    orderBy: {
-      createdAt: 'desc',
-    },
-    take: 10,
-    select: {
-      id: true,
-      type: true,
-      payload: true,
-      createdAt: true,
-      actor: {
-        select: {
-          username: true,
-        },
-      },
-    },
-  });
+  // Non-managers must not receive other members' contribution / visibility /
+  // sharing settings or the admin roster — strip them so a member's payload
+  // carries only their own preferences (P7.5 privacy).
+  const giftGroupForViewer = canManageSettings
+    ? giftGroup
+    : { ...giftGroup, groupMembers: [], groupInvitations: [], reminders: [] };
   return {
-    giftGroup,
-    canManageInvites,
+    giftGroup: giftGroupForViewer,
     canManageSettings,
-    canPromote,
-    canDemote,
-    canRemove,
-    canBan,
-    canTransfer,
     canDelete,
     canLeave,
-    joinRequests,
     viewerMember,
-    activities,
   };
 }
 export enum SettingsIntent {
@@ -450,16 +387,26 @@ export async function action({ request }: ActionFunctionArgs) {
           : undefined,
         budgetVisibilityOverride: (v.budgetVisibilityOverride ??
           'INHERIT') as any,
-        shareWishlist: v.shareWishlist === 'on' ? true : undefined,
-        shareBirthday: v.shareBirthday === 'on' ? true : undefined,
+        // Explicit booleans so a member can turn sharing OFF, not just on.
+        shareWishlist:
+          v.shareWishlist === undefined
+            ? undefined
+            : v.shareWishlist === 'true',
+        shareBirthday:
+          v.shareBirthday === undefined
+            ? undefined
+            : v.shareBirthday === 'true',
       });
-      return data(submission.reply(), {
-        headers: await createToastHeaders({
-          type: 'success',
-          title: 'Saved',
-          description: 'Your preferences have been saved.',
-        }),
-      });
+      return data(
+        { ...submission.reply(), ok: true },
+        {
+          headers: await createToastHeaders({
+            type: 'success',
+            title: 'Saved',
+            description: 'Your preferences have been saved.',
+          }),
+        },
+      );
     }
     case SettingsIntent.DeleteGroup: {
       await deleteGiftGroup(request, {
@@ -482,7 +429,7 @@ export async function action({ request }: ActionFunctionArgs) {
   }
 }
 const GroupSettingsRoute = () => {
-  const { giftGroup, canDelete, canLeave, viewerMember } =
+  const { giftGroup, canManageSettings, canDelete, canLeave, viewerMember } =
     useLoaderData<typeof loader>();
   const actionData = useActionData<typeof action>();
   const fetchers = useFetchers();
@@ -513,179 +460,179 @@ const GroupSettingsRoute = () => {
     optimisticViewerRole === 'OWNER' || optimisticViewerRole === 'ADMIN';
   return (
     <div className="space-y-6">
-      <div className="rounded-2xl border bg-card p-4 sm:p-6">
-        <div className="mb-1 text-lg font-semibold">Group Settings</div>
-        <div className="mb-4 text-sm text-muted-foreground">
-          Configure how the group operates
-        </div>
-        <SettingsForm giftGroup={giftGroup} lastResult={actionData} />
-        <div className="my-4 h-px w-full bg-border" />
-        <RemindersSection giftGroup={giftGroup} />
-      </div>
-
-      {/* Member preferences (self) */}
+      {/* Your preferences — visible & editable by every member (P7.5) */}
       {viewerMember ? (
-        <div className="rounded-2xl border bg-card p-4 sm:p-6">
-          <div className="mb-1 text-lg font-semibold">Your Preferences</div>
-          <div className="mb-4 text-sm text-muted-foreground">
-            Control your budget visibility and sharing settings for this group
-          </div>
-          <MemberPreferencesForm
-            giftGroupId={giftGroup.id}
-            prefs={viewerMember}
-          />
-        </div>
+        <MemberPreferencesCard
+          giftGroupId={giftGroup.id}
+          prefs={viewerMember}
+        />
       ) : null}
 
-      {/* Transfer ownership */}
-      {canTransfer ? (
-        <div className="rounded-2xl border bg-card p-4 sm:p-6">
-          <div className="mb-1 text-lg font-semibold">Transfer Ownership</div>
-          <div className="mb-4 text-sm text-muted-foreground">
-            Make another admin the owner of this group
+      {/* Admin controls — a separate surface, only for managers */}
+      {canManageSettings ? (
+        <>
+          <SettingsCard giftGroup={giftGroup} lastResult={actionData} />
+          <div className="rounded-2xl border bg-card p-4 sm:p-6">
+            <RemindersSection giftGroup={giftGroup} />
           </div>
-          <TransferOwnershipForm
-            giftGroupId={giftGroup.id}
-            members={optimisticMembers}
-          />
-        </div>
-      ) : null}
 
-      {/* Member management */}
-      <div className="rounded-2xl border bg-card p-4 sm:p-6">
-        <div className="mb-1 text-lg font-semibold">Member Actions</div>
-        <div className="mb-4 text-sm text-muted-foreground">
-          Promote or demote admins, remove or ban members
-        </div>
-        <ul className="divide-y divide-border rounded-md border">
-          {optimisticMembers.map((m: any) => {
-            const isViewer = m.userId === viewerMember?.userId;
-            return (
-              <li
-                key={m.userId}
-                className="flex flex-wrap items-center gap-3 p-3 sm:flex-nowrap"
-              >
-                <div className="flex min-w-0 flex-1 items-center gap-3">
-                  <Avatar size="s" image={m.user.image} user={m.user} />
-                  <div className="min-w-0">
-                    <div className="flex items-center gap-1.5 font-medium">
-                      <span className="truncate">{m.user.username}</span>
-                      {isViewer ? <SystemLabel>you</SystemLabel> : null}
-                    </div>
-                    <div className="mt-0.5 flex items-center gap-2 text-xs text-muted-foreground">
-                      <RoleBadge role={m.role} />
-                      {m.bannedUntil ? (
-                        <span className="text-destructive">Banned</span>
-                      ) : null}
-                    </div>
-                  </div>
-                </div>
-                <div className="flex flex-wrap items-center gap-2">
-                  {/* Promote / Demote (owner only) */}
-                  {canPromote && m.role === 'MEMBER' && !isViewer ? (
-                    <memberActionFetcher.Form
-                      method="post"
-                      action={settingsAction}
-                    >
-                      <input
-                        type="hidden"
-                        name="giftGroupId"
-                        value={giftGroup.id}
-                      />
-                      <input
-                        type="hidden"
-                        name="memberUserId"
-                        value={m.userId}
-                      />
-                      <Button
-                        size="sm"
-                        variant="secondary"
-                        name="intent"
-                        value={SettingsIntent.MemberPromoteAdmin}
-                      >
-                        Promote to Admin
-                      </Button>
-                    </memberActionFetcher.Form>
-                  ) : null}
-                  {canDemote && m.role === 'ADMIN' && !isViewer ? (
-                    <memberActionFetcher.Form
-                      method="post"
-                      action={settingsAction}
-                    >
-                      <input
-                        type="hidden"
-                        name="giftGroupId"
-                        value={giftGroup.id}
-                      />
-                      <input
-                        type="hidden"
-                        name="memberUserId"
-                        value={m.userId}
-                      />
-                      <Button
-                        size="sm"
-                        variant="secondary"
-                        name="intent"
-                        value={SettingsIntent.MemberDemoteMember}
-                      >
-                        Demote to Member
-                      </Button>
-                    </memberActionFetcher.Form>
-                  ) : null}
-
-                  <MemberActions
-                    giftGroupId={giftGroup.id}
-                    memberUserId={m.userId}
-                    bannedUntil={m.bannedUntil}
-                    canRemove={canRemove && !isViewer}
-                    canBan={canBan && !isViewer}
-                  />
-                </div>
-              </li>
-            );
-          })}
-        </ul>
-      </div>
-
-      {canDelete ? (
-        <div className="rounded-2xl border bg-card p-4 sm:p-6">
-          <div className="rounded-md bg-destructive/10 p-4">
-            <div className="mb-1 font-semibold text-destructive">
-              Danger Zone
-            </div>
-            <div className="mb-3 text-sm text-destructive/80">
-              These actions cannot be undone. Please be careful. As the owner,
-              you can't leave directly — transfer ownership first or delete
-              the group.
-            </div>
-            <Form method="post" id="delete-group-form">
-              <input type="hidden" name="giftGroupId" value={giftGroup.id} />
-              <input
-                type="hidden"
-                name="intent"
-                value={SettingsIntent.DeleteGroup}
+          {/* Transfer ownership */}
+          {canTransfer ? (
+            <div className="rounded-2xl border bg-card p-4 sm:p-6">
+              <div className="mb-1 text-lg font-semibold">
+                Transfer Ownership
+              </div>
+              <div className="mb-4 text-sm text-muted-foreground">
+                Make another admin the owner of this group
+              </div>
+              <TransferOwnershipForm
+                giftGroupId={giftGroup.id}
+                members={optimisticMembers}
               />
-            </Form>
-            <ConfirmDialog
-              title="Delete Group"
-              description={
-                <div>Type DELETE to confirm. This cannot be undone.</div>
-              }
-              confirmText="Delete"
-              requireText="DELETE"
-              onConfirm={() => {
-                const form = document.getElementById(
-                  'delete-group-form',
-                ) as HTMLFormElement;
-                form?.requestSubmit();
-              }}
-            >
-              <Button variant="destructive">
-                <Icon name="trash" className="mr-2" /> Delete Group
-              </Button>
-            </ConfirmDialog>
+            </div>
+          ) : null}
+
+          {/* Member management */}
+          <div className="rounded-2xl border bg-card p-4 sm:p-6">
+            <div className="mb-1 text-lg font-semibold">Member Actions</div>
+            <div className="mb-4 text-sm text-muted-foreground">
+              Promote or demote admins, remove or ban members
+            </div>
+            <ul className="divide-y divide-border rounded-md border">
+              {optimisticMembers.map((m: any) => {
+                const isViewer = m.userId === viewerMember?.userId;
+                return (
+                  <li
+                    key={m.userId}
+                    className="flex flex-wrap items-center gap-3 p-3 sm:flex-nowrap"
+                  >
+                    <div className="flex min-w-0 flex-1 items-center gap-3">
+                      <Avatar size="s" image={m.user.image} user={m.user} />
+                      <div className="min-w-0">
+                        <div className="flex items-center gap-1.5 font-medium">
+                          <span className="truncate">{m.user.username}</span>
+                          {isViewer ? <SystemLabel>you</SystemLabel> : null}
+                        </div>
+                        <div className="mt-0.5 flex items-center gap-2 text-xs text-muted-foreground">
+                          <RoleBadge role={m.role} />
+                          {m.bannedUntil ? (
+                            <span className="text-destructive">Banned</span>
+                          ) : null}
+                        </div>
+                      </div>
+                    </div>
+                    <div className="flex flex-wrap items-center gap-2">
+                      {/* Promote / Demote (owner only) */}
+                      {canPromote && m.role === 'MEMBER' && !isViewer ? (
+                        <memberActionFetcher.Form
+                          method="post"
+                          action={settingsAction}
+                        >
+                          <input
+                            type="hidden"
+                            name="giftGroupId"
+                            value={giftGroup.id}
+                          />
+                          <input
+                            type="hidden"
+                            name="memberUserId"
+                            value={m.userId}
+                          />
+                          <Button
+                            size="sm"
+                            variant="secondary"
+                            name="intent"
+                            value={SettingsIntent.MemberPromoteAdmin}
+                          >
+                            Promote to Admin
+                          </Button>
+                        </memberActionFetcher.Form>
+                      ) : null}
+                      {canDemote && m.role === 'ADMIN' && !isViewer ? (
+                        <memberActionFetcher.Form
+                          method="post"
+                          action={settingsAction}
+                        >
+                          <input
+                            type="hidden"
+                            name="giftGroupId"
+                            value={giftGroup.id}
+                          />
+                          <input
+                            type="hidden"
+                            name="memberUserId"
+                            value={m.userId}
+                          />
+                          <Button
+                            size="sm"
+                            variant="secondary"
+                            name="intent"
+                            value={SettingsIntent.MemberDemoteMember}
+                          >
+                            Demote to Member
+                          </Button>
+                        </memberActionFetcher.Form>
+                      ) : null}
+
+                      <MemberActions
+                        giftGroupId={giftGroup.id}
+                        memberUserId={m.userId}
+                        bannedUntil={m.bannedUntil}
+                        canRemove={canRemove && !isViewer}
+                        canBan={canBan && !isViewer}
+                      />
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
           </div>
-        </div>
+
+          {canDelete ? (
+            <div className="rounded-2xl border bg-card p-4 sm:p-6">
+              <div className="rounded-md bg-destructive/10 p-4">
+                <div className="mb-1 font-semibold text-destructive">
+                  Danger Zone
+                </div>
+                <div className="mb-3 text-sm text-destructive/80">
+                  These actions cannot be undone. Please be careful. As the
+                  owner, you can't leave directly — transfer ownership first or
+                  delete the group.
+                </div>
+                <Form method="post" id="delete-group-form">
+                  <input
+                    type="hidden"
+                    name="giftGroupId"
+                    value={giftGroup.id}
+                  />
+                  <input
+                    type="hidden"
+                    name="intent"
+                    value={SettingsIntent.DeleteGroup}
+                  />
+                </Form>
+                <ConfirmDialog
+                  title="Delete Group"
+                  description={
+                    <div>Type DELETE to confirm. This cannot be undone.</div>
+                  }
+                  confirmText="Delete"
+                  requireText="DELETE"
+                  onConfirm={() => {
+                    const form = document.getElementById(
+                      'delete-group-form',
+                    ) as HTMLFormElement;
+                    form?.requestSubmit();
+                  }}
+                >
+                  <Button variant="destructive">
+                    <Icon name="trash" className="mr-2" /> Delete Group
+                  </Button>
+                </ConfirmDialog>
+              </div>
+            </div>
+          ) : null}
+        </>
       ) : null}
 
       {canLeave ? (
@@ -721,16 +668,21 @@ const GroupSettingsRoute = () => {
   );
 };
 export default GroupSettingsRoute;
-const SettingsForm = ({
+const SettingsCard = ({
   giftGroup,
   lastResult,
 }: {
   giftGroup: any;
   lastResult: any;
 }) => {
+  const fetcher = useFetcher<typeof action>();
+  const [editing, setEditing] = React.useState(false);
+  const stopEditing = React.useCallback(() => setEditing(false), []);
   const [form] = useForm<z.input<typeof UpdateSettingsSchema>>({
     id: 'settings-form',
-    lastResult: lastResult as unknown as SubmissionResult<string[]>,
+    lastResult: (fetcher.data ?? lastResult) as unknown as SubmissionResult<
+      string[]
+    >,
     constraint: getZodConstraint(UpdateSettingsSchema),
     onValidate({ formData }) {
       return parseWithZod(formData, {
@@ -743,30 +695,63 @@ const SettingsForm = ({
       budgetVisibility: giftGroup.budgetVisibility,
     },
   });
+  useExitOnSubmitSuccess({
+    state: fetcher.state,
+    success: form.status === 'success',
+    onExit: stopEditing,
+  });
   return (
-    <Form method="post" {...getFormProps(form)} className="grid gap-3">
-      <input type="hidden" name="giftGroupId" value={giftGroup.id} />
-      {/* keep budget visibility using hidden to satisfy schema */}
-      <input
-        type="hidden"
-        name="budgetVisibility"
-        value={giftGroup.budgetVisibility}
-      />
-      <Label htmlFor="name">Group Name</Label>
-      <Input name="name" defaultValue={giftGroup.name} />
-      <Label htmlFor="description">Description</Label>
-      <Textarea name="description" defaultValue={giftGroup.description ?? ''} />
-      <div className="flex items-center justify-end">
-        <Button
-          name="intent"
-          value={SettingsIntent.UpdateSettings}
-          type="submit"
-        >
-          Save
-        </Button>
-      </div>
-      <ErrorList errors={form.errors} id={form.errorId} />
-    </Form>
+    <EditableSection
+      title="Group settings"
+      description="Name and description for this group."
+      editing={editing}
+      onEdit={() => setEditing(true)}
+      read={
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <ReadField label="Name" value={giftGroup.name} />
+          <ReadField
+            label="Description"
+            value={giftGroup.description || 'No description'}
+            className="sm:col-span-2"
+          />
+        </div>
+      }
+    >
+      <fetcher.Form
+        method="post"
+        {...getFormProps(form)}
+        className="grid gap-3"
+      >
+        <input type="hidden" name="giftGroupId" value={giftGroup.id} />
+        {/* keep budget visibility using hidden to satisfy schema */}
+        <input
+          type="hidden"
+          name="budgetVisibility"
+          value={giftGroup.budgetVisibility}
+        />
+        <Label htmlFor="name">Group name</Label>
+        <Input id="name" name="name" defaultValue={giftGroup.name} />
+        <Label htmlFor="description">Description</Label>
+        <Textarea
+          id="description"
+          name="description"
+          defaultValue={giftGroup.description ?? ''}
+        />
+        <div className="flex items-center justify-end gap-2">
+          <Button type="button" variant="ghost" onClick={stopEditing}>
+            Cancel
+          </Button>
+          <Button
+            name="intent"
+            value={SettingsIntent.UpdateSettings}
+            type="submit"
+          >
+            Save
+          </Button>
+        </div>
+        <ErrorList errors={form.errors} id={form.errorId} />
+      </fetcher.Form>
+    </EditableSection>
   );
 };
 const MemberActions = ({
@@ -835,8 +820,6 @@ const MemberActions = ({
   );
 };
 const RemindersSection = ({ giftGroup }: { giftGroup: any }) => {
-  const [emailOn, setEmailOn] = React.useState<boolean>(true);
-  const [pushOn, setPushOn] = React.useState<boolean>(false);
   return (
     <div className="space-y-4">
       <div>
@@ -877,58 +860,6 @@ const RemindersSection = ({ giftGroup }: { giftGroup: any }) => {
           day thresholds
         </div>
       </div>
-      <div className="grid gap-4">
-        <div className="flex items-center justify-between">
-          <div>
-            <div className="font-medium">Email Reminders</div>
-            <div className="text-sm text-muted-foreground">
-              Send email notifications for upcoming birthdays
-            </div>
-          </div>
-          <button
-            type="button"
-            role="switch"
-            aria-checked={emailOn}
-            onClick={() => setEmailOn((v) => !v)}
-            className={cn(
-              'h-6 w-11 rounded-full p-0.5 transition-colors',
-              emailOn ? 'bg-primary' : 'bg-muted',
-            )}
-          >
-            <span
-              className={cn(
-                'block h-5 w-5 rounded-full bg-background transition-transform',
-                emailOn ? 'translate-x-5' : 'translate-x-0',
-              )}
-            />
-          </button>
-        </div>
-        <div className="flex items-center justify-between">
-          <div>
-            <div className="font-medium">Push Notifications</div>
-            <div className="text-sm text-muted-foreground">
-              Send push notifications for upcoming birthdays
-            </div>
-          </div>
-          <button
-            type="button"
-            role="switch"
-            aria-checked={pushOn}
-            onClick={() => setPushOn((v) => !v)}
-            className={cn(
-              'h-6 w-11 rounded-full p-0.5 transition-colors',
-              pushOn ? 'bg-primary' : 'bg-muted',
-            )}
-          >
-            <span
-              className={cn(
-                'block h-5 w-5 rounded-full bg-background transition-transform',
-                pushOn ? 'translate-x-5' : 'translate-x-0',
-              )}
-            />
-          </button>
-        </div>
-      </div>
       <ul className="space-y-1">
         {giftGroup.reminders.map((r: any) => (
           <li
@@ -957,74 +888,138 @@ const RemindersSection = ({ giftGroup }: { giftGroup: any }) => {
 
 // GiftPlansSection removed (unused)
 
-const MemberPreferencesForm = ({
+const BUDGET_VISIBILITY_LABELS: Record<string, string> = {
+  INHERIT: 'Inherit group setting',
+  EVERYONE: 'Everyone',
+  ADMINS: 'Admins',
+  ONLY_SELF: 'Only self',
+};
+
+// Every member can see and edit their own preferences here, regardless of role
+// (P7.5). Contribution stays on the group Overview's dollar editor; this card
+// owns budget visibility + what you share with the group.
+const MemberPreferencesCard = ({
   giftGroupId,
   prefs,
 }: {
   giftGroupId: string;
   prefs: any;
 }) => {
-  const [form] = useForm({
-    id: 'member-prefs',
-    defaultValue: {
-      contributionCents: String(prefs?.contributionCents ?? 0),
-      budgetVisibilityOverride: prefs?.budgetVisibilityOverride ?? 'INHERIT',
-      shareWishlist: prefs?.shareWishlist ? 'on' : '',
-      shareBirthday: prefs?.shareBirthday ? 'on' : '',
-    },
+  const fetcher = useFetcher<typeof action>();
+  const [editing, setEditing] = React.useState(false);
+  const stopEditing = React.useCallback(() => setEditing(false), []);
+  const currentVisibility = prefs?.budgetVisibilityOverride ?? 'INHERIT';
+  const [shareWishlist, setShareWishlist] = React.useState(
+    !!prefs?.shareWishlist,
+  );
+  const [shareBirthday, setShareBirthday] = React.useState(
+    !!prefs?.shareBirthday,
+  );
+
+  const startEditing = () => {
+    // Reset drafts to stored values each time we open the editor.
+    setShareWishlist(!!prefs?.shareWishlist);
+    setShareBirthday(!!prefs?.shareBirthday);
+    setEditing(true);
+  };
+
+  const saved = Boolean((fetcher.data as { ok?: boolean } | undefined)?.ok);
+  useExitOnSubmitSuccess({
+    state: fetcher.state,
+    success: saved,
+    onExit: stopEditing,
   });
+
   return (
-    <Form
-      method="post"
-      {...getFormProps(form)}
-      className="grid gap-2 rounded-md border p-3"
+    <EditableSection
+      title="Your preferences"
+      description="Your budget visibility and sharing settings for this group."
+      editing={editing}
+      onEdit={startEditing}
+      read={
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <ReadField
+            label="Budget visibility"
+            value={
+              BUDGET_VISIBILITY_LABELS[currentVisibility] ??
+              'Inherit group setting'
+            }
+          />
+          <ReadField
+            label="Share wishlist"
+            value={prefs?.shareWishlist ? 'Shared with group' : 'Hidden'}
+          />
+          <ReadField
+            label="Share birthday"
+            value={prefs?.shareBirthday ? 'Shared with group' : 'Hidden'}
+          />
+        </div>
+      }
     >
-      <input type="hidden" name="giftGroupId" value={giftGroupId} />
-      <input
-        type="hidden"
-        name="intent"
-        value={SettingsIntent.MemberUpdateSelf}
-      />
-      <Label>Contribution (USD cents)</Label>
-      <Input
-        name="contributionCents"
-        defaultValue={String(prefs?.contributionCents ?? 0)}
-      />
-      <Label>Budget visibility override</Label>
-      <Select
-        name="budgetVisibilityOverride"
-        defaultValue={prefs?.budgetVisibilityOverride ?? 'INHERIT'}
+      <fetcher.Form
+        method="post"
+        action={`/groups/${giftGroupId}/settings`}
+        className="grid gap-3"
       >
-        <SelectTrigger>
-          <SelectValue placeholder="Inherit group setting" />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value="INHERIT">Inherit group setting</SelectItem>
-          <SelectItem value="EVERYONE">Everyone</SelectItem>
-          <SelectItem value="ADMINS">Admins</SelectItem>
-          <SelectItem value="ONLY_SELF">Only self</SelectItem>
-        </SelectContent>
-      </Select>
-      <div className="flex items-center gap-2">
+        <input type="hidden" name="giftGroupId" value={giftGroupId} />
         <input
-          type="checkbox"
-          id="prefs-share-wishlist"
+          type="hidden"
+          name="intent"
+          value={SettingsIntent.MemberUpdateSelf}
+        />
+        {/* Controlled hidden inputs so unchecking persists `false` (the old
+            checkbox-only form could never turn sharing off). */}
+        <input
+          type="hidden"
           name="shareWishlist"
-          defaultChecked={!!prefs?.shareWishlist}
+          value={shareWishlist ? 'true' : 'false'}
         />
-        <Label htmlFor="prefs-share-wishlist">Share wishlist</Label>
-      </div>
-      <div className="flex items-center gap-2">
         <input
-          type="checkbox"
-          id="prefs-share-birthday"
+          type="hidden"
           name="shareBirthday"
-          defaultChecked={!!prefs?.shareBirthday}
+          value={shareBirthday ? 'true' : 'false'}
         />
-        <Label htmlFor="prefs-share-birthday">Share birthday</Label>
-      </div>
-      <Button type="submit">Save Preferences</Button>
-    </Form>
+        <div className="grid gap-1.5">
+          <Label htmlFor="budgetVisibilityOverride">Budget visibility</Label>
+          <Select
+            name="budgetVisibilityOverride"
+            defaultValue={currentVisibility}
+          >
+            <SelectTrigger id="budgetVisibilityOverride">
+              <SelectValue placeholder="Inherit group setting" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="INHERIT">Inherit group setting</SelectItem>
+              <SelectItem value="EVERYONE">Everyone</SelectItem>
+              <SelectItem value="ADMINS">Admins</SelectItem>
+              <SelectItem value="ONLY_SELF">Only self</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={shareWishlist}
+            onChange={(e) => setShareWishlist(e.currentTarget.checked)}
+          />
+          Share my wishlist with this group
+        </label>
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={shareBirthday}
+            onChange={(e) => setShareBirthday(e.currentTarget.checked)}
+          />
+          Share my birthday with this group
+        </label>
+        <div className="flex items-center justify-end gap-2">
+          <Button type="button" variant="ghost" onClick={stopEditing}>
+            Cancel
+          </Button>
+          <Button type="submit">Save</Button>
+        </div>
+      </fetcher.Form>
+    </EditableSection>
   );
 };
 const TransferOwnershipForm = ({

--- a/app/utils/group-member-menu.test.ts
+++ b/app/utils/group-member-menu.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { memberMenuActions } from './group-member-menu.ts';
+
+describe('memberMenuActions — group member permission matrix', () => {
+  it('never offers actions on your own row', () => {
+    expect(memberMenuActions('OWNER', 'OWNER', true)).toEqual([]);
+    expect(memberMenuActions('ADMIN', 'ADMIN', true)).toEqual([]);
+    expect(memberMenuActions('MEMBER', 'MEMBER', true)).toEqual([]);
+  });
+
+  it('never offers actions on the owner row', () => {
+    expect(memberMenuActions('OWNER', 'OWNER', false)).toEqual([]);
+    expect(memberMenuActions('ADMIN', 'OWNER', false)).toEqual([]);
+    expect(memberMenuActions('MEMBER', 'OWNER', false)).toEqual([]);
+  });
+
+  it('shows nothing to a member viewer on any row', () => {
+    expect(memberMenuActions('MEMBER', 'ADMIN', false)).toEqual([]);
+    expect(memberMenuActions('MEMBER', 'MEMBER', false)).toEqual([]);
+  });
+
+  it('lets an admin remove members only', () => {
+    expect(memberMenuActions('ADMIN', 'MEMBER', false)).toEqual(['remove']);
+    // Admins cannot act on other admins (matches server 403).
+    expect(memberMenuActions('ADMIN', 'ADMIN', false)).toEqual([]);
+  });
+
+  it('lets the owner promote+remove members and demote+remove admins', () => {
+    expect(memberMenuActions('OWNER', 'MEMBER', false)).toEqual([
+      'promote',
+      'remove',
+    ]);
+    expect(memberMenuActions('OWNER', 'ADMIN', false)).toEqual([
+      'demote',
+      'remove',
+    ]);
+  });
+});

--- a/app/utils/group-member-menu.ts
+++ b/app/utils/group-member-menu.ts
@@ -1,0 +1,44 @@
+import { type GroupRole } from './group-role.ts';
+
+/**
+ * Manager actions that can appear in a member row's three-dot menu.
+ * Mirrors the server-side hierarchy enforced in `groups.server.ts`
+ * (owner > admin > member; you can only act on people below you).
+ */
+export type MemberMenuAction = 'promote' | 'demote' | 'remove';
+
+/**
+ * Which manager actions the viewer may take on a given member row.
+ *
+ * Source of truth is the server (`removeMember` rejects admin→admin/owner;
+ * `promoteToAdmin` / `demoteAdminToMember` require OWNER). This function must
+ * stay stricter-than-or-equal-to that enforcement so the UI never offers an
+ * action the server will 403.
+ *
+ * Rules:
+ *  - Your own row: nothing.
+ *  - A member viewing: nothing (non-managers see no menu).
+ *  - An admin viewing: may remove MEMBERS only.
+ *  - The owner viewing: promote+remove on member rows, demote+remove on admin
+ *    rows. (Transfer-ownership is intentionally not surfaced here.)
+ *  - Nobody can act on the OWNER row.
+ */
+export function memberMenuActions(
+  viewerRole: GroupRole,
+  targetRole: GroupRole,
+  isViewer: boolean,
+): MemberMenuAction[] {
+  if (isViewer) return [];
+  if (targetRole === 'OWNER') return [];
+
+  if (viewerRole === 'OWNER') {
+    if (targetRole === 'ADMIN') return ['demote', 'remove'];
+    return ['promote', 'remove'];
+  }
+
+  if (viewerRole === 'ADMIN') {
+    return targetRole === 'MEMBER' ? ['remove'] : [];
+  }
+
+  return [];
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@radix-ui/react-checkbox": "^1.1.1",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.1",
+        "@radix-ui/react-hover-card": "^1.1.17",
         "@radix-ui/react-label": "^2.1.0",
         "@radix-ui/react-popover": "^1.1.15",
         "@radix-ui/react-select": "^2.1.2",
@@ -2063,9 +2064,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2081,9 +2079,6 @@
       "integrity": "sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -2101,9 +2096,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2119,9 +2111,6 @@
       "integrity": "sha512-Ilays+w2bXdnxzxtQdmXR62u8o8GYa3eL4+Gr+1KiE4xperMZUslRaVPJwwPkzlHEjGfXAfRVAa/7CYCtSqsBw==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -2139,9 +2128,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2157,9 +2143,6 @@
       "integrity": "sha512-+c8ukgwU62DS54nCAjw7keOfHUkmr0B5QHEdcOqRnodF/MNXJbVI8Eopoj4B/0H8Asr65I+A4Amrn7a85/md6A==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -2177,9 +2160,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2196,9 +2176,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2214,9 +2191,6 @@
       "integrity": "sha512-SE4kzF2mepn6z+6E7L6lsV8FzuLL6IPQdyX8ZiwROAG/G8td+hP/m7FsFPwidtrF19gvajuC9l6TxAVcsA4S7A==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2240,9 +2214,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2264,9 +2235,6 @@
       "integrity": "sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2290,9 +2258,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2314,9 +2279,6 @@
       "integrity": "sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2340,9 +2302,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2365,9 +2324,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2389,9 +2345,6 @@
       "integrity": "sha512-YBqMMcjDi4QGYiSn4vNOYBhmlC4z5AXqkOUUqI2e0AFA4urNv4ESgOgwNl3K+4etQhha0twXlzeF20bbULm9Yg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -3401,6 +3354,37 @@
         "@radix-ui/react-compose-refs": "1.1.3",
         "@radix-ui/react-primitive": "2.1.6",
         "@radix-ui/react-use-callback-ref": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-hover-card": {
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-hover-card/-/react-hover-card-1.1.17.tgz",
+      "integrity": "sha512-GjZQIEANVkuuWeztlKz6QEHe31ZX2iDfHzcTMCQVZXC0JyQrgfKWSC+LOOEw6aVV64zyjzobIzSA4AU4eKWrHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-dismissable-layer": "1.1.13",
+        "@radix-ui/react-popper": "1.3.1",
+        "@radix-ui/react-portal": "1.1.12",
+        "@radix-ui/react-presence": "1.1.6",
+        "@radix-ui/react-primitive": "2.1.6",
+        "@radix-ui/react-use-controllable-state": "1.2.3"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "@radix-ui/react-checkbox": "^1.1.1",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.1",
+    "@radix-ui/react-hover-card": "^1.1.17",
     "@radix-ui/react-label": "^2.1.0",
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-select": "^2.1.2",

--- a/tests/e2e/groups-optimistic.test.ts
+++ b/tests/e2e/groups-optimistic.test.ts
@@ -17,7 +17,7 @@ async function createGroupWithOwnerAndMember({
 
   const [owner, member] = await Promise.all([
     prisma.user.create({
-      select: { id: true, username: true },
+      select: { id: true, username: true, name: true },
       data: {
         ...ownerData,
         roles: { connect: { name: 'user' } },
@@ -25,7 +25,7 @@ async function createGroupWithOwnerAndMember({
       },
     }),
     prisma.user.create({
-      select: { id: true, username: true },
+      select: { id: true, username: true, name: true },
       data: {
         ...memberData,
         roles: { connect: { name: 'user' } },
@@ -88,21 +88,24 @@ test('members page shows optimistic role change before promote request resolves'
 
     await page.goto(`/groups/${groupId}/members`);
 
-    const memberRow = page.getByRole('listitem').filter({ hasText: member.username }).first();
-    const promoteButton = memberRow.getByRole('button', {
-      name: /promote to admin/i,
-    });
-    const demoteButton = memberRow.getByRole('button', {
-      name: /demote to member/i,
-    });
+    const memberDisplay = member.name ?? member.username;
+    const memberRow = page
+      .getByRole('listitem')
+      .filter({ hasText: memberDisplay })
+      .first();
 
-    await expect(promoteButton).toBeVisible();
-    await promoteButton.click();
+    // Open the row's three-dot menu (desktop dropdown) and choose Promote,
+    // then confirm — the action only fires after the confirmation step.
+    await memberRow.getByRole('button', { name: /actions for/i }).click();
+    await page.getByRole('menuitem', { name: /promote to admin/i }).click();
+    await page.getByRole('button', { name: 'Promote', exact: true }).click();
 
-    await expect(demoteButton).toBeVisible();
+    // The role flips optimistically to admin before the gated POST resolves.
+    const adminBadge = memberRow.getByText('admin', { exact: true });
+    await expect(adminBadge).toBeVisible();
 
     resolvePromoteGate();
-    await expect(demoteButton).toBeVisible();
+    await expect(adminBadge).toBeVisible();
   } finally {
     await prisma.giftGroup.delete({ where: { id: groupId } }).catch(() => {});
     await prisma.user


### PR DESCRIPTION
Reworks the group page: a calmer members row, role-correct admin actions behind confirmations, a desktop profile hover-card, and a single desktop dashboard that collapses the three mobile tabs.

> **Heads-up on base:** this was stacked on `fix/group-settings-rework` (PR #446), which is **not yet merged**. Targeting `main` as requested means this PR's diff also contains #446's two commits (`fix(groups): make group settings member-aware`, `refactor(groups): reach settings from a header gear`). Merge #446 first, or treat this as superseding it.

## Commits (atomic, backout-able)
1. **Confirm-gated member actions menu + permission matrix** — replaces the inline icon-button cluster (fired on click) with a three-dot menu: desktop dropdown / mobile bottom sheet, each action behind a tap-confirm. Pure `memberMenuActions` matrix mirrors server enforcement (owner > admin > member; you only act on people below you). Owner gets promote+remove on member rows, demote+remove on admin rows; admin gets remove on member rows only. Transfer-ownership and Ban dropped from the UI (server intents left dormant).
2. **Reduce the members row to the essentials** — shared `MembersList`/`MemberRow` showing only avatar, name, role badge, birthday; tap the row for the profile, three-dot is a separate 44×44 target. Removes the gift-budget number, friend button, gift-history icon, and inline pool actions.
3. **Desktop profile hover-preview card** — Radix `HoverCard` preview in a header avatar cluster (≤5 avatars + a non-hoverable `+N` chip). Reads "Your profile" for your own avatar; gated off touch via `useHasHover`.
4. **Single desktop dashboard (Option A)** — action feed (For you / Active pools / Coming up / Past gifts) on the left, context rail (Members / Group info / Activity) on the right, inside the existing `max-w-6xl` container. Tabs hidden at `lg`, retained on mobile. Members rail renders every member (no scroll cap). Per-gift cap is now an inline read→edit on all sizes (mobile modal removed).

## Decisions (confirmed with reviewer)
- Owner's admin-row menu = **Demote + Remove** (transfer-ownership dropped from UI).
- Confirmations are **plain tap** (Cancel / Confirm), not typed.
- Verified against `groups.server.ts`: the UI is stricter-than-or-equal-to server enforcement everywhere, so it never offers a 403 action.

## Verification
- `npm run typecheck` ✓ · `npm run lint` ✓ (0 errors) · `npm test -- --run` ✓ (1098 passed) · `npm run test:e2e:run` ✓ (no failures; includes the `recipient-privacy` specs driving `/groups/:id`, `/members`, `/activity`).
- New tests: permission matrix, menu confirm flow, hover-card content + cluster, members rail, inline per-gift-cap editor.

## Notes
- New dep: `@radix-ui/react-hover-card`.
- Row avatars use a `!h-10 !w-10` literal (numeric `Avatar` sizes aren't in the Tailwind safelist).
- Out of scope (unchanged): the gift/past-gifts back-button bug, app-wide layout architecture, the settings tab→route migration, and the dormant server ban/transfer intents.

https://claude.ai/code/session_01YXfkgLdXAPPg8wMbuBCN2E