### PR TITLE
fix(groups): prevent mobile members overflow

### DIFF
--- a/app/components/groups/members-list.tsx
+++ b/app/components/groups/members-list.tsx
@@ -41,7 +41,7 @@ function MemberRow({
   const birthdayLabel = formatBirthday(member.user.birthday);
 
   return (
-    <li className="relative flex items-center gap-3 px-2 py-2.5">
+    <li className="relative flex min-w-0 items-center gap-3 px-2 py-2.5">
       {/*
        * Whole-row click target navigates to the profile. The menu cell
        * below re-enables pointer events for itself (same isolation pattern
@@ -53,19 +53,24 @@ function MemberRow({
         className="absolute inset-0 rounded-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
       />
 
-      <div className="pointer-events-none flex min-w-0 flex-1 items-center gap-3">
+      <div className="pointer-events-none flex min-w-0 flex-1 items-center gap-3 overflow-hidden">
         <Avatar
           size="s"
           className="!h-10 !w-10"
           image={member.user.image}
           user={member.user}
         />
-        <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-2">
-            <span className="truncate font-semibold text-foreground">
+        <div className="min-w-0 w-0 flex-1 overflow-hidden">
+          <div className="flex min-w-0 items-center gap-2">
+            <span
+              className="block min-w-0 flex-1 truncate font-semibold text-foreground"
+              data-testid="member-display-name"
+            >
               {displayName}
             </span>
-            <RoleBadge role={role} />
+            <span className="shrink-0">
+              <RoleBadge role={role} />
+            </span>
             {isViewer ? <SystemLabel>you</SystemLabel> : null}
           </div>
           <div className="mt-0.5 flex items-center gap-1.5 text-xs text-muted-foreground">

--- a/tests/e2e/groups-optimistic.test.ts
+++ b/tests/e2e/groups-optimistic.test.ts
@@ -1,3 +1,4 @@
+import { type Page } from '@playwright/test';
 import { prisma } from '#app/utils/db.server.ts';
 import {
   createPassword,
@@ -9,11 +10,19 @@ import {
 
 async function createGroupWithOwnerAndMember({
   ownerContributionCents = 1000,
+  ownerUser = {},
+  memberUser = {},
 }: {
   ownerContributionCents?: number;
+  ownerUser?: Partial<ReturnType<typeof createUser>> & {
+    birthday?: Date | null;
+  };
+  memberUser?: Partial<ReturnType<typeof createUser>> & {
+    birthday?: Date | null;
+  };
 } = {}) {
-  const ownerData = createUser();
-  const memberData = createUser();
+  const ownerData = { ...createUser(), ...ownerUser };
+  const memberData = { ...createUser(), ...memberUser };
 
   const [owner, member] = await Promise.all([
     prisma.user.create({
@@ -58,6 +67,139 @@ async function createGroupWithOwnerAndMember({
 
   return { groupId: group.id, owner, member };
 }
+
+const assertNoHorizontalOverflow = async (page: Page) => {
+  const metrics = await page.evaluate(() => {
+    const documentElement = document.documentElement;
+    const appScrollArea = document.querySelector(
+      '[data-testid="app-scroll-area"]',
+    ) as HTMLElement | null;
+
+    return {
+      documentScrollWidth: documentElement.scrollWidth,
+      documentClientWidth: documentElement.clientWidth,
+      appScrollWidth: appScrollArea?.scrollWidth ?? null,
+      appClientWidth: appScrollArea?.clientWidth ?? null,
+    };
+  });
+
+  expect(metrics.documentScrollWidth).toBeLessThanOrEqual(
+    metrics.documentClientWidth + 1,
+  );
+  expect(metrics.appScrollWidth).not.toBeNull();
+  expect(metrics.appClientWidth).not.toBeNull();
+  expect(metrics.appScrollWidth ?? 0).toBeLessThanOrEqual(
+    (metrics.appClientWidth ?? 0) + 1,
+  );
+};
+
+test('members page keeps long member rows within mobile viewport', async ({
+  page,
+  login,
+}) => {
+  const suffix = Date.now().toString(36).slice(-4);
+  const longOwnerUsername = `mmmmmmmmmmmmmmm${suffix}o`;
+  const longMemberUsername = `mmmmmmmmmmmmmmm${suffix}m`;
+  const longOwnerDisplayName =
+    'Olivia Longviewer With An Exceptionally Long Display Name';
+  const longMemberDisplayName =
+    'Francisco Di Giandomenico With An Exceptionally Long Display Name';
+  const { groupId, owner, member } = await createGroupWithOwnerAndMember({
+    ownerUser: {
+      username: longOwnerUsername,
+      name: longOwnerDisplayName,
+      email: `${longOwnerUsername}@example.com`,
+    },
+    memberUser: {
+      username: longMemberUsername,
+      name: longMemberDisplayName,
+      email: `${longMemberUsername}@example.com`,
+      birthday: new Date('1992-05-26T12:00:00.000Z'),
+    },
+  });
+
+  try {
+    await login({ id: owner.id });
+
+    for (const width of [320, 390, 430]) {
+      await page.setViewportSize({ width, height: 844 });
+      await page.goto(`/groups/${groupId}/members`);
+      await page.waitForLoadState('networkidle');
+
+      const memberRow = page
+        .getByRole('listitem')
+        .filter({ hasText: longMemberDisplayName })
+        .first();
+      await expect(memberRow).toBeVisible();
+      await expect(memberRow.getByText(/^member$/).first()).toBeVisible();
+
+      await assertNoHorizontalOverflow(page);
+
+      if (width === 320) {
+        const viewerRow = page
+          .getByRole('listitem')
+          .filter({ hasText: longOwnerDisplayName })
+          .first();
+        await expect(viewerRow.getByText(/^you$/)).toBeVisible();
+        const nameMetrics = await viewerRow
+          .getByTestId('member-display-name')
+          .first()
+          .evaluate((element) => {
+            const styles = window.getComputedStyle(element);
+            return {
+              clientWidth: element.clientWidth,
+              scrollWidth: element.scrollWidth,
+              overflowX: styles.overflowX,
+              textOverflow: styles.textOverflow,
+              whiteSpace: styles.whiteSpace,
+            };
+          });
+
+        expect(nameMetrics.scrollWidth).toBeGreaterThan(
+          nameMetrics.clientWidth,
+        );
+        expect(nameMetrics.overflowX).toBe('hidden');
+        expect(nameMetrics.textOverflow).toBe('ellipsis');
+        expect(nameMetrics.whiteSpace).toBe('nowrap');
+      }
+    }
+
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await page.goto(`/groups/${groupId}/members`);
+
+    const desktopRow = page
+      .getByRole('listitem')
+      .filter({ hasText: longMemberDisplayName })
+      .first();
+    const usernameBox = await desktopRow
+      .getByTestId('member-display-name')
+      .first()
+      .boundingBox();
+    const roleBox = await desktopRow
+      .getByText(/^member$/)
+      .first()
+      .boundingBox();
+
+    expect(usernameBox).not.toBeNull();
+    expect(roleBox).not.toBeNull();
+    if (!usernameBox || !roleBox) {
+      throw new Error('Expected desktop member row elements to be visible');
+    }
+    expect(
+      Math.abs(
+        usernameBox.y +
+          usernameBox.height / 2 -
+          (roleBox.y + roleBox.height / 2),
+      ),
+    ).toBeLessThan(16);
+    await assertNoHorizontalOverflow(page);
+  } finally {
+    await prisma.giftGroup.delete({ where: { id: groupId } }).catch(() => {});
+    await prisma.user
+      .deleteMany({ where: { id: { in: [owner.id, member.id] } } })
+      .catch(() => {});
+  }
+});
 
 test('members page shows optimistic role change before promote request resolves', async ({
   page,


### PR DESCRIPTION
## Summary
- Fix the group Members row so mobile layout cannot create horizontal page scroll.
- Let the member identity area shrink and truncate long names while badges stay on the row.
- Add Playwright coverage for 320px, 390px, 430px, and desktop members views.

## Root Cause
The extracted `MembersList` row used a flex name/badge group where the display-name element could keep its intrinsic width. On mobile, long display names plus fixed badges/actions could push past the viewport unless the text column and display-name span were explicitly allowed to shrink.

## Validation
- `PATH=/Users/twoplustwoone/.nvm/versions/node/v20.19.0/bin:$PATH PORT=3137 SENTRY_DSN=https://public@example.com/1 LITEFS_DIR=tests/prisma npm run test:e2e:run -- --project chromium --reporter=line --grep "members page keeps long member rows"`