### PR TITLE
fix(groups): prevent mobile group tabs from overflowing the viewport

### DIFF
--- a/app/routes/groups+/$giftGroupId_+/_layout.component.test.tsx
+++ b/app/routes/groups+/$giftGroupId_+/_layout.component.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const layoutLoaderData = {
+  giftGroup: {
+    id: 'group-1',
+    name: 'Family',
+    groupMembers: [
+      { user: { id: 'viewer-1', username: 'ada', name: 'Ada', image: null } },
+      { user: { id: 'marco', username: 'marco', name: 'Marco', image: null } },
+    ],
+  },
+  viewer: { userId: 'viewer-1', role: 'OWNER' as const },
+};
+
+const location = { pathname: '/groups/group-1' };
+
+// The layout re-exports the server loader/action; stub it so importing the
+// component never pulls the server module into the jsdom test.
+vi.mock('./__route.server', () => ({ loader: vi.fn(), action: vi.fn() }));
+
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual('react-router');
+  return {
+    ...actual,
+    Link: ({
+      to,
+      children,
+      ...rest
+    }: {
+      to: string;
+      children?: React.ReactNode;
+    }) => (
+      <a href={to} {...rest}>
+        {children}
+      </a>
+    ),
+    NavLink: ({
+      to,
+      children,
+      className,
+    }: {
+      to: string;
+      children?: React.ReactNode;
+      className?: (state: { isActive: boolean }) => string;
+    }) => (
+      <a href={to} className={className?.({ isActive: false })}>
+        {children}
+      </a>
+    ),
+    Outlet: () => <div data-testid="outlet" />,
+    useLoaderData: () => layoutLoaderData,
+    useLocation: () => location,
+  };
+});
+
+vi.mock('#app/components/groups/group-avatar-cluster.tsx', () => ({
+  GroupAvatarCluster: () => <div data-testid="avatar-cluster" />,
+}));
+
+vi.mock('#app/components/groups/RoleBadge.tsx', () => ({
+  RoleBadge: ({ role }: { role: string }) => <span>{role}</span>,
+}));
+
+import GroupLayout from './_layout.tsx';
+
+beforeEach(() => {
+  location.pathname = '/groups/group-1';
+});
+
+describe('group layout shell', () => {
+  it('renders the group header, tab bar and shell on a tab route', () => {
+    render(<GroupLayout />);
+
+    // The shell carries the overflow-guarding container.
+    expect(screen.getByTestId('group-shell')).toBeInTheDocument();
+    // Group header (not the settings header) with the group name.
+    expect(screen.getByText('Family')).toBeInTheDocument();
+    expect(screen.getByText('2 members')).toBeInTheDocument();
+    // Two-tab bar, Activity removed.
+    expect(screen.getByRole('link', { name: 'Overview' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Members' })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: 'Activity' }),
+    ).not.toBeInTheDocument();
+    // Gear link to settings lives in the header for every member.
+    expect(
+      screen.getByRole('link', { name: /group settings/i }),
+    ).toHaveAttribute('href', '/groups/group-1/settings');
+    expect(screen.getByTestId('outlet')).toBeInTheDocument();
+  });
+
+  it('renders the distinct settings header with no tab bar on the settings route', () => {
+    location.pathname = '/groups/group-1/settings';
+    render(<GroupLayout />);
+
+    expect(screen.getByTestId('group-shell')).toBeInTheDocument();
+    expect(screen.getByText('Group settings')).toBeInTheDocument();
+    // Back affordance returns to the group, not the groups list.
+    expect(
+      screen.getByRole('link', { name: /back to family/i }),
+    ).toHaveAttribute('href', '/groups/group-1');
+    // The tab bar is suppressed on the settings sub-page.
+    expect(
+      screen.queryByRole('link', { name: 'Overview' }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: 'Members' }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/app/routes/groups+/$giftGroupId_+/_layout.tsx
+++ b/app/routes/groups+/$giftGroupId_+/_layout.tsx
@@ -26,7 +26,14 @@ const GroupLayout = () => {
     location.pathname === `/groups/${giftGroup.id}/settings`;
 
   return (
-    <div className="flex h-full min-h-0 flex-col">
+    // min-w-0: this is a grid item in the app shell; without it the default
+    // `min-width: auto` keeps the whole group view from shrinking below its
+    // content's intrinsic width, overflowing the track (sideways scroll on
+    // mobile). Applies to every group tab since they all render inside here.
+    <div
+      className="flex h-full min-h-0 min-w-0 flex-col"
+      data-testid="group-shell"
+    >
       {isSettings ? (
         <PageHeader
           variant="detail"

--- a/app/routes/groups+/$giftGroupId_+/index.tsx
+++ b/app/routes/groups+/$giftGroupId_+/index.tsx
@@ -372,13 +372,13 @@ const PoolRow = ({ pool }: { pool: PoolSummary }) => {
             <Text weight="semibold" className="truncate">
               {pool.title}
             </Text>
-            <Text size="sm" className="text-muted-foreground">
+            <Text size="sm" className="truncate text-muted-foreground">
               {OCCASION_TYPE_LABELS[occasion]} for{' '}
               <span className="font-medium text-foreground">
                 {pool.recipientName}
               </span>
             </Text>
-            <Flex gap={2} align="center" className="mt-0.5">
+            <Flex gap={2} align="center" wrap="wrap" className="mt-0.5 min-w-0">
               <Text size="xs" className="text-muted-foreground">
                 {progressLabel}
               </Text>
@@ -448,7 +448,7 @@ const OccasionRow = ({ occasion }: { occasion: UpcomingOccasion }) => (
           alt=""
           className="h-8 w-8 shrink-0 rounded-full object-cover"
         />
-        <Stack gap={0} className="min-w-0">
+        <Stack gap={0} className="min-w-0 flex-1">
           <Text size="sm" weight="medium" className="truncate">
             {occasion.name}
           </Text>
@@ -520,11 +520,15 @@ const PastGiftRow = ({ gift }: { gift: PastGift }) => {
       <Card padding="sm" className="transition-shadow hover:shadow-md">
         <Flex justify="between" align="center" gap={3}>
           <Stack gap={0} className="min-w-0 flex-1">
-            <Flex gap={2} align="center">
-              <Text size="sm" weight="medium" className="truncate">
+            <Flex gap={2} align="center" className="min-w-0">
+              <Text
+                size="sm"
+                weight="medium"
+                className="min-w-0 flex-1 truncate"
+              >
                 {gift.recipientName}
               </Text>
-              <Text size="xs" className="text-muted-foreground">
+              <Text size="xs" className="shrink-0 text-muted-foreground">
                 · {OCCASION_TYPE_LABELS[gift.occasionType as OccasionType]}
               </Text>
             </Flex>
@@ -592,7 +596,7 @@ const GroupEssentialsCard = ({
       </Text>
       <Stack gap={3} className="mt-3">
         {description && (
-          <Text size="sm" className="text-muted-foreground">
+          <Text size="sm" className="break-words text-muted-foreground">
             {description}
           </Text>
         )}

--- a/tests/e2e/groups-optimistic.test.ts
+++ b/tests/e2e/groups-optimistic.test.ts
@@ -201,6 +201,60 @@ test('members page keeps long member rows within mobile viewport', async ({
   }
 });
 
+// The group shell (`[data-testid="group-shell"]`) is a grid item in the app
+// shell. Without `min-w-0` it keeps its default `min-width: auto` and refuses
+// to shrink below its content's intrinsic width, overflowing its grid track —
+// the sideways scroll. Assert its rendered width never exceeds the viewport.
+const assertShellWithinViewport = async (page: Page) => {
+  const metrics = await page.getByTestId('group-shell').evaluate((el) => ({
+    shellWidth: Math.round(el.getBoundingClientRect().width),
+    viewportWidth: window.innerWidth,
+  }));
+  expect(metrics.shellWidth).toBeLessThanOrEqual(metrics.viewportWidth + 1);
+};
+
+test('group tabs stay within the mobile viewport (no sideways scroll)', async ({
+  page,
+  login,
+}) => {
+  // An upcoming birthday drives the For-you action + Coming-up rows (each with
+  // a trailing button) that, with the Group-info card, pushed the group shell
+  // wider than the viewport before the min-w-0 fix.
+  const soon = new Date();
+  soon.setDate(soon.getDate() + 6);
+  const birthday = new Date(1990, soon.getMonth(), soon.getDate(), 12);
+  const { groupId, owner, member } = await createGroupWithOwnerAndMember({
+    memberUser: { name: 'Leonardo Bianchi', birthday },
+  });
+
+  try {
+    await login({ id: owner.id });
+
+    // Every group tab renders inside the same shell, so all are covered.
+    for (const path of ['', '/members', '/settings']) {
+      for (const width of [320, 375, 430]) {
+        await page.setViewportSize({ width, height: 812 });
+        await page.goto(`/groups/${groupId}${path}`);
+        await page.waitForLoadState('networkidle');
+        await assertShellWithinViewport(page);
+        await assertNoHorizontalOverflow(page);
+      }
+    }
+
+    // Desktop is unaffected — the shell fits its (wider) track with no overflow.
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await page.goto(`/groups/${groupId}`);
+    await page.waitForLoadState('networkidle');
+    await assertShellWithinViewport(page);
+    await assertNoHorizontalOverflow(page);
+  } finally {
+    await prisma.giftGroup.delete({ where: { id: groupId } }).catch(() => {});
+    await prisma.user
+      .deleteMany({ where: { id: { in: [owner.id, member.id] } } })
+      .catch(() => {});
+  }
+});
+
 test('members page shows optimistic role change before promote request resolves', async ({
   page,
   login,


### PR DESCRIPTION
## Problem

On narrow (mobile) viewports every group tab — Overview, Members, Settings — scrolled sideways: the header's gear/role badge, tab bar, and card CTAs were pushed off the right edge. This is the same *class* of bug as the Members-row fix (#452), but that fix only addressed one tab's content.

## Root cause (shared container)

The group view root — `<div className="flex h-full min-h-0 flex-col">` in `_layout.tsx` — is a **grid item** in the app shell. Grid items default to `min-width: auto`, so it refused to shrink below its content's intrinsic width and overflowed its grid track. Measured at a 362px viewport, the shell rendered **468px** wide. Because all group tabs render inside this one container, they all overflowed.

The Members #452 fix worked only by shrinking the member rows' min-content below the track; Overview has other wide content (Group-info card, occasion/action rows with trailing buttons) so it still overflowed.

## Fix

**Commit 1 — the fix:** add `min-w-0` to the shared group layout container so the grid item shrinks to its track; internal flex/`truncate` handle the rest. One line, covers every tab. Regression test asserts the group shell (`data-testid="group-shell"`) never exceeds the viewport across Overview/Members/Settings at 320–430px, plus a desktop check.

**Commit 2 — defensive hardening:** even inside the constrained shell, long/unbreakable content in a non-truncated cell can re-overflow, so apply the #452 flex pattern to the Overview rows (truncate the pool recipient line, wrap the pool progress meta, `min-w-0`/`flex-1` on the occasion row, `min-w-0`/`shrink-0` on the past-gift row, `break-words` on the group description).

## Verification

Driven against the dev server with a reproduction of the reported scenario (Book Club + upcoming birthdays). Before: shell 468px @ 362px viewport (sideways scroll). After: shell width == viewport at 320 / 362 / 430 / 1280 across all three tabs; desktop unchanged. Screenshot below shows the gear icon, "owner" badge, tab bar, and all "Start a pool" buttons now inside the viewport.

`typecheck` + `lint` clean. (Local e2e couldn't run — the `login` test fixture fails environment-wide here, affecting all pre-existing tests in the file too — so the new test is verified structurally and will run in CI.)

https://claude.ai/code/session_01YXfkgLdXAPPg8wMbuBCN2E