### PR TITLE
feat(groups): rework mobile Overview layout — header invite + cap strip

### DIFF
--- a/app/components/groups/group-invite-button.test.tsx
+++ b/app/components/groups/group-invite-button.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const clipboardWriteText = vi.fn();
+const toastSuccess = vi.fn();
+
+const fetcherState = {
+  data: undefined as undefined | { inviteUrl?: string },
+  state: 'idle' as 'idle' | 'submitting',
+};
+
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual('react-router');
+  return {
+    ...actual,
+    useFetcher: () => ({
+      Form: (props: React.ComponentProps<'form'>) => <form {...props} />,
+      data: fetcherState.data,
+      state: fetcherState.state,
+    }),
+  };
+});
+
+vi.mock('sonner', () => ({
+  toast: { success: (...args: Array<unknown>) => toastSuccess(...args) },
+}));
+
+import { GroupInviteButton } from './group-invite-button.tsx';
+
+beforeEach(() => {
+  clipboardWriteText.mockReset().mockResolvedValue(undefined);
+  toastSuccess.mockReset();
+  fetcherState.data = undefined;
+  fetcherState.state = 'idle';
+  vi.stubGlobal('navigator', {
+    clipboard: { writeText: clipboardWriteText },
+  });
+});
+
+describe('GroupInviteButton', () => {
+  it('copies an existing invite link and toasts', async () => {
+    render(
+      <GroupInviteButton giftGroupId="g1" inviteLink="https://x/join/abc" />,
+    );
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Invite to group' }),
+    );
+
+    expect(clipboardWriteText).toHaveBeenCalledWith('https://x/join/abc');
+    await waitFor(() =>
+      expect(toastSuccess).toHaveBeenCalledWith('Invite link copied'),
+    );
+  });
+
+  it('renders a create-invite-link submit when there is no link yet', () => {
+    render(<GroupInviteButton giftGroupId="g1" inviteLink={null} />);
+
+    const button = screen.getByRole('button', { name: 'Invite to group' });
+    expect(button).toBeInTheDocument();
+    // Reuses the existing create-invite-link action — no new mechanism.
+    const form = button.closest('form');
+    expect(form?.querySelector('input[name="intent"]')).toHaveValue(
+      'create-invite-link',
+    );
+  });
+
+  it('copies a freshly created link silently (server toast covers it)', async () => {
+    // The action has settled and returned a new invite URL.
+    fetcherState.data = { inviteUrl: 'https://x/join/new' };
+    fetcherState.state = 'idle';
+
+    render(<GroupInviteButton giftGroupId="g1" inviteLink={null} />);
+
+    await waitFor(() =>
+      expect(clipboardWriteText).toHaveBeenCalledWith('https://x/join/new'),
+    );
+    // No client-side toast on the create path — avoids doubling the server one.
+    expect(toastSuccess).not.toHaveBeenCalled();
+  });
+});

--- a/app/components/groups/group-invite-button.tsx
+++ b/app/components/groups/group-invite-button.tsx
@@ -1,0 +1,86 @@
+import { useEffect, useRef, useState } from 'react';
+import { LuUserPlus } from 'react-icons/lu';
+import { useFetcher } from 'react-router';
+import { toast } from 'sonner';
+import { Button } from '#app/components/ui/button.tsx';
+
+/**
+ * Icon-only header control that surfaces the group's invite link.
+ *
+ * Reuses the existing invite mechanism — no new route/action:
+ * - If a link already exists, clicking copies it.
+ * - Otherwise it POSTs `intent=create-invite-link` to `/groups/:id` (the same
+ *   action the Group info card uses) and copies the returned URL once created.
+ *
+ * Permission is enforced server-side (`requireUserWithGroupPermission
+ * 'manageInvites'` throws 403); callers only render this for users who can
+ * invite, so the UI never presents an action the server would reject.
+ */
+export const GroupInviteButton = ({
+  giftGroupId,
+  inviteLink,
+}: {
+  giftGroupId: string;
+  inviteLink: string | null;
+}) => {
+  const createFetcher = useFetcher();
+  const [localInviteLink, setLocalInviteLink] = useState<string | null>(
+    inviteLink,
+  );
+  const resolvedInviteLink = localInviteLink ?? inviteLink;
+  const pending = createFetcher.state !== 'idle';
+  const copiedUrlRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    setLocalInviteLink(inviteLink);
+  }, [inviteLink]);
+
+  // Copy the freshly-created link once the action settles. The
+  // create-invite-link action already surfaces its own success toast, so copy
+  // silently here — a second toast would double up on the first click. The ref
+  // guards against re-copying the same URL on incidental re-renders.
+  useEffect(() => {
+    const url = (createFetcher.data as { inviteUrl?: string } | undefined)
+      ?.inviteUrl;
+    if (createFetcher.state === 'idle' && url && copiedUrlRef.current !== url) {
+      copiedUrlRef.current = url;
+      setLocalInviteLink(url);
+      navigator.clipboard.writeText(url).catch(() => {});
+    }
+  }, [createFetcher.state, createFetcher.data]);
+
+  if (resolvedInviteLink) {
+    return (
+      <Button
+        variant="ghost"
+        size="icon"
+        aria-label="Invite to group"
+        className="text-muted-foreground hover:text-foreground"
+        onClick={async () => {
+          await navigator.clipboard.writeText(resolvedInviteLink);
+          toast.success('Invite link copied');
+        }}
+      >
+        <LuUserPlus className="h-5 w-5" />
+      </Button>
+    );
+  }
+
+  return (
+    <createFetcher.Form method="post" action={`/groups/${giftGroupId}`}>
+      <input type="hidden" name="giftGroupId" value={giftGroupId} />
+      <input type="hidden" name="intent" value="create-invite-link" />
+      <input type="hidden" name="expiresInDays" value="7" />
+      <Button
+        type="submit"
+        variant="ghost"
+        size="icon"
+        aria-label="Invite to group"
+        className="text-muted-foreground hover:text-foreground"
+        disabled={pending}
+      >
+        <LuUserPlus className="h-5 w-5" />
+      </Button>
+    </createFetcher.Form>
+  );
+};

--- a/app/routes/groups+/$giftGroupId_+/_layout.tsx
+++ b/app/routes/groups+/$giftGroupId_+/_layout.tsx
@@ -7,6 +7,7 @@ import {
   useLocation,
 } from 'react-router';
 import { GroupAvatarCluster } from '#app/components/groups/group-avatar-cluster.tsx';
+import { GroupInviteButton } from '#app/components/groups/group-invite-button.tsx';
 import { RoleBadge } from '#app/components/groups/RoleBadge.tsx';
 import { PageHeader } from '#app/components/page-header.tsx';
 import { Stack } from '#app/components/ui-kit/stack.tsx';
@@ -18,7 +19,8 @@ import { type loader as routeLoader } from './__route.server';
 export { loader, action } from './__route.server';
 
 const GroupLayout = () => {
-  const { giftGroup, viewer } = useLoaderData<typeof routeLoader>();
+  const { giftGroup, viewer, canInvite, inviteLink } =
+    useLoaderData<typeof routeLoader>();
   const location = useLocation();
   // Settings is a distinct sub-page, not a tab: it gets its own header with a
   // back affordance to the group, and never shows the Overview/Members tab bar.
@@ -56,6 +58,17 @@ const GroupLayout = () => {
               viewerId={viewer.userId}
             />
             <RoleBadge role={viewer.role as GroupRole} />
+            {/* Invite — mobile only (desktop keeps it in the Group info rail
+                card). Rendered only for users who can invite; permission is also
+                enforced server-side in the create-invite-link action. */}
+            {canInvite ? (
+              <div className="lg:hidden">
+                <GroupInviteButton
+                  giftGroupId={giftGroup.id}
+                  inviteLink={inviteLink}
+                />
+              </div>
+            ) : null}
             {/* Settings is reachable by every member — it's where your own
                 group preferences live, not just admin controls (P7.5). */}
             <Link

--- a/app/routes/groups+/$giftGroupId_+/index.tsx
+++ b/app/routes/groups+/$giftGroupId_+/index.tsx
@@ -121,29 +121,54 @@ const GiftGroupOverview = () => {
     // inside the existing max-w-6xl container — the page scrolls naturally,
     // no independent-scroll columns. On mobile the rail simply flows under
     // the feed and shows Group info only (Members remains its own tab).
-    <div className="lg:grid lg:grid-cols-[minmax(0,1fr)_22rem] lg:items-start lg:gap-6">
-      <Stack gap={6}>
-        <ForYouSection
-          items={data.actionQueue}
-          nextOccasion={data.upcomingOccasions[0] ?? null}
+    <>
+      {/* Mobile-only per-gift cap strip: a slim row directly under the tab bar
+          and above "For you". Desktop keeps the cap in the Group info rail card
+          (below), so this is hidden at lg+. */}
+      <Flex
+        justify="between"
+        align="center"
+        className="lg:hidden"
+        data-testid="mobile-cap-strip"
+      >
+        <Text size="xs" className="text-muted-foreground">
+          Your per-gift cap
+        </Text>
+        <InlineBudgetEditor
+          giftGroupId={giftGroup.id}
+          initialCents={viewer.contributionCents ?? 0}
+          editLabel="Edit your per-gift cap"
+          amountTestId=""
         />
-        <ActivePoolsSection pools={data.activePools} groupId={giftGroup.id} />
-        <UpcomingOccasionsSection occasions={data.upcomingOccasions} />
-        <PastGiftsSection gifts={data.pastGifts} />
-      </Stack>
+      </Flex>
 
-      <Stack gap={6} className="mt-6 lg:mt-0">
-        <div className="hidden lg:block">
-          <MembersRailCard
-            giftGroupId={giftGroup.id}
-            members={giftGroup.groupMembers}
-            viewerId={viewer.userId}
-            viewerRole={viewer.role as GroupRole}
+      <div className="lg:grid lg:grid-cols-[minmax(0,1fr)_22rem] lg:items-start lg:gap-6">
+        <Stack gap={6}>
+          <ForYouSection
+            items={data.actionQueue}
+            nextOccasion={data.upcomingOccasions[0] ?? null}
           />
+          <ActivePoolsSection pools={data.activePools} groupId={giftGroup.id} />
+          <UpcomingOccasionsSection occasions={data.upcomingOccasions} />
+          <PastGiftsSection gifts={data.pastGifts} />
+        </Stack>
+
+        {/* Context rail — desktop only. On mobile the cap moves to the strip
+            above, invite moves to the header, and the description lives on the
+            settings screen, so the whole rail is hidden. */}
+        <div className="hidden lg:block">
+          <Stack gap={6}>
+            <MembersRailCard
+              giftGroupId={giftGroup.id}
+              members={giftGroup.groupMembers}
+              viewerId={viewer.userId}
+              viewerRole={viewer.role as GroupRole}
+            />
+            {essentials}
+          </Stack>
         </div>
-        {essentials}
-      </Stack>
-    </div>
+      </div>
+    </>
   );
 };
 export default GiftGroupOverview;
@@ -683,9 +708,13 @@ const SectionHeader = ({
 const InlineBudgetEditor = ({
   giftGroupId,
   initialCents,
+  editLabel = 'Edit your budget',
+  amountTestId = 'budget-amount',
 }: {
   giftGroupId: string;
   initialCents: number;
+  editLabel?: string;
+  amountTestId?: string;
 }) => {
   const fetcher = useFetcher<typeof settingsAction>();
   const [editing, setEditing] = useState(false);
@@ -759,14 +788,14 @@ const InlineBudgetEditor = ({
           <>
             <span
               className="text-base font-bold text-foreground"
-              data-testid="budget-amount"
+              data-testid={amountTestId || undefined}
             >
               ${dollars}
             </span>
             <Button
               variant="ghost"
               size="icon"
-              aria-label="Edit your budget"
+              aria-label={editLabel}
               onClick={() => setEditing(true)}
             >
               <Icon name="pencil-1" />

--- a/app/routes/groups+/$giftGroupId_+/settings.tsx
+++ b/app/routes/groups+/$giftGroupId_+/settings.tsx
@@ -469,6 +469,19 @@ const GroupSettingsRoute = () => {
         />
       ) : null}
 
+      {/* Group description — read-only for regular members. Managers edit it in
+          the SettingsCard below, so this only renders for non-managers. The
+          description no longer appears on the mobile Overview, so this keeps it
+          visible to everyone. */}
+      {!canManageSettings && giftGroup.description ? (
+        <div className="rounded-2xl border bg-card p-4 sm:p-6">
+          <div className="mb-1 text-lg font-semibold">About this group</div>
+          <p className="whitespace-pre-line break-words text-sm text-muted-foreground">
+            {giftGroup.description}
+          </p>
+        </div>
+      ) : null}
+
       {/* Admin controls — a separate surface, only for managers */}
       {canManageSettings ? (
         <>

--- a/app/utils/group-invitations.server.test.ts
+++ b/app/utils/group-invitations.server.test.ts
@@ -1,0 +1,83 @@
+/**
+ * @vitest-environment node
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// These mocks isolate the DB/auth boundary but leave the real permission check
+// (`requireUserWithGroupPermission`) in place, so the test exercises the actual
+// server-side authorization — not a mock of it.
+const requireUserId = vi.fn();
+const findUnique = vi.fn();
+const create = vi.fn();
+const logGroupActivity = vi.fn();
+const nanoid = vi.fn();
+
+vi.mock('nanoid', () => ({
+  nanoid: () => nanoid(),
+}));
+
+vi.mock('#app/utils/auth.server.ts', () => ({
+  requireUserId: (...args: Array<unknown>) => requireUserId(...args),
+}));
+
+vi.mock('#app/utils/db.server.ts', () => ({
+  prisma: {
+    usersInGiftGroups: {
+      findUnique: (...args: Array<unknown>) => findUnique(...args),
+    },
+    groupInvitation: {
+      create: (...args: Array<unknown>) => create(...args),
+    },
+  },
+}));
+
+vi.mock('#app/utils/group-activity.server.ts', () => ({
+  logGroupActivity: (...args: Array<unknown>) => logGroupActivity(...args),
+}));
+
+import { createInviteLink } from './group-invitations.server.ts';
+
+const statusOf = (err: unknown): number | undefined => {
+  const e = err as { status?: number; init?: { status?: number } };
+  return e?.init?.status ?? e?.status;
+};
+
+beforeEach(() => {
+  requireUserId.mockReset().mockResolvedValue('user-1');
+  findUnique.mockReset();
+  create.mockReset().mockResolvedValue({ code: 'new-code' });
+  logGroupActivity.mockReset().mockResolvedValue(undefined);
+  nanoid.mockReset().mockReturnValue('new-code');
+});
+
+const args = { giftGroupId: 'group-1', expiresInDays: '7' };
+
+describe('createInviteLink server-side authorization', () => {
+  it('rejects a MEMBER with 403 and never creates an invitation', async () => {
+    findUnique.mockResolvedValue({ role: 'MEMBER' });
+
+    const promise = createInviteLink(new Request('https://x'), args);
+
+    await expect(promise).rejects.toBeDefined();
+    await promise.catch((err) => expect(statusOf(err)).toBe(403));
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-member with 403 and never creates an invitation', async () => {
+    findUnique.mockResolvedValue(null);
+
+    const promise = createInviteLink(new Request('https://x'), args);
+
+    await expect(promise).rejects.toBeDefined();
+    await promise.catch((err) => expect(statusOf(err)).toBe(403));
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('allows an ADMIN to create an invitation', async () => {
+    findUnique.mockResolvedValue({ role: 'ADMIN' });
+
+    await createInviteLink(new Request('https://x'), args);
+
+    expect(create).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/e2e/groups-optimistic.test.ts
+++ b/tests/e2e/groups-optimistic.test.ts
@@ -255,6 +255,64 @@ test('group tabs stay within the mobile viewport (no sideways scroll)', async ({
   }
 });
 
+test('mobile overview: header invite (owner only) + cap strip, no overflow', async ({
+  page,
+  login,
+}) => {
+  const { groupId, owner, member } = await createGroupWithOwnerAndMember({
+    // A long name stresses the tightest 320px header row (back arrow, group
+    // icon, name, member count, avatars, role badge, invite icon, gear).
+    ownerUser: { name: 'Maximiliano Featherstonehaugh' },
+  });
+
+  try {
+    // ── Owner: the icon-only Invite appears in the header on mobile ──────────
+    await login({ id: owner.id });
+    for (const width of [320, 375, 430]) {
+      await page.setViewportSize({ width, height: 812 });
+      await page.goto(`/groups/${groupId}`);
+      await page.waitForLoadState('networkidle');
+
+      await expect(
+        page.getByRole('button', { name: 'Invite to group' }),
+      ).toBeVisible();
+      // Cap strip is shown; the desktop "Group info" card is present in the DOM
+      // (hidden lg:block) but not visible on mobile.
+      await expect(page.getByTestId('mobile-cap-strip')).toBeVisible();
+      await expect(page.getByText('Group info')).toBeHidden();
+
+      await assertShellWithinViewport(page);
+      await assertNoHorizontalOverflow(page);
+    }
+
+    // ── Member: the invite control is not rendered at all ───────────────────
+    await login({ id: member.id });
+    await page.setViewportSize({ width: 320, height: 812 });
+    await page.goto(`/groups/${groupId}`);
+    await page.waitForLoadState('networkidle');
+    await expect(
+      page.getByRole('button', { name: 'Invite to group' }),
+    ).toHaveCount(0);
+
+    // ── Desktop owner: header invite is hidden; Group info rail is intact ────
+    await login({ id: owner.id });
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await page.goto(`/groups/${groupId}`);
+    await page.waitForLoadState('networkidle');
+    // lg:hidden — present in DOM but not visible at desktop width.
+    await expect(
+      page.getByRole('button', { name: 'Invite to group' }),
+    ).toBeHidden();
+    await expect(page.getByTestId('mobile-cap-strip')).toBeHidden();
+    await expect(page.getByText('Group info')).toBeVisible();
+  } finally {
+    await prisma.giftGroup.delete({ where: { id: groupId } }).catch(() => {});
+    await prisma.user
+      .deleteMany({ where: { id: { in: [owner.id, member.id] } } })
+      .catch(() => {});
+  }
+});
+
 test('members page shows optimistic role change before promote request resolves', async ({
   page,
   login,


### PR DESCRIPTION
## Summary

Reworks the **mobile** group Overview to a resolved hierarchy — structure/placement only, no restyle, reusing existing components and tokens. **Desktop Overview is unchanged** (all new mobile bits are `lg:hidden`; the context rail becomes `hidden lg:block`).

Mobile top→bottom is now: header (with new invite) → Overview/Members tabs → slim per-gift cap strip → For you → Coming up. The old bottom "Group info" card is dissolved.

## Changes

- **Header invite** (`_layout.tsx` + new `group-invite-button.tsx`): an **icon-only** `LuUserPlus` control (`aria-label="Invite to group"`), mobile-only, rendered only when `canInvite` (owner/admin). Reuses the existing `create-invite-link` action + copy flow — no new mechanism. Copies silently on create (the server action already toasts) and only toasts on the direct-copy path; a `copiedUrlRef` guard prevents a duplicate copy.
- **Cap strip** (`index.tsx`): per-gift cap moved to a slim single row directly under the tab bar, above "For you". `InlineBudgetEditor` gained optional `editLabel`/`amountTestId` so the strip doesn't collide with the desktop editor's selectors.
- **Group info card** is now desktop-only; the group description is removed from Overview. A read-only **"About this group"** card now shows the description to regular members on the settings screen (managers still edit it in the settings card).

## Security

Invite permission is enforced **server-side**: `createInviteLink` calls `requireUserWithGroupPermission(..., 'manageInvites')` (throws 403) before creating anything, and the existing-link path is loader-gated. The header button is a UI reflection of that rule, not a substitute. Added a unit test proving a non-permissioned `createInviteLink` call is rejected 403 and never reaches `groupInvitation.create`.

## Testing

- `typecheck` clean · `lint` 0 errors · unit suite **1132 passed** (incl. new authz test).
- New e2e (`groups-optimistic.test.ts`) asserts, at **320/375/430px** (with a long owner name): the header invite is visible for owners and **absent from the DOM** for members, the cap strip shows, the Group-info card is hidden, and there is no shell/horizontal overflow. Desktop asserts the header invite + strip are hidden and the Group-info rail is intact.

## Notes

- Regular members previously couldn't see the group description anywhere after removal from Overview; the new read-only settings card addresses that (chosen over deferring).
- No visual redesign — existing spacing scale, card styling, and tokens are preserved (Option A: structural rework, visual polish deferred).

https://claude.ai/code/session_01NNtYyKUwVd1T9AUv1yQnkH
