### PR TITLE
fix(pools): enforce recipient≠contributor invariant in createPool

### DIFF
--- a/app/utils/pool.server.test.ts
+++ b/app/utils/pool.server.test.ts
@@ -5,6 +5,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const nanoid = vi.fn(() => 'invite-123');
 
+const captureMessage = vi.fn();
+
 const giftIdeaCreate = vi.fn();
 const giftIdeaDelete = vi.fn();
 const giftIdeaFindFirst = vi.fn();
@@ -21,6 +23,11 @@ const poolUpdate = vi.fn();
 
 vi.mock('nanoid', () => ({
   nanoid: () => nanoid(),
+}));
+
+vi.mock('@sentry/react-router', () => ({
+  captureException: vi.fn(),
+  captureMessage: (...args: Array<unknown>) => captureMessage(...args),
 }));
 
 vi.mock('#app/utils/db.server.ts', () => ({
@@ -81,6 +88,7 @@ import {
 
 beforeEach(() => {
   nanoid.mockReset().mockReturnValue('invite-123');
+  captureMessage.mockReset();
   giftIdeaCreate.mockReset().mockResolvedValue({ id: 'idea-1', name: 'Speaker' });
   giftIdeaDelete.mockReset().mockResolvedValue(undefined);
   giftIdeaFindFirst.mockReset();
@@ -154,6 +162,51 @@ describe('pool server utilities', () => {
       actorId: 'organizer-1',
       payload: { title: 'Birthday Pool' },
     });
+  });
+
+  it('createPool rejects a pool whose recipient is the organizer', async () => {
+    await expect(
+      createPool({
+        organizerId: 'organizer-1',
+        recipientUserId: 'organizer-1',
+        title: 'Self Pool',
+      }),
+    ).rejects.toMatchObject({ init: { status: 400 } });
+
+    expect(poolCreate).not.toHaveBeenCalled();
+  });
+
+  it('createPool filters the recipient out of groupMemberDefaults and reports it', async () => {
+    await createPool({
+      groupMemberDefaults: [
+        { contributionCents: 2000, userId: 'recipient-1' },
+        { contributionCents: 1000, userId: 'member-2' },
+      ],
+      organizerId: 'organizer-1',
+      recipientUserId: 'recipient-1',
+      title: 'Birthday Pool',
+    });
+
+    expect(poolCreate).toHaveBeenCalledWith({
+      data: {
+        contributors: {
+          create: [
+            { contributionCents: null, userId: 'organizer-1' },
+            { contributionCents: 1000, userId: 'member-2' },
+          ],
+        },
+        decisionMode: 'ORGANIZER_PICKS',
+        eventDate: null,
+        giftGroupId: null,
+        occasionType: 'BIRTHDAY',
+        organizerId: 'organizer-1',
+        recipientName: null,
+        recipientUserId: 'recipient-1',
+        title: 'Birthday Pool',
+      },
+      select: { id: true, organizerId: true, title: true },
+    });
+    expect(captureMessage).toHaveBeenCalledTimes(1);
   });
 
   it('updatePool updates the pool and logs changed fields', async () => {

--- a/app/utils/pool.server.ts
+++ b/app/utils/pool.server.ts
@@ -1,3 +1,4 @@
+import { captureMessage } from '@sentry/react-router'
 import { data } from 'react-router'
 import { nanoid } from 'nanoid'
 import { queueLogEvent } from '#app/utils/analytics.server.ts'
@@ -117,10 +118,36 @@ export async function createPool(input: CreatePoolInput) {
 		groupMemberDefaults = [],
 	} = input
 
+	// Secrecy invariant: the recipient must never be a contributor on their own
+	// pool. Enforce it here at write time so no caller can seed a leak.
+	if (recipientUserId != null && recipientUserId === organizerId) {
+		// String body (not an { error } object) so the thrown response renders
+		// cleanly through the root GeneralErrorBoundary as a 400 rather than
+		// crashing it into a 500.
+		throw data('A pool recipient cannot also be its organizer.', {
+			status: 400,
+		})
+	}
+
+	// Filter the recipient out of the seeded contributors. A caller passing the
+	// recipient in defaults is an upstream bug — report it, but still proceed
+	// with the filtered list.
+	const filteredDefaults =
+		recipientUserId != null
+			? groupMemberDefaults.filter(m => m.userId !== recipientUserId)
+			: groupMemberDefaults
+
+	if (filteredDefaults.length !== groupMemberDefaults.length) {
+		captureMessage('createPool: recipient present in groupMemberDefaults', {
+			level: 'warning',
+			extra: { recipientUserId, organizerId, giftGroupId },
+		})
+	}
+
 	// Build the contributor list. The organizer is always first.
 	const contributorData = [
 		{ userId: organizerId, contributionCents: null },
-		...groupMemberDefaults
+		...filteredDefaults
 			.filter(m => m.userId !== organizerId)
 			.map(m => ({
 				userId: m.userId,

--- a/tests/e2e/pool-recipient-invariant.test.ts
+++ b/tests/e2e/pool-recipient-invariant.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Server-boundary audit for the pool secrecy invariant.
+ *
+ * Contract: `createPool` — the domain write path behind `POST /pools/new` —
+ * must never seed the recipient as a contributor on their own pool. This is
+ * enforced at write time regardless of what the route caller passes:
+ *   - recipient === organizer is rejected outright (no Pool row).
+ *   - a recipient smuggled into the contributor list is silently dropped.
+ *
+ * These hit the real action over HTTP (not the mocked route unit tests) so a
+ * tampered, direct POST is what's being verified.
+ */
+
+import { getPasswordHash } from '#app/utils/auth.server.ts';
+import { prisma } from '#app/utils/db.server.ts';
+import { createUser } from '#tests/db-utils.ts';
+import { expect, loginWithPassword, test } from '#tests/playwright-utils.ts';
+
+type SeededUser = { id: string; username: string; password: string };
+
+async function seedUser(): Promise<SeededUser> {
+  const userData = createUser();
+  const password = userData.username;
+  const user = await prisma.user.create({
+    select: { id: true, username: true },
+    data: {
+      ...userData,
+      roles: { connect: { name: 'user' } },
+      password: { create: { hash: await getPasswordHash(password) } },
+    },
+  });
+  return { ...user, password };
+}
+
+test.describe('pool recipient invariant (server boundary)', () => {
+  let organizer: SeededUser;
+  let recipient: SeededUser;
+  let member3: SeededUser;
+  let groupId: string;
+  const createdPoolIds: string[] = [];
+
+  test.beforeAll(async () => {
+    [organizer, recipient, member3] = await Promise.all([
+      seedUser(),
+      seedUser(),
+      seedUser(),
+    ]);
+
+    const group = await prisma.giftGroup.create({
+      select: { id: true },
+      data: {
+        name: 'Recipient-invariant Crew',
+        description: 'boundary test',
+        groupMembers: {
+          create: [
+            { userId: organizer.id, role: 'OWNER' },
+            { userId: recipient.id, role: 'MEMBER' },
+            { userId: member3.id, role: 'MEMBER' },
+          ],
+        },
+      },
+    });
+    groupId = group.id;
+  });
+
+  test.afterAll(async () => {
+    // Pools reference the organizer with no cascade — delete them first, then
+    // the group (cascades memberships), then the seeded users.
+    for (const id of createdPoolIds) {
+      await prisma.pool.delete({ where: { id } }).catch(() => {});
+    }
+    await prisma.giftGroup.delete({ where: { id: groupId } }).catch(() => {});
+    await prisma.user
+      .deleteMany({
+        where: { id: { in: [organizer.id, recipient.id, member3.id] } },
+      })
+      .catch(() => {});
+  });
+
+  test('rejects a group-backed pool whose recipient is the organizer', async ({
+    page,
+  }) => {
+    await loginWithPassword(page, {
+      username: organizer.username,
+      password: organizer.password,
+    });
+    const title = `Self Pool ${Date.now()}`;
+
+    const response = await page.request.post('/pools/new', {
+      form: {
+        title,
+        occasionType: 'BIRTHDAY',
+        decisionMode: 'ORGANIZER_PICKS',
+        giftGroupId: groupId,
+        // recipient === organizer: the group-backed path lets this through to
+        // createPool, which must reject it.
+        recipientUserId: organizer.id,
+        contributorIds: organizer.id,
+      },
+      maxRedirects: 0,
+    });
+
+    // Rejected as a 400 at the route (not a 302 redirect, not a 500 crash).
+    expect(response.status()).toBe(400);
+
+    // The strong assertion: nothing was persisted.
+    const pool = await prisma.pool.findFirst({
+      where: { organizerId: organizer.id, title },
+      select: { id: true },
+    });
+    expect(pool).toBeNull();
+
+    const contributor = await prisma.poolContributor.findFirst({
+      where: { userId: organizer.id, pool: { title } },
+      select: { poolId: true },
+    });
+    expect(contributor).toBeNull();
+  });
+
+  test('excludes the recipient from contributors even when smuggled into contributorIds', async ({
+    page,
+  }) => {
+    await loginWithPassword(page, {
+      username: organizer.username,
+      password: organizer.password,
+    });
+    const title = `Privacy-safe Pool ${Date.now()}`;
+
+    const response = await page.request.post('/pools/new', {
+      form: {
+        title,
+        occasionType: 'BIRTHDAY',
+        decisionMode: 'ORGANIZER_PICKS',
+        giftGroupId: groupId,
+        recipientUserId: recipient.id,
+        // Recipient smuggled into the contributor list alongside real members.
+        contributorIds: [organizer.id, recipient.id, member3.id].join(','),
+      },
+      maxRedirects: 0,
+    });
+
+    // Pool was created — the action redirects to the new pool.
+    expect(response.status()).toBe(302);
+
+    const pool = await prisma.pool.findFirst({
+      where: { organizerId: organizer.id, title },
+      select: {
+        id: true,
+        contributors: { select: { userId: true } },
+      },
+    });
+    expect(pool).not.toBeNull();
+    createdPoolIds.push(pool!.id);
+
+    const contributorIds = pool!.contributors.map((c) => c.userId);
+    // Recipient must NOT be a contributor; organizer + member3 must be.
+    expect(contributorIds).not.toContain(recipient.id);
+    expect(contributorIds).toContain(organizer.id);
+    expect(contributorIds).toContain(member3.id);
+  });
+});


### PR DESCRIPTION
## Context

The pool secrecy invariant — **the recipient must never be a contributor on their own pool** — was enforced only in the route caller (`resolveGroupBackedRecipient` in `app/routes/pools+/new.tsx`). `createPool` blindly seeded `organizerId` plus whatever `groupMemberDefaults` it received, so any future caller (or a path the route filter misses) could silently create a pool where the recipient sees the surprise gift.

Notably the **group-backed** action path already let a self-recipient through to `createPool` when `recipientUserId === organizerId`.

## Change

Move the invariant into `createPool` as a write-time guarantee:

- **Hard invariant** — reject a recipient-as-organizer pool with a `400` before any writes. Uses a string-bodied `data(...)` so the thrown response renders cleanly through the root `GeneralErrorBoundary` as a 400 rather than crashing it into a 500 (the boundary renders `{error.data}`, so an `{ error }` object body would 500).
- **Filter + report** — strip the recipient out of `groupMemberDefaults`; if anything was removed, report to Sentry (`captureMessage`, warning) but still proceed with the filtered list.
- Read paths untouched (invariant is write-time only).
- The route-level filter in `resolveGroupBackedRecipient` stays as belt-and-suspenders.

## Tests

- **Unit** (`pool.server.test.ts`): rejects `recipient === organizer` (no `poolCreate`); filters a recipient out of `groupMemberDefaults` and fires `captureMessage` once.
- **E2E boundary** (`pool-recipient-invariant.test.ts`): a tampered direct `POST /pools/new` with `recipient === organizer` is rejected **400** with no rows created; a group-backed pool with the recipient smuggled into `contributorIds` is created with the recipient excluded from `PoolContributor`.

## Verification

- `npm run typecheck` — clean
- `pool.server.test.ts` 31/31, `new.test.tsx` 13/13 (no regression)
- new e2e 2/2, `recipient-privacy.test.ts` 8/8
- lint clean on changed files