### PR TITLE
fix(birthday): unify visibility behind a single canViewBirthday helper

### DIFF
--- a/app/components/friends/friend-row.test.tsx
+++ b/app/components/friends/friend-row.test.tsx
@@ -97,6 +97,19 @@ describe('<FriendRow />', () => {
     expect(screen.getByText('Apr 15')).toBeInTheDocument();
   });
 
+  it('hides the birthday badge when the server marks it not visible (NOBODY)', () => {
+    // Birthday would be within the window, but birthdayVisible=false (e.g. the
+    // owner set birthdayVisibility=NOBODY) must suppress the pill.
+    renderRow({
+      user: {
+        ...baseUser,
+        birthday: new Date(1990, 3, 15),
+        birthdayVisible: false,
+      },
+    });
+    expect(screen.queryByText('Apr 15')).not.toBeInTheDocument();
+  });
+
   it('renders a "Tomorrow" badge when the birthday is exactly 1 day away', () => {
     renderRow({
       user: {

--- a/app/components/friends/friend-row.tsx
+++ b/app/components/friends/friend-row.tsx
@@ -41,10 +41,11 @@ export type FriendRowEntry = {
     username: string;
     name: string | null;
     birthday: Date | string | null;
-    // String, not a true enum — see schema note. 'FRIENDS' | 'EVERYONE' |
-    // 'NOBODY'. Optional because some callers (legacy test fixtures) don't
-    // set it; defaults to showing the pill.
-    birthdayVisibility?: string;
+    // Server-computed via `canViewBirthday` (the single source of truth for
+    // birthday visibility). Optional because optimistic just-accepted entries
+    // are built client-side before the loader has computed it — `undefined`
+    // shows the pill, and the next loader run fills in the real value.
+    birthdayVisible?: boolean;
     image: { id: string; altText: string | null } | null;
   };
   mutualGroups: Array<{ id: string; name: string }>;
@@ -60,9 +61,9 @@ export function FriendRow({
   onRemove: () => void;
 }>) {
   const { user, mutualGroups } = friend;
-  // Friend has explicitly hidden their birthday — don't compute the upcoming
-  // label at all so nothing shows up in the row slot.
-  const birthdayHidden = user.birthdayVisibility === 'NOBODY';
+  // Friend has hidden their birthday from the viewer (per `canViewBirthday`) —
+  // don't compute the upcoming label at all so nothing shows up in the row slot.
+  const birthdayHidden = user.birthdayVisible === false;
   const upcoming = birthdayHidden ? null : getUpcomingBirthday(user.birthday);
   const birthdaySoon =
     upcoming && upcoming.daysUntil <= BIRTHDAY_VISIBILITY_DAYS

--- a/app/routes/resources+/home.panels.tsx
+++ b/app/routes/resources+/home.panels.tsx
@@ -1,5 +1,6 @@
 import { type LoaderFunctionArgs } from 'react-router';
 import { getUserId } from '#app/utils/auth.server';
+import { canViewBirthday } from '#app/utils/birthday-visibility.server';
 import { prisma } from '#app/utils/db.server';
 
 const SIXTY_DAYS_MS = 60 * 24 * 60 * 60 * 1000;
@@ -56,26 +57,6 @@ function nextBirthdayDate(birthday: Date, now = new Date()) {
   return new Date(now.getFullYear() + 1, bMonth, bDate);
 }
 
-// Is this group-mate's birthday visible to the viewer?
-// - `NOBODY` → never.
-// - `FRIENDS` → only when the viewer has a confirmed friendship.
-// - `FRIENDS_OF_FRIENDS` → only when the viewer is a direct friend OR shares a mutual friend.
-// - `EVERYONE` → always.
-// - Unexpected values default to the most restrictive behaviour (treat as FRIENDS).
-function isBirthdayVisibleToViewer(
-  user: GroupMemberUser,
-  friendIds: Set<string>,
-  friendOfFriendIds: Set<string>,
-) {
-  if (user.birthdayVisibility === 'NOBODY') return false;
-  if (user.birthdayVisibility === 'EVERYONE') return true;
-  if (user.birthdayVisibility === 'FRIENDS_OF_FRIENDS') {
-    return friendIds.has(user.id) || friendOfFriendIds.has(user.id);
-  }
-  // FRIENDS or any unrecognised value: require a direct friendship
-  return friendIds.has(user.id);
-}
-
 // Walk the viewer's group memberships and build a de-duped map of
 // `userId → upcoming-birthday entry`. Pulled out of the loader body to keep
 // the complexity low — the loader just orchestrates DB calls and formats.
@@ -91,7 +72,16 @@ function collectUpcomingBirthdays(
     for (const gm of m.giftGroup.groupMembers) {
       const u = gm.user;
       if (!u.birthday || u.id === viewerId) continue;
-      if (!isBirthdayVisibleToViewer(u, friendIds, friendOfFriendIds)) continue;
+      // The home panel stays friend-gated: it deliberately does not apply the
+      // group-share override (condition (b) of `canViewBirthday`), so a
+      // group-mate who isn't a friend can't surface here just by enabling
+      // shareBirthday. That override is the group overview's concern.
+      const visible = canViewBirthday(u, {
+        isDirectFriend: friendIds.has(u.id),
+        isMutualFriend: friendOfFriendIds.has(u.id),
+        sharesActiveBirthdayGroup: false,
+      });
+      if (!visible) continue;
       if (birthdayMap.has(u.id)) continue;
       birthdayMap.set(u.id, {
         id: u.id,

--- a/app/routes/users+/$username_+/index.loader.test.ts
+++ b/app/routes/users+/$username_+/index.loader.test.ts
@@ -1,0 +1,86 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+const requireUserId = vi.fn();
+const findFirst = vi.fn();
+const getRelationshipDetails = vi.fn();
+const loadProfilePageData = vi.fn();
+
+vi.mock('#app/utils/auth.server.ts', () => ({
+  requireUserId: (...args: Array<unknown>) => requireUserId(...args),
+}));
+
+vi.mock('#app/utils/db.server.ts', () => ({
+  prisma: {
+    user: {
+      findFirst: (...args: Array<unknown>) => findFirst(...args),
+    },
+  },
+}));
+
+vi.mock('#app/utils/friends.server.ts', () => ({
+  getRelationshipDetails: (...args: Array<unknown>) =>
+    getRelationshipDetails(...args),
+}));
+
+vi.mock('#app/utils/profile-page.server.ts', () => ({
+  loadProfilePageData: (...args: Array<unknown>) => loadProfilePageData(...args),
+}));
+
+import { loader } from './index.tsx';
+
+function setup(birthdayVisibility: string) {
+  requireUserId.mockResolvedValue('viewer-1');
+  // First findFirst: the lightweight targetUser lookup.
+  findFirst.mockResolvedValueOnce({
+    id: 'target-1',
+    name: 'Alex',
+    username: 'alex',
+    image: { id: 'image-1' },
+  });
+  // The viewer is a confirmed friend, so the gated branch is reached.
+  getRelationshipDetails.mockResolvedValue({
+    state: 'FRIENDS',
+    friendship: { id: 'friendship-1' },
+  });
+  // Second findFirst: the full profile including birthdayVisibility.
+  findFirst.mockResolvedValueOnce({
+    id: 'target-1',
+    name: 'Alex',
+    username: 'alex',
+    createdAt: new Date('2025-01-01T00:00:00.000Z'),
+    bio: null,
+    birthday: new Date('1990-04-15T12:00:00.000Z'),
+    birthdayVisibility,
+    image: { id: 'image-1' },
+  });
+  loadProfilePageData.mockResolvedValue({
+    mutualGroups: [],
+    mutualFriends: [],
+    wishlistPreview: { items: [], totalCount: 0 },
+  });
+}
+
+async function runLoader() {
+  return loader({
+    context: {},
+    params: { username: 'alex' },
+    request: new Request('https://giftpool.app/users/alex'),
+  } as never);
+}
+
+describe('app/routes/users+/$username_+/index.tsx loader — birthday visibility', () => {
+  it('marks the birthday hidden for a NOBODY target even though the viewer is a friend', async () => {
+    setup('NOBODY');
+    const result = (await runLoader()) as { birthdayVisible: boolean };
+    expect(result.birthdayVisible).toBe(false);
+  });
+
+  it('marks the birthday visible for a non-NOBODY target when the viewer is a friend', async () => {
+    setup('FRIENDS');
+    const result = (await runLoader()) as { birthdayVisible: boolean };
+    expect(result.birthdayVisible).toBe(true);
+  });
+});

--- a/app/routes/users+/$username_+/index.tsx
+++ b/app/routes/users+/$username_+/index.tsx
@@ -19,6 +19,7 @@ import {
   formatBirthdayLabel,
   getUpcomingBirthday,
 } from '#app/utils/birthday.ts';
+import { canViewBirthday } from '#app/utils/birthday-visibility.server.ts';
 import { prisma } from '#app/utils/db.server.ts';
 import { getRelationshipDetails } from '#app/utils/friends.server.ts';
 import { type RelationshipState } from '#app/utils/friends.ts';
@@ -103,12 +104,22 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
 
   const profileData = await loadProfilePageData(userId, targetUser.id);
 
+  // The viewer is a confirmed direct friend to reach this branch, so the rule
+  // reduces to "visible unless NOBODY" — but route it through the shared helper
+  // so the pill consults the single source of truth.
+  const birthdayVisible = canViewBirthday(user, {
+    isDirectFriend: true,
+    isMutualFriend: false,
+    sharesActiveBirthdayGroup: false,
+  });
+
   return {
     canViewProfile,
     user,
     userJoinedDisplay: user.createdAt.toLocaleDateString(),
     relationship,
     profileData,
+    birthdayVisible,
   } as const;
 }
 
@@ -136,6 +147,7 @@ const ProfileRoute = () => {
       userJoinedDisplay={data.userJoinedDisplay}
       relationship={relationship}
       profileData={data.profileData}
+      birthdayVisible={data.birthdayVisible}
     />
   );
 };
@@ -153,6 +165,7 @@ type FriendProfileViewProps = Readonly<{
   userJoinedDisplay: string;
   relationship: Relationship;
   profileData: ProfilePageData;
+  birthdayVisible: boolean;
 }>;
 
 function FriendProfileView({
@@ -160,13 +173,12 @@ function FriendProfileView({
   userJoinedDisplay,
   relationship,
   profileData,
+  birthdayVisible,
 }: FriendProfileViewProps) {
   const userDisplayName = user.name ?? user.username;
-  // Viewer is already a confirmed friend to reach this view, so we only
-  // need to suppress the pill when the owner has opted into NOBODY. EVERYONE
-  // and FRIENDS both end up rendering it.
-  const birthdayHidden = user.birthdayVisibility === 'NOBODY';
-  const upcoming = birthdayHidden ? null : getUpcomingBirthday(user.birthday);
+  // Visibility is decided server-side by `canViewBirthday` (single source of
+  // truth); the pill is suppressed when the owner opted into NOBODY.
+  const upcoming = birthdayVisible ? getUpcomingBirthday(user.birthday) : null;
   const birthdayLabel =
     upcoming && upcoming.daysUntil <= BIRTHDAY_VISIBILITY_DAYS
       ? formatBirthdayLabel(upcoming.date, upcoming.daysUntil)

--- a/app/utils/birthday-visibility.server.test.ts
+++ b/app/utils/birthday-visibility.server.test.ts
@@ -1,0 +1,82 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+  canViewBirthday,
+  type BirthdayVisibilityFacts,
+} from './birthday-visibility.server.ts';
+
+const NONE: BirthdayVisibilityFacts = {
+  isDirectFriend: false,
+  isMutualFriend: false,
+  sharesActiveBirthdayGroup: false,
+};
+
+function facts(overrides: Partial<BirthdayVisibilityFacts>): BirthdayVisibilityFacts {
+  return { ...NONE, ...overrides };
+}
+
+describe('canViewBirthday', () => {
+  it('NOBODY is hidden unconditionally — even from a direct friend or shared birthday-group', () => {
+    expect(
+      canViewBirthday(
+        { birthdayVisibility: 'NOBODY' },
+        facts({ isDirectFriend: true, sharesActiveBirthdayGroup: true }),
+      ),
+    ).toBe(false);
+  });
+
+  it('FRIENDS is visible to a direct friend and hidden from a friend-of-friend', () => {
+    expect(
+      canViewBirthday({ birthdayVisibility: 'FRIENDS' }, facts({ isDirectFriend: true })),
+    ).toBe(true);
+    expect(
+      canViewBirthday({ birthdayVisibility: 'FRIENDS' }, facts({ isMutualFriend: true })),
+    ).toBe(false);
+    expect(canViewBirthday({ birthdayVisibility: 'FRIENDS' }, NONE)).toBe(false);
+  });
+
+  it('FRIENDS_OF_FRIENDS is visible to direct and mutual friends, hidden from strangers', () => {
+    expect(
+      canViewBirthday(
+        { birthdayVisibility: 'FRIENDS_OF_FRIENDS' },
+        facts({ isDirectFriend: true }),
+      ),
+    ).toBe(true);
+    expect(
+      canViewBirthday(
+        { birthdayVisibility: 'FRIENDS_OF_FRIENDS' },
+        facts({ isMutualFriend: true }),
+      ),
+    ).toBe(true);
+    expect(
+      canViewBirthday({ birthdayVisibility: 'FRIENDS_OF_FRIENDS' }, NONE),
+    ).toBe(false);
+  });
+
+  it('EVERYONE is visible to a stranger', () => {
+    expect(canViewBirthday({ birthdayVisibility: 'EVERYONE' }, NONE)).toBe(true);
+  });
+
+  it('a shared active birthday-group grants any non-NOBODY target regardless of friendship', () => {
+    for (const visibility of ['EVERYONE', 'FRIENDS_OF_FRIENDS', 'FRIENDS']) {
+      expect(
+        canViewBirthday(
+          { birthdayVisibility: visibility },
+          facts({ sharesActiveBirthdayGroup: true }),
+        ),
+      ).toBe(true);
+    }
+  });
+
+  it('an unrecognised visibility value falls back to the most-restrictive FRIENDS behaviour', () => {
+    expect(
+      canViewBirthday({ birthdayVisibility: 'WHATEVER' }, facts({ isDirectFriend: true })),
+    ).toBe(true);
+    expect(
+      canViewBirthday({ birthdayVisibility: 'WHATEVER' }, facts({ isMutualFriend: true })),
+    ).toBe(false);
+  });
+});

--- a/app/utils/birthday-visibility.server.ts
+++ b/app/utils/birthday-visibility.server.ts
@@ -1,0 +1,54 @@
+// Single source of truth for "can this viewer see this target's birthday?".
+//
+// Two independent gates used to guard different surfaces and never composed:
+// the group overview filtered only on the per-group `shareBirthday` membership
+// flag, while the home panel checked only the user's global
+// `birthdayVisibility`. As a result a user with `birthdayVisibility === 'NOBODY'`
+// still leaked into the group-overview birthday feed. This helper unifies the
+// rule so every birthday surface agrees.
+//
+// The function is pure (no Prisma) — callers gather the relationship/group facts
+// however is efficient for their surface (single lookup, batch query, or a value
+// already implied by the population) and pass them in. It lives in a `.server.ts`
+// file because only server code consults it; client surfaces receive a computed
+// boolean.
+
+export type BirthdayVisibilityFacts = {
+  // Viewer and target have a confirmed direct friendship.
+  isDirectFriend: boolean;
+  // Viewer and target share ≥1 mutual friend (friend-of-friend), but are not
+  // direct friends. Only consulted for `FRIENDS_OF_FRIENDS`.
+  isMutualFriend: boolean;
+  // Viewer and target share ≥1 active group membership (removedAt: null) where
+  // the TARGET's `shareBirthday === true` for that group. This is the
+  // group-share override — condition (b) below.
+  sharesActiveBirthdayGroup: boolean;
+};
+
+// Rule:
+// - `NOBODY` → false, unconditionally (even a direct friend or a shared
+//   birthday-group can't override it).
+// - Otherwise true if EITHER:
+//   (a) the relationship satisfies `birthdayVisibility`, OR
+//   (b) the target opted into `shareBirthday` for a group they actively share
+//       with the viewer.
+export function canViewBirthday(
+  target: { birthdayVisibility: string },
+  facts: BirthdayVisibilityFacts,
+): boolean {
+  if (target.birthdayVisibility === 'NOBODY') return false;
+
+  // Condition (b): group-share override.
+  if (facts.sharesActiveBirthdayGroup) return true;
+
+  // Condition (a): the relationship satisfies the visibility setting.
+  switch (target.birthdayVisibility) {
+    case 'EVERYONE':
+      return true;
+    case 'FRIENDS_OF_FRIENDS':
+      return facts.isDirectFriend || facts.isMutualFriend;
+    default:
+      // 'FRIENDS' or any unrecognised value → require a direct friendship.
+      return facts.isDirectFriend;
+  }
+}

--- a/app/utils/friends.server.ts
+++ b/app/utils/friends.server.ts
@@ -1,5 +1,6 @@
 import { captureException } from '@sentry/react-router';
 import { queueLogEvent } from '#app/utils/analytics.server.ts';
+import { canViewBirthday } from '#app/utils/birthday-visibility.server.ts';
 import { prisma } from '#app/utils/db.server.ts';
 import { NOTIFICATION_TYPES } from '#app/utils/notification-registry.ts';
 import { notifyUser } from '#app/utils/notification-service.server.tsx';
@@ -126,10 +127,25 @@ export async function listFriends(userId: string) {
   return friendships.map((friendship) => {
     const otherUser =
       friendship.userAId === userId ? friendship.userB : friendship.userA;
+    // The viewer is a direct friend of every entry in this list, so the rule
+    // reduces to "visible unless NOBODY". Compute it via the shared helper so
+    // the friend row consults the single source of truth rather than
+    // re-checking birthdayVisibility itself.
+    const birthdayVisible = canViewBirthday(otherUser, {
+      isDirectFriend: true,
+      isMutualFriend: false,
+      sharesActiveBirthdayGroup: false,
+    });
     return {
       friendshipId: friendship.id,
       createdAt: friendship.createdAt,
-      user: otherUser,
+      // `birthdayVisible` is optional in the type so optimistic client entries
+      // (just-accepted friend requests, built before a loader run) can omit it
+      // — an absent value renders the birthday pill, and the next loader fills
+      // in the real value.
+      user: { ...otherUser, birthdayVisible } as typeof otherUser & {
+        birthdayVisible?: boolean;
+      },
     };
   });
 }

--- a/app/utils/group-overview.server.test.ts
+++ b/app/utils/group-overview.server.test.ts
@@ -507,4 +507,76 @@ describe('getGroupOverviewData (integration)', () => {
       );
     }
   });
+
+  it('drops NOBODY members from the birthday feed even with shareBirthday=true', async () => {
+    const inTenDays = new Date(NOW);
+    inTenDays.setDate(inTenDays.getDate() + 10);
+
+    poolFindMany.mockResolvedValueOnce([]); // active pools
+    // Both rows come back from the shareBirthday=true query; only the NOBODY
+    // one must be filtered out by canViewBirthday.
+    usersInGiftGroupsFindMany.mockResolvedValueOnce([
+      {
+        userId: 'hidden',
+        user: {
+          name: 'Hidden',
+          username: 'hidden',
+          birthday: inTenDays,
+          birthdayVisibility: 'NOBODY',
+          image: null,
+        },
+      },
+      {
+        userId: 'visible',
+        user: {
+          name: 'Visible',
+          username: 'visible',
+          birthday: inTenDays,
+          birthdayVisibility: 'FRIENDS',
+          image: null,
+        },
+      },
+    ]);
+    poolFindMany.mockResolvedValueOnce([]); // past gifts
+
+    const result = await getGroupOverviewData('group-1', 'viewer-1');
+
+    const ids = result.upcomingOccasions.map((o) => o.userId);
+    expect(ids).toEqual(['visible']);
+    expect(ids).not.toContain('hidden');
+  });
+
+  it('shows a non-friend group-mate on the birthday feed, and excludes shareBirthday=false at the DB level', async () => {
+    const inTenDays = new Date(NOW);
+    inTenDays.setDate(inTenDays.getDate() + 10);
+
+    poolFindMany.mockResolvedValueOnce([]); // active pools
+    // `viewer-1` has no friendship with `colleague` — friendship is irrelevant
+    // to the group-based feed. The row is returned because they shareBirthday.
+    usersInGiftGroupsFindMany.mockResolvedValueOnce([
+      {
+        userId: 'colleague',
+        user: {
+          name: 'Colleague',
+          username: 'colleague',
+          birthday: inTenDays,
+          birthdayVisibility: 'FRIENDS',
+          image: null,
+        },
+      },
+    ]);
+    poolFindMany.mockResolvedValueOnce([]); // past gifts
+
+    const result = await getGroupOverviewData('group-1', 'viewer-1');
+
+    expect(result.upcomingOccasions.map((o) => o.userId)).toEqual(['colleague']);
+
+    // shareBirthday=false members are excluded at the DB level, so the false
+    // case never reaches the app-side filter.
+    const membersCall = usersInGiftGroupsFindMany.mock.calls[0]?.[0] as {
+      where: { shareBirthday: boolean; removedAt: null };
+    };
+    expect(membersCall.where.shareBirthday).toBe(true);
+    expect(membersCall.where.removedAt).toBeNull();
+  });
 });

--- a/app/utils/group-overview.server.ts
+++ b/app/utils/group-overview.server.ts
@@ -1,3 +1,4 @@
+import { canViewBirthday } from '#app/utils/birthday-visibility.server.ts'
 import { prisma } from '#app/utils/db.server.ts'
 import {
 	ACTION_TYPE,
@@ -124,7 +125,7 @@ async function queryActivePools(groupId: string, viewerId: string) {
 type ActivePoolRow = Awaited<ReturnType<typeof queryActivePools>>[number]
 
 async function queryGroupMembers(groupId: string, viewerId: string) {
-	return prisma.usersInGiftGroups.findMany({
+	const members = await prisma.usersInGiftGroups.findMany({
 		where: {
 			giftGroupId: groupId,
 			userId: { not: viewerId },
@@ -139,11 +140,25 @@ async function queryGroupMembers(groupId: string, viewerId: string) {
 					name: true,
 					username: true,
 					birthday: true,
+					birthdayVisibility: true,
 					image: { select: { id: true } },
 				},
 			},
 		},
 	})
+
+	// The `where` above already restricts to active memberships that opted into
+	// shareBirthday for this group, so condition (b) of `canViewBirthday` holds
+	// for every row — the only remaining gate is the target's global
+	// `birthdayVisibility`. This drops users who set NOBODY, which the raw
+	// shareBirthday filter used to leak into the birthday feed.
+	return members.filter((member) =>
+		canViewBirthday(member.user, {
+			isDirectFriend: false,
+			isMutualFriend: false,
+			sharesActiveBirthdayGroup: true,
+		}),
+	)
 }
 
 type MemberRow = Awaited<ReturnType<typeof queryGroupMembers>>[number]


### PR DESCRIPTION
## Context

Birthday visibility was enforced by **two independent gates that never composed**:

- **Group overview** (`group-overview.server.ts`, `queryGroupMembers`) filtered only on the per-group `shareBirthday` membership flag — never the user's global `birthdayVisibility`.
- **Home panel** (`home.panels.tsx`, `isBirthdayVisibleToViewer`) checked only `birthdayVisibility` — never `shareBirthday`.

**Bug:** a user who set `birthdayVisibility='NOBODY'` still appeared in the group-overview upcoming-birthday feed as long as they left `shareBirthday=true` for that group. `NOBODY` is meant to hide their birthday everywhere.

## The fix — one source of truth

New pure helper `canViewBirthday(target, facts)` in `app/utils/birthday-visibility.server.ts`:
- `birthdayVisibility === 'NOBODY'` → hidden, unconditionally.
- Otherwise visible if EITHER (a) the relationship satisfies `birthdayVisibility` (`EVERYONE` / `FRIENDS_OF_FRIENDS` → direct or mutual friend / `FRIENDS` → direct friend), OR (b) the target opted into `shareBirthday` for an active shared group.

Every birthday surface now consults it:
- **group-overview** — selects `birthdayVisibility`, filters through the helper → **drops NOBODY** (the bug fix).
- **home panel** — swaps in the helper with `sharesActiveBirthdayGroup: false`; stays friend-gated, behavior unchanged (the group-share override stays scoped to the group overview).
- **friends list** (`listFriends` + `friend-row.tsx`) — visibility computed server-side, row consumes a `birthdayVisible` flag.
- **public profile pill** (`users+/$username_+/index.tsx`) — loader computes `birthdayVisible` via the helper.

The only behavior change anywhere is the group-overview NOBODY fix.

## Tests
- New `birthday-visibility.server.test.ts` — full rule matrix.
- group-overview: NOBODY dropped even with `shareBirthday=true`; non-friend group-mate shown; `shareBirthday=false` excluded at DB level.
- friend-row: `birthdayVisible: false` suppresses the pill.
- new profile loader test: NOBODY → `birthdayVisible: false`, non-NOBODY → `true`.
- Existing home-panel FRIENDS_OF_FRIENDS / NOBODY tests stay green.

`npm run typecheck` clean · `npm run lint` 0 errors · all affected suites pass.