### PR TITLE
fix(birthday): preserve NOBODY for optimistic friend rows

### DIFF
--- a/app/routes/friends.test.tsx
+++ b/app/routes/friends.test.tsx
@@ -404,6 +404,14 @@ describe('/friends route helpers', () => {
     ]);
   });
 
+  it('derives birthdayVisible for optimistic entries so a NOBODY friend does not leak', () => {
+    const hiddenUser = { ...createUser('user-2', 'sam', 'Sam'), birthdayVisibility: 'NOBODY' };
+    expect(buildFriendEntry('request-3', hiddenUser).user.birthdayVisible).toBe(false);
+
+    const friendsUser = createUser('user-3', 'jo', 'Jo'); // birthdayVisibility: 'FRIENDS'
+    expect(buildFriendEntry('request-4', friendsUser).user.birthdayVisible).toBe(true);
+  });
+
   it('submits request mutations and batches failures', async () => {
     vi.stubGlobal(
       'fetch',

--- a/app/routes/friends.tsx
+++ b/app/routes/friends.tsx
@@ -156,7 +156,16 @@ export function buildFriendEntry(
   return {
     friendshipId: friendshipId ?? requestId,
     createdAt: new Date(),
-    user,
+    user: {
+      ...user,
+      // Optimistic entries come from a just-accepted friend request, so the
+      // viewer is now a direct friend — NOBODY is the only visibility gate
+      // that still applies. The pending-request payload carries
+      // birthdayVisibility but not the server-computed birthdayVisible, so
+      // derive it here (falling back to the legacy field) to stop a NOBODY
+      // friend's birthday flashing in the list before the loader recomputes it.
+      birthdayVisible: user.birthdayVisible ?? user.birthdayVisibility !== 'NOBODY',
+    },
     // Optimistic entries (just-accepted friend requests) start without
     // mutual-groups data. The next loader run will fill them in.
     mutualGroups: [],


### PR DESCRIPTION
Follow-up to #458 (flagged by Codex review).

## Problem

`buildFriendEntry` builds optimistic friend entries (just-accepted friend requests, friendship events) from a pending-request user payload — which carries `birthdayVisibility` but **not** the server-computed `birthdayVisible`. The friend-row only hides the pill when `birthdayVisible === false`, so with `birthdayVisible` undefined the check is falsy and the pill renders.

Result: if the just-accepted friend set `birthdayVisibility: 'NOBODY'` and has a birthday within the 60-day window, their birthday badge flashes in the accepter's friends list in the window between accepting and the next loader run — a (brief) violation of the `NOBODY` guarantee #458 enforces.

## Fix

Derive `birthdayVisible` in `buildFriendEntry`. These entries are for a person who is **definitionally a direct friend** at that moment, so `NOBODY` is the only visibility gate that still applies — `birthdayVisible = user.birthdayVisible ?? user.birthdayVisibility !== 'NOBODY'`. This is a narrow, correct application of the one rule fragment relevant here, not a re-implementation of the server-side `canViewBirthday` helper.

## Test

`friends.test.tsx`: a `NOBODY` optimistic user yields `birthdayVisible: false`; a `FRIENDS` user yields `true`.

`npm run typecheck` clean · `eslint` 0 errors · `friends.test.tsx` 13 passing.