### PR TITLE
feat(groups): record group creator (createdById provenance)

### DIFF
--- a/app/routes/groups+/__group-editor.server.test.ts
+++ b/app/routes/groups+/__group-editor.server.test.ts
@@ -1,0 +1,61 @@
+/**
+ * @vitest-environment node
+ */
+import { type AppLoadContext } from 'react-router';
+import { describe, expect, it, vi } from 'vitest';
+import { prisma } from '#app/utils/db.server.ts';
+import { createUser } from '#tests/db-utils.ts';
+import { toActionArgs } from '#tests/route-module-test-utils.ts';
+
+const requireUserId = vi.fn();
+
+vi.mock('#app/utils/auth.server.ts', () => ({
+  requireUserId: (...args: Array<unknown>) => requireUserId(...args),
+}));
+
+import { action } from './__group-editor.server.tsx';
+
+const context = {
+  cspNonce: undefined,
+  serverBuild: undefined,
+} as unknown as AppLoadContext;
+
+function createFormRequest(form: Record<string, string>) {
+  return new Request('https://giftpool.app/groups/new', {
+    body: new URLSearchParams(form),
+    headers: {
+      'content-type': 'application/x-www-form-urlencoded',
+    },
+    method: 'POST',
+  });
+}
+
+describe('group create action', () => {
+  it('records the acting user as the group creator', async () => {
+    const user = await prisma.user.create({ data: createUser() });
+    requireUserId.mockResolvedValue(user.id);
+
+    const result = await action(
+      toActionArgs({
+        context,
+        params: {},
+        request: createFormRequest({ name: 'Birthday Squad' }),
+      }),
+    );
+
+    // The create branch redirects to the new group on success.
+    expect(result).toBeInstanceOf(Response);
+    expect((result as Response).status).toBe(302);
+
+    const group = await prisma.giftGroup.findFirstOrThrow({
+      where: { name: 'Birthday Squad' },
+      include: { groupMembers: true },
+    });
+
+    expect(group.createdById).toBe(user.id);
+    // Provenance is recorded alongside the OWNER membership, not instead of it.
+    expect(group.groupMembers).toEqual([
+      expect.objectContaining({ userId: user.id, role: 'OWNER' }),
+    ]);
+  });
+});

--- a/app/routes/groups+/__group-editor.server.tsx
+++ b/app/routes/groups+/__group-editor.server.tsx
@@ -73,6 +73,7 @@ export async function action({ request }: ActionFunctionArgs) {
     create: {
       name,
       description,
+      createdById: userId,
       groupMembers: {
         create: {
           userId,

--- a/prisma/migrations/20260703050411_add_group_created_by/migration.sql
+++ b/prisma/migrations/20260703050411_add_group_created_by/migration.sql
@@ -1,0 +1,31 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Group" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "budgetVisibility" TEXT NOT NULL DEFAULT 'EVERYONE',
+    "createdById" TEXT,
+    CONSTRAINT "Group_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "User" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+INSERT INTO "new_Group" ("budgetVisibility", "createdAt", "description", "id", "name", "updatedAt") SELECT "budgetVisibility", "createdAt", "description", "id", "name", "updatedAt" FROM "Group";
+DROP TABLE "Group";
+ALTER TABLE "new_Group" RENAME TO "Group";
+CREATE INDEX "Group_createdById_idx" ON "Group"("createdById");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;
+
+-- Backfill createdById by INFERENCE — no authoritative creator was recorded for
+-- historical groups. Prefer the earliest-joined OWNER; else the earliest-joined
+-- member; else leave NULL.
+UPDATE "Group"
+SET "createdById" = (
+    SELECT u."userId"
+    FROM "UsersInGiftGroups" u
+    WHERE u."giftGroupId" = "Group"."id"
+    ORDER BY (u."role" = 'OWNER') DESC, u."joinedAt" ASC
+    LIMIT 1
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -35,6 +35,7 @@ model User {
   sessions                     Session[]
   image                        UserImage?
   giftGroups                   UsersInGiftGroups[]
+  giftGroupsCreated            GiftGroup[]                   @relation("GiftGroup_CreatedBy")
   wishlistItems                WishlistItem[]
   wishlistCategories           WishlistCategory[]
   roles                        Role[]                        @relation("RoleToUser")
@@ -184,6 +185,11 @@ model GiftGroup {
   name             String
   description      String?
   budgetVisibility String              @default("EVERYONE")
+  // Provenance/analytics only — the user who created this group. NOT a
+  // permission input: role on UsersInGiftGroups remains the sole authority for
+  // authorization. Nullable because historical groups have no recorded creator.
+  createdById      String?
+  createdBy        User?               @relation("GiftGroup_CreatedBy", fields: [createdById], references: [id], onDelete: SetNull)
   pools            Pool[]
   activities       GroupActivity[]
   groupInvitations GroupInvitation[]
@@ -191,6 +197,7 @@ model GiftGroup {
   joinRequests     JoinRequest[]
   groupMembers     UsersInGiftGroups[]
 
+  @@index([createdById])
   @@map("Group")
 }
 


### PR DESCRIPTION
## What

Adds a nullable `createdById` to `GiftGroup` (`@@map("Group")`) recording who created a group, so we can measure group formation — specifically the future **pool → group conversion** funnel.

## Why

Membership role (`OWNER`/`ADMIN`/`MEMBER`) is mutable (ownership transfers) and is the authority for *permissions* — it isn't a durable record of the original creator. `createdById` is **provenance/analytics only** and never feeds authorization (stated in a schema comment).

## Changes

- **Schema** (`prisma/schema.prisma`): `createdById String?` + `createdBy User?` relation (`onDelete: SetNull`, named `GiftGroup_CreatedBy`), `@@index([createdById])`, and a `giftGroupsCreated` back-relation on `User` — matching the existing `FriendInvitation_CreatedBy` / `GroupReminder_CreatedBy` convention.
- **Migration**: Prisma `RedefineTables` + index, plus a hand-appended **best-effort inference backfill** for historical rows (earliest-joined `OWNER`, else earliest-joined member, else `NULL`) — flagged as inference in a comment.
- **Creation**: wires `createdById: userId` into the single create path (the `giftGroup.upsert` `create` branch in `__group-editor.server.tsx`) — never on `update`, so edits don't rewrite provenance.

## Not included

No UI changes, no permission-logic changes. Role remains the sole authorization authority.

## Testing

- New real-DB integration test asserting a created group records the creator alongside the `OWNER` membership.
- Backfill left untested (no existing migration-test pattern in the repo).
- `npm run typecheck` clean, new test + lint pass. Verified backfill populated existing dev-DB groups to their OWNER.