### PR TITLE
[codex] Person surface gift occasion launchpad

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,14 @@ tests/
 - kebab-case filenames, PascalCase exports
 - Colocate tests: `ComponentName.test.tsx`
 
+### Modals are sheets on mobile — HARD RULE
+
+**Every modal renders as a bottom sheet on mobile (< 640px) and a centered dialog on desktop. No exceptions.** A centered modal on a phone is a bug.
+
+- Use `ResponsiveDialog` from `app/components/ui/responsive-dialog.tsx` for ALL modals. Its sub-components (`ResponsiveDialogContent`, `ResponsiveDialogHeader`, `ResponsiveDialogFooter`, `ResponsiveDialogTitle`, `ResponsiveDialogDescription`, `ResponsiveDialogTrigger`, `ResponsiveDialogClose`) mirror the `Dialog` API exactly, so they are drop-in — commonly imported `as Dialog`, `as DialogContent`, … to keep JSX unchanged. It swaps to the `MobileBottomSheet` family below the breakpoint via `useIsDesktop`.
+- Do NOT use the raw `Dialog` primitive (`app/components/ui/dialog.tsx`) directly for a modal — it is centered at every width. `Dialog`/`MobileBottomSheet` are the low-level primitives that `ResponsiveDialog` composes; reach for them only when building `ResponsiveDialog` itself.
+- This does not apply to non-modal overlays (dropdown menus, popovers, tooltips, toasts) — only to modal dialogs.
+
 ### Database
 
 - Always create migrations for schema changes

--- a/app/components/ui/responsive-dialog.test.tsx
+++ b/app/components/ui/responsive-dialog.test.tsx
@@ -1,0 +1,142 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import { type ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+let isDesktop = true;
+
+vi.mock('#app/components/wishlist/hooks/use-is-desktop.ts', () => ({
+  useIsDesktop: () => isDesktop,
+}));
+
+vi.mock('./dialog.tsx', () => ({
+  Dialog: ({ children }: { children: ReactNode }) => (
+    <div data-testid="desktop-root">{children}</div>
+  ),
+  DialogClose: ({ children }: { children: ReactNode }) => (
+    <button type="button" data-testid="desktop-close">
+      {children}
+    </button>
+  ),
+  DialogContent: ({ children }: { children: ReactNode }) => (
+    <div data-testid="desktop-content">{children}</div>
+  ),
+  DialogDescription: ({ children }: { children: ReactNode }) => (
+    <p data-testid="desktop-description">{children}</p>
+  ),
+  DialogFooter: ({ children }: { children: ReactNode }) => (
+    <footer data-testid="desktop-footer">{children}</footer>
+  ),
+  DialogHeader: ({ children }: { children: ReactNode }) => (
+    <header data-testid="desktop-header">{children}</header>
+  ),
+  DialogTitle: ({ children }: { children: ReactNode }) => (
+    <h2 data-testid="desktop-title">{children}</h2>
+  ),
+  DialogTrigger: ({ children }: { children: ReactNode }) => (
+    <button type="button" data-testid="desktop-trigger">
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock('./mobile-bottom-sheet.tsx', () => ({
+  MobileBottomSheet: ({ children }: { children: ReactNode }) => (
+    <div data-testid="mobile-root">{children}</div>
+  ),
+  MobileBottomSheetClose: ({ children }: { children: ReactNode }) => (
+    <button type="button" data-testid="mobile-close">
+      {children}
+    </button>
+  ),
+  MobileBottomSheetContent: ({ children }: { children: ReactNode }) => (
+    <div data-testid="mobile-content">{children}</div>
+  ),
+  MobileBottomSheetDescription: ({ children }: { children: ReactNode }) => (
+    <p data-testid="mobile-description">{children}</p>
+  ),
+  MobileBottomSheetFooter: ({ children }: { children: ReactNode }) => (
+    <footer data-testid="mobile-footer">{children}</footer>
+  ),
+  MobileBottomSheetHeader: ({ children }: { children: ReactNode }) => (
+    <header data-testid="mobile-header">{children}</header>
+  ),
+  MobileBottomSheetTitle: ({ children }: { children: ReactNode }) => (
+    <h2 data-testid="mobile-title">{children}</h2>
+  ),
+  MobileBottomSheetTrigger: ({ children }: { children: ReactNode }) => (
+    <button type="button" data-testid="mobile-trigger">
+      {children}
+    </button>
+  ),
+}));
+
+import {
+  ResponsiveDialog,
+  ResponsiveDialogClose,
+  ResponsiveDialogContent,
+  ResponsiveDialogDescription,
+  ResponsiveDialogFooter,
+  ResponsiveDialogHeader,
+  ResponsiveDialogTitle,
+  ResponsiveDialogTrigger,
+} from './responsive-dialog.tsx';
+
+function renderDialog() {
+  render(
+    <ResponsiveDialog open onOpenChange={vi.fn()}>
+      <ResponsiveDialogTrigger>Open</ResponsiveDialogTrigger>
+      <ResponsiveDialogContent>
+        <ResponsiveDialogHeader>
+          <ResponsiveDialogTitle>Gift details</ResponsiveDialogTitle>
+          <ResponsiveDialogDescription>
+            Pick the right surface.
+          </ResponsiveDialogDescription>
+        </ResponsiveDialogHeader>
+        <ResponsiveDialogFooter>
+          <ResponsiveDialogClose>Close</ResponsiveDialogClose>
+        </ResponsiveDialogFooter>
+      </ResponsiveDialogContent>
+    </ResponsiveDialog>,
+  );
+}
+
+describe('ResponsiveDialog', () => {
+  it('uses dialog primitives on desktop', () => {
+    isDesktop = true;
+    renderDialog();
+
+    expect(screen.getByTestId('desktop-root')).toBeInTheDocument();
+    expect(screen.getByTestId('desktop-trigger')).toHaveTextContent('Open');
+    expect(screen.getByTestId('desktop-content')).toBeInTheDocument();
+    expect(screen.getByTestId('desktop-header')).toBeInTheDocument();
+    expect(screen.getByTestId('desktop-title')).toHaveTextContent(
+      'Gift details',
+    );
+    expect(screen.getByTestId('desktop-description')).toHaveTextContent(
+      'Pick the right surface.',
+    );
+    expect(screen.getByTestId('desktop-footer')).toBeInTheDocument();
+    expect(screen.getByTestId('desktop-close')).toHaveTextContent('Close');
+  });
+
+  it('uses bottom-sheet primitives on mobile', () => {
+    isDesktop = false;
+    renderDialog();
+
+    expect(screen.getByTestId('mobile-root')).toBeInTheDocument();
+    expect(screen.getByTestId('mobile-trigger')).toHaveTextContent('Open');
+    expect(screen.getByTestId('mobile-content')).toBeInTheDocument();
+    expect(screen.getByTestId('mobile-header')).toBeInTheDocument();
+    expect(screen.getByTestId('mobile-title')).toHaveTextContent(
+      'Gift details',
+    );
+    expect(screen.getByTestId('mobile-description')).toHaveTextContent(
+      'Pick the right surface.',
+    );
+    expect(screen.getByTestId('mobile-footer')).toBeInTheDocument();
+    expect(screen.getByTestId('mobile-close')).toHaveTextContent('Close');
+  });
+});

--- a/app/components/ui/responsive-dialog.tsx
+++ b/app/components/ui/responsive-dialog.tsx
@@ -1,0 +1,108 @@
+import { createContext, useContext } from 'react';
+import { useIsDesktop } from '#app/components/wishlist/hooks/use-is-desktop.ts';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from './dialog.tsx';
+import {
+  MobileBottomSheet,
+  MobileBottomSheetClose,
+  MobileBottomSheetContent,
+  MobileBottomSheetDescription,
+  MobileBottomSheetFooter,
+  MobileBottomSheetHeader,
+  MobileBottomSheetTitle,
+  MobileBottomSheetTrigger,
+} from './mobile-bottom-sheet.tsx';
+
+/**
+ * The one modal primitive to use for dialogs.
+ *
+ * HARD RULE (see CLAUDE.md → "Modals are sheets on mobile"): every modal in the
+ * app renders as a bottom sheet on mobile (< 640px) and a centered dialog on
+ * desktop. Do NOT reach for the raw `Dialog` primitive for a modal — use this.
+ * The sub-components mirror the `Dialog` API exactly, so they are drop-in
+ * (`ResponsiveDialog` ⇒ `Dialog`, `ResponsiveDialogContent` ⇒ `DialogContent`,
+ * etc.), and swap to the `MobileBottomSheet` family below the breakpoint.
+ */
+
+const IsDesktopContext = createContext(true);
+
+export function ResponsiveDialog(props: React.ComponentProps<typeof Dialog>) {
+  const isDesktop = useIsDesktop();
+  const Root = isDesktop ? Dialog : MobileBottomSheet;
+  return (
+    <IsDesktopContext.Provider value={isDesktop}>
+      <Root {...props} />
+    </IsDesktopContext.Provider>
+  );
+}
+
+export function ResponsiveDialogTrigger(
+  props: React.ComponentProps<typeof DialogTrigger>,
+) {
+  const Cmp = useContext(IsDesktopContext)
+    ? DialogTrigger
+    : MobileBottomSheetTrigger;
+  return <Cmp {...props} />;
+}
+
+export function ResponsiveDialogContent(
+  props: React.ComponentProps<typeof DialogContent>,
+) {
+  const Cmp = useContext(IsDesktopContext)
+    ? DialogContent
+    : MobileBottomSheetContent;
+  return <Cmp {...props} />;
+}
+
+export function ResponsiveDialogHeader(
+  props: React.ComponentProps<typeof DialogHeader>,
+) {
+  const Cmp = useContext(IsDesktopContext)
+    ? DialogHeader
+    : MobileBottomSheetHeader;
+  return <Cmp {...props} />;
+}
+
+export function ResponsiveDialogFooter(
+  props: React.ComponentProps<typeof DialogFooter>,
+) {
+  const Cmp = useContext(IsDesktopContext)
+    ? DialogFooter
+    : MobileBottomSheetFooter;
+  return <Cmp {...props} />;
+}
+
+export function ResponsiveDialogTitle(
+  props: React.ComponentProps<typeof DialogTitle>,
+) {
+  const Cmp = useContext(IsDesktopContext)
+    ? DialogTitle
+    : MobileBottomSheetTitle;
+  return <Cmp {...props} />;
+}
+
+export function ResponsiveDialogDescription(
+  props: React.ComponentProps<typeof DialogDescription>,
+) {
+  const Cmp = useContext(IsDesktopContext)
+    ? DialogDescription
+    : MobileBottomSheetDescription;
+  return <Cmp {...props} />;
+}
+
+export function ResponsiveDialogClose(
+  props: React.ComponentProps<typeof DialogClose>,
+) {
+  const Cmp = useContext(IsDesktopContext)
+    ? DialogClose
+    : MobileBottomSheetClose;
+  return <Cmp {...props} />;
+}

--- a/app/components/users/person-surface.tsx
+++ b/app/components/users/person-surface.tsx
@@ -1,4 +1,10 @@
-import { useEffect, useRef, useState } from 'react';
+import {
+  cloneElement,
+  isValidElement,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import {
   LuCake,
   LuCheck,
@@ -12,7 +18,7 @@ import {
   LuUsers,
   LuX,
 } from 'react-icons/lu';
-import { Form, useFetcher, useNavigate } from 'react-router';
+import { Form, Link, useFetcher, useNavigate } from 'react-router';
 import { FriendActionButton } from '#app/components/friends/friend-action-button.tsx';
 import { Avatar } from '#app/components/ui/avatar.tsx';
 import { Button } from '#app/components/ui/button.tsx';
@@ -214,16 +220,20 @@ function OccasionHeader({
           size={14}
         />
         <div className="min-w-0 flex-1">
-          <div className="text-xl font-extrabold leading-tight tracking-tight">
+          <h1 className="text-xl font-extrabold leading-tight tracking-tight">
             {displayName}
-          </div>
+          </h1>
           <div className="mt-0.5 text-sm font-semibold text-muted-foreground">
             @{user.username}
           </div>
         </div>
       </div>
       {occasion ? (
-        <div className="mt-4 flex items-center gap-2.5">
+        <div
+          className="mt-4 flex items-center gap-2.5"
+          role="group"
+          aria-label={`Birthday ${occasion.label}`}
+        >
           <span
             className="flex h-9 w-9 flex-none items-center justify-center rounded-xl text-gift"
             style={{ background: tint('gift', 0.16) }}
@@ -265,9 +275,13 @@ function DeclinedHeader({
           />
         </span>
         <div className="min-w-0 flex-1">
-          <div className="text-[17px] font-extrabold">{displayName}</div>
+          <h1 className="text-[17px] font-extrabold">{displayName}</h1>
           {occasionLabel ? (
-            <div className="mt-px text-xs font-semibold text-muted-foreground">
+            <div
+              className="mt-px text-xs font-semibold text-muted-foreground"
+              role="group"
+              aria-label={`Birthday ${occasionLabel}`}
+            >
               Birthday · {occasionLabel}
             </div>
           ) : null}
@@ -332,9 +346,9 @@ function IdentityHeader({
         user={data.user}
         size={20}
       />
-      <div className="mt-3 text-xl font-extrabold tracking-tight">
+      <h1 className="mt-3 text-xl font-extrabold tracking-tight">
         {displayName}
-      </div>
+      </h1>
       <div className="mt-0.5 text-sm font-semibold text-muted-foreground">
         @{data.user.username}
       </div>
@@ -529,11 +543,19 @@ function TriggerButton({
   trigger: React.ReactNode;
   onClick: () => void;
 }) {
-  return (
-    <span onClick={onClick} className="contents">
-      {trigger}
-    </span>
-  );
+  if (!isValidElement(trigger)) return null;
+
+  const element = trigger as React.ReactElement<{
+    onClick?: React.MouseEventHandler<HTMLElement>;
+  }>;
+  const triggerClick = element.props.onClick;
+
+  return cloneElement(element, {
+    onClick(event: React.MouseEvent<HTMLElement>) {
+      triggerClick?.(event);
+      if (!event.defaultPrevented) onClick();
+    },
+  });
 }
 
 function SaveIdeaDialog({
@@ -779,9 +801,18 @@ function IdeationBlock({
             token="gift"
             title="Their wishlist"
             right={
-              <span className="text-[11px] font-bold text-muted-foreground">
-                {data.wishlistSource.length} items
-              </span>
+              <div className="flex items-center gap-2">
+                <span className="text-[11px] font-bold text-muted-foreground">
+                  {data.wishlistSource.length} items
+                </span>
+                <Link
+                  to={`/users/${data.user.username}/wishlist`}
+                  aria-label={`${displayName}'s wishlist`}
+                  className="rounded-full px-2 py-1 text-[11px] font-extrabold text-gift hover:bg-gift/10"
+                >
+                  See all
+                </Link>
+              </div>
             }
           />
           <div className="flex flex-col gap-2.5">
@@ -1167,11 +1198,7 @@ function ProposeControl({
         className={variant === 'wishlist' ? 'flex-1' : undefined}
       >
         {hidden(openPools[0]!.id)}
-        <button
-          type="submit"
-          className={btnClass}
-          style={btnStyle}
-        >
+        <button type="submit" className={btnClass} style={btnStyle}>
           <LuUsers size={15} />
           Propose to pool
         </button>

--- a/app/components/users/person-surface.tsx
+++ b/app/components/users/person-surface.tsx
@@ -1,0 +1,733 @@
+import { useEffect, useRef, useState } from 'react';
+import {
+  LuCake,
+  LuGift,
+  LuHeart,
+  LuMessageCircle,
+  LuUser,
+  LuUsers,
+  LuX,
+} from 'react-icons/lu';
+import { useFetcher, useNavigate } from 'react-router';
+import { FriendActionButton } from '#app/components/friends/friend-action-button.tsx';
+import { Avatar } from '#app/components/ui/avatar.tsx';
+import { Button } from '#app/components/ui/button.tsx';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '#app/components/ui/dialog.tsx';
+import { Input } from '#app/components/ui/input.tsx';
+import { Label } from '#app/components/ui/label.tsx';
+import { Textarea } from '#app/components/ui/textarea.tsx';
+import { MutualStrip } from '#app/components/users/mutual-strip.tsx';
+import { WishlistPreviewCard } from '#app/components/users/wishlist-preview-card.tsx';
+import { type RelationshipState } from '#app/utils/friends.ts';
+
+export type TemporalState = 'occasion-near' | 'cold' | 'declined';
+
+type Relationship = {
+  state: RelationshipState;
+  friendshipId: string | null;
+  incomingRequestId: string | null;
+  outgoingRequestId: string | null;
+};
+
+type SurfaceUser = {
+  id: string;
+  username: string;
+  name: string | null;
+  bio: string | null;
+  birthday: Date | string | null;
+  image: { id: string } | null;
+};
+
+export type PersonSurfaceViewData = {
+  user: SurfaceUser;
+  userJoinedDisplay: string;
+  relationship: Relationship;
+  isFriend: boolean;
+  birthdayVisible: boolean;
+  canViewWishlist: boolean;
+  mutualGroups: Array<{ id: string; name: string }>;
+  mutualFriends: Array<{
+    id: string;
+    username: string;
+    name: string | null;
+    image: { id: string } | null;
+  }>;
+  wishlistPreview: {
+    totalCount: number;
+    items: Array<{
+      id: string;
+      title: string;
+      hasImage: boolean;
+      url: string | null;
+      updatedAt: Date | string;
+    }>;
+  };
+  temporalState: TemporalState;
+  occasion: { label: string; daysUntil: number } | null;
+  declined: boolean;
+  organizeGroups: Array<{
+    id: string;
+    name: string;
+    memberCount: number;
+    budgetCents: number;
+  }>;
+};
+
+const tint = (token: 'gift' | 'pool', pct: number) =>
+  `hsl(var(--${token}) / ${pct})`;
+
+function formatBudget(cents: number) {
+  return `~$${Math.round(cents / 100)}`;
+}
+
+// Close a dialog once its fetcher settles without a validation error.
+function useCloseOnSuccess(
+  fetcher: ReturnType<typeof useFetcher>,
+  onSuccess: () => void,
+) {
+  const wasSubmitting = useRef(false);
+  useEffect(() => {
+    const submitting = fetcher.state !== 'idle';
+    if (wasSubmitting.current && !submitting) {
+      const data = fetcher.data as { error?: Record<string, unknown> } | null;
+      const hasError = data && data.error && Object.keys(data.error).length > 0;
+      if (!hasError) onSuccess();
+    }
+    wasSubmitting.current = submitting;
+  }, [fetcher.state, fetcher.data, onSuccess]);
+}
+
+export function PersonSurface(data: PersonSurfaceViewData) {
+  const displayName = data.user.name ?? data.user.username;
+  const isOccasionNear = data.temporalState === 'occasion-near';
+  const isDeclined = data.temporalState === 'declined';
+
+  return (
+    <div className="mx-auto flex w-full max-w-xl flex-col gap-4 px-4 py-6 sm:py-10">
+      {isDeclined ? (
+        <DeclinedHeader
+          user={data.user}
+          displayName={displayName}
+          occasionLabel={data.occasion?.label ?? null}
+        />
+      ) : isOccasionNear ? (
+        <OccasionHeader
+          user={data.user}
+          displayName={displayName}
+          occasion={data.occasion}
+        />
+      ) : (
+        <IdentityHeader data={data} displayName={displayName} />
+      )}
+
+      {isOccasionNear ? (
+        <ActionRow data={data} displayName={displayName} />
+      ) : null}
+
+      {!isOccasionNear && !isDeclined ? (
+        <CaptureCard displayName={displayName} />
+      ) : null}
+
+      {/* Ideation body — the full circle-private block lands in commit 4. */}
+      <div
+        className={isDeclined ? 'pointer-events-none opacity-50' : undefined}
+      >
+        <div className="flex flex-col gap-6">
+          <MutualStrip
+            groups={data.mutualGroups}
+            friends={data.mutualFriends}
+          />
+          {data.canViewWishlist ? (
+            <WishlistPreviewCard
+              items={data.wishlistPreview.items}
+              totalCount={data.wishlistPreview.totalCount}
+              fullListTo="wishlist"
+              ownerName={displayName}
+            />
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Headers ────────────────────────────────────────────────────────────────
+
+function OccasionHeader({
+  user,
+  displayName,
+  occasion,
+}: {
+  user: SurfaceUser;
+  displayName: string;
+  occasion: { label: string; daysUntil: number } | null;
+}) {
+  return (
+    <div
+      className="relative overflow-hidden rounded-3xl border p-5"
+      style={{
+        borderColor: tint('gift', 0.22),
+        background: `linear-gradient(150deg, ${tint('gift', 0.14)}, ${tint('gift', 0.05)} 62%, hsl(var(--card)))`,
+      }}
+    >
+      <div className="flex items-center gap-3.5">
+        <Avatar
+          image={user.image ? { ...user.image, altText: null } : null}
+          user={user}
+          size={14}
+        />
+        <div className="min-w-0 flex-1">
+          <div className="text-xl font-extrabold leading-tight tracking-tight">
+            {displayName}
+          </div>
+          <div className="mt-0.5 text-sm font-semibold text-muted-foreground">
+            @{user.username}
+          </div>
+        </div>
+      </div>
+      {occasion ? (
+        <div className="mt-4 flex items-center gap-2.5">
+          <span
+            className="flex h-9 w-9 flex-none items-center justify-center rounded-xl text-gift"
+            style={{ background: tint('gift', 0.16) }}
+          >
+            <LuCake size={18} />
+          </span>
+          <div className="min-w-0">
+            <div className="text-[15px] font-extrabold leading-tight">
+              Birthday · {occasion.label}
+            </div>
+            <div className="mt-px text-xs font-bold text-gift">
+              {countdownLabel(occasion.daysUntil)}
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function DeclinedHeader({
+  user,
+  displayName,
+  occasionLabel,
+}: {
+  user: SurfaceUser;
+  displayName: string;
+  occasionLabel: string | null;
+}) {
+  const fetcher = useFetcher();
+  return (
+    <div className="rounded-3xl border bg-muted/60 p-4">
+      <div className="flex items-center gap-3.5">
+        <span className="opacity-75">
+          <Avatar
+            image={user.image ? { ...user.image, altText: null } : null}
+            user={user}
+            size={12}
+          />
+        </span>
+        <div className="min-w-0 flex-1">
+          <div className="text-[17px] font-extrabold">{displayName}</div>
+          {occasionLabel ? (
+            <div className="mt-px text-xs font-semibold text-muted-foreground">
+              Birthday · {occasionLabel}
+            </div>
+          ) : null}
+        </div>
+      </div>
+      <div className="mt-4 flex items-center gap-2.5 border-t pt-4">
+        <span className="flex h-9 w-9 flex-none items-center justify-center rounded-xl bg-muted text-muted-foreground">
+          <LuX size={18} />
+        </span>
+        <div className="min-w-0 flex-1">
+          <div className="text-[15px] font-extrabold">
+            You're sitting this one out
+          </div>
+          <div className="mt-px text-xs font-bold text-muted-foreground">
+            Only you can see this
+          </div>
+        </div>
+        <fetcher.Form method="post">
+          <input type="hidden" name="intent" value="undo-decline" />
+          <Button
+            type="submit"
+            variant="outline"
+            size="sm"
+            disabled={fetcher.state !== 'idle'}
+          >
+            Undo
+          </Button>
+        </fetcher.Form>
+      </div>
+    </div>
+  );
+}
+
+function IdentityHeader({
+  data,
+  displayName,
+}: {
+  data: PersonSurfaceViewData;
+  displayName: string;
+}) {
+  const facts: Array<{ icon: React.ReactNode; label: string }> = [];
+  if (data.birthdayVisible && data.occasion) {
+    facts.push({ icon: <LuCake size={14} />, label: data.occasion.label });
+  }
+  if (data.mutualGroups.length > 0) {
+    facts.push({
+      icon: <LuUsers size={14} />,
+      label: `${data.mutualGroups.length} shared ${data.mutualGroups.length === 1 ? 'group' : 'groups'}`,
+    });
+  }
+  if (data.mutualFriends.length > 0) {
+    facts.push({
+      icon: <LuHeart size={14} />,
+      label: `${data.mutualFriends.length} mutual ${data.mutualFriends.length === 1 ? 'friend' : 'friends'}`,
+    });
+  }
+
+  return (
+    <div className="flex flex-col items-center py-2 text-center">
+      <Avatar
+        image={data.user.image ? { ...data.user.image, altText: null } : null}
+        user={data.user}
+        size={20}
+      />
+      <div className="mt-3 text-xl font-extrabold tracking-tight">
+        {displayName}
+      </div>
+      <div className="mt-0.5 text-sm font-semibold text-muted-foreground">
+        @{data.user.username}
+      </div>
+      {facts.length > 0 ? (
+        <div className="mt-3.5 flex flex-wrap justify-center gap-2">
+          {facts.map((f) => (
+            <span
+              key={f.label}
+              className="inline-flex h-8 items-center gap-1.5 rounded-full border bg-card px-3 text-xs font-bold"
+            >
+              {f.icon}
+              {f.label}
+            </span>
+          ))}
+        </div>
+      ) : null}
+      <div className="mt-4">
+        <FriendActionButton
+          targetUserId={data.user.id}
+          targetUserName={displayName}
+          relationship={data.relationship}
+          variant="compact"
+        />
+      </div>
+    </div>
+  );
+}
+
+function countdownLabel(daysUntil: number) {
+  if (daysUntil === 0) return 'Today';
+  if (daysUntil === 1) return 'Tomorrow';
+  if (daysUntil < 14) return `in ${daysUntil} days`;
+  const weeks = Math.round(daysUntil / 7);
+  return `in ${weeks} weeks`;
+}
+
+// ─── Action row ───────────────────────────────────────────────────────────────
+
+function ActionRow({
+  data,
+  displayName,
+}: {
+  data: PersonSurfaceViewData;
+  displayName: string;
+}) {
+  return (
+    <div>
+      <OrganizeButton recipientId={data.user.id} groups={data.organizeGroups} />
+      <div className="mt-2.5 flex gap-2">
+        <SoloCommitButton displayName={displayName} />
+        <SaveIdeaButton displayName={displayName} />
+        <DeclineButton />
+      </div>
+    </div>
+  );
+}
+
+function OrganizeButton({
+  recipientId,
+  groups,
+}: {
+  recipientId: string;
+  groups: PersonSurfaceViewData['organizeGroups'];
+}) {
+  const navigate = useNavigate();
+  const [pickerOpen, setPickerOpen] = useState(false);
+
+  const goStandalone = () => navigate(`/pools/new?recipientId=${recipientId}`);
+  const goGroup = (groupId: string) =>
+    navigate(`/pools/new?groupId=${groupId}&recipientId=${recipientId}`);
+
+  const primary = (onClick: () => void, label: string) => (
+    <Button
+      type="button"
+      onClick={onClick}
+      className="h-12 w-full rounded-full bg-gift text-base font-extrabold text-white hover:bg-gift/90"
+    >
+      <LuGift size={20} className="mr-2" />
+      {label}
+    </Button>
+  );
+
+  if (groups.length === 0) {
+    return primary(goStandalone, 'Organize a gift');
+  }
+  if (groups.length === 1) {
+    return primary(
+      () => goGroup(groups[0]!.id),
+      `Organize with ${groups[0]!.name}`,
+    );
+  }
+
+  return (
+    <>
+      {primary(() => setPickerOpen(true), 'Organize a gift')}
+      <Dialog open={pickerOpen} onOpenChange={setPickerOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Organize with which circle?</DialogTitle>
+            <DialogDescription>
+              Your call, every time — we never pick for you.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex flex-col gap-2.5">
+            {groups.map((g) => (
+              <button
+                key={g.id}
+                type="button"
+                onClick={() => goGroup(g.id)}
+                className="flex w-full items-center gap-3 rounded-2xl border bg-card p-3.5 text-left transition-colors hover:border-gift/50"
+              >
+                <span
+                  className="flex h-11 w-11 flex-none items-center justify-center rounded-xl text-gift"
+                  style={{ background: tint('gift', 0.12) }}
+                >
+                  <LuUsers size={22} />
+                </span>
+                <div className="min-w-0 flex-1">
+                  <div className="font-extrabold">{g.name}</div>
+                  <div className="mt-0.5 text-xs font-semibold text-muted-foreground">
+                    {g.memberCount} {g.memberCount === 1 ? 'member' : 'members'}
+                    {g.budgetCents > 0
+                      ? ` · can cover ${formatBudget(g.budgetCents)}`
+                      : ''}
+                  </div>
+                </div>
+              </button>
+            ))}
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+function SecondaryAction({
+  icon,
+  label,
+  onClick,
+  muted,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  onClick: () => void;
+  muted?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`flex flex-1 flex-col items-center gap-1.5 rounded-2xl border bg-card px-1 py-3 text-xs font-bold transition-colors hover:bg-accent ${muted ? 'text-muted-foreground' : ''}`}
+    >
+      {icon}
+      {label}
+    </button>
+  );
+}
+
+function SoloCommitButton({ displayName }: { displayName: string }) {
+  const [open, setOpen] = useState(false);
+  const fetcher = useFetcher();
+  useCloseOnSuccess(fetcher, () => setOpen(false));
+  return (
+    <>
+      <SecondaryAction
+        icon={<LuUser size={18} />}
+        label="Just me"
+        onClick={() => setOpen(true)}
+      />
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <fetcher.Form method="post">
+            <input type="hidden" name="intent" value="solo-commit" />
+            <DialogHeader>
+              <DialogTitle>I've got this one</DialogTitle>
+              <DialogDescription>
+                A private gift, just from you — {displayName} never sees it.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="mt-4 flex flex-col gap-2">
+              <Label htmlFor="solo-name">What are you getting them?</Label>
+              <Input
+                id="solo-name"
+                name="name"
+                required
+                maxLength={200}
+                placeholder="e.g. Trail running shoes"
+                autoFocus
+              />
+            </div>
+            <DialogFooter className="mt-5 gap-2">
+              <Button
+                type="button"
+                variant="secondary"
+                onClick={() => setOpen(false)}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" disabled={fetcher.state !== 'idle'}>
+                I've got this
+              </Button>
+            </DialogFooter>
+          </fetcher.Form>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+function SaveIdeaButton({ displayName }: { displayName: string }) {
+  const [open, setOpen] = useState(false);
+  const fetcher = useFetcher();
+  useCloseOnSuccess(fetcher, () => setOpen(false));
+  return (
+    <>
+      <SecondaryAction
+        icon={<LuHeart size={18} />}
+        label="Save idea"
+        onClick={() => setOpen(true)}
+      />
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <fetcher.Form method="post">
+            <input type="hidden" name="intent" value="save-idea" />
+            <DialogHeader>
+              <DialogTitle>Save an idea for {displayName}</DialogTitle>
+              <DialogDescription>
+                Private to you — pull it up when an occasion arrives.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="mt-4 flex flex-col gap-3">
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="idea-name">Idea</Label>
+                <Input
+                  id="idea-name"
+                  name="name"
+                  required
+                  maxLength={200}
+                  placeholder="e.g. Ceramics class"
+                  autoFocus
+                />
+              </div>
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="idea-url">
+                  Link <span className="text-muted-foreground">(optional)</span>
+                </Label>
+                <Input
+                  id="idea-url"
+                  name="url"
+                  type="url"
+                  placeholder="https://…"
+                />
+              </div>
+            </div>
+            <DialogFooter className="mt-5 gap-2">
+              <Button
+                type="button"
+                variant="secondary"
+                onClick={() => setOpen(false)}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" disabled={fetcher.state !== 'idle'}>
+                Save idea
+              </Button>
+            </DialogFooter>
+          </fetcher.Form>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+function DeclineButton() {
+  const fetcher = useFetcher();
+  return (
+    <fetcher.Form method="post" className="flex flex-1">
+      <input type="hidden" name="intent" value="decline-occasion" />
+      <button
+        type="submit"
+        disabled={fetcher.state !== 'idle'}
+        className="flex flex-1 flex-col items-center gap-1.5 rounded-2xl border bg-card px-1 py-3 text-xs font-bold text-muted-foreground transition-colors hover:bg-muted"
+      >
+        <LuX size={18} />
+        Not this time
+      </button>
+    </fetcher.Form>
+  );
+}
+
+// ─── Capture card (cold / day-one) ────────────────────────────────────────────
+
+function CaptureCard({ displayName }: { displayName: string }) {
+  return (
+    <div className="flex gap-2.5">
+      <SaveIdeaCapture displayName={displayName} />
+      <AddNoteCapture displayName={displayName} />
+    </div>
+  );
+}
+
+function SaveIdeaCapture({ displayName }: { displayName: string }) {
+  const [open, setOpen] = useState(false);
+  const fetcher = useFetcher();
+  useCloseOnSuccess(fetcher, () => setOpen(false));
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="flex flex-1 flex-col gap-2.5 rounded-2xl border-none bg-gift p-4 text-left text-white"
+      >
+        <span className="flex h-8 w-8 items-center justify-center rounded-xl bg-white/20">
+          <LuHeart size={18} />
+        </span>
+        <span>
+          <span className="block text-sm font-extrabold">Save an idea</span>
+          <span className="mt-0.5 block text-[11px] font-semibold opacity-85">
+            for when it counts
+          </span>
+        </span>
+      </button>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <fetcher.Form method="post">
+            <input type="hidden" name="intent" value="save-idea" />
+            <DialogHeader>
+              <DialogTitle>Save an idea for {displayName}</DialogTitle>
+              <DialogDescription>
+                Private to you — pull it up when an occasion arrives.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="mt-4 flex flex-col gap-2">
+              <Label htmlFor="capture-idea-name">Idea</Label>
+              <Input
+                id="capture-idea-name"
+                name="name"
+                required
+                maxLength={200}
+                placeholder="e.g. Trail running shoes"
+                autoFocus
+              />
+            </div>
+            <DialogFooter className="mt-5 gap-2">
+              <Button
+                type="button"
+                variant="secondary"
+                onClick={() => setOpen(false)}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" disabled={fetcher.state !== 'idle'}>
+                Save idea
+              </Button>
+            </DialogFooter>
+          </fetcher.Form>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+function AddNoteCapture({ displayName }: { displayName: string }) {
+  const [open, setOpen] = useState(false);
+  const fetcher = useFetcher();
+  useCloseOnSuccess(fetcher, () => setOpen(false));
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="flex flex-1 flex-col gap-2.5 rounded-2xl border bg-card p-4 text-left"
+      >
+        <span
+          className="flex h-8 w-8 items-center justify-center rounded-xl text-pool"
+          style={{ background: tint('pool', 0.13) }}
+        >
+          <LuMessageCircle size={18} />
+        </span>
+        <span>
+          <span className="block text-sm font-extrabold">Add a note</span>
+          <span className="mt-0.5 block text-[11px] font-semibold text-muted-foreground">
+            something you noticed
+          </span>
+        </span>
+      </button>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <fetcher.Form method="post">
+            <input type="hidden" name="intent" value="add-note" />
+            <DialogHeader>
+              <DialogTitle>Add a note about {displayName}</DialogTitle>
+              <DialogDescription>
+                Private to you — never visible to {displayName}.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="mt-4 flex flex-col gap-2">
+              <Label htmlFor="note-body">Note</Label>
+              <Textarea
+                id="note-body"
+                name="body"
+                required
+                maxLength={1000}
+                rows={3}
+                placeholder="e.g. Started running this spring — needs real gear."
+                autoFocus
+              />
+            </div>
+            <DialogFooter className="mt-5 gap-2">
+              <Button
+                type="button"
+                variant="secondary"
+                onClick={() => setOpen(false)}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" disabled={fetcher.state !== 'idle'}>
+                Add note
+              </Button>
+            </DialogFooter>
+          </fetcher.Form>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/app/components/users/person-surface.tsx
+++ b/app/components/users/person-surface.tsx
@@ -1,9 +1,13 @@
 import { useEffect, useRef, useState } from 'react';
 import {
   LuCake,
+  LuCheck,
+  LuClock,
   LuGift,
   LuHeart,
+  LuList,
   LuMessageCircle,
+  LuSparkles,
   LuUser,
   LuUsers,
   LuX,
@@ -23,9 +27,8 @@ import {
 import { Input } from '#app/components/ui/input.tsx';
 import { Label } from '#app/components/ui/label.tsx';
 import { Textarea } from '#app/components/ui/textarea.tsx';
-import { MutualStrip } from '#app/components/users/mutual-strip.tsx';
-import { WishlistPreviewCard } from '#app/components/users/wishlist-preview-card.tsx';
 import { type RelationshipState } from '#app/utils/friends.ts';
+import { formatCents } from '#app/utils/pool-contributions.ts';
 
 export type TemporalState = 'occasion-near' | 'cold' | 'declined';
 
@@ -45,6 +48,8 @@ type SurfaceUser = {
   image: { id: string } | null;
 };
 
+type OpenPool = { id: string; title: string };
+
 export type PersonSurfaceViewData = {
   user: SurfaceUser;
   userJoinedDisplay: string;
@@ -59,16 +64,6 @@ export type PersonSurfaceViewData = {
     name: string | null;
     image: { id: string } | null;
   }>;
-  wishlistPreview: {
-    totalCount: number;
-    items: Array<{
-      id: string;
-      title: string;
-      hasImage: boolean;
-      url: string | null;
-      updatedAt: Date | string;
-    }>;
-  };
   temporalState: TemporalState;
   occasion: { label: string; daysUntil: number } | null;
   declined: boolean;
@@ -78,13 +73,43 @@ export type PersonSurfaceViewData = {
     memberCount: number;
     budgetCents: number;
   }>;
+  budgetLine: { groupName: string; cents: number } | null;
+  wishlistSource: Array<{
+    id: string;
+    title: string;
+    url: string | null;
+    priceCents: number | null;
+    currency: string | null;
+    claimed: boolean;
+    claimedByViewer: boolean;
+  }>;
+  ideation: {
+    giftHistory: Array<{
+      id: string;
+      name: string;
+      year: number;
+      contributorCount: number;
+      priceCents: number | null;
+    }>;
+    proposedUnused: Array<{ id: string; name: string; year: number }>;
+    notes: Array<{ id: string; body: string }>;
+    savedIdeas: Array<{
+      id: string;
+      name: string;
+      url: string | null;
+      priceCents: number | null;
+      currency: string | null;
+    }>;
+  };
+  openPools: OpenPool[];
 };
 
 const tint = (token: 'gift' | 'pool', pct: number) =>
   `hsl(var(--${token}) / ${pct})`;
 
-function formatBudget(cents: number) {
-  return `~$${Math.round(cents / 100)}`;
+function money(cents: number | null, currency: string | null) {
+  if (cents == null) return null;
+  return formatCents(cents, currency ?? 'USD');
 }
 
 // Close a dialog once its fetcher settles without a validation error.
@@ -131,28 +156,10 @@ export function PersonSurface(data: PersonSurfaceViewData) {
         <ActionRow data={data} displayName={displayName} />
       ) : null}
 
-      {!isOccasionNear && !isDeclined ? (
-        <CaptureCard displayName={displayName} />
-      ) : null}
-
-      {/* Ideation body — the full circle-private block lands in commit 4. */}
       <div
         className={isDeclined ? 'pointer-events-none opacity-50' : undefined}
       >
-        <div className="flex flex-col gap-6">
-          <MutualStrip
-            groups={data.mutualGroups}
-            friends={data.mutualFriends}
-          />
-          {data.canViewWishlist ? (
-            <WishlistPreviewCard
-              items={data.wishlistPreview.items}
-              totalCount={data.wishlistPreview.totalCount}
-              fullListTo="wishlist"
-              ownerName={displayName}
-            />
-          ) : null}
-        </div>
+        <IdeationBlock data={data} displayName={displayName} />
       </div>
     </div>
   );
@@ -354,8 +361,18 @@ function ActionRow({
     <div>
       <OrganizeButton recipientId={data.user.id} groups={data.organizeGroups} />
       <div className="mt-2.5 flex gap-2">
-        <SoloCommitButton displayName={displayName} />
-        <SaveIdeaButton displayName={displayName} />
+        <SoloCommitDialog
+          displayName={displayName}
+          trigger={
+            <SecondaryAction icon={<LuUser size={18} />} label="Just me" />
+          }
+        />
+        <SaveIdeaDialog
+          displayName={displayName}
+          trigger={
+            <SecondaryAction icon={<LuHeart size={18} />} label="Save idea" />
+          }
+        />
         <DeclineButton />
       </div>
     </div>
@@ -427,7 +444,7 @@ function OrganizeButton({
                   <div className="mt-0.5 text-xs font-semibold text-muted-foreground">
                     {g.memberCount} {g.memberCount === 1 ? 'member' : 'members'}
                     {g.budgetCents > 0
-                      ? ` · can cover ${formatBudget(g.budgetCents)}`
+                      ? ` · can cover ~$${Math.round(g.budgetCents / 100)}`
                       : ''}
                   </div>
                 </div>
@@ -448,7 +465,7 @@ function SecondaryAction({
 }: {
   icon: React.ReactNode;
   label: string;
-  onClick: () => void;
+  onClick?: () => void;
   muted?: boolean;
 }) {
   return (
@@ -463,68 +480,52 @@ function SecondaryAction({
   );
 }
 
-function SoloCommitButton({ displayName }: { displayName: string }) {
-  const [open, setOpen] = useState(false);
+function DeclineButton() {
   const fetcher = useFetcher();
-  useCloseOnSuccess(fetcher, () => setOpen(false));
   return (
-    <>
-      <SecondaryAction
-        icon={<LuUser size={18} />}
-        label="Just me"
-        onClick={() => setOpen(true)}
-      />
-      <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent>
-          <fetcher.Form method="post">
-            <input type="hidden" name="intent" value="solo-commit" />
-            <DialogHeader>
-              <DialogTitle>I've got this one</DialogTitle>
-              <DialogDescription>
-                A private gift, just from you — {displayName} never sees it.
-              </DialogDescription>
-            </DialogHeader>
-            <div className="mt-4 flex flex-col gap-2">
-              <Label htmlFor="solo-name">What are you getting them?</Label>
-              <Input
-                id="solo-name"
-                name="name"
-                required
-                maxLength={200}
-                placeholder="e.g. Trail running shoes"
-                autoFocus
-              />
-            </div>
-            <DialogFooter className="mt-5 gap-2">
-              <Button
-                type="button"
-                variant="secondary"
-                onClick={() => setOpen(false)}
-              >
-                Cancel
-              </Button>
-              <Button type="submit" disabled={fetcher.state !== 'idle'}>
-                I've got this
-              </Button>
-            </DialogFooter>
-          </fetcher.Form>
-        </DialogContent>
-      </Dialog>
-    </>
+    <fetcher.Form method="post" className="flex flex-1">
+      <input type="hidden" name="intent" value="decline-occasion" />
+      <button
+        type="submit"
+        disabled={fetcher.state !== 'idle'}
+        className="flex flex-1 flex-col items-center gap-1.5 rounded-2xl border bg-card px-1 py-3 text-xs font-bold text-muted-foreground transition-colors hover:bg-muted"
+      >
+        <LuX size={18} />
+        Not this time
+      </button>
+    </fetcher.Form>
   );
 }
 
-function SaveIdeaButton({ displayName }: { displayName: string }) {
+// ─── Reusable mutation dialogs ─────────────────────────────────────────────────
+
+function TriggerButton({
+  trigger,
+  onClick,
+}: {
+  trigger: React.ReactNode;
+  onClick: () => void;
+}) {
+  return (
+    <span onClick={onClick} className="contents">
+      {trigger}
+    </span>
+  );
+}
+
+function SaveIdeaDialog({
+  displayName,
+  trigger,
+}: {
+  displayName: string;
+  trigger: React.ReactNode;
+}) {
   const [open, setOpen] = useState(false);
   const fetcher = useFetcher();
   useCloseOnSuccess(fetcher, () => setOpen(false));
   return (
     <>
-      <SecondaryAction
-        icon={<LuHeart size={18} />}
-        label="Save idea"
-        onClick={() => setOpen(true)}
-      />
+      <TriggerButton trigger={trigger} onClick={() => setOpen(true)} />
       <Dialog open={open} onOpenChange={setOpen}>
         <DialogContent>
           <fetcher.Form method="post">
@@ -578,119 +579,19 @@ function SaveIdeaButton({ displayName }: { displayName: string }) {
   );
 }
 
-function DeclineButton() {
-  const fetcher = useFetcher();
-  return (
-    <fetcher.Form method="post" className="flex flex-1">
-      <input type="hidden" name="intent" value="decline-occasion" />
-      <button
-        type="submit"
-        disabled={fetcher.state !== 'idle'}
-        className="flex flex-1 flex-col items-center gap-1.5 rounded-2xl border bg-card px-1 py-3 text-xs font-bold text-muted-foreground transition-colors hover:bg-muted"
-      >
-        <LuX size={18} />
-        Not this time
-      </button>
-    </fetcher.Form>
-  );
-}
-
-// ─── Capture card (cold / day-one) ────────────────────────────────────────────
-
-function CaptureCard({ displayName }: { displayName: string }) {
-  return (
-    <div className="flex gap-2.5">
-      <SaveIdeaCapture displayName={displayName} />
-      <AddNoteCapture displayName={displayName} />
-    </div>
-  );
-}
-
-function SaveIdeaCapture({ displayName }: { displayName: string }) {
+function AddNoteDialog({
+  displayName,
+  trigger,
+}: {
+  displayName: string;
+  trigger: React.ReactNode;
+}) {
   const [open, setOpen] = useState(false);
   const fetcher = useFetcher();
   useCloseOnSuccess(fetcher, () => setOpen(false));
   return (
     <>
-      <button
-        type="button"
-        onClick={() => setOpen(true)}
-        className="flex flex-1 flex-col gap-2.5 rounded-2xl border-none bg-gift p-4 text-left text-white"
-      >
-        <span className="flex h-8 w-8 items-center justify-center rounded-xl bg-white/20">
-          <LuHeart size={18} />
-        </span>
-        <span>
-          <span className="block text-sm font-extrabold">Save an idea</span>
-          <span className="mt-0.5 block text-[11px] font-semibold opacity-85">
-            for when it counts
-          </span>
-        </span>
-      </button>
-      <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent>
-          <fetcher.Form method="post">
-            <input type="hidden" name="intent" value="save-idea" />
-            <DialogHeader>
-              <DialogTitle>Save an idea for {displayName}</DialogTitle>
-              <DialogDescription>
-                Private to you — pull it up when an occasion arrives.
-              </DialogDescription>
-            </DialogHeader>
-            <div className="mt-4 flex flex-col gap-2">
-              <Label htmlFor="capture-idea-name">Idea</Label>
-              <Input
-                id="capture-idea-name"
-                name="name"
-                required
-                maxLength={200}
-                placeholder="e.g. Trail running shoes"
-                autoFocus
-              />
-            </div>
-            <DialogFooter className="mt-5 gap-2">
-              <Button
-                type="button"
-                variant="secondary"
-                onClick={() => setOpen(false)}
-              >
-                Cancel
-              </Button>
-              <Button type="submit" disabled={fetcher.state !== 'idle'}>
-                Save idea
-              </Button>
-            </DialogFooter>
-          </fetcher.Form>
-        </DialogContent>
-      </Dialog>
-    </>
-  );
-}
-
-function AddNoteCapture({ displayName }: { displayName: string }) {
-  const [open, setOpen] = useState(false);
-  const fetcher = useFetcher();
-  useCloseOnSuccess(fetcher, () => setOpen(false));
-  return (
-    <>
-      <button
-        type="button"
-        onClick={() => setOpen(true)}
-        className="flex flex-1 flex-col gap-2.5 rounded-2xl border bg-card p-4 text-left"
-      >
-        <span
-          className="flex h-8 w-8 items-center justify-center rounded-xl text-pool"
-          style={{ background: tint('pool', 0.13) }}
-        >
-          <LuMessageCircle size={18} />
-        </span>
-        <span>
-          <span className="block text-sm font-extrabold">Add a note</span>
-          <span className="mt-0.5 block text-[11px] font-semibold text-muted-foreground">
-            something you noticed
-          </span>
-        </span>
-      </button>
+      <TriggerButton trigger={trigger} onClick={() => setOpen(true)} />
       <Dialog open={open} onOpenChange={setOpen}>
         <DialogContent>
           <fetcher.Form method="post">
@@ -729,5 +630,611 @@ function AddNoteCapture({ displayName }: { displayName: string }) {
         </DialogContent>
       </Dialog>
     </>
+  );
+}
+
+function SoloCommitDialog({
+  displayName,
+  trigger,
+  defaultName = '',
+}: {
+  displayName: string;
+  trigger: React.ReactNode;
+  defaultName?: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const fetcher = useFetcher();
+  useCloseOnSuccess(fetcher, () => setOpen(false));
+  return (
+    <>
+      <TriggerButton trigger={trigger} onClick={() => setOpen(true)} />
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <fetcher.Form method="post">
+            <input type="hidden" name="intent" value="solo-commit" />
+            <DialogHeader>
+              <DialogTitle>I've got this one</DialogTitle>
+              <DialogDescription>
+                A private gift, just from you — {displayName} never sees it.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="mt-4 flex flex-col gap-2">
+              <Label htmlFor="solo-name">What are you getting them?</Label>
+              <Input
+                id="solo-name"
+                name="name"
+                required
+                maxLength={200}
+                defaultValue={defaultName}
+                placeholder="e.g. Trail running shoes"
+                autoFocus
+              />
+            </div>
+            <DialogFooter className="mt-5 gap-2">
+              <Button
+                type="button"
+                variant="secondary"
+                onClick={() => setOpen(false)}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" disabled={fetcher.state !== 'idle'}>
+                I've got this
+              </Button>
+            </DialogFooter>
+          </fetcher.Form>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+// ─── Ideation block (§7) ───────────────────────────────────────────────────────
+
+function SectionHeading({
+  icon,
+  token,
+  title,
+  right,
+}: {
+  icon: React.ReactNode;
+  token: 'gift' | 'pool';
+  title: string;
+  right?: React.ReactNode;
+}) {
+  return (
+    <div className="mb-3 mt-2 flex items-center gap-2.5">
+      <span
+        className={`flex h-7 w-7 flex-none items-center justify-center rounded-lg ${token === 'gift' ? 'text-gift' : 'text-pool'}`}
+        style={{ background: tint(token, 0.12) }}
+      >
+        {icon}
+      </span>
+      <h2 className="flex-1 text-base font-extrabold">{title}</h2>
+      {right}
+    </div>
+  );
+}
+
+function IdeationBlock({
+  data,
+  displayName,
+}: {
+  data: PersonSurfaceViewData;
+  displayName: string;
+}) {
+  const { ideation } = data;
+  const hasMemory =
+    ideation.giftHistory.length > 0 ||
+    ideation.proposedUnused.length > 0 ||
+    ideation.notes.length > 0 ||
+    ideation.savedIdeas.length > 0;
+  const showWishlist = data.canViewWishlist && data.wishlistSource.length > 0;
+  const isOccasionNear = data.temporalState === 'occasion-near';
+
+  const isCold = data.temporalState === 'cold';
+
+  return (
+    <div className="flex flex-col">
+      {isCold ? <ColdCapture displayName={displayName} /> : null}
+
+      {isOccasionNear ? (
+        <div className="mb-1 mt-4 px-0.5">
+          <div className="text-lg font-extrabold tracking-tight">
+            What should we get them?
+          </div>
+          <div className="mt-0.5 text-sm font-semibold text-muted-foreground">
+            Everything this circle knows about {displayName} — in one place.
+          </div>
+        </div>
+      ) : null}
+
+      {showWishlist ? (
+        <section>
+          <SectionHeading
+            icon={<LuList size={16} />}
+            token="gift"
+            title="Their wishlist"
+            right={
+              <span className="text-[11px] font-bold text-muted-foreground">
+                {data.wishlistSource.length} items
+              </span>
+            }
+          />
+          <div className="flex flex-col gap-2.5">
+            {data.wishlistSource.map((item) => (
+              <WishlistSourceRow
+                key={item.id}
+                item={item}
+                recipientId={data.user.id}
+                openPools={data.openPools}
+              />
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      {ideation.giftHistory.length > 0 ? (
+        <section>
+          <SectionHeading
+            icon={<LuClock size={16} />}
+            token="pool"
+            title="What this circle gave before"
+          />
+          <div className="rounded-2xl border bg-card px-3.5 py-1">
+            {ideation.giftHistory.map((g, i) => (
+              <div
+                key={g.id}
+                className={`flex items-center gap-2.5 py-2.5 ${i > 0 ? 'border-t' : ''}`}
+              >
+                <div className="min-w-0 flex-1">
+                  <div className="text-sm font-bold">{g.name}</div>
+                  <div className="text-xs font-semibold text-muted-foreground">
+                    {g.year} · pooled by {g.contributorCount}
+                  </div>
+                </div>
+                {g.priceCents != null ? (
+                  <div className="flex-none text-[13px] font-extrabold text-pool">
+                    {formatCents(g.priceCents)}
+                  </div>
+                ) : null}
+              </div>
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      {ideation.proposedUnused.length > 0 ? (
+        <section>
+          <SectionHeading
+            icon={<LuSparkles size={16} />}
+            token="gift"
+            title="We almost got them…"
+          />
+          <div className="flex flex-wrap gap-2">
+            {ideation.proposedUnused.map((idea) => (
+              <span
+                key={idea.id}
+                className="inline-flex items-center gap-1.5 rounded-full border bg-card px-3 py-2 text-[13px] font-bold"
+              >
+                {idea.name}
+                <span className="text-[11px] font-semibold text-muted-foreground">
+                  '{String(idea.year).slice(2)}
+                </span>
+              </span>
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      {ideation.notes.length > 0 ? (
+        <section>
+          <SectionHeading
+            icon={<LuMessageCircle size={16} />}
+            token="pool"
+            title="Your notes · private"
+            right={
+              <AddNoteDialog
+                displayName={displayName}
+                trigger={
+                  <button
+                    type="button"
+                    className="inline-flex h-7 items-center gap-1 rounded-full border bg-card px-2.5 text-xs font-bold"
+                  >
+                    Add
+                  </button>
+                }
+              />
+            }
+          />
+          <div className="flex flex-col gap-2">
+            {ideation.notes.map((note) => (
+              <div
+                key={note.id}
+                className="rounded-2xl border bg-card px-3.5 py-3 text-[13px] font-semibold leading-relaxed"
+              >
+                {note.body}
+              </div>
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      {ideation.savedIdeas.length > 0 ? (
+        <section>
+          <SectionHeading
+            icon={<LuHeart size={16} />}
+            token="gift"
+            title="Your saved ideas · private"
+          />
+          <div className="flex flex-col gap-2">
+            {ideation.savedIdeas.map((idea) => (
+              <div
+                key={idea.id}
+                className="flex items-center gap-2.5 rounded-2xl border bg-card px-3.5 py-3"
+              >
+                <div className="min-w-0 flex-1">
+                  <div className="text-sm font-bold">{idea.name}</div>
+                  {money(idea.priceCents, idea.currency) ? (
+                    <div className="text-xs font-semibold text-muted-foreground">
+                      {money(idea.priceCents, idea.currency)}
+                    </div>
+                  ) : null}
+                </div>
+                <ProposeControl
+                  recipientId={data.user.id}
+                  openPools={data.openPools}
+                  name={idea.name}
+                  giftListItemId={idea.id}
+                  url={idea.url}
+                  priceCents={idea.priceCents}
+                />
+              </div>
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      {data.budgetLine ? (
+        <div
+          className="mt-5 flex items-center gap-2.5 rounded-2xl border p-3.5"
+          style={{
+            background: tint('pool', 0.08),
+            borderColor: tint('pool', 0.18),
+          }}
+        >
+          <span
+            className="flex h-8 w-8 flex-none items-center justify-center rounded-lg text-pool"
+            style={{ background: tint('pool', 0.16) }}
+          >
+            <LuUsers size={16} />
+          </span>
+          <div className="text-[13px] font-semibold leading-snug">
+            {data.budgetLine.groupName} can cover{' '}
+            <strong className="font-extrabold text-pool">
+              ~${Math.round(data.budgetLine.cents / 100)}
+            </strong>{' '}
+            together.
+          </div>
+        </div>
+      ) : null}
+
+      {isOccasionNear && !hasMemory ? (
+        <DayOneCapture displayName={displayName} />
+      ) : null}
+    </div>
+  );
+}
+
+// Cold-state year-round capture — the prominent "save an idea / add a note"
+// habit (mock 1b), shown above the wishlist.
+function ColdCapture({ displayName }: { displayName: string }) {
+  return (
+    <div className="mb-2 mt-3 flex gap-2.5">
+      <SaveIdeaDialog
+        displayName={displayName}
+        trigger={
+          <button
+            type="button"
+            className="flex flex-1 flex-col gap-2.5 rounded-2xl bg-gift p-4 text-left text-white"
+          >
+            <span className="flex h-8 w-8 items-center justify-center rounded-xl bg-white/20">
+              <LuHeart size={18} />
+            </span>
+            <span>
+              <span className="block text-sm font-extrabold">Save an idea</span>
+              <span className="mt-0.5 block text-[11px] font-semibold opacity-85">
+                for when it counts
+              </span>
+            </span>
+          </button>
+        }
+      />
+      <AddNoteDialog
+        displayName={displayName}
+        trigger={
+          <button
+            type="button"
+            className="flex flex-1 flex-col gap-2.5 rounded-2xl border bg-card p-4 text-left"
+          >
+            <span
+              className="flex h-8 w-8 items-center justify-center rounded-xl text-pool"
+              style={{ background: tint('pool', 0.13) }}
+            >
+              <LuMessageCircle size={18} />
+            </span>
+            <span>
+              <span className="block text-sm font-extrabold">Add a note</span>
+              <span className="mt-0.5 block text-[11px] font-semibold text-muted-foreground">
+                something you noticed
+              </span>
+            </span>
+          </button>
+        }
+      />
+    </div>
+  );
+}
+
+function WishlistSourceRow({
+  item,
+  recipientId,
+  openPools,
+}: {
+  item: PersonSurfaceViewData['wishlistSource'][number];
+  recipientId: string;
+  openPools: OpenPool[];
+}) {
+  const claimFetcher = useFetcher();
+  const price = money(item.priceCents, item.currency);
+
+  if (item.claimed && !item.claimedByViewer) {
+    return (
+      <div className="rounded-2xl border bg-muted/50 p-3.5">
+        <div className="flex items-start gap-2.5">
+          <div className="min-w-0 flex-1">
+            <div className="text-sm font-bold text-muted-foreground line-through">
+              {item.title}
+            </div>
+            {price ? (
+              <div className="text-[13px] font-semibold text-muted-foreground">
+                {price}
+              </div>
+            ) : null}
+          </div>
+          <span className="inline-flex h-[22px] flex-none items-center gap-1 rounded-full bg-muted px-2.5 text-[11px] font-extrabold text-muted-foreground">
+            <LuCheck size={12} />
+            Spoken for
+          </span>
+        </div>
+        <div className="mt-2 text-[11.5px] font-semibold text-muted-foreground">
+          Someone's already covering this one.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-2xl border bg-card p-3.5">
+      <div className="flex items-start gap-2.5">
+        <div className="min-w-0 flex-1">
+          <div className="text-sm font-bold">{item.title}</div>
+          {price ? (
+            <div className="mt-0.5 text-[13px] font-extrabold text-pool">
+              {price}
+            </div>
+          ) : null}
+        </div>
+        {item.claimedByViewer ? (
+          <span className="inline-flex h-[22px] flex-none items-center gap-1 rounded-full bg-gift/15 px-2.5 text-[11px] font-extrabold text-gift">
+            <LuCheck size={12} />
+            You're getting this
+          </span>
+        ) : null}
+      </div>
+      <div className="mt-3 flex gap-2">
+        <claimFetcher.Form
+          method="post"
+          action="/wishlist/purchase"
+          className="flex-1"
+        >
+          <input
+            type="hidden"
+            name="intent"
+            value={item.claimedByViewer ? 'unpurchase' : 'purchase'}
+          />
+          <input type="hidden" name="wishlistItemId" value={item.id} />
+          <button
+            type="submit"
+            disabled={claimFetcher.state !== 'idle'}
+            className="inline-flex h-9 w-full items-center justify-center gap-1.5 rounded-full border text-[12.5px] font-bold transition-colors hover:bg-accent"
+          >
+            <LuCheck size={15} />
+            {item.claimedByViewer ? "I'm not, actually" : "I'm getting this"}
+          </button>
+        </claimFetcher.Form>
+        {!item.claimedByViewer ? (
+          <ProposeControl
+            recipientId={recipientId}
+            openPools={openPools}
+            name={item.title}
+            wishlistItemId={item.id}
+            url={item.url}
+            priceCents={item.priceCents}
+            variant="wishlist"
+          />
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+// Propose an idea into a pool. 0 open pools → Organize (create a pool); 1 →
+// propose directly; 2+ → pick a pool. Never dead-ends.
+function ProposeControl({
+  recipientId,
+  openPools,
+  name,
+  wishlistItemId,
+  giftListItemId,
+  url,
+  priceCents,
+  variant = 'saved',
+}: {
+  recipientId: string;
+  openPools: OpenPool[];
+  name: string;
+  wishlistItemId?: string;
+  giftListItemId?: string;
+  url?: string | null;
+  priceCents?: number | null;
+  variant?: 'wishlist' | 'saved';
+}) {
+  const navigate = useNavigate();
+  const fetcher = useFetcher();
+  const [pickerOpen, setPickerOpen] = useState(false);
+
+  const hidden = (poolId: string) => (
+    <>
+      <input type="hidden" name="intent" value="propose-to-pool" />
+      <input type="hidden" name="poolId" value={poolId} />
+      <input type="hidden" name="name" value={name} />
+      {wishlistItemId ? (
+        <input type="hidden" name="wishlistItemId" value={wishlistItemId} />
+      ) : null}
+      {giftListItemId ? (
+        <input type="hidden" name="giftListItemId" value={giftListItemId} />
+      ) : null}
+      {url ? <input type="hidden" name="url" value={url} /> : null}
+      {priceCents != null ? (
+        <input type="hidden" name="priceCents" value={priceCents / 100} />
+      ) : null}
+    </>
+  );
+
+  const btnClass =
+    variant === 'wishlist'
+      ? 'inline-flex h-9 w-full flex-1 items-center justify-center gap-1.5 rounded-full text-[12.5px] font-extrabold text-pool'
+      : 'inline-flex h-8 items-center gap-1.5 rounded-full px-3 text-xs font-extrabold text-pool';
+  const btnStyle = { background: tint('pool', 0.12) };
+
+  // 0 open pools → route into Organize (the idea seeds the new pool's title).
+  if (openPools.length === 0) {
+    return (
+      <button
+        type="button"
+        onClick={() =>
+          navigate(
+            `/pools/new?recipientId=${recipientId}&title=${encodeURIComponent(name)}`,
+          )
+        }
+        className={btnClass}
+        style={btnStyle}
+      >
+        <LuUsers size={15} />
+        Propose to pool
+      </button>
+    );
+  }
+
+  // 1 open pool → propose directly.
+  if (openPools.length === 1) {
+    return (
+      <fetcher.Form
+        method="post"
+        className={variant === 'wishlist' ? 'flex-1' : undefined}
+      >
+        {hidden(openPools[0]!.id)}
+        <button
+          type="submit"
+          disabled={fetcher.state !== 'idle'}
+          className={btnClass}
+          style={btnStyle}
+        >
+          <LuUsers size={15} />
+          Propose to pool
+        </button>
+      </fetcher.Form>
+    );
+  }
+
+  // 2+ open pools → pick which one.
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setPickerOpen(true)}
+        className={btnClass}
+        style={btnStyle}
+      >
+        <LuUsers size={15} />
+        Propose to pool
+      </button>
+      <Dialog open={pickerOpen} onOpenChange={setPickerOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Propose to which pool?</DialogTitle>
+          </DialogHeader>
+          <div className="flex flex-col gap-2">
+            {openPools.map((pool) => (
+              <fetcher.Form key={pool.id} method="post">
+                {hidden(pool.id)}
+                <button
+                  type="submit"
+                  onClick={() => setPickerOpen(false)}
+                  className="flex w-full items-center justify-between rounded-2xl border bg-card p-3.5 text-left font-bold transition-colors hover:border-pool/50"
+                >
+                  {pool.title}
+                </button>
+              </fetcher.Form>
+            ))}
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+function DayOneCapture({ displayName }: { displayName: string }) {
+  return (
+    <div className="mt-6 rounded-3xl border border-dashed p-5 text-center">
+      <span
+        className="mb-3 inline-flex h-11 w-11 items-center justify-center rounded-xl text-pool"
+        style={{ background: tint('pool', 0.1) }}
+      >
+        <LuSparkles size={22} />
+      </span>
+      <div className="text-[15px] font-extrabold">Start the memory</div>
+      <div className="mx-auto mb-4 mt-1 max-w-xs text-[12.5px] font-semibold leading-relaxed text-muted-foreground">
+        Notes and gift history fill in as your circle uses them. Nothing to see
+        yet — and that's fine.
+      </div>
+      <div className="flex gap-2">
+        <SaveIdeaDialog
+          displayName={displayName}
+          trigger={
+            <button
+              type="button"
+              className="inline-flex h-10 flex-1 items-center justify-center gap-1.5 rounded-full bg-gift text-[13px] font-extrabold text-white"
+            >
+              <LuHeart size={15} />
+              Save an idea
+            </button>
+          }
+        />
+        <AddNoteDialog
+          displayName={displayName}
+          trigger={
+            <button
+              type="button"
+              className="inline-flex h-10 flex-1 items-center justify-center gap-1.5 rounded-full border text-[13px] font-bold"
+            >
+              <LuMessageCircle size={15} />
+              Add a note
+            </button>
+          }
+        />
+      </div>
+    </div>
   );
 }

--- a/app/components/users/person-surface.tsx
+++ b/app/components/users/person-surface.tsx
@@ -12,7 +12,7 @@ import {
   LuUsers,
   LuX,
 } from 'react-icons/lu';
-import { useFetcher, useNavigate } from 'react-router';
+import { Form, useFetcher, useNavigate } from 'react-router';
 import { FriendActionButton } from '#app/components/friends/friend-action-button.tsx';
 import { Avatar } from '#app/components/ui/avatar.tsx';
 import { Button } from '#app/components/ui/button.tsx';
@@ -1114,7 +1114,6 @@ function ProposeControl({
   variant?: 'wishlist' | 'saved';
 }) {
   const navigate = useNavigate();
-  const fetcher = useFetcher();
   const [pickerOpen, setPickerOpen] = useState(false);
 
   const hidden = (poolId: string) => (
@@ -1163,21 +1162,20 @@ function ProposeControl({
   // 1 open pool → propose directly.
   if (openPools.length === 1) {
     return (
-      <fetcher.Form
+      <Form
         method="post"
         className={variant === 'wishlist' ? 'flex-1' : undefined}
       >
         {hidden(openPools[0]!.id)}
         <button
           type="submit"
-          disabled={fetcher.state !== 'idle'}
           className={btnClass}
           style={btnStyle}
         >
           <LuUsers size={15} />
           Propose to pool
         </button>
-      </fetcher.Form>
+      </Form>
     );
   }
 
@@ -1200,16 +1198,15 @@ function ProposeControl({
           </DialogHeader>
           <div className="flex flex-col gap-2">
             {openPools.map((pool) => (
-              <fetcher.Form key={pool.id} method="post">
+              <Form key={pool.id} method="post">
                 {hidden(pool.id)}
                 <button
                   type="submit"
-                  onClick={() => setPickerOpen(false)}
                   className="flex w-full items-center justify-between rounded-2xl border bg-card p-3.5 text-left font-bold transition-colors hover:border-pool/50"
                 >
                   {pool.title}
                 </button>
-              </fetcher.Form>
+              </Form>
             ))}
           </div>
         </DialogContent>

--- a/app/components/users/person-surface.tsx
+++ b/app/components/users/person-surface.tsx
@@ -30,7 +30,17 @@ import { Textarea } from '#app/components/ui/textarea.tsx';
 import { type RelationshipState } from '#app/utils/friends.ts';
 import { formatCents } from '#app/utils/pool-contributions.ts';
 
-export type TemporalState = 'occasion-near' | 'cold' | 'declined';
+export type TemporalState =
+  | 'occasion-near'
+  | 'cold'
+  | 'declined'
+  | 'post-occasion';
+
+type PostOccasion = {
+  occasionLabel: string;
+  gift: { kind: 'pool' | 'wishlist'; id: string; name: string };
+  recordedGroupPoolName: string | null;
+};
 
 type Relationship = {
   state: RelationshipState;
@@ -102,6 +112,7 @@ export type PersonSurfaceViewData = {
     }>;
   };
   openPools: OpenPool[];
+  postOccasion: PostOccasion | null;
 };
 
 const tint = (token: 'gift' | 'pool', pct: number) =>
@@ -133,6 +144,18 @@ export function PersonSurface(data: PersonSurfaceViewData) {
   const displayName = data.user.name ?? data.user.username;
   const isOccasionNear = data.temporalState === 'occasion-near';
   const isDeclined = data.temporalState === 'declined';
+
+  if (data.temporalState === 'post-occasion' && data.postOccasion) {
+    return (
+      <div className="mx-auto flex w-full max-w-xl flex-col gap-4 px-4 py-6 sm:py-10">
+        <PostOccasionFlow
+          user={data.user}
+          displayName={displayName}
+          postOccasion={data.postOccasion}
+        />
+      </div>
+    );
+  }
 
   return (
     <div className="mx-auto flex w-full max-w-xl flex-col gap-4 px-4 py-6 sm:py-10">
@@ -1191,6 +1214,145 @@ function ProposeControl({
           </div>
         </DialogContent>
       </Dialog>
+    </>
+  );
+}
+
+// ─── Post-occasion memory write (§4, mock 1c) ─────────────────────────────────
+
+function PostOccasionFlow({
+  user,
+  displayName,
+  postOccasion,
+}: {
+  user: SurfaceUser;
+  displayName: string;
+  postOccasion: PostOccasion;
+}) {
+  const fetcher = useFetcher();
+  const { gift } = postOccasion;
+
+  const feedbackForm = (feedback: 'LOVED' | 'OKAY' | 'SKIPPED') => (
+    <fetcher.Form method="post">
+      <input type="hidden" name="intent" value="record-outcome" />
+      <input type="hidden" name="kind" value={gift.kind} />
+      <input
+        type="hidden"
+        name={gift.kind === 'pool' ? 'poolId' : 'wishlistItemId'}
+        value={gift.id}
+      />
+      <input type="hidden" name="feedback" value={feedback} />
+      {feedback === 'LOVED' ? (
+        <button
+          type="submit"
+          disabled={fetcher.state !== 'idle'}
+          className="inline-flex h-10 w-full items-center justify-center gap-1.5 rounded-full bg-gift text-[13px] font-extrabold text-white hover:bg-gift/90"
+        >
+          <LuHeart size={15} />
+          They loved it
+        </button>
+      ) : feedback === 'OKAY' ? (
+        <button
+          type="submit"
+          disabled={fetcher.state !== 'idle'}
+          className="inline-flex h-10 items-center justify-center rounded-full border px-4 text-[13px] font-bold hover:bg-accent"
+        >
+          It was okay
+        </button>
+      ) : (
+        <button
+          type="submit"
+          disabled={fetcher.state !== 'idle'}
+          className="h-9 rounded-full px-4 text-[13px] font-bold text-muted-foreground hover:text-foreground"
+        >
+          Skip for now
+        </button>
+      )}
+    </fetcher.Form>
+  );
+
+  return (
+    <>
+      {/* quiet header */}
+      <div className="flex items-center gap-3.5 px-0.5 pt-1">
+        <Avatar
+          image={user.image ? { ...user.image, altText: null } : null}
+          user={user}
+          size={12}
+        />
+        <div className="min-w-0">
+          <div className="text-[17px] font-extrabold">
+            {displayName}'s birthday
+          </div>
+          <div className="mt-px text-xs font-semibold text-muted-foreground">
+            {postOccasion.occasionLabel}
+          </div>
+        </div>
+      </div>
+
+      <div className="mb-1 mt-3 px-0.5">
+        <div className="text-lg font-extrabold tracking-tight">
+          How did it go?
+        </div>
+        <div className="mt-0.5 text-sm font-semibold text-muted-foreground">
+          Just one thing to confirm — then this rests.
+        </div>
+      </div>
+
+      {/* solo gift confirm */}
+      <div className="rounded-3xl border bg-card p-4">
+        <div className="flex items-center gap-2.5">
+          <span
+            className="flex h-10 w-10 flex-none items-center justify-center rounded-xl text-gift"
+            style={{ background: tint('gift', 0.12) }}
+          >
+            <LuUser size={20} />
+          </span>
+          <div className="min-w-0 flex-1">
+            <div className="text-sm font-extrabold">
+              Your gift · {gift.name}
+            </div>
+            <div className="mt-0.5 text-xs font-semibold text-muted-foreground">
+              You had this one covered on your own.
+            </div>
+          </div>
+        </div>
+        <div className="mb-2.5 mt-4 text-[13.5px] font-bold">Did it land?</div>
+        <div className="flex gap-2">
+          <div className="flex-1">{feedbackForm('LOVED')}</div>
+          {feedbackForm('OKAY')}
+        </div>
+      </div>
+
+      {/* group pool recorded automatically */}
+      {postOccasion.recordedGroupPoolName ? (
+        <div
+          className="flex items-center gap-2.5 rounded-2xl border p-3.5"
+          style={{
+            background: tint('pool', 0.08),
+            borderColor: tint('pool', 0.18),
+          }}
+        >
+          <span
+            className="flex h-8 w-8 flex-none items-center justify-center rounded-lg text-pool"
+            style={{ background: tint('pool', 0.16) }}
+          >
+            <LuCheck size={17} />
+          </span>
+          <div className="min-w-0 flex-1">
+            <div className="text-[13.5px] font-extrabold">
+              The circle's pool — recorded
+            </div>
+            <div className="mt-px text-xs font-semibold text-muted-foreground">
+              {postOccasion.recordedGroupPoolName} · saved to memory
+              automatically
+            </div>
+          </div>
+        </div>
+      ) : null}
+
+      {/* skippable — never re-nagged */}
+      <div className="mt-2 text-center">{feedbackForm('SKIPPED')}</div>
     </>
   );
 }

--- a/app/components/users/person-surface.tsx
+++ b/app/components/users/person-surface.tsx
@@ -16,16 +16,16 @@ import { useFetcher, useNavigate } from 'react-router';
 import { FriendActionButton } from '#app/components/friends/friend-action-button.tsx';
 import { Avatar } from '#app/components/ui/avatar.tsx';
 import { Button } from '#app/components/ui/button.tsx';
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '#app/components/ui/dialog.tsx';
 import { Input } from '#app/components/ui/input.tsx';
 import { Label } from '#app/components/ui/label.tsx';
+import {
+  ResponsiveDialog as Dialog,
+  ResponsiveDialogContent as DialogContent,
+  ResponsiveDialogDescription as DialogDescription,
+  ResponsiveDialogFooter as DialogFooter,
+  ResponsiveDialogHeader as DialogHeader,
+  ResponsiveDialogTitle as DialogTitle,
+} from '#app/components/ui/responsive-dialog.tsx';
 import { Textarea } from '#app/components/ui/textarea.tsx';
 import { type RelationshipState } from '#app/utils/friends.ts';
 import { formatCents } from '#app/utils/pool-contributions.ts';

--- a/app/routes/pools+/new.test.tsx
+++ b/app/routes/pools+/new.test.tsx
@@ -34,7 +34,8 @@ vi.mock('#app/utils/db.server.ts', () => ({
       findUnique: (...args: Array<unknown>) => giftGroupFindUnique(...args),
     },
     usersInGiftGroups: {
-      findUnique: (...args: Array<unknown>) => usersInGiftGroupsFindUnique(...args),
+      findUnique: (...args: Array<unknown>) =>
+        usersInGiftGroupsFindUnique(...args),
       findMany: (...args: Array<unknown>) => usersInGiftGroupsFindMany(...args),
     },
     friendship: {
@@ -79,7 +80,11 @@ describe('app/routes/pools+/new.tsx', () => {
       }),
     );
 
-    expect(result).toEqual({ groupContext: null, candidates: [] });
+    expect(result).toEqual({
+      groupContext: null,
+      candidates: [],
+      preselectedRecipient: null,
+    });
     expect(requireUserId).toHaveBeenCalledWith(expect.any(Request));
   });
 
@@ -264,7 +269,9 @@ describe('app/routes/pools+/new.tsx', () => {
       screen.getByLabelText(/Find a friend or group member/i),
     ).toBeInTheDocument();
     expect(screen.getByLabelText(/Or just their name/i)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Start Pool' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Start Pool' }),
+    ).toBeInTheDocument();
     expect(
       screen.getByRole('radio', { name: /Organizer chooses/i }),
     ).toBeChecked();

--- a/app/routes/pools+/new.test.tsx
+++ b/app/routes/pools+/new.test.tsx
@@ -84,6 +84,7 @@ describe('app/routes/pools+/new.tsx', () => {
       groupContext: null,
       candidates: [],
       preselectedRecipient: null,
+      titlePrefill: '',
     });
     expect(requireUserId).toHaveBeenCalledWith(expect.any(Request));
   });

--- a/app/routes/pools+/new.tsx
+++ b/app/routes/pools+/new.tsx
@@ -1,872 +1,878 @@
-import { getFormProps, getInputProps, useForm } from '@conform-to/react'
-import { parseWithZod } from '@conform-to/zod'
-import { useState } from 'react'
-import { LuGift } from 'react-icons/lu'
+import { getFormProps, getInputProps, useForm } from '@conform-to/react';
+import { parseWithZod } from '@conform-to/zod';
+import { useState } from 'react';
+import { LuGift } from 'react-icons/lu';
 import {
-	data,
-	Form,
-	Link,
-	redirect,
-	type ActionFunctionArgs,
-	type LoaderFunctionArgs,
-	useActionData,
-	useLoaderData,
-} from 'react-router'
-import { z } from 'zod'
-import { Button } from '#app/components/ui/button.tsx'
-import { Card } from '#app/components/ui/card.tsx'
-import { Icon } from '#app/components/ui/icon.tsx'
-import { Input } from '#app/components/ui/input.tsx'
-import { Label } from '#app/components/ui/label.tsx'
-import { Flex, Stack, Text } from '#app/components/ui-kit'
-import { requireUserId } from '#app/utils/auth.server.ts'
-import { prisma } from '#app/utils/db.server.ts'
-import { getUserImgSrc } from '#app/utils/misc.tsx'
+  data,
+  Form,
+  Link,
+  redirect,
+  type ActionFunctionArgs,
+  type LoaderFunctionArgs,
+  useActionData,
+  useLoaderData,
+} from 'react-router';
+import { z } from 'zod';
+import { Button } from '#app/components/ui/button.tsx';
+import { Card } from '#app/components/ui/card.tsx';
+import { Icon } from '#app/components/ui/icon.tsx';
+import { Input } from '#app/components/ui/input.tsx';
+import { Label } from '#app/components/ui/label.tsx';
+import { Flex, Stack, Text } from '#app/components/ui-kit';
+import { requireUserId } from '#app/utils/auth.server.ts';
+import { prisma } from '#app/utils/db.server.ts';
+import { getUserImgSrc } from '#app/utils/misc.tsx';
 import {
-	OCCASION_TYPE,
-	OCCASION_TYPE_LABELS,
-	DECISION_MODE,
-	DECISION_MODE_LABELS,
-	type OccasionType,
-} from '#app/utils/pool-constants.ts'
-import { createPool } from '#app/utils/pool.server.ts'
+  OCCASION_TYPE,
+  OCCASION_TYPE_LABELS,
+  DECISION_MODE,
+  DECISION_MODE_LABELS,
+  type OccasionType,
+} from '#app/utils/pool-constants.ts';
+import { createPool } from '#app/utils/pool.server.ts';
 
 // ─── Schema ──────────────────────────────────────────────────────────────────
 
 const CreatePoolSchema = z.object({
-	title: z.string().min(1, 'Give your pool a title').max(100),
-	occasionType: z.enum(
-		Object.values(OCCASION_TYPE) as [OccasionType, ...OccasionType[]],
-	),
-	eventDate: z.string().optional(),
-	decisionMode: z.enum(['ORGANIZER_PICKS', 'VOTE']),
-	recipientName: z.string().optional(),
-	giftGroupId: z.string().optional(),
-	recipientUserId: z.string().optional(),
-	contributorIds: z.string().optional(),
-})
+  title: z.string().min(1, 'Give your pool a title').max(100),
+  occasionType: z.enum(
+    Object.values(OCCASION_TYPE) as [OccasionType, ...OccasionType[]],
+  ),
+  eventDate: z.string().optional(),
+  decisionMode: z.enum(['ORGANIZER_PICKS', 'VOTE']),
+  recipientName: z.string().optional(),
+  giftGroupId: z.string().optional(),
+  recipientUserId: z.string().optional(),
+  contributorIds: z.string().optional(),
+});
 
 // ─── Loader ──────────────────────────────────────────────────────────────────
 
 type GroupContext = {
-	groupId: string
-	groupName: string
-	recipient: { id: string; name: string; username: string }
-	members: Array<{
-		userId: string
-		name: string
-		username: string
-		imageId: string | null
-		contributionCents: number
-	}>
-}
+  groupId: string;
+  groupName: string;
+  recipient: { id: string; name: string; username: string };
+  members: Array<{
+    userId: string;
+    name: string;
+    username: string;
+    imageId: string | null;
+    contributionCents: number;
+  }>;
+};
 
 type RecipientCandidate = {
-	id: string
-	name: string
-	username: string
-	imageId: string | null
-}
+  id: string;
+  name: string;
+  username: string;
+  imageId: string | null;
+};
 
 async function fetchRecipientCandidates(
-	viewerId: string,
+  viewerId: string,
 ): Promise<RecipientCandidate[]> {
-	const [friendships, groupMemberships] = await Promise.all([
-		prisma.friendship.findMany({
-			where: {
-				OR: [{ userAId: viewerId }, { userBId: viewerId }],
-			},
-			select: {
-				userA: {
-					select: {
-						id: true,
-						name: true,
-						username: true,
-						image: { select: { id: true } },
-					},
-				},
-				userB: {
-					select: {
-						id: true,
-						name: true,
-						username: true,
-						image: { select: { id: true } },
-					},
-				},
-			},
-		}),
-		prisma.usersInGiftGroups.findMany({
-			where: {
-				giftGroup: { groupMembers: { some: { userId: viewerId } } },
-				userId: { not: viewerId },
-				removedAt: null,
-			},
-			select: {
-				user: {
-					select: {
-						id: true,
-						name: true,
-						username: true,
-						image: { select: { id: true } },
-					},
-				},
-			},
-		}),
-	])
+  const [friendships, groupMemberships] = await Promise.all([
+    prisma.friendship.findMany({
+      where: {
+        OR: [{ userAId: viewerId }, { userBId: viewerId }],
+      },
+      select: {
+        userA: {
+          select: {
+            id: true,
+            name: true,
+            username: true,
+            image: { select: { id: true } },
+          },
+        },
+        userB: {
+          select: {
+            id: true,
+            name: true,
+            username: true,
+            image: { select: { id: true } },
+          },
+        },
+      },
+    }),
+    prisma.usersInGiftGroups.findMany({
+      where: {
+        giftGroup: { groupMembers: { some: { userId: viewerId } } },
+        userId: { not: viewerId },
+        removedAt: null,
+      },
+      select: {
+        user: {
+          select: {
+            id: true,
+            name: true,
+            username: true,
+            image: { select: { id: true } },
+          },
+        },
+      },
+    }),
+  ]);
 
-	const map = new Map<string, RecipientCandidate>()
-	for (const f of friendships) {
-		const other = f.userA.id === viewerId ? f.userB : f.userA
-		map.set(other.id, {
-			id: other.id,
-			name: other.name ?? other.username,
-			username: other.username,
-			imageId: other.image?.id ?? null,
-		})
-	}
-	for (const m of groupMemberships) {
-		if (map.has(m.user.id)) continue
-		map.set(m.user.id, {
-			id: m.user.id,
-			name: m.user.name ?? m.user.username,
-			username: m.user.username,
-			imageId: m.user.image?.id ?? null,
-		})
-	}
+  const map = new Map<string, RecipientCandidate>();
+  for (const f of friendships) {
+    const other = f.userA.id === viewerId ? f.userB : f.userA;
+    map.set(other.id, {
+      id: other.id,
+      name: other.name ?? other.username,
+      username: other.username,
+      imageId: other.image?.id ?? null,
+    });
+  }
+  for (const m of groupMemberships) {
+    if (map.has(m.user.id)) continue;
+    map.set(m.user.id, {
+      id: m.user.id,
+      name: m.user.name ?? m.user.username,
+      username: m.user.username,
+      imageId: m.user.image?.id ?? null,
+    });
+  }
 
-	return [...map.values()].sort((a, b) => a.name.localeCompare(b.name))
+  return [...map.values()].sort((a, b) => a.name.localeCompare(b.name));
 }
 
 export async function loader({ request }: LoaderFunctionArgs) {
-	const userId = await requireUserId(request)
-	const url = new URL(request.url)
-	const groupId = url.searchParams.get('groupId')
-	const recipientId = url.searchParams.get('recipientId')
+  const userId = await requireUserId(request);
+  const url = new URL(request.url);
+  const groupId = url.searchParams.get('groupId');
+  const recipientId = url.searchParams.get('recipientId');
 
-	if (!groupId || !recipientId) {
-		const candidates = await fetchRecipientCandidates(userId)
-		return {
-			groupContext: null as GroupContext | null,
-			candidates,
-		}
-	}
+  if (!groupId || !recipientId) {
+    const candidates = await fetchRecipientCandidates(userId);
+    // Standalone prefill: the person surface can pass ?recipientId=<id> alone
+    // (friend-only Organize). Preselect that candidate so the organizer lands
+    // with the recipient already chosen.
+    const preselectedRecipient = recipientId
+      ? (candidates.find((c) => c.id === recipientId) ?? null)
+      : null;
+    return {
+      groupContext: null as GroupContext | null,
+      candidates,
+      preselectedRecipient,
+    };
+  }
 
-	const group = await prisma.giftGroup.findUnique({
-		where: { id: groupId },
-		select: {
-			name: true,
-			groupMembers: {
-				where: { removedAt: null },
-				select: {
-					userId: true,
-					contributionCents: true,
-					user: {
-						select: {
-							id: true,
-							name: true,
-							username: true,
-							image: { select: { id: true } },
-						},
-					},
-				},
-			},
-		},
-	})
+  const group = await prisma.giftGroup.findUnique({
+    where: { id: groupId },
+    select: {
+      name: true,
+      groupMembers: {
+        where: { removedAt: null },
+        select: {
+          userId: true,
+          contributionCents: true,
+          user: {
+            select: {
+              id: true,
+              name: true,
+              username: true,
+              image: { select: { id: true } },
+            },
+          },
+        },
+      },
+    },
+  });
 
-	if (!group) {
-		return { groupContext: null as GroupContext | null, candidates: [] as RecipientCandidate[] }
-	}
+  if (!group) {
+    return {
+      groupContext: null as GroupContext | null,
+      candidates: [] as RecipientCandidate[],
+      preselectedRecipient: null as RecipientCandidate | null,
+    };
+  }
 
-	const viewerMember = group.groupMembers.find((m) => m.userId === userId)
-	if (!viewerMember) {
-		return { groupContext: null as GroupContext | null, candidates: [] as RecipientCandidate[] }
-	}
+  const viewerMember = group.groupMembers.find((m) => m.userId === userId);
+  if (!viewerMember) {
+    return {
+      groupContext: null as GroupContext | null,
+      candidates: [] as RecipientCandidate[],
+      preselectedRecipient: null as RecipientCandidate | null,
+    };
+  }
 
-	const recipientMember = group.groupMembers.find(
-		(m) => m.userId === recipientId,
-	)
-	if (!recipientMember) {
-		return { groupContext: null as GroupContext | null, candidates: [] as RecipientCandidate[] }
-	}
+  const recipientMember = group.groupMembers.find(
+    (m) => m.userId === recipientId,
+  );
+  if (!recipientMember) {
+    return {
+      groupContext: null as GroupContext | null,
+      candidates: [] as RecipientCandidate[],
+      preselectedRecipient: null as RecipientCandidate | null,
+    };
+  }
 
-	const members = group.groupMembers
-		.filter((m) => m.userId !== recipientId)
-		.map((m) => ({
-			userId: m.userId,
-			name: m.user.name ?? m.user.username,
-			username: m.user.username,
-			imageId: m.user.image?.id ?? null,
-			contributionCents: m.contributionCents,
-		}))
+  const members = group.groupMembers
+    .filter((m) => m.userId !== recipientId)
+    .map((m) => ({
+      userId: m.userId,
+      name: m.user.name ?? m.user.username,
+      username: m.user.username,
+      imageId: m.user.image?.id ?? null,
+      contributionCents: m.contributionCents,
+    }));
 
-	const groupContext: GroupContext = {
-		groupId,
-		groupName: group.name,
-		recipient: {
-			id: recipientMember.userId,
-			name: recipientMember.user.name ?? recipientMember.user.username,
-			username: recipientMember.user.username,
-		},
-		members,
-	}
+  const groupContext: GroupContext = {
+    groupId,
+    groupName: group.name,
+    recipient: {
+      id: recipientMember.userId,
+      name: recipientMember.user.name ?? recipientMember.user.username,
+      username: recipientMember.user.username,
+    },
+    members,
+  };
 
-	return { groupContext, candidates: [] as RecipientCandidate[] }
+  return {
+    groupContext,
+    candidates: [] as RecipientCandidate[],
+    preselectedRecipient: null as RecipientCandidate | null,
+  };
 }
 
 // ─── Action ──────────────────────────────────────────────────────────────────
 
 type RecipientResolution = {
-	recipientUserId: string | null
-	groupMemberDefaults: Array<{ userId: string; contributionCents: number }>
-}
+  recipientUserId: string | null;
+  groupMemberDefaults: Array<{ userId: string; contributionCents: number }>;
+};
 
 type ResolutionResult =
-	| { ok: true; value: RecipientResolution }
-	| { ok: false; response: ReturnType<typeof data> }
+  | { ok: true; value: RecipientResolution }
+  | { ok: false; response: ReturnType<typeof data> };
 
 async function resolveGroupBackedRecipient(
-	userId: string,
-	giftGroupId: string,
-	formRecipientUserId: string,
-	contributorIdsRaw: string | undefined,
-	submission: Awaited<
-		ReturnType<typeof parseWithZod<typeof CreatePoolSchema>>
-	>,
+  userId: string,
+  giftGroupId: string,
+  formRecipientUserId: string,
+  contributorIdsRaw: string | undefined,
+  submission: Awaited<ReturnType<typeof parseWithZod<typeof CreatePoolSchema>>>,
 ): Promise<ResolutionResult> {
-	// Validate: organizer must be in the group
-	const membership = await prisma.usersInGiftGroups.findUnique({
-		where: { userId_giftGroupId: { userId, giftGroupId } },
-		select: { userId: true },
-	})
-	if (!membership) {
-		return {
-			ok: false,
-			response: data(
-				submission.reply({
-					formErrors: ['You are not a member of this group.'],
-				}),
-				{ status: 403 },
-			),
-		}
-	}
+  // Validate: organizer must be in the group
+  const membership = await prisma.usersInGiftGroups.findUnique({
+    where: { userId_giftGroupId: { userId, giftGroupId } },
+    select: { userId: true },
+  });
+  if (!membership) {
+    return {
+      ok: false,
+      response: data(
+        submission.reply({
+          formErrors: ['You are not a member of this group.'],
+        }),
+        { status: 403 },
+      ),
+    };
+  }
 
-	// Validate: recipient must be in the group
-	const recipientMembership = await prisma.usersInGiftGroups.findUnique({
-		where: {
-			userId_giftGroupId: { userId: formRecipientUserId, giftGroupId },
-		},
-		select: { userId: true },
-	})
-	if (!recipientMembership) {
-		return {
-			ok: false,
-			response: data(
-				submission.reply({
-					formErrors: ['The recipient is not a member of this group.'],
-				}),
-				{ status: 400 },
-			),
-		}
-	}
+  // Validate: recipient must be in the group
+  const recipientMembership = await prisma.usersInGiftGroups.findUnique({
+    where: {
+      userId_giftGroupId: { userId: formRecipientUserId, giftGroupId },
+    },
+    select: { userId: true },
+  });
+  if (!recipientMembership) {
+    return {
+      ok: false,
+      response: data(
+        submission.reply({
+          formErrors: ['The recipient is not a member of this group.'],
+        }),
+        { status: 400 },
+      ),
+    };
+  }
 
-	const selectedIds = contributorIdsRaw
-		? contributorIdsRaw.split(',').filter(Boolean)
-		: []
-	if (selectedIds.length === 0) {
-		return {
-			ok: false,
-			response: data(
-				submission.reply({
-					formErrors: ['Select at least one contributor.'],
-				}),
-				{ status: 400 },
-			),
-		}
-	}
+  const selectedIds = contributorIdsRaw
+    ? contributorIdsRaw.split(',').filter(Boolean)
+    : [];
+  if (selectedIds.length === 0) {
+    return {
+      ok: false,
+      response: data(
+        submission.reply({
+          formErrors: ['Select at least one contributor.'],
+        }),
+        { status: 400 },
+      ),
+    };
+  }
 
-	// Re-derive authoritative contribution defaults from the DB; filter out
-	// the recipient — they must never be a contributor.
-	const members = await prisma.usersInGiftGroups.findMany({
-		where: {
-			giftGroupId,
-			userId: { in: selectedIds },
-			removedAt: null,
-		},
-		select: { userId: true, contributionCents: true },
-	})
-	const groupMemberDefaults = members
-		.filter((m) => m.userId !== formRecipientUserId)
-		.map((m) => ({
-			userId: m.userId,
-			contributionCents: m.contributionCents,
-		}))
+  // Re-derive authoritative contribution defaults from the DB; filter out
+  // the recipient — they must never be a contributor.
+  const members = await prisma.usersInGiftGroups.findMany({
+    where: {
+      giftGroupId,
+      userId: { in: selectedIds },
+      removedAt: null,
+    },
+    select: { userId: true, contributionCents: true },
+  });
+  const groupMemberDefaults = members
+    .filter((m) => m.userId !== formRecipientUserId)
+    .map((m) => ({
+      userId: m.userId,
+      contributionCents: m.contributionCents,
+    }));
 
-	return {
-		ok: true,
-		value: {
-			recipientUserId: formRecipientUserId,
-			groupMemberDefaults,
-		},
-	}
+  return {
+    ok: true,
+    value: {
+      recipientUserId: formRecipientUserId,
+      groupMemberDefaults,
+    },
+  };
 }
 
 async function resolveStandaloneRecipient(
-	userId: string,
-	formRecipientUserId: string,
-	submission: Awaited<
-		ReturnType<typeof parseWithZod<typeof CreatePoolSchema>>
-	>,
+  userId: string,
+  formRecipientUserId: string,
+  submission: Awaited<ReturnType<typeof parseWithZod<typeof CreatePoolSchema>>>,
 ): Promise<ResolutionResult> {
-	// Validate the picker selection against the viewer's candidate pool
-	// (friends + group members). Prevents arbitrary user ids being
-	// submitted via a tampered form.
-	const candidates = await fetchRecipientCandidates(userId)
-	const match = candidates.find((c) => c.id === formRecipientUserId)
-	if (!match) {
-		return {
-			ok: false,
-			response: data(
-				submission.reply({
-					formErrors: [
-						'That person is not in your friends or group members.',
-					],
-				}),
-				{ status: 400 },
-			),
-		}
-	}
-	return {
-		ok: true,
-		value: {
-			recipientUserId: match.id,
-			groupMemberDefaults: [],
-		},
-	}
+  // Validate the picker selection against the viewer's candidate pool
+  // (friends + group members). Prevents arbitrary user ids being
+  // submitted via a tampered form.
+  const candidates = await fetchRecipientCandidates(userId);
+  const match = candidates.find((c) => c.id === formRecipientUserId);
+  if (!match) {
+    return {
+      ok: false,
+      response: data(
+        submission.reply({
+          formErrors: ['That person is not in your friends or group members.'],
+        }),
+        { status: 400 },
+      ),
+    };
+  }
+  return {
+    ok: true,
+    value: {
+      recipientUserId: match.id,
+      groupMemberDefaults: [],
+    },
+  };
 }
 
 export async function action({ request }: ActionFunctionArgs) {
-	const userId = await requireUserId(request)
-	const formData = await request.formData()
-	const submission = parseWithZod(formData, { schema: CreatePoolSchema })
+  const userId = await requireUserId(request);
+  const formData = await request.formData();
+  const submission = parseWithZod(formData, { schema: CreatePoolSchema });
 
-	if (submission.status !== 'success') {
-		return data(submission.reply(), { status: 400 })
-	}
+  if (submission.status !== 'success') {
+    return data(submission.reply(), { status: 400 });
+  }
 
-	const {
-		title,
-		occasionType,
-		eventDate,
-		decisionMode,
-		recipientName,
-		giftGroupId,
-		recipientUserId: formRecipientUserId,
-		contributorIds: contributorIdsRaw,
-	} = submission.value
+  const {
+    title,
+    occasionType,
+    eventDate,
+    decisionMode,
+    recipientName,
+    giftGroupId,
+    recipientUserId: formRecipientUserId,
+    contributorIds: contributorIdsRaw,
+  } = submission.value;
 
-	let recipientUserId: string | null = null
-	let groupMemberDefaults: Array<{
-		userId: string
-		contributionCents: number
-	}> = []
+  let recipientUserId: string | null = null;
+  let groupMemberDefaults: Array<{
+    userId: string;
+    contributionCents: number;
+  }> = [];
 
-	if (giftGroupId && formRecipientUserId) {
-		const result = await resolveGroupBackedRecipient(
-			userId,
-			giftGroupId,
-			formRecipientUserId,
-			contributorIdsRaw,
-			submission,
-		)
-		if (!result.ok) return result.response
-		recipientUserId = result.value.recipientUserId
-		groupMemberDefaults = result.value.groupMemberDefaults
-	} else if (formRecipientUserId) {
-		const result = await resolveStandaloneRecipient(
-			userId,
-			formRecipientUserId,
-			submission,
-		)
-		if (!result.ok) return result.response
-		recipientUserId = result.value.recipientUserId
-	}
+  if (giftGroupId && formRecipientUserId) {
+    const result = await resolveGroupBackedRecipient(
+      userId,
+      giftGroupId,
+      formRecipientUserId,
+      contributorIdsRaw,
+      submission,
+    );
+    if (!result.ok) return result.response;
+    recipientUserId = result.value.recipientUserId;
+    groupMemberDefaults = result.value.groupMemberDefaults;
+  } else if (formRecipientUserId) {
+    const result = await resolveStandaloneRecipient(
+      userId,
+      formRecipientUserId,
+      submission,
+    );
+    if (!result.ok) return result.response;
+    recipientUserId = result.value.recipientUserId;
+  }
 
-	const pool = await createPool({
-		title,
-		occasionType,
-		eventDate: eventDate ? new Date(eventDate) : null,
-		decisionMode,
-		recipientUserId,
-		recipientName: recipientName || null,
-		giftGroupId: giftGroupId || null,
-		organizerId: userId,
-		groupMemberDefaults,
-	})
+  const pool = await createPool({
+    title,
+    occasionType,
+    eventDate: eventDate ? new Date(eventDate) : null,
+    decisionMode,
+    recipientUserId,
+    recipientName: recipientName || null,
+    giftGroupId: giftGroupId || null,
+    organizerId: userId,
+    groupMemberDefaults,
+  });
 
-	return redirect(`/pools/${pool.id}`)
+  return redirect(`/pools/${pool.id}`);
 }
 
 // ─── Component ───────────────────────────────────────────────────────────────
 
 const NewPool = () => {
-	const { groupContext, candidates } = useLoaderData<typeof loader>()
-	const actionData = useActionData<typeof action>()
+  const { groupContext, candidates, preselectedRecipient } =
+    useLoaderData<typeof loader>();
+  const actionData = useActionData<typeof action>();
 
-	const [form, fields] = useForm<z.input<typeof CreatePoolSchema>>({
-		// `action` returns a union of data() responses with differently-shaped
-		// formErrors (string[] in some branches, unknown in others). Cast so
-		// useForm's stricter SubmissionResult<string[]> binding is satisfied.
-		lastResult: actionData as
-			| Parameters<typeof useForm<z.input<typeof CreatePoolSchema>>>[0]['lastResult']
-			| undefined,
-		onValidate({ formData }) {
-			return parseWithZod(formData, { schema: CreatePoolSchema })
-		},
-		defaultValue: {
-			occasionType: OCCASION_TYPE.BIRTHDAY,
-			decisionMode: DECISION_MODE.ORGANIZER_PICKS,
-		},
-	})
+  const [form, fields] = useForm<z.input<typeof CreatePoolSchema>>({
+    // `action` returns a union of data() responses with differently-shaped
+    // formErrors (string[] in some branches, unknown in others). Cast so
+    // useForm's stricter SubmissionResult<string[]> binding is satisfied.
+    lastResult: actionData as
+      | Parameters<
+          typeof useForm<z.input<typeof CreatePoolSchema>>
+        >[0]['lastResult']
+      | undefined,
+    onValidate({ formData }) {
+      return parseWithZod(formData, { schema: CreatePoolSchema });
+    },
+    defaultValue: {
+      occasionType: OCCASION_TYPE.BIRTHDAY,
+      decisionMode: DECISION_MODE.ORGANIZER_PICKS,
+    },
+  });
 
-	const cancelHref = groupContext
-		? `/groups/${groupContext.groupId}`
-		: '/pools'
-	const backLabel = groupContext ? groupContext.groupName : 'Pools'
-	const backHref = cancelHref
+  const cancelHref = groupContext
+    ? `/groups/${groupContext.groupId}`
+    : '/pools';
+  const backLabel = groupContext ? groupContext.groupName : 'Pools';
+  const backHref = cancelHref;
 
-	return (
-		<div className="flex h-full min-h-0 flex-col">
-			<div className="border-b bg-surface px-4 py-4 shadow">
-				<div className="container flex items-center gap-3">
-					<Button asChild variant="ghost" size="sm" className="px-2">
-						<Link to={backHref}>
-							<Icon name="arrow-left" className="mr-1" /> {backLabel}
-						</Link>
-					</Button>
-					<Flex gap={2} align="center">
-						<LuGift className="text-primary" />
-						<Text weight="bold">Start a Pool</Text>
-					</Flex>
-				</div>
-			</div>
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="border-b bg-surface px-4 py-4 shadow">
+        <div className="container flex items-center gap-3">
+          <Button asChild variant="ghost" size="sm" className="px-2">
+            <Link to={backHref}>
+              <Icon name="arrow-left" className="mr-1" /> {backLabel}
+            </Link>
+          </Button>
+          <Flex gap={2} align="center">
+            <LuGift className="text-primary" />
+            <Text weight="bold">Start a Pool</Text>
+          </Flex>
+        </div>
+      </div>
 
-			<div className="container max-w-lg py-8">
-				<Form method="post" {...getFormProps(form)}>
-					{groupContext && (
-						<>
-							<input
-								type="hidden"
-								name="giftGroupId"
-								value={groupContext.groupId}
-							/>
-							<input
-								type="hidden"
-								name="recipientUserId"
-								value={groupContext.recipient.id}
-							/>
-						</>
-					)}
+      <div className="container max-w-lg py-8">
+        <Form method="post" {...getFormProps(form)}>
+          {groupContext && (
+            <>
+              <input
+                type="hidden"
+                name="giftGroupId"
+                value={groupContext.groupId}
+              />
+              <input
+                type="hidden"
+                name="recipientUserId"
+                value={groupContext.recipient.id}
+              />
+            </>
+          )}
 
-					{form.errors && form.errors.length > 0 && (
-						<Card padding="md" className="mb-6 border-destructive">
-							{form.errors.map((error) => (
-								<Text key={error} size="sm" className="text-destructive">
-									{error}
-								</Text>
-							))}
-						</Card>
-					)}
+          {form.errors && form.errors.length > 0 && (
+            <Card padding="md" className="mb-6 border-destructive">
+              {form.errors.map((error) => (
+                <Text key={error} size="sm" className="text-destructive">
+                  {error}
+                </Text>
+              ))}
+            </Card>
+          )}
 
-					<Stack gap={6}>
-						{groupContext && (
-							<Card padding="md" className="border-primary/20 bg-primary/5">
-								<Flex gap={2} align="center">
-									<LuGift className="shrink-0 text-primary" size={16} />
-									<Text size="sm">
-										Creating a pool in{' '}
-										<span className="font-semibold">
-											{groupContext.groupName}
-										</span>{' '}
-										for{' '}
-										<span className="font-semibold">
-											{groupContext.recipient.name}
-										</span>
-									</Text>
-								</Flex>
-							</Card>
-						)}
+          <Stack gap={6}>
+            {groupContext && (
+              <Card padding="md" className="border-primary/20 bg-primary/5">
+                <Flex gap={2} align="center">
+                  <LuGift className="shrink-0 text-primary" size={16} />
+                  <Text size="sm">
+                    Creating a pool in{' '}
+                    <span className="font-semibold">
+                      {groupContext.groupName}
+                    </span>{' '}
+                    for{' '}
+                    <span className="font-semibold">
+                      {groupContext.recipient.name}
+                    </span>
+                  </Text>
+                </Flex>
+              </Card>
+            )}
 
-						<Stack gap={2}>
-							<Label htmlFor={fields.title.id}>Pool title</Label>
-							<Input
-								{...getInputProps(fields.title, { type: 'text' })}
-								placeholder={
-									groupContext
-										? `e.g. ${groupContext.recipient.name}'s Birthday`
-										: "e.g. Marco's 30th Birthday"
-								}
-								autoFocus
-							/>
-							{fields.title.errors && (
-								<Text size="sm" className="text-destructive">
-									{fields.title.errors[0]}
-								</Text>
-							)}
-						</Stack>
+            <Stack gap={2}>
+              <Label htmlFor={fields.title.id}>Pool title</Label>
+              <Input
+                {...getInputProps(fields.title, { type: 'text' })}
+                placeholder={
+                  groupContext
+                    ? `e.g. ${groupContext.recipient.name}'s Birthday`
+                    : "e.g. Marco's 30th Birthday"
+                }
+                autoFocus
+              />
+              {fields.title.errors && (
+                <Text size="sm" className="text-destructive">
+                  {fields.title.errors[0]}
+                </Text>
+              )}
+            </Stack>
 
-						<Stack gap={2}>
-							<Label htmlFor={fields.occasionType.id}>Occasion</Label>
-							<select
-								{...getInputProps(fields.occasionType, { type: 'text' })}
-								className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring"
-							>
-								{Object.entries(OCCASION_TYPE_LABELS).map(
-									([value, label]) => (
-										<option key={value} value={value}>
-											{label}
-										</option>
-									),
-								)}
-							</select>
-						</Stack>
+            <Stack gap={2}>
+              <Label htmlFor={fields.occasionType.id}>Occasion</Label>
+              <select
+                {...getInputProps(fields.occasionType, { type: 'text' })}
+                className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring"
+              >
+                {Object.entries(OCCASION_TYPE_LABELS).map(([value, label]) => (
+                  <option key={value} value={value}>
+                    {label}
+                  </option>
+                ))}
+              </select>
+            </Stack>
 
-						<Stack gap={2}>
-							<Label htmlFor={fields.eventDate.id}>
-								Event date{' '}
-								<span className="text-muted-foreground">(optional)</span>
-							</Label>
-							<Input
-								{...getInputProps(fields.eventDate, { type: 'date' })}
-							/>
-						</Stack>
+            <Stack gap={2}>
+              <Label htmlFor={fields.eventDate.id}>
+                Event date{' '}
+                <span className="text-muted-foreground">(optional)</span>
+              </Label>
+              <Input {...getInputProps(fields.eventDate, { type: 'date' })} />
+            </Stack>
 
-						{groupContext ? (
-							<ContributorPicker members={groupContext.members} />
-						) : (
-							<RecipientPicker
-								candidates={candidates}
-								nameFieldName={fields.recipientName.name}
-							/>
-						)}
+            {groupContext ? (
+              <ContributorPicker members={groupContext.members} />
+            ) : (
+              <RecipientPicker
+                candidates={candidates}
+                nameFieldName={fields.recipientName.name}
+                initialSelected={preselectedRecipient}
+              />
+            )}
 
-						<Stack gap={2}>
-							<Label>How will you pick the gift?</Label>
-							<Stack gap={2}>
-								{Object.entries(DECISION_MODE_LABELS).map(
-									([value, label]) => (
-										<label
-											key={value}
-											className="flex cursor-pointer items-center gap-3"
-										>
-											<input
-												type="radio"
-												name={fields.decisionMode.name}
-												value={value}
-												defaultChecked={
-													value === DECISION_MODE.ORGANIZER_PICKS
-												}
-												className="text-primary"
-											/>
-											<Stack gap={0}>
-												<Text weight="medium" size="sm">
-													{label}
-												</Text>
-												<Text
-													size="xs"
-													className="text-muted-foreground"
-												>
-													{value === DECISION_MODE.ORGANIZER_PICKS
-														? 'You pick the winner from the ideas list.'
-														: 'Everyone votes and the most popular idea wins.'}
-												</Text>
-											</Stack>
-										</label>
-									),
-								)}
-							</Stack>
-						</Stack>
+            <Stack gap={2}>
+              <Label>How will you pick the gift?</Label>
+              <Stack gap={2}>
+                {Object.entries(DECISION_MODE_LABELS).map(([value, label]) => (
+                  <label
+                    key={value}
+                    className="flex cursor-pointer items-center gap-3"
+                  >
+                    <input
+                      type="radio"
+                      name={fields.decisionMode.name}
+                      value={value}
+                      defaultChecked={value === DECISION_MODE.ORGANIZER_PICKS}
+                      className="text-primary"
+                    />
+                    <Stack gap={0}>
+                      <Text weight="medium" size="sm">
+                        {label}
+                      </Text>
+                      <Text size="xs" className="text-muted-foreground">
+                        {value === DECISION_MODE.ORGANIZER_PICKS
+                          ? 'You pick the winner from the ideas list.'
+                          : 'Everyone votes and the most popular idea wins.'}
+                      </Text>
+                    </Stack>
+                  </label>
+                ))}
+              </Stack>
+            </Stack>
 
-						<Flex gap={3} justify="end">
-							<Button asChild variant="outline">
-								<Link to={cancelHref}>Cancel</Link>
-							</Button>
-							<Button type="submit">Start Pool</Button>
-						</Flex>
-					</Stack>
-				</Form>
-			</div>
-		</div>
-	)
-}
+            <Flex gap={3} justify="end">
+              <Button asChild variant="outline">
+                <Link to={cancelHref}>Cancel</Link>
+              </Button>
+              <Button type="submit">Start Pool</Button>
+            </Flex>
+          </Stack>
+        </Form>
+      </div>
+    </div>
+  );
+};
 
-export default NewPool
+export default NewPool;
 
 // ─── Recipient Picker (standalone flow) ──────────────────────────────────────
 
 const RecipientPicker = ({
-	candidates,
-	nameFieldName,
+  candidates,
+  nameFieldName,
+  initialSelected = null,
 }: {
-	candidates: RecipientCandidate[]
-	nameFieldName: string
+  candidates: RecipientCandidate[];
+  nameFieldName: string;
+  initialSelected?: RecipientCandidate | null;
 }) => {
-	const [selected, setSelected] = useState<RecipientCandidate | null>(null)
-	const [query, setQuery] = useState('')
-	const [open, setOpen] = useState(false)
+  const [selected, setSelected] = useState<RecipientCandidate | null>(
+    initialSelected,
+  );
+  const [query, setQuery] = useState('');
+  const [open, setOpen] = useState(false);
 
-	const normalizedQuery = query.trim().toLowerCase()
-	const matches = normalizedQuery
-		? candidates
-				.filter(
-					(c) =>
-						c.name.toLowerCase().includes(normalizedQuery) ||
-						c.username.toLowerCase().includes(normalizedQuery),
-				)
-				.slice(0, 8)
-		: candidates.slice(0, 8)
+  const normalizedQuery = query.trim().toLowerCase();
+  const matches = normalizedQuery
+    ? candidates
+        .filter(
+          (c) =>
+            c.name.toLowerCase().includes(normalizedQuery) ||
+            c.username.toLowerCase().includes(normalizedQuery),
+        )
+        .slice(0, 8)
+    : candidates.slice(0, 8);
 
-	if (selected) {
-		return (
-			<Stack gap={2}>
-				<Text weight="medium">Who is this for?</Text>
-				<input type="hidden" name="recipientUserId" value={selected.id} />
-				<Card padding="sm" className="border-primary/30 bg-primary/5">
-					<Flex gap={3} align="center">
-						<img
-							src={getUserImgSrc(selected.imageId, { size: 64 })}
-							alt=""
-							className="h-8 w-8 shrink-0 rounded-full object-cover"
-						/>
-						<Stack gap={0} className="min-w-0 flex-1">
-							<Text size="sm" weight="medium" className="truncate">
-								{selected.name}
-							</Text>
-							<Text size="xs" className="text-muted-foreground">
-								@{selected.username}
-							</Text>
-						</Stack>
-						<Button
-							type="button"
-							variant="ghost"
-							size="sm"
-							onClick={() => {
-								setSelected(null)
-								setQuery('')
-							}}
-							aria-label="Clear selection"
-						>
-							<Icon name="cross-1" />
-						</Button>
-					</Flex>
-				</Card>
-				<Text size="xs" className="text-muted-foreground">
-					They'll never see this pool. We'll link their wishlist if they have
-					one.
-				</Text>
-			</Stack>
-		)
-	}
+  if (selected) {
+    return (
+      <Stack gap={2}>
+        <Text weight="medium">Who is this for?</Text>
+        <input type="hidden" name="recipientUserId" value={selected.id} />
+        <Card padding="sm" className="border-primary/30 bg-primary/5">
+          <Flex gap={3} align="center">
+            <img
+              src={getUserImgSrc(selected.imageId, { size: 64 })}
+              alt=""
+              className="h-8 w-8 shrink-0 rounded-full object-cover"
+            />
+            <Stack gap={0} className="min-w-0 flex-1">
+              <Text size="sm" weight="medium" className="truncate">
+                {selected.name}
+              </Text>
+              <Text size="xs" className="text-muted-foreground">
+                @{selected.username}
+              </Text>
+            </Stack>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => {
+                setSelected(null);
+                setQuery('');
+              }}
+              aria-label="Clear selection"
+            >
+              <Icon name="cross-1" />
+            </Button>
+          </Flex>
+        </Card>
+        <Text size="xs" className="text-muted-foreground">
+          They'll never see this pool. We'll link their wishlist if they have
+          one.
+        </Text>
+      </Stack>
+    );
+  }
 
-	return (
-		<Stack gap={4}>
-			<Text weight="medium">Who is this for?</Text>
-			<Stack gap={2}>
-				<Label htmlFor="recipient-search">
-					Find a friend or group member
-				</Label>
-				<div className="relative">
-					<Input
-						id="recipient-search"
-						type="text"
-						value={query}
-						placeholder="Search by name or @username"
-						autoComplete="off"
-						onChange={(e) => {
-							setQuery(e.target.value)
-							setOpen(true)
-						}}
-						onFocus={() => setOpen(true)}
-						onBlur={() => {
-							// Delay so a click on a dropdown row fires before we close.
-							setTimeout(() => setOpen(false), 150)
-						}}
-					/>
-					{open && matches.length > 0 && (
-						<Card
-							padding="none"
-							className="absolute top-full z-10 mt-1 max-h-72 w-full overflow-y-auto"
-						>
-							<ul>
-								{matches.map((c, i) => (
-									<li key={c.id}>
-										<button
-											type="button"
-											onMouseDown={(e) => {
-												// Prevent input blur from firing before onClick.
-												e.preventDefault()
-											}}
-											onClick={() => {
-												setSelected(c)
-												setQuery('')
-												setOpen(false)
-											}}
-											className={`flex w-full items-center gap-3 px-3 py-2 text-left transition-colors hover:bg-muted/50 ${i > 0 ? 'border-t border-border' : ''}`}
-										>
-											<img
-												src={getUserImgSrc(c.imageId, { size: 64 })}
-												alt=""
-												className="h-7 w-7 shrink-0 rounded-full object-cover"
-											/>
-											<div className="min-w-0 flex-1">
-												<div className="truncate text-sm font-medium">
-													{c.name}
-												</div>
-												<div className="text-xs text-muted-foreground">
-													@{c.username}
-												</div>
-											</div>
-										</button>
-									</li>
-								))}
-							</ul>
-						</Card>
-					)}
-					{open && query && matches.length === 0 && (
-						<Card
-							padding="sm"
-							className="absolute top-full z-10 mt-1 w-full"
-						>
-							<Text size="xs" className="text-muted-foreground">
-								No matches in your friends or groups. Use the name field
-								below instead.
-							</Text>
-						</Card>
-					)}
-				</div>
-				{candidates.length === 0 && (
-					<Text size="xs" className="text-muted-foreground">
-						Once you add friends or join groups, they'll show up here.
-					</Text>
-				)}
-			</Stack>
-			<Stack gap={2}>
-				<Label htmlFor="recipient-name-fallback">
-					Or just their name{' '}
-					<span className="text-muted-foreground">(optional)</span>
-				</Label>
-				<Input
-					id="recipient-name-fallback"
-					name={nameFieldName}
-					type="text"
-					placeholder="e.g. Marco"
-				/>
-				<Text size="xs" className="text-muted-foreground">
-					For someone who isn't on GiftPool yet.
-				</Text>
-			</Stack>
-		</Stack>
-	)
-}
+  return (
+    <Stack gap={4}>
+      <Text weight="medium">Who is this for?</Text>
+      <Stack gap={2}>
+        <Label htmlFor="recipient-search">Find a friend or group member</Label>
+        <div className="relative">
+          <Input
+            id="recipient-search"
+            type="text"
+            value={query}
+            placeholder="Search by name or @username"
+            autoComplete="off"
+            onChange={(e) => {
+              setQuery(e.target.value);
+              setOpen(true);
+            }}
+            onFocus={() => setOpen(true)}
+            onBlur={() => {
+              // Delay so a click on a dropdown row fires before we close.
+              setTimeout(() => setOpen(false), 150);
+            }}
+          />
+          {open && matches.length > 0 && (
+            <Card
+              padding="none"
+              className="absolute top-full z-10 mt-1 max-h-72 w-full overflow-y-auto"
+            >
+              <ul>
+                {matches.map((c, i) => (
+                  <li key={c.id}>
+                    <button
+                      type="button"
+                      onMouseDown={(e) => {
+                        // Prevent input blur from firing before onClick.
+                        e.preventDefault();
+                      }}
+                      onClick={() => {
+                        setSelected(c);
+                        setQuery('');
+                        setOpen(false);
+                      }}
+                      className={`flex w-full items-center gap-3 px-3 py-2 text-left transition-colors hover:bg-muted/50 ${i > 0 ? 'border-t border-border' : ''}`}
+                    >
+                      <img
+                        src={getUserImgSrc(c.imageId, { size: 64 })}
+                        alt=""
+                        className="h-7 w-7 shrink-0 rounded-full object-cover"
+                      />
+                      <div className="min-w-0 flex-1">
+                        <div className="truncate text-sm font-medium">
+                          {c.name}
+                        </div>
+                        <div className="text-xs text-muted-foreground">
+                          @{c.username}
+                        </div>
+                      </div>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </Card>
+          )}
+          {open && query && matches.length === 0 && (
+            <Card padding="sm" className="absolute top-full z-10 mt-1 w-full">
+              <Text size="xs" className="text-muted-foreground">
+                No matches in your friends or groups. Use the name field below
+                instead.
+              </Text>
+            </Card>
+          )}
+        </div>
+        {candidates.length === 0 && (
+          <Text size="xs" className="text-muted-foreground">
+            Once you add friends or join groups, they'll show up here.
+          </Text>
+        )}
+      </Stack>
+      <Stack gap={2}>
+        <Label htmlFor="recipient-name-fallback">
+          Or just their name{' '}
+          <span className="text-muted-foreground">(optional)</span>
+        </Label>
+        <Input
+          id="recipient-name-fallback"
+          name={nameFieldName}
+          type="text"
+          placeholder="e.g. Marco"
+        />
+        <Text size="xs" className="text-muted-foreground">
+          For someone who isn't on GiftPool yet.
+        </Text>
+      </Stack>
+    </Stack>
+  );
+};
 
 // ─── Contributor Picker (group-backed flow) ──────────────────────────────────
 
 type PickerMember = {
-	userId: string
-	name: string
-	username: string
-	imageId: string | null
-	contributionCents: number
-}
+  userId: string;
+  name: string;
+  username: string;
+  imageId: string | null;
+  contributionCents: number;
+};
 
 const ContributorPicker = ({ members }: { members: PickerMember[] }) => {
-	const [selected, setSelected] = useState<Set<string>>(
-		() => new Set(members.map((m) => m.userId)),
-	)
+  const [selected, setSelected] = useState<Set<string>>(
+    () => new Set(members.map((m) => m.userId)),
+  );
 
-	const toggle = (userId: string) => {
-		setSelected((prev) => {
-			const next = new Set(prev)
-			if (next.has(userId)) {
-				next.delete(userId)
-			} else {
-				next.add(userId)
-			}
-			return next
-		})
-	}
+  const toggle = (userId: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(userId)) {
+        next.delete(userId);
+      } else {
+        next.add(userId);
+      }
+      return next;
+    });
+  };
 
-	const allSelected = selected.size === members.length
-	const toggleAll = () => {
-		if (allSelected) {
-			setSelected(new Set())
-		} else {
-			setSelected(new Set(members.map((m) => m.userId)))
-		}
-	}
+  const allSelected = selected.size === members.length;
+  const toggleAll = () => {
+    if (allSelected) {
+      setSelected(new Set());
+    } else {
+      setSelected(new Set(members.map((m) => m.userId)));
+    }
+  };
 
-	return (
-		<Stack gap={2}>
-			<input
-				type="hidden"
-				name="contributorIds"
-				value={Array.from(selected).join(',')}
-			/>
-			<Flex justify="between" align="center">
-				<Text weight="medium">Contributors</Text>
-				<button
-					type="button"
-					onClick={toggleAll}
-					className="text-xs text-primary hover:underline"
-				>
-					{allSelected ? 'Deselect all' : 'Select all'}
-				</button>
-			</Flex>
-			<Text size="xs" className="text-muted-foreground">
-				Everyone selected will be added to this pool automatically.
-			</Text>
-			<Card padding="none">
-				<Stack gap={0}>
-					{members.map((member, i) => (
-						<label
-							key={member.userId}
-							className={`flex cursor-pointer items-center gap-3 px-3 py-2.5 transition-colors hover:bg-muted/50 ${i > 0 ? 'border-t border-border' : ''}`}
-						>
-							<input
-								type="checkbox"
-								checked={selected.has(member.userId)}
-								onChange={() => toggle(member.userId)}
-								className="h-4 w-4 rounded border-input text-primary focus:ring-primary"
-							/>
-							<img
-								src={getUserImgSrc(member.imageId, { size: 64 })}
-								alt=""
-								className="h-7 w-7 shrink-0 rounded-full object-cover"
-							/>
-							<Stack gap={0} className="min-w-0 flex-1">
-								<Text size="sm" weight="medium" className="truncate">
-									{member.name}
-								</Text>
-								<Text size="xs" className="text-muted-foreground">
-									@{member.username}
-								</Text>
-							</Stack>
-							{member.contributionCents > 0 && (
-								<Text
-									size="xs"
-									className="shrink-0 text-muted-foreground"
-								>
-									${(member.contributionCents / 100).toFixed(0)} cap
-								</Text>
-							)}
-						</label>
-					))}
-				</Stack>
-			</Card>
-			{selected.size === 0 && (
-				<Text size="xs" className="text-destructive">
-					Select at least one contributor.
-				</Text>
-			)}
-		</Stack>
-	)
-}
+  return (
+    <Stack gap={2}>
+      <input
+        type="hidden"
+        name="contributorIds"
+        value={Array.from(selected).join(',')}
+      />
+      <Flex justify="between" align="center">
+        <Text weight="medium">Contributors</Text>
+        <button
+          type="button"
+          onClick={toggleAll}
+          className="text-xs text-primary hover:underline"
+        >
+          {allSelected ? 'Deselect all' : 'Select all'}
+        </button>
+      </Flex>
+      <Text size="xs" className="text-muted-foreground">
+        Everyone selected will be added to this pool automatically.
+      </Text>
+      <Card padding="none">
+        <Stack gap={0}>
+          {members.map((member, i) => (
+            <label
+              key={member.userId}
+              className={`flex cursor-pointer items-center gap-3 px-3 py-2.5 transition-colors hover:bg-muted/50 ${i > 0 ? 'border-t border-border' : ''}`}
+            >
+              <input
+                type="checkbox"
+                checked={selected.has(member.userId)}
+                onChange={() => toggle(member.userId)}
+                className="h-4 w-4 rounded border-input text-primary focus:ring-primary"
+              />
+              <img
+                src={getUserImgSrc(member.imageId, { size: 64 })}
+                alt=""
+                className="h-7 w-7 shrink-0 rounded-full object-cover"
+              />
+              <Stack gap={0} className="min-w-0 flex-1">
+                <Text size="sm" weight="medium" className="truncate">
+                  {member.name}
+                </Text>
+                <Text size="xs" className="text-muted-foreground">
+                  @{member.username}
+                </Text>
+              </Stack>
+              {member.contributionCents > 0 && (
+                <Text size="xs" className="shrink-0 text-muted-foreground">
+                  ${(member.contributionCents / 100).toFixed(0)} cap
+                </Text>
+              )}
+            </label>
+          ))}
+        </Stack>
+      </Card>
+      {selected.size === 0 && (
+        <Text size="xs" className="text-destructive">
+          Select at least one contributor.
+        </Text>
+      )}
+    </Stack>
+  );
+};

--- a/app/routes/pools+/new.tsx
+++ b/app/routes/pools+/new.tsx
@@ -143,6 +143,10 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const groupId = url.searchParams.get('groupId');
   const recipientId = url.searchParams.get('recipientId');
 
+  // Optional idea title prefill — the person surface's "Propose to pool" with
+  // no open pool routes here carrying the idea so it seeds the new pool.
+  const titlePrefill = url.searchParams.get('title') ?? '';
+
   if (!groupId || !recipientId) {
     const candidates = await fetchRecipientCandidates(userId);
     // Standalone prefill: the person surface can pass ?recipientId=<id> alone
@@ -155,6 +159,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
       groupContext: null as GroupContext | null,
       candidates,
       preselectedRecipient,
+      titlePrefill,
     };
   }
 
@@ -185,6 +190,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
       groupContext: null as GroupContext | null,
       candidates: [] as RecipientCandidate[],
       preselectedRecipient: null as RecipientCandidate | null,
+      titlePrefill,
     };
   }
 
@@ -194,6 +200,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
       groupContext: null as GroupContext | null,
       candidates: [] as RecipientCandidate[],
       preselectedRecipient: null as RecipientCandidate | null,
+      titlePrefill,
     };
   }
 
@@ -205,6 +212,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
       groupContext: null as GroupContext | null,
       candidates: [] as RecipientCandidate[],
       preselectedRecipient: null as RecipientCandidate | null,
+      titlePrefill,
     };
   }
 
@@ -233,6 +241,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
     groupContext,
     candidates: [] as RecipientCandidate[],
     preselectedRecipient: null as RecipientCandidate | null,
+    titlePrefill,
   };
 }
 
@@ -426,7 +435,7 @@ export async function action({ request }: ActionFunctionArgs) {
 // ─── Component ───────────────────────────────────────────────────────────────
 
 const NewPool = () => {
-  const { groupContext, candidates, preselectedRecipient } =
+  const { groupContext, candidates, preselectedRecipient, titlePrefill } =
     useLoaderData<typeof loader>();
   const actionData = useActionData<typeof action>();
 
@@ -443,6 +452,7 @@ const NewPool = () => {
       return parseWithZod(formData, { schema: CreatePoolSchema });
     },
     defaultValue: {
+      title: titlePrefill || undefined,
       occasionType: OCCASION_TYPE.BIRTHDAY,
       decisionMode: DECISION_MODE.ORGANIZER_PICKS,
     },

--- a/app/routes/users+/$username.loader.test.ts
+++ b/app/routes/users+/$username.loader.test.ts
@@ -137,7 +137,8 @@ test('friends can view the full profile details', async () => {
   expect(data.relationship.state).toBe('FRIENDS');
   expect(data).toHaveProperty('mutualGroups');
   expect(data).toHaveProperty('mutualFriends');
-  expect(data).toHaveProperty('wishlistPreview');
+  expect(data).toHaveProperty('ideation');
+  expect(data).toHaveProperty('wishlistSource');
 });
 
 test('viewing your own profile redirects to /me', async () => {

--- a/app/routes/users+/$username.loader.test.ts
+++ b/app/routes/users+/$username.loader.test.ts
@@ -72,7 +72,7 @@ test('non-friends receive minimal profile data from the loader', async () => {
   expect(getRouteResultStatus(response)).toBe(200);
   const data = await getRouteResultData<any>(response);
 
-  expect(data.canViewProfile).toBe(false);
+  expect(data.unlocked).toBe(false);
   expect(data.user).toEqual({
     id: targetUser.id,
     name: targetUser.name,
@@ -83,7 +83,7 @@ test('non-friends receive minimal profile data from the loader', async () => {
   expect(data.user).not.toHaveProperty('createdAt');
   expect(data.user).not.toHaveProperty('birthday');
   expect(data).not.toHaveProperty('userJoinedDisplay');
-  expect(data).not.toHaveProperty('profileData');
+  expect(data).not.toHaveProperty('wishlistPreview');
 });
 
 test('friends can view the full profile details', async () => {
@@ -128,17 +128,16 @@ test('friends can view the full profile details', async () => {
   expect(getRouteResultStatus(response)).toBe(200);
   const data = await getRouteResultData<any>(response);
 
-  expect(data.canViewProfile).toBe(true);
+  expect(data.unlocked).toBe(true);
   expect(data.user.id).toBe(targetUser.id);
   expect(data.user.username).toBe(targetUser.username);
   expect(data.user).toHaveProperty('createdAt');
   expect(data.user).toHaveProperty('birthday');
   expect(data).toHaveProperty('userJoinedDisplay');
   expect(data.relationship.state).toBe('FRIENDS');
-  expect(data).toHaveProperty('profileData');
-  expect(data.profileData).toHaveProperty('mutualGroups');
-  expect(data.profileData).toHaveProperty('mutualFriends');
-  expect(data.profileData).toHaveProperty('wishlistPreview');
+  expect(data).toHaveProperty('mutualGroups');
+  expect(data).toHaveProperty('mutualFriends');
+  expect(data).toHaveProperty('wishlistPreview');
 });
 
 test('viewing your own profile redirects to /me', async () => {

--- a/app/routes/users+/$username.test.tsx
+++ b/app/routes/users+/$username.test.tsx
@@ -50,7 +50,15 @@ const baseUser = {
 const emptyBody = {
   mutualGroups: [],
   mutualFriends: [],
-  wishlistPreview: { items: [], totalCount: 0 },
+  budgetLine: null,
+  wishlistSource: [],
+  ideation: {
+    giftHistory: [],
+    proposedUnused: [],
+    notes: [],
+    savedIdeas: [],
+  },
+  openPools: [],
 };
 
 const unlockedBase = {

--- a/app/routes/users+/$username.test.tsx
+++ b/app/routes/users+/$username.test.tsx
@@ -38,38 +38,62 @@ vi.mock('#app/utils/misc.tsx', async () => {
 
 import ProfileRoute, { meta } from './$username_+/index.tsx';
 
-const emptyProfileData = {
+const baseUser = {
+  id: 'user-2',
+  image: null,
+  name: 'Taylor',
+  username: 'taylor',
+  bio: null,
+  birthday: null,
+};
+
+const emptyBody = {
   mutualGroups: [],
   mutualFriends: [],
   wishlistPreview: { items: [], totalCount: 0 },
 };
 
-describe('/users/:username route component', () => {
-  it('renders the friend gate when the profile is not visible', async () => {
-    const App = createRoutesStub([
-      {
-        Component: ProfileRoute,
-        HydrateFallback: () => null,
-        loader: async () => ({
-          unlocked: false,
-          relationship: {
-            friendshipId: null,
-            incomingRequestId: null,
-            outgoingRequestId: null,
-            state: 'NONE',
-          },
-          user: {
-            id: 'user-1',
-            name: 'Taylor',
-            username: 'taylor',
-            image: null,
-          },
-        }),
-        path: '/users/:username',
-      },
-    ]);
+const unlockedBase = {
+  unlocked: true,
+  relationship: {
+    friendshipId: 'friendship-1',
+    incomingRequestId: null,
+    outgoingRequestId: null,
+    state: 'FRIENDS',
+  },
+  user: baseUser,
+  userJoinedDisplay: '3/31/2026',
+  isFriend: true,
+  birthdayVisible: false,
+  canViewWishlist: true,
+  declined: false,
+  ...emptyBody,
+};
 
-    render(<App initialEntries={['/users/taylor']} />);
+function renderWith(loaderData: unknown) {
+  const App = createRoutesStub([
+    {
+      Component: ProfileRoute,
+      HydrateFallback: () => null,
+      loader: async () => loaderData,
+      path: '/users/:username',
+    },
+  ]);
+  render(<App initialEntries={['/users/taylor']} />);
+}
+
+describe('/users/:username person surface component', () => {
+  it('renders the friend gate when not unlocked', async () => {
+    renderWith({
+      unlocked: false,
+      relationship: {
+        friendshipId: null,
+        incomingRequestId: null,
+        outgoingRequestId: null,
+        state: 'NONE',
+      },
+      user: { id: 'user-1', name: 'Taylor', username: 'taylor', image: null },
+    });
 
     expect(
       await screen.findByRole('heading', {
@@ -83,54 +107,59 @@ describe('/users/:username route component', () => {
     );
   });
 
-  it('renders the friend profile view with wishlist CTA', async () => {
-    const App = createRoutesStub([
-      {
-        Component: ProfileRoute,
-        HydrateFallback: () => null,
-        loader: async () => ({
-          unlocked: true,
-          relationship: {
-            friendshipId: 'friendship-1',
-            incomingRequestId: null,
-            outgoingRequestId: null,
-            state: 'FRIENDS',
-          },
-          user: {
-            createdAt: new Date('2026-03-31T00:00:00.000Z'),
-            id: 'user-2',
-            image: { id: 'image-2' },
-            name: 'Taylor',
-            username: 'taylor',
-            bio: null,
-            birthday: null,
-            birthdayVisibility: 'FRIENDS',
-          },
-          userJoinedDisplay: '3/31/2026',
-          isFriend: true,
-          birthdayVisible: true,
-          canViewWishlist: true,
-          ...emptyProfileData,
-        }),
-        path: '/users/:username',
-      },
-    ]);
-
-    render(<App initialEntries={['/users/taylor']} />);
+  it('cold state leads with identity + capture card', async () => {
+    renderWith({
+      ...unlockedBase,
+      temporalState: 'cold',
+      occasion: null,
+      organizeGroups: [],
+    });
 
     expect(
-      await screen.findByRole('heading', { level: 1, name: 'Taylor' }),
+      await screen.findByText('Taylor', { selector: 'div' }),
     ).toBeInTheDocument();
-    expect(screen.getByText('Joined 3/31/2026')).toBeInTheDocument();
-    expect(
-      screen.getByRole('link', { name: "Taylor's wishlist" }),
-    ).toHaveAttribute('href', '/users/taylor/wishlist');
+    expect(screen.getByText('Save an idea')).toBeInTheDocument();
+    expect(screen.getByText('Add a note')).toBeInTheDocument();
     expect(
       screen.getByRole('button', { name: 'Add Taylor' }),
     ).toBeInTheDocument();
+  });
+
+  it('occasion-near state shows the occasion header + full action row', async () => {
+    renderWith({
+      ...unlockedBase,
+      birthdayVisible: true,
+      temporalState: 'occasion-near',
+      occasion: { label: 'Aug 14', daysUntil: 42 },
+      organizeGroups: [
+        { id: 'g1', name: 'The Crew', memberCount: 3, budgetCents: 18000 },
+      ],
+    });
+
     expect(
-      screen.queryByRole('button', { name: 'Logout' }),
-    ).not.toBeInTheDocument();
+      await screen.findByRole('button', { name: /Organize with The Crew/ }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Birthday · Aug 14/)).toBeInTheDocument();
+    expect(screen.getByText('Just me')).toBeInTheDocument();
+    expect(screen.getByText('Save idea')).toBeInTheDocument();
+    expect(screen.getByText('Not this time')).toBeInTheDocument();
+  });
+
+  it('declined state shows the quiet sitting-out header with undo', async () => {
+    renderWith({
+      ...unlockedBase,
+      birthdayVisible: true,
+      temporalState: 'declined',
+      occasion: { label: 'Aug 14', daysUntil: 42 },
+      declined: true,
+      organizeGroups: [],
+    });
+
+    expect(
+      await screen.findByText("You're sitting this one out"),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Only you can see this')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Undo' })).toBeInTheDocument();
   });
 
   it('builds route meta from data and params', () => {

--- a/app/routes/users+/$username.test.tsx
+++ b/app/routes/users+/$username.test.tsx
@@ -2,6 +2,7 @@
  * @vitest-environment jsdom
  */
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { createRoutesStub } from 'react-router';
 import { describe, expect, it, vi } from 'vitest';
@@ -125,13 +126,101 @@ describe('/users/:username person surface component', () => {
     });
 
     expect(
-      await screen.findByText('Taylor', { selector: 'div' }),
+      await screen.findByRole('heading', { level: 1, name: 'Taylor' }),
     ).toBeInTheDocument();
     expect(screen.getByText('Save an idea')).toBeInTheDocument();
     expect(screen.getByText('Add a note')).toBeInTheDocument();
     expect(
       screen.getByRole('button', { name: 'Add Taylor' }),
     ).toBeInTheDocument();
+  });
+
+  it('opens cold-state idea and note capture dialogs', async () => {
+    const user = userEvent.setup();
+    renderWith({
+      ...unlockedBase,
+      temporalState: 'cold',
+      occasion: null,
+      organizeGroups: [],
+    });
+
+    await user.click(
+      await screen.findByRole('button', {
+        name: /Save an idea\s+for when it counts/,
+      }),
+    );
+    expect(
+      screen.getByRole('heading', { name: /Save an idea for Taylor/ }),
+    ).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    await user.click(screen.getByRole('button', { name: /Add a note/ }));
+    expect(
+      screen.getByRole('heading', { name: /Add a note about Taylor/ }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders wishlist and circle-private memory sections', async () => {
+    renderWith({
+      ...unlockedBase,
+      temporalState: 'cold',
+      occasion: null,
+      organizeGroups: [],
+      budgetLine: { groupName: 'The Crew', cents: 18000 },
+      wishlistSource: [
+        {
+          id: 'wish-1',
+          title: 'Vintage espresso machine',
+          url: 'https://example.com/espresso',
+          priceCents: 12000,
+          currency: 'USD',
+          claimed: false,
+          claimedByViewer: false,
+        },
+      ],
+      ideation: {
+        giftHistory: [
+          {
+            id: 'gift-1',
+            name: 'Pizza oven',
+            year: 2025,
+            contributorCount: 4,
+            priceCents: 24000,
+          },
+        ],
+        proposedUnused: [{ id: 'idea-old', name: 'Running vest', year: 2024 }],
+        notes: [{ id: 'note-1', body: 'Started running this spring.' }],
+        savedIdeas: [
+          {
+            id: 'saved-1',
+            name: 'Trail shoes',
+            url: null,
+            priceCents: 9000,
+            currency: 'USD',
+          },
+        ],
+      },
+      openPools: [{ id: 'pool-1', title: "Taylor's birthday" }],
+    });
+
+    expect(await screen.findByText('Their wishlist')).toBeInTheDocument();
+    expect(screen.getByText('Vintage espresso machine')).toBeInTheDocument();
+    expect(
+      screen.getByText('What this circle gave before'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Pizza oven')).toBeInTheDocument();
+    expect(screen.getByText('We almost got them…')).toBeInTheDocument();
+    expect(screen.getByText('Running vest')).toBeInTheDocument();
+    expect(screen.getByText('Your notes · private')).toBeInTheDocument();
+    expect(
+      screen.getByText('Started running this spring.'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Your saved ideas · private')).toBeInTheDocument();
+    expect(screen.getByText('Trail shoes')).toBeInTheDocument();
+    expect(screen.getByText(/The Crew can cover/)).toBeInTheDocument();
+    expect(
+      screen.getAllByRole('button', { name: 'Propose to pool' }),
+    ).toHaveLength(2);
   });
 
   it('occasion-near state shows the occasion header + full action row', async () => {

--- a/app/routes/users+/$username.test.tsx
+++ b/app/routes/users+/$username.test.tsx
@@ -51,7 +51,7 @@ describe('/users/:username route component', () => {
         Component: ProfileRoute,
         HydrateFallback: () => null,
         loader: async () => ({
-          canViewProfile: false,
+          unlocked: false,
           relationship: {
             friendshipId: null,
             incomingRequestId: null,
@@ -89,7 +89,7 @@ describe('/users/:username route component', () => {
         Component: ProfileRoute,
         HydrateFallback: () => null,
         loader: async () => ({
-          canViewProfile: true,
+          unlocked: true,
           relationship: {
             friendshipId: 'friendship-1',
             incomingRequestId: null,
@@ -102,10 +102,15 @@ describe('/users/:username route component', () => {
             image: { id: 'image-2' },
             name: 'Taylor',
             username: 'taylor',
+            bio: null,
             birthday: null,
+            birthdayVisibility: 'FRIENDS',
           },
           userJoinedDisplay: '3/31/2026',
-          profileData: emptyProfileData,
+          isFriend: true,
+          birthdayVisible: true,
+          canViewWishlist: true,
+          ...emptyProfileData,
         }),
         path: '/users/:username',
       },

--- a/app/routes/users+/$username.test.tsx
+++ b/app/routes/users+/$username.test.tsx
@@ -59,6 +59,7 @@ const emptyBody = {
     savedIdeas: [],
   },
   openPools: [],
+  postOccasion: null,
 };
 
 const unlockedBase = {
@@ -168,6 +169,36 @@ describe('/users/:username person surface component', () => {
     ).toBeInTheDocument();
     expect(screen.getByText('Only you can see this')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Undo' })).toBeInTheDocument();
+  });
+
+  it('post-occasion state shows the did-it-land confirm + recorded note', async () => {
+    renderWith({
+      ...unlockedBase,
+      birthdayVisible: true,
+      temporalState: 'post-occasion',
+      occasion: null,
+      organizeGroups: [],
+      postOccasion: {
+        occasionLabel: 'was Aug 14 · a few days ago',
+        gift: { kind: 'pool', id: 'pool-1', name: 'Trail running shoes' },
+        recordedGroupPoolName: 'Weber pizza oven',
+      },
+    });
+
+    expect(await screen.findByText('How did it go?')).toBeInTheDocument();
+    expect(
+      screen.getByText(/Your gift · Trail running shoes/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /They loved it/ }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'It was okay' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Skip for now' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Weber pizza oven/)).toBeInTheDocument();
   });
 
   it('builds route meta from data and params', () => {

--- a/app/routes/users+/$username_+/index.authz.test.ts
+++ b/app/routes/users+/$username_+/index.authz.test.ts
@@ -262,7 +262,7 @@ describe('person surface write authorization', () => {
     expect(await prisma.giftIdea.count()).toBe(0);
   });
 
-  it('propose-to-pool promotes a saved idea and links it (giftListItemId)', async () => {
+  it('propose-to-pool promotes a saved idea and redirects to the pool', async () => {
     const viewer = await createUserRecord();
     const target = await createUserRecord();
     await makeFriends(viewer.id, target.id);
@@ -284,16 +284,18 @@ describe('person surface write authorization', () => {
     });
     const cookie = await withSession(viewer.id);
 
-    expect(
-      await statusOf(
-        invoke(target.username, cookie, {
-          intent: 'propose-to-pool',
-          poolId: pool.id,
-          name: 'Trail shoes',
-          giftListItemId: saved.id,
-        }),
-      ),
-    ).toBe(200);
+    const result = await invoke(target.username, cookie, {
+      intent: 'propose-to-pool',
+      poolId: pool.id,
+      name: 'Trail shoes',
+      giftListItemId: saved.id,
+    });
+
+    expect(getRouteResultStatus(result)).toBe(302);
+    expect(result).toBeInstanceOf(Response);
+    expect((result as Response).headers.get('Location')).toBe(
+      `/pools/${pool.id}`,
+    );
 
     const idea = await prisma.giftIdea.findFirstOrThrow();
     expect(idea.poolId).toBe(pool.id);

--- a/app/routes/users+/$username_+/index.authz.test.ts
+++ b/app/routes/users+/$username_+/index.authz.test.ts
@@ -1,0 +1,280 @@
+/**
+ * @vitest-environment node
+ */
+import { type AppLoadContext } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getSessionExpirationDate } from '#app/utils/auth.server.ts';
+import { prisma } from '#app/utils/db.server.ts';
+import { REQUEST_ID_HEADER } from '#app/utils/request-context.server.ts';
+import { createPassword, createUser } from '#tests/db-utils.ts';
+import {
+  getRouteResultStatus,
+  toActionArgs,
+} from '#tests/route-module-test-utils.ts';
+import { getSessionCookieHeader } from '#tests/utils.ts';
+
+const queueLogEvent = vi.fn();
+vi.mock('#app/utils/analytics.server.ts', () => ({
+  queueLogEvent: (...args: Array<unknown>) => queueLogEvent(...args),
+}));
+
+import { action } from './index.tsx';
+
+const context = {
+  cspNonce: undefined,
+  serverBuild: undefined,
+} as unknown as AppLoadContext;
+
+const ensureUserRole = () =>
+  prisma.role.upsert({
+    where: { name: 'user' },
+    update: {},
+    create: { name: 'user' },
+  });
+
+async function createUserRecord(birthday?: Date) {
+  await ensureUserRole();
+  return prisma.user.create({
+    data: {
+      ...createUser(),
+      birthday: birthday ?? null,
+      password: { create: createPassword() },
+      roles: { connect: { name: 'user' } },
+    },
+  });
+}
+
+async function withSession(userId: string) {
+  const session = await prisma.session.create({
+    data: { userId, expirationDate: getSessionExpirationDate() },
+    select: { id: true },
+  });
+  return getSessionCookieHeader(session);
+}
+
+async function makeFriends(aId: string, bId: string) {
+  const [userAId, userBId] = aId < bId ? [aId, bId] : [bId, aId];
+  await prisma.friendship.create({ data: { userAId, userBId } });
+}
+
+async function createGroupWith(
+  members: Array<{ userId: string; contributionCents?: number }>,
+) {
+  const group = await prisma.giftGroup.create({ data: { name: 'The Crew' } });
+  for (const m of members) {
+    await prisma.usersInGiftGroups.create({
+      data: {
+        userId: m.userId,
+        giftGroupId: group.id,
+        contributionCents: m.contributionCents ?? 0,
+      },
+    });
+  }
+  return group;
+}
+
+function invoke(
+  username: string,
+  cookie: string,
+  fields: Record<string, string>,
+) {
+  const formData = new FormData();
+  for (const [k, v] of Object.entries(fields)) formData.set(k, v);
+  const request = new Request('https://www.giftpool.app/users/' + username, {
+    body: formData,
+    headers: { cookie, [REQUEST_ID_HEADER]: 'req-1' },
+    method: 'POST',
+  });
+  return action(toActionArgs({ context, params: { username }, request }));
+}
+
+async function statusOf(promise: Promise<unknown>): Promise<number> {
+  try {
+    return getRouteResultStatus(await promise);
+  } catch (thrown) {
+    return getRouteResultStatus(thrown);
+  }
+}
+
+beforeEach(() => {
+  queueLogEvent.mockReset();
+  queueLogEvent.mockReturnValue({ eventId: 'evt-1' });
+});
+
+describe('person surface write authorization', () => {
+  it('rejects save-idea / add-note / solo-commit for a stranger (neither friend nor groupmate)', async () => {
+    const viewer = await createUserRecord();
+    const target = await createUserRecord();
+    const cookie = await withSession(viewer.id);
+
+    expect(
+      await statusOf(
+        invoke(target.username, cookie, { intent: 'save-idea', name: 'Shoes' }),
+      ),
+    ).toBe(403);
+    expect(
+      await statusOf(
+        invoke(target.username, cookie, {
+          intent: 'add-note',
+          body: 'Runs now',
+        }),
+      ),
+    ).toBe(403);
+    expect(
+      await statusOf(
+        invoke(target.username, cookie, {
+          intent: 'solo-commit',
+          name: 'Book',
+        }),
+      ),
+    ).toBe(403);
+
+    expect(await prisma.giftListItem.count()).toBe(0);
+    expect(await prisma.personNote.count()).toBe(0);
+    expect(await prisma.pool.count()).toBe(0);
+  });
+
+  it('allows solo-commit for a groupmate who is NOT a friend, seeding a recipient-excluded pool-of-one', async () => {
+    const viewer = await createUserRecord();
+    const target = await createUserRecord();
+    await createGroupWith([
+      { userId: viewer.id, contributionCents: 5000 },
+      { userId: target.id, contributionCents: 4000 },
+    ]);
+    const cookie = await withSession(viewer.id);
+
+    const status = await statusOf(
+      invoke(target.username, cookie, {
+        intent: 'solo-commit',
+        name: 'Trail shoes',
+      }),
+    );
+    expect(status).toBe(200);
+
+    const pool = await prisma.pool.findFirstOrThrow({
+      include: { contributors: true },
+    });
+    expect(pool.title).toBe('Trail shoes');
+    expect(pool.organizerId).toBe(viewer.id);
+    expect(pool.recipientUserId).toBe(target.id);
+    expect(pool.giftGroupId).toBeNull();
+    // Recipient is never a contributor; a pool-of-one has exactly the organizer.
+    expect(pool.contributors).toHaveLength(1);
+    expect(pool.contributors[0]!.userId).toBe(viewer.id);
+  });
+
+  it('allows save-idea and add-note for a friend and writes owner/target + author/subject correctly', async () => {
+    const viewer = await createUserRecord();
+    const target = await createUserRecord();
+    await makeFriends(viewer.id, target.id);
+    const cookie = await withSession(viewer.id);
+
+    expect(
+      await statusOf(
+        invoke(target.username, cookie, {
+          intent: 'save-idea',
+          name: 'Ceramics class',
+          priceCents: '120',
+        }),
+      ),
+    ).toBe(200);
+    expect(
+      await statusOf(
+        invoke(target.username, cookie, {
+          intent: 'add-note',
+          body: 'Buys everything himself — go novelty.',
+        }),
+      ),
+    ).toBe(200);
+
+    const idea = await prisma.giftListItem.findFirstOrThrow();
+    expect(idea.ownerId).toBe(viewer.id);
+    expect(idea.targetUserId).toBe(target.id);
+    expect(idea.priceCents).toBe(12000); // dollars → cents
+
+    const note = await prisma.personNote.findFirstOrThrow();
+    expect(note.authorId).toBe(viewer.id);
+    expect(note.subjectUserId).toBe(target.id);
+  });
+
+  it('never lets the recipient act on their own surface', async () => {
+    const viewer = await createUserRecord();
+    const cookie = await withSession(viewer.id);
+    // Acting on your own username → 404 (recipient never sees this surface).
+    expect(
+      await statusOf(
+        invoke(viewer.username, cookie, { intent: 'save-idea', name: 'x' }),
+      ),
+    ).toBe(404);
+  });
+
+  it('decline is self-scoped: creates one row for the current cycle, undo removes it', async () => {
+    const nextMonth = new Date();
+    nextMonth.setUTCMonth(nextMonth.getUTCMonth() + 1);
+    const viewer = await createUserRecord();
+    const target = await createUserRecord(nextMonth);
+    await makeFriends(viewer.id, target.id);
+    const cookie = await withSession(viewer.id);
+
+    expect(
+      await statusOf(
+        invoke(target.username, cookie, { intent: 'decline-occasion' }),
+      ),
+    ).toBe(200);
+    const decline = await prisma.occasionDecline.findFirstOrThrow();
+    expect(decline.userId).toBe(viewer.id);
+    expect(decline.targetUserId).toBe(target.id);
+
+    expect(
+      await statusOf(
+        invoke(target.username, cookie, { intent: 'undo-decline' }),
+      ),
+    ).toBe(200);
+    expect(await prisma.occasionDecline.count()).toBe(0);
+  });
+
+  it('record-outcome rejects a non-owner and accepts the pool organizer', async () => {
+    const organizer = await createUserRecord();
+    const target = await createUserRecord();
+    const stranger = await createUserRecord();
+    await makeFriends(organizer.id, target.id);
+
+    const pool = await prisma.pool.create({
+      data: {
+        title: 'Solo gift',
+        organizerId: organizer.id,
+        recipientUserId: target.id,
+      },
+    });
+
+    // A different user cannot record the outcome.
+    const strangerCookie = await withSession(stranger.id);
+    expect(
+      await statusOf(
+        invoke(target.username, strangerCookie, {
+          intent: 'record-outcome',
+          kind: 'pool',
+          poolId: pool.id,
+          feedback: 'LOVED',
+        }),
+      ),
+    ).toBe(404);
+
+    // The organizer can.
+    const organizerCookie = await withSession(organizer.id);
+    expect(
+      await statusOf(
+        invoke(target.username, organizerCookie, {
+          intent: 'record-outcome',
+          kind: 'pool',
+          poolId: pool.id,
+          feedback: 'LOVED',
+        }),
+      ),
+    ).toBe(200);
+    const updated = await prisma.pool.findUniqueOrThrow({
+      where: { id: pool.id },
+    });
+    expect(updated.outcomeFeedback).toBe('LOVED');
+  });
+});

--- a/app/routes/users+/$username_+/index.authz.test.ts
+++ b/app/routes/users+/$username_+/index.authz.test.ts
@@ -233,6 +233,73 @@ describe('person surface write authorization', () => {
     expect(await prisma.occasionDecline.count()).toBe(0);
   });
 
+  it('propose-to-pool rejects a viewer who is not a contributor of the pool', async () => {
+    const viewer = await createUserRecord();
+    const target = await createUserRecord();
+    const other = await createUserRecord();
+    await makeFriends(viewer.id, target.id);
+    // An OPEN pool the viewer is NOT part of.
+    const pool = await prisma.pool.create({
+      data: {
+        title: 'Their pool',
+        organizerId: other.id,
+        recipientUserId: target.id,
+        status: 'OPEN',
+        contributors: { create: [{ userId: other.id }] },
+      },
+    });
+    const cookie = await withSession(viewer.id);
+
+    expect(
+      await statusOf(
+        invoke(target.username, cookie, {
+          intent: 'propose-to-pool',
+          poolId: pool.id,
+          name: 'Espresso machine',
+        }),
+      ),
+    ).toBe(404);
+    expect(await prisma.giftIdea.count()).toBe(0);
+  });
+
+  it('propose-to-pool promotes a saved idea and links it (giftListItemId)', async () => {
+    const viewer = await createUserRecord();
+    const target = await createUserRecord();
+    await makeFriends(viewer.id, target.id);
+    const pool = await prisma.pool.create({
+      data: {
+        title: 'Our pool',
+        organizerId: viewer.id,
+        recipientUserId: target.id,
+        status: 'OPEN',
+        contributors: { create: [{ userId: viewer.id }] },
+      },
+    });
+    const saved = await prisma.giftListItem.create({
+      data: {
+        ownerId: viewer.id,
+        targetUserId: target.id,
+        name: 'Trail shoes',
+      },
+    });
+    const cookie = await withSession(viewer.id);
+
+    expect(
+      await statusOf(
+        invoke(target.username, cookie, {
+          intent: 'propose-to-pool',
+          poolId: pool.id,
+          name: 'Trail shoes',
+          giftListItemId: saved.id,
+        }),
+      ),
+    ).toBe(200);
+
+    const idea = await prisma.giftIdea.findFirstOrThrow();
+    expect(idea.poolId).toBe(pool.id);
+    expect(idea.giftListItemId).toBe(saved.id);
+  });
+
   it('record-outcome rejects a non-owner and accepts the pool organizer', async () => {
     const organizer = await createUserRecord();
     const target = await createUserRecord();

--- a/app/routes/users+/$username_+/index.loader.test.ts
+++ b/app/routes/users+/$username_+/index.loader.test.ts
@@ -1,86 +1,213 @@
 /**
  * @vitest-environment node
  */
+import { type AppLoadContext } from 'react-router';
 import { describe, expect, it, vi } from 'vitest';
+import { getSessionExpirationDate } from '#app/utils/auth.server.ts';
+import { prisma } from '#app/utils/db.server.ts';
+import { createPassword, createUser } from '#tests/db-utils.ts';
+import { toLoaderArgs } from '#tests/route-module-test-utils.ts';
+import { getSessionCookieHeader } from '#tests/utils.ts';
 
-const requireUserId = vi.fn();
-const findFirst = vi.fn();
-const getRelationshipDetails = vi.fn();
-const loadProfilePageData = vi.fn();
-
-vi.mock('#app/utils/auth.server.ts', () => ({
-  requireUserId: (...args: Array<unknown>) => requireUserId(...args),
-}));
-
-vi.mock('#app/utils/db.server.ts', () => ({
-  prisma: {
-    user: {
-      findFirst: (...args: Array<unknown>) => findFirst(...args),
-    },
-  },
-}));
-
-vi.mock('#app/utils/friends.server.ts', () => ({
-  getRelationshipDetails: (...args: Array<unknown>) =>
-    getRelationshipDetails(...args),
-}));
-
-vi.mock('#app/utils/profile-page.server.ts', () => ({
-  loadProfilePageData: (...args: Array<unknown>) => loadProfilePageData(...args),
+vi.mock('#app/utils/analytics.server.ts', () => ({
+  queueLogEvent: vi.fn(() => ({ eventId: 'evt-1' })),
 }));
 
 import { loader } from './index.tsx';
 
-function setup(birthdayVisibility: string) {
-  requireUserId.mockResolvedValue('viewer-1');
-  // First findFirst: the lightweight targetUser lookup.
-  findFirst.mockResolvedValueOnce({
-    id: 'target-1',
-    name: 'Alex',
-    username: 'alex',
-    image: { id: 'image-1' },
+const context = {
+  cspNonce: undefined,
+  serverBuild: undefined,
+} as unknown as AppLoadContext;
+
+const ensureUserRole = () =>
+  prisma.role.upsert({
+    where: { name: 'user' },
+    update: {},
+    create: { name: 'user' },
   });
-  // The viewer is a confirmed friend, so the gated branch is reached.
-  getRelationshipDetails.mockResolvedValue({
-    state: 'FRIENDS',
-    friendship: { id: 'friendship-1' },
-  });
-  // Second findFirst: the full profile including birthdayVisibility.
-  findFirst.mockResolvedValueOnce({
-    id: 'target-1',
-    name: 'Alex',
-    username: 'alex',
-    createdAt: new Date('2025-01-01T00:00:00.000Z'),
-    bio: null,
-    birthday: new Date('1990-04-15T12:00:00.000Z'),
-    birthdayVisibility,
-    image: { id: 'image-1' },
-  });
-  loadProfilePageData.mockResolvedValue({
-    mutualGroups: [],
-    mutualFriends: [],
-    wishlistPreview: { items: [], totalCount: 0 },
+
+async function createUserRecord(
+  overrides: {
+    birthday?: Date | null;
+    birthdayVisibility?: string;
+    wishlistVisibility?: string;
+  } = {},
+) {
+  await ensureUserRole();
+  return prisma.user.create({
+    data: {
+      ...createUser(),
+      birthday: overrides.birthday ?? null,
+      birthdayVisibility: overrides.birthdayVisibility ?? 'FRIENDS',
+      wishlistVisibility: overrides.wishlistVisibility ?? 'FRIENDS',
+      password: { create: createPassword() },
+      roles: { connect: { name: 'user' } },
+    },
   });
 }
 
-async function runLoader() {
-  return loader({
-    context: {},
-    params: { username: 'alex' },
-    request: new Request('https://giftpool.app/users/alex'),
-  } as never);
+async function makeFriends(aId: string, bId: string) {
+  const [userAId, userBId] = aId < bId ? [aId, bId] : [bId, aId];
+  await prisma.friendship.create({ data: { userAId, userBId } });
 }
 
-describe('app/routes/users+/$username_+/index.tsx loader — birthday visibility', () => {
-  it('marks the birthday hidden for a NOBODY target even though the viewer is a friend', async () => {
-    setup('NOBODY');
-    const result = (await runLoader()) as { birthdayVisible: boolean };
+async function createSharedGroup(
+  viewerId: string,
+  targetId: string,
+  targetFlags: { shareWishlist: boolean; shareBirthday: boolean },
+) {
+  const group = await prisma.giftGroup.create({ data: { name: 'The Crew' } });
+  await prisma.usersInGiftGroups.create({
+    data: { userId: viewerId, giftGroupId: group.id },
+  });
+  await prisma.usersInGiftGroups.create({
+    data: {
+      userId: targetId,
+      giftGroupId: group.id,
+      shareWishlist: targetFlags.shareWishlist,
+      shareBirthday: targetFlags.shareBirthday,
+    },
+  });
+  return group;
+}
+
+async function withSession(userId: string) {
+  const session = await prisma.session.create({
+    data: { userId, expirationDate: getSessionExpirationDate() },
+    select: { id: true },
+  });
+  return getSessionCookieHeader(session);
+}
+
+async function runLoader(viewerId: string, username: string) {
+  const cookie = await withSession(viewerId);
+  const request = new Request('https://giftpool.app/users/' + username, {
+    headers: { cookie },
+  });
+  return loader(toLoaderArgs({ context, params: { username }, request }));
+}
+
+const soon = () => {
+  const d = new Date();
+  d.setUTCMonth(d.getUTCMonth() + 1);
+  return d;
+};
+
+describe('person surface loader — access gate & visibility', () => {
+  it('gates a stranger (neither friend nor groupmate): identity only, no data', async () => {
+    const viewer = await createUserRecord();
+    const target = await createUserRecord({ birthday: soon() });
+
+    const result = (await runLoader(viewer.id, target.username)) as any;
+    expect(result.unlocked).toBe(false);
+    // Payload carries identity only — no birthday, wishlist, or mutual data.
+    expect(result.user.username).toBe(target.username);
+    expect(result).not.toHaveProperty('birthdayVisible');
+    expect(result).not.toHaveProperty('mutualFriends');
+    expect(result).not.toHaveProperty('wishlistPreview');
+  });
+
+  it('groupmate-not-friend: wishlist visible only when the group shareWishlist grant is on', async () => {
+    const viewer = await createUserRecord();
+    const target = await createUserRecord({
+      wishlistVisibility: 'FRIENDS',
+      birthday: soon(),
+    });
+    await createSharedGroup(viewer.id, target.id, {
+      shareWishlist: true,
+      shareBirthday: false,
+    });
+
+    const result = (await runLoader(viewer.id, target.username)) as any;
+    expect(result.unlocked).toBe(true);
+    expect(result.isFriend).toBe(false);
+    expect(result.canViewWishlist).toBe(true);
+  });
+
+  it('groupmate-not-friend: wishlist hidden when shareWishlist is off and not friends', async () => {
+    const viewer = await createUserRecord();
+    const target = await createUserRecord({ wishlistVisibility: 'FRIENDS' });
+    await createSharedGroup(viewer.id, target.id, {
+      shareWishlist: false,
+      shareBirthday: true,
+    });
+
+    const result = (await runLoader(viewer.id, target.username)) as any;
+    expect(result.unlocked).toBe(true);
+    expect(result.canViewWishlist).toBe(false);
+  });
+
+  it('groupmate-not-friend: birthday visible when shareBirthday is on, honoring canViewBirthday', async () => {
+    const viewer = await createUserRecord();
+    const target = await createUserRecord({
+      birthday: soon(),
+      birthdayVisibility: 'FRIENDS', // not visible to non-friends by global rule
+    });
+    await createSharedGroup(viewer.id, target.id, {
+      shareWishlist: false,
+      shareBirthday: true, // ...but the group grant makes it visible
+    });
+
+    const result = (await runLoader(viewer.id, target.username)) as any;
+    expect(result.birthdayVisible).toBe(true);
+  });
+
+  it('groupmate-not-friend: NOBODY birthday stays hidden even with a group grant', async () => {
+    const viewer = await createUserRecord();
+    const target = await createUserRecord({
+      birthday: soon(),
+      birthdayVisibility: 'NOBODY',
+    });
+    await createSharedGroup(viewer.id, target.id, {
+      shareWishlist: false,
+      shareBirthday: true,
+    });
+
+    const result = (await runLoader(viewer.id, target.username)) as any;
     expect(result.birthdayVisible).toBe(false);
   });
 
-  it('marks the birthday visible for a non-NOBODY target when the viewer is a friend', async () => {
-    setup('FRIENDS');
-    const result = (await runLoader()) as { birthdayVisible: boolean };
+  it('groupmate-not-friend: mutual friends are never in the payload', async () => {
+    const viewer = await createUserRecord();
+    const target = await createUserRecord();
+    const shared = await createUserRecord();
+    await createSharedGroup(viewer.id, target.id, {
+      shareWishlist: true,
+      shareBirthday: true,
+    });
+    // viewer and target share a mutual friend, but they aren't friends with
+    // each other — the friend graph must stay friends-only.
+    await makeFriends(viewer.id, shared.id);
+    await makeFriends(target.id, shared.id);
+
+    const result = (await runLoader(viewer.id, target.username)) as any;
+    expect(result.mutualFriends).toEqual([]);
+  });
+
+  it('friend with NOBODY birthday: hidden despite friendship (single canViewBirthday source)', async () => {
+    const viewer = await createUserRecord();
+    const target = await createUserRecord({
+      birthday: soon(),
+      birthdayVisibility: 'NOBODY',
+    });
+    await makeFriends(viewer.id, target.id);
+
+    const result = (await runLoader(viewer.id, target.username)) as any;
+    expect(result.unlocked).toBe(true);
+    expect(result.isFriend).toBe(true);
+    expect(result.birthdayVisible).toBe(false);
+  });
+
+  it('friend with default birthday visibility: birthday shown', async () => {
+    const viewer = await createUserRecord();
+    const target = await createUserRecord({
+      birthday: soon(),
+      birthdayVisibility: 'FRIENDS',
+    });
+    await makeFriends(viewer.id, target.id);
+
+    const result = (await runLoader(viewer.id, target.username)) as any;
     expect(result.birthdayVisible).toBe(true);
   });
 });

--- a/app/routes/users+/$username_+/index.loader.test.ts
+++ b/app/routes/users+/$username_+/index.loader.test.ts
@@ -330,3 +330,63 @@ describe('person surface loader — ideation reads (circle-keyed)', () => {
     expect(otherResult.ideation.savedIdeas).toEqual([]);
   });
 });
+
+// A birthday that fell a few days ago (within the 14-day post-occasion window).
+const daysAgoBirthday = (n: number) => {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() - n);
+  // Store as noon UTC like real birthdays.
+  return new Date(Date.UTC(1990, d.getUTCMonth(), d.getUTCDate(), 12, 0, 0));
+};
+
+describe('person surface loader — post-occasion memory write', () => {
+  it('detects an unconfirmed pool-of-one solo intent within the window', async () => {
+    const viewer = await createUserRecord();
+    const target = await createUserRecord({ birthday: daysAgoBirthday(3) });
+    await makeFriends(viewer.id, target.id);
+    await prisma.pool.create({
+      data: {
+        title: 'Trail shoes',
+        organizerId: viewer.id,
+        recipientUserId: target.id,
+        contributors: { create: [{ userId: viewer.id }] },
+      },
+    });
+
+    const result = (await runLoader(viewer.id, target.username)) as any;
+    expect(result.temporalState).toBe('post-occasion');
+    expect(result.postOccasion.gift).toMatchObject({
+      kind: 'pool',
+      name: 'Trail shoes',
+    });
+  });
+
+  it('does not re-nag once the solo outcome is recorded/skipped', async () => {
+    const viewer = await createUserRecord();
+    const target = await createUserRecord({ birthday: daysAgoBirthday(3) });
+    await makeFriends(viewer.id, target.id);
+    await prisma.pool.create({
+      data: {
+        title: 'Trail shoes',
+        organizerId: viewer.id,
+        recipientUserId: target.id,
+        outcomeFeedback: 'SKIPPED',
+        contributors: { create: [{ userId: viewer.id }] },
+      },
+    });
+
+    const result = (await runLoader(viewer.id, target.username)) as any;
+    expect(result.temporalState).not.toBe('post-occasion');
+    expect(result.postOccasion).toBeNull();
+  });
+
+  it('does not trigger post-occasion for a viewer with no solo intent', async () => {
+    const viewer = await createUserRecord();
+    const target = await createUserRecord({ birthday: daysAgoBirthday(3) });
+    await makeFriends(viewer.id, target.id);
+
+    const result = (await runLoader(viewer.id, target.username)) as any;
+    expect(result.postOccasion).toBeNull();
+    expect(result.temporalState).toBe('cold');
+  });
+});

--- a/app/routes/users+/$username_+/index.loader.test.ts
+++ b/app/routes/users+/$username_+/index.loader.test.ts
@@ -211,3 +211,122 @@ describe('person surface loader — access gate & visibility', () => {
     expect(result.birthdayVisible).toBe(true);
   });
 });
+
+async function createDecidedPool(opts: {
+  recipientId: string;
+  contributorIds: string[];
+  chosenName: string;
+  eventDate: Date | null;
+  status?: string;
+  otherIdeas?: string[];
+}) {
+  const organizerId = opts.contributorIds[0]!;
+  const pool = await prisma.pool.create({
+    data: {
+      title: opts.chosenName,
+      organizerId,
+      recipientUserId: opts.recipientId,
+      status: opts.status ?? 'DECIDED',
+      eventDate: opts.eventDate,
+      contributors: {
+        create: opts.contributorIds.map((userId) => ({ userId })),
+      },
+    },
+  });
+  const chosen = await prisma.giftIdea.create({
+    data: { poolId: pool.id, proposedById: organizerId, name: opts.chosenName },
+  });
+  for (const name of opts.otherIdeas ?? []) {
+    await prisma.giftIdea.create({
+      data: { poolId: pool.id, proposedById: organizerId, name },
+    });
+  }
+  await prisma.pool.update({
+    where: { id: pool.id },
+    data: { chosenIdeaId: chosen.id, finalPriceCents: 21000 },
+  });
+  return pool;
+}
+
+const daysAgo = (n: number) => new Date(Date.now() - n * 24 * 60 * 60 * 1000);
+
+describe('person surface loader — ideation reads (circle-keyed)', () => {
+  it('gift history is empty for a viewer who was not a contributor', async () => {
+    const viewer = await createUserRecord();
+    const target = await createUserRecord();
+    const other = await createUserRecord();
+    await makeFriends(viewer.id, target.id);
+    // Pool the viewer was NOT part of.
+    await createDecidedPool({
+      recipientId: target.id,
+      contributorIds: [other.id],
+      chosenName: 'Weber grill',
+      eventDate: daysAgo(30),
+    });
+
+    const result = (await runLoader(viewer.id, target.username)) as any;
+    expect(result.ideation.giftHistory).toEqual([]);
+    expect(result.ideation.proposedUnused).toEqual([]);
+  });
+
+  it('gift history includes a past decided pool the viewer contributed to', async () => {
+    const viewer = await createUserRecord();
+    const target = await createUserRecord();
+    await makeFriends(viewer.id, target.id);
+    await createDecidedPool({
+      recipientId: target.id,
+      contributorIds: [viewer.id],
+      chosenName: 'Weber grill',
+      eventDate: daysAgo(30),
+      otherIdeas: ['Espresso machine'],
+    });
+
+    const result = (await runLoader(viewer.id, target.username)) as any;
+    expect(result.ideation.giftHistory).toHaveLength(1);
+    expect(result.ideation.giftHistory[0].name).toBe('Weber grill');
+    // Proposed-but-unused excludes the chosen idea.
+    expect(result.ideation.proposedUnused.map((i: any) => i.name)).toEqual([
+      'Espresso machine',
+    ]);
+  });
+
+  it('excludes the active-cycle pool (future event date) from gift history', async () => {
+    const viewer = await createUserRecord();
+    const target = await createUserRecord();
+    await makeFriends(viewer.id, target.id);
+    await createDecidedPool({
+      recipientId: target.id,
+      contributorIds: [viewer.id],
+      chosenName: 'This year gift',
+      eventDate: soon(), // future → still mid-flight
+    });
+
+    const result = (await runLoader(viewer.id, target.username)) as any;
+    expect(result.ideation.giftHistory).toEqual([]);
+  });
+
+  it('notes and saved ideas are private to their author/owner', async () => {
+    const author = await createUserRecord();
+    const other = await createUserRecord();
+    const target = await createUserRecord();
+    await makeFriends(author.id, target.id);
+    await makeFriends(other.id, target.id);
+
+    await prisma.personNote.create({
+      data: { authorId: author.id, subjectUserId: target.id, body: 'secret' },
+    });
+    await prisma.giftListItem.create({
+      data: { ownerId: author.id, targetUserId: target.id, name: 'Shoes' },
+    });
+
+    // The author sees their own note + saved idea.
+    const authorResult = (await runLoader(author.id, target.username)) as any;
+    expect(authorResult.ideation.notes).toHaveLength(1);
+    expect(authorResult.ideation.savedIdeas).toHaveLength(1);
+
+    // Another viewer (also a friend of the target) sees neither.
+    const otherResult = (await runLoader(other.id, target.username)) as any;
+    expect(otherResult.ideation.notes).toEqual([]);
+    expect(otherResult.ideation.savedIdeas).toEqual([]);
+  });
+});

--- a/app/routes/users+/$username_+/index.tsx
+++ b/app/routes/users+/$username_+/index.tsx
@@ -7,16 +7,14 @@ import {
   redirect,
   useLoaderData,
   type MetaFunction,
-  Link,
 } from 'react-router';
 import { z } from 'zod';
-import { FriendActionButton } from '#app/components/friends/friend-action-button.tsx';
 import { FriendGateCard } from '#app/components/friends/friend-gate-card.tsx';
-import { Button } from '#app/components/ui/button.tsx';
-import { MutualStrip } from '#app/components/users/mutual-strip.tsx';
-import { ProfileHeader } from '#app/components/users/profile-header.tsx';
+import {
+  PersonSurface,
+  type TemporalState,
+} from '#app/components/users/person-surface.tsx';
 import { getUserProfileMeta } from '#app/components/users/user-profile-route.tsx';
-import { WishlistPreviewCard } from '#app/components/users/wishlist-preview-card.tsx';
 import { requireUserId } from '#app/utils/auth.server.ts';
 import { canViewBirthday } from '#app/utils/birthday-visibility.server.ts';
 import {
@@ -32,11 +30,13 @@ import {
 } from '#app/utils/friends.server.ts';
 import { type RelationshipState } from '#app/utils/friends.ts';
 import {
+  circleBudgetCents,
   commitSoloGift,
   createPersonNote,
   declineOccasion,
   getOccasionYear,
   getPersonSurfaceAccess,
+  PERSON_SURFACE_OCCASION_TYPE,
   recordPoolOutcome,
   recordWishlistPurchaseOutcome,
   requirePersonSurfaceUnlock,
@@ -44,10 +44,7 @@ import {
   undoOccasionDecline,
 } from '#app/utils/person-surface.server.ts';
 import { dollarsToCents } from '#app/utils/price.ts';
-import {
-  loadProfilePageData,
-  type ProfilePageData,
-} from '#app/utils/profile-page.server.ts';
+import { loadProfilePageData } from '#app/utils/profile-page.server.ts';
 import { getRequestContext } from '#app/utils/request-context.server.ts';
 
 type Relationship = {
@@ -163,6 +160,52 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
     ? profileData.wishlistPreview
     : { items: [], totalCount: 0 };
 
+  // ── Temporal state (spec §4) ──
+  const upcoming = birthdayVisible ? getUpcomingBirthday(user.birthday) : null;
+  const occasionNear =
+    upcoming != null &&
+    upcoming.daysUntil >= 0 &&
+    upcoming.daysUntil <= BIRTHDAY_VISIBILITY_DAYS;
+  const occasion = upcoming
+    ? {
+        label: formatBirthdayLabel(upcoming.date, upcoming.daysUntil),
+        daysUntil: upcoming.daysUntil,
+      }
+    : null;
+
+  // A decline for the current cycle flips the occasion header to a quiet,
+  // private "sitting this one out" variant.
+  const occasionYear = getOccasionYear(user.birthday);
+  const declined =
+    occasionYear != null &&
+    (await prisma.occasionDecline.findUnique({
+      where: {
+        userId_targetUserId_occasionType_occasionYear: {
+          userId,
+          targetUserId: user.id,
+          occasionType: PERSON_SURFACE_OCCASION_TYPE,
+          occasionYear,
+        },
+      },
+      select: { id: true },
+    })) != null;
+
+  const temporalState: TemporalState =
+    occasionNear && declined
+      ? 'declined'
+      : occasionNear
+        ? 'occasion-near'
+        : 'cold';
+
+  // Organize routing candidates: the active shared groups, each with the
+  // recipient-excluded budget ceiling and member count.
+  const organizeGroups = access.sharedActiveGroups.map((g) => ({
+    id: g.id,
+    name: g.name,
+    memberCount: g.members.filter((m) => m.userId !== user.id).length,
+    budgetCents: circleBudgetCents(g, user.id),
+  }));
+
   return {
     unlocked: true,
     user,
@@ -174,6 +217,10 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
     mutualGroups,
     mutualFriends,
     wishlistPreview,
+    temporalState,
+    occasion,
+    declined,
+    organizeGroups,
   } as const;
 }
 
@@ -368,103 +415,23 @@ const ProfileRoute = () => {
   }
 
   return (
-    <FriendProfileView
+    <PersonSurface
       user={data.user}
       userJoinedDisplay={data.userJoinedDisplay}
       relationship={relationship}
+      isFriend={data.isFriend}
       birthdayVisible={data.birthdayVisible}
       canViewWishlist={data.canViewWishlist}
       mutualGroups={data.mutualGroups}
       mutualFriends={data.mutualFriends}
       wishlistPreview={data.wishlistPreview}
+      temporalState={data.temporalState}
+      occasion={data.occasion}
+      declined={data.declined}
+      organizeGroups={data.organizeGroups}
     />
   );
 };
-
-type FriendProfileViewProps = Readonly<{
-  user: {
-    id: string;
-    username: string;
-    name: string | null;
-    bio: string | null;
-    birthday: Date | string | null;
-    birthdayVisibility: string;
-    image: { id: string } | null;
-  };
-  userJoinedDisplay: string;
-  relationship: Relationship;
-  birthdayVisible: boolean;
-  canViewWishlist: boolean;
-  mutualGroups: ProfilePageData['mutualGroups'];
-  mutualFriends: ProfilePageData['mutualFriends'];
-  wishlistPreview: ProfilePageData['wishlistPreview'];
-}>;
-
-function FriendProfileView({
-  user,
-  userJoinedDisplay,
-  relationship,
-  birthdayVisible,
-  canViewWishlist,
-  mutualGroups,
-  mutualFriends,
-  wishlistPreview,
-}: FriendProfileViewProps) {
-  const userDisplayName = user.name ?? user.username;
-  // Visibility is decided server-side by `canViewBirthday` (single source of
-  // truth); the pill is suppressed when the owner opted into NOBODY.
-  const upcoming = birthdayVisible ? getUpcomingBirthday(user.birthday) : null;
-  const birthdayLabel =
-    upcoming && upcoming.daysUntil <= BIRTHDAY_VISIBILITY_DAYS
-      ? formatBirthdayLabel(upcoming.date, upcoming.daysUntil)
-      : null;
-
-  return (
-    <div className="mx-auto flex w-full max-w-3xl flex-col gap-8 px-4 py-10 sm:py-14">
-      <ProfileHeader
-        user={user}
-        bio={user.bio}
-        birthdayLabel={birthdayLabel}
-        joinedDisplay={userJoinedDisplay}
-        actions={
-          canViewWishlist ? (
-            <>
-              <Button asChild>
-                <Link to="wishlist" prefetch="intent">
-                  {userDisplayName}'s wishlist
-                </Link>
-              </Button>
-              <FriendActionButton
-                targetUserId={user.id}
-                targetUserName={userDisplayName}
-                relationship={relationship}
-                variant="compact"
-              />
-            </>
-          ) : (
-            <FriendActionButton
-              targetUserId={user.id}
-              targetUserName={userDisplayName}
-              relationship={relationship}
-              variant="compact"
-            />
-          )
-        }
-      />
-
-      <MutualStrip groups={mutualGroups} friends={mutualFriends} />
-
-      {canViewWishlist ? (
-        <WishlistPreviewCard
-          items={wishlistPreview.items}
-          totalCount={wishlistPreview.totalCount}
-          fullListTo="wishlist"
-          ownerName={userDisplayName}
-        />
-      ) : null}
-    </div>
-  );
-}
 
 export default ProfileRoute;
 export const meta: MetaFunction<typeof loader> = getUserProfileMeta;

--- a/app/routes/users+/$username_+/index.tsx
+++ b/app/routes/users+/$username_+/index.tsx
@@ -1,11 +1,15 @@
+import { parseWithZod } from '@conform-to/zod';
 import { invariantResponse } from '@epic-web/invariant';
 import {
+  type ActionFunctionArgs,
   type LoaderFunctionArgs,
+  data,
   redirect,
   useLoaderData,
   type MetaFunction,
   Link,
 } from 'react-router';
+import { z } from 'zod';
 import { FriendActionButton } from '#app/components/friends/friend-action-button.tsx';
 import { FriendGateCard } from '#app/components/friends/friend-gate-card.tsx';
 import { Button } from '#app/components/ui/button.tsx';
@@ -14,19 +18,32 @@ import { ProfileHeader } from '#app/components/users/profile-header.tsx';
 import { getUserProfileMeta } from '#app/components/users/user-profile-route.tsx';
 import { WishlistPreviewCard } from '#app/components/users/wishlist-preview-card.tsx';
 import { requireUserId } from '#app/utils/auth.server.ts';
+import { canViewBirthday } from '#app/utils/birthday-visibility.server.ts';
 import {
   BIRTHDAY_VISIBILITY_DAYS,
   formatBirthdayLabel,
   getUpcomingBirthday,
 } from '#app/utils/birthday.ts';
-import { canViewBirthday } from '#app/utils/birthday-visibility.server.ts';
 import { prisma } from '#app/utils/db.server.ts';
 import { getRelationshipDetails } from '#app/utils/friends.server.ts';
 import { type RelationshipState } from '#app/utils/friends.ts';
 import {
+  commitSoloGift,
+  createPersonNote,
+  declineOccasion,
+  getOccasionYear,
+  recordPoolOutcome,
+  recordWishlistPurchaseOutcome,
+  requirePersonSurfaceUnlock,
+  saveGiftListItem,
+  undoOccasionDecline,
+} from '#app/utils/person-surface.server.ts';
+import { dollarsToCents } from '#app/utils/price.ts';
+import {
   loadProfilePageData,
   type ProfilePageData,
 } from '#app/utils/profile-page.server.ts';
+import { getRequestContext } from '#app/utils/request-context.server.ts';
 
 type Relationship = {
   state: RelationshipState;
@@ -121,6 +138,178 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
     profileData,
     birthdayVisible,
   } as const;
+}
+
+// ─── Write actions (person-surface memory) ──────────────────────────────────
+
+enum PersonIntent {
+  SaveIdea = 'save-idea',
+  AddNote = 'add-note',
+  DeclineOccasion = 'decline-occasion',
+  UndoDecline = 'undo-decline',
+  SoloCommit = 'solo-commit',
+  RecordOutcome = 'record-outcome',
+}
+
+const OptionalDollarAmountSchema = z.preprocess(
+  (value) => (value === '' ? undefined : value),
+  z.coerce.number().min(0).transform(dollarsToCents).optional(),
+);
+
+const SaveIdeaSchema = z.object({
+  intent: z.literal(PersonIntent.SaveIdea),
+  name: z.string().min(1, 'Give the idea a name').max(200),
+  url: z.string().url('Must be a valid URL').optional().or(z.literal('')),
+  priceCents: OptionalDollarAmountSchema,
+  currency: z.string().max(3).optional(),
+});
+const AddNoteSchema = z.object({
+  intent: z.literal(PersonIntent.AddNote),
+  body: z.string().min(1, 'Write something').max(1000),
+});
+const DeclineSchema = z.object({
+  intent: z.literal(PersonIntent.DeclineOccasion),
+});
+const UndoDeclineSchema = z.object({
+  intent: z.literal(PersonIntent.UndoDecline),
+});
+const SoloCommitSchema = z.object({
+  intent: z.literal(PersonIntent.SoloCommit),
+  // A pool-of-one has no chosenIdea; the name becomes the display name, so it
+  // is required (spec amendment: no nameless solo gift).
+  name: z.string().min(1, 'Name the gift').max(200),
+});
+const RecordOutcomeSchema = z
+  .object({
+    intent: z.literal(PersonIntent.RecordOutcome),
+    kind: z.enum(['pool', 'wishlist']),
+    feedback: z.enum(['LOVED', 'OKAY', 'SKIPPED']),
+    poolId: z.string().optional(),
+    wishlistItemId: z.string().optional(),
+  })
+  .refine((v) => (v.kind === 'pool' ? !!v.poolId : !!v.wishlistItemId), {
+    message: 'Missing target for outcome.',
+  });
+
+const PersonActionSchema = z.union([
+  SaveIdeaSchema,
+  AddNoteSchema,
+  DeclineSchema,
+  UndoDeclineSchema,
+  SoloCommitSchema,
+  RecordOutcomeSchema,
+]);
+
+export async function action({ params, request }: ActionFunctionArgs) {
+  const userId = await requireUserId(request);
+  const target = await prisma.user.findFirst({
+    where: { username: params.username },
+    select: { id: true, birthday: true },
+  });
+  invariantResponse(target, 'User not found', { status: 404 });
+  // The recipient must never act on this surface about themselves.
+  if (target.id === userId) {
+    throw data({ error: 'Not found.' }, { status: 404 });
+  }
+
+  const formData = await request.formData();
+  const submission = parseWithZod(formData, { schema: PersonActionSchema });
+  if (submission.status !== 'success') {
+    return data(submission.reply(), { status: 400 });
+  }
+  const v = submission.value;
+  const { requestId } = await getRequestContext(request);
+
+  switch (v.intent) {
+    case PersonIntent.SaveIdea: {
+      await requirePersonSurfaceUnlock(userId, target.id);
+      await saveGiftListItem({
+        ownerId: userId,
+        targetUserId: target.id,
+        name: v.name,
+        url: v.url || null,
+        priceCents: v.priceCents ?? null,
+        currency: v.currency ?? null,
+        requestId,
+      });
+      return data(submission.reply({ resetForm: true }));
+    }
+    case PersonIntent.AddNote: {
+      await requirePersonSurfaceUnlock(userId, target.id);
+      await createPersonNote({
+        authorId: userId,
+        subjectUserId: target.id,
+        body: v.body,
+        requestId,
+      });
+      return data(submission.reply({ resetForm: true }));
+    }
+    case PersonIntent.DeclineOccasion:
+    case PersonIntent.UndoDecline: {
+      await requirePersonSurfaceUnlock(userId, target.id);
+      const occasionYear = getOccasionYear(target.birthday);
+      if (occasionYear == null) {
+        return data(
+          submission.reply({
+            formErrors: ['No upcoming occasion to decline.'],
+          }),
+          { status: 400 },
+        );
+      }
+      if (v.intent === PersonIntent.DeclineOccasion) {
+        await declineOccasion({
+          userId,
+          targetUserId: target.id,
+          occasionYear,
+          requestId,
+        });
+      } else {
+        await undoOccasionDecline({
+          userId,
+          targetUserId: target.id,
+          occasionYear,
+          requestId,
+        });
+      }
+      return data(submission.reply());
+    }
+    case PersonIntent.SoloCommit: {
+      await requirePersonSurfaceUnlock(userId, target.id);
+      // Anchor the pool-of-one to the upcoming birthday so the post-occasion
+      // window and gift-history cycle guard line up.
+      const upcoming = getUpcomingBirthday(target.birthday);
+      await commitSoloGift({
+        organizerId: userId,
+        recipientUserId: target.id,
+        name: v.name,
+        eventDate: upcoming?.date ?? null,
+        requestId,
+      });
+      return data(submission.reply({ resetForm: true }));
+    }
+    case PersonIntent.RecordOutcome: {
+      // Authorized by ownership inside the helper (organizer / claimer).
+      if (v.kind === 'pool') {
+        await recordPoolOutcome({
+          userId,
+          poolId: v.poolId!,
+          feedback: v.feedback,
+          requestId,
+        });
+      } else {
+        await recordWishlistPurchaseOutcome({
+          userId,
+          wishlistItemId: v.wishlistItemId!,
+          feedback: v.feedback,
+          requestId,
+        });
+      }
+      return data(submission.reply());
+    }
+    default: {
+      return data(submission.reply(), { status: 400 });
+    }
+  }
 }
 
 const ProfileRoute = () => {

--- a/app/routes/users+/$username_+/index.tsx
+++ b/app/routes/users+/$username_+/index.tsx
@@ -25,13 +25,18 @@ import {
   getUpcomingBirthday,
 } from '#app/utils/birthday.ts';
 import { prisma } from '#app/utils/db.server.ts';
-import { getRelationshipDetails } from '#app/utils/friends.server.ts';
+import {
+  canViewWishlistOf,
+  getRelationshipDetails,
+  isFriendOfFriend,
+} from '#app/utils/friends.server.ts';
 import { type RelationshipState } from '#app/utils/friends.ts';
 import {
   commitSoloGift,
   createPersonNote,
   declineOccasion,
   getOccasionYear,
+  getPersonSurfaceAccess,
   recordPoolOutcome,
   recordWishlistPurchaseOutcome,
   requirePersonSurfaceUnlock,
@@ -85,11 +90,14 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
     incomingRequestId: relationshipDetails.incoming?.id ?? null,
     outgoingRequestId: relationshipDetails.outgoing?.id ?? null,
   };
-  const canViewProfile = relationship.state === 'FRIENDS';
 
-  if (!canViewProfile) {
+  // Unlock rule (spec §6): FRIENDS or ≥1 shared active group. Groupmates who
+  // aren't friends now reach the surface — the old friends-only gate is gone.
+  const access = await getPersonSurfaceAccess(userId, targetUser.id);
+
+  if (!access.unlocked) {
     return {
-      canViewProfile,
+      unlocked: false,
       user: targetUser,
       relationship,
     } as const;
@@ -119,24 +127,53 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
     status: 404,
   });
 
-  const profileData = await loadProfilePageData(userId, targetUser.id);
-
-  // The viewer is a confirmed direct friend to reach this branch, so the rule
-  // reduces to "visible unless NOBODY" — but route it through the shared helper
-  // so the pill consults the single source of truth.
+  // Birthday visibility via the single canViewBirthday helper, fed the REAL
+  // facts for this viewer — the shared-group override (a groupmate seeing a
+  // birthday shared with the group) is honored here, not hardcoded false.
+  const sharesActiveBirthdayGroup = access.sharedActiveGroups.some(
+    (g) => g.shareBirthday,
+  );
+  const isMutualFriend = access.isFriend
+    ? false
+    : await isFriendOfFriend(userId, targetUser.id);
   const birthdayVisible = canViewBirthday(user, {
-    isDirectFriend: true,
-    isMutualFriend: false,
-    sharesActiveBirthdayGroup: false,
+    isDirectFriend: access.isFriend,
+    isMutualFriend,
+    sharesActiveBirthdayGroup,
   });
 
+  // Wishlist: existing friendship/FoF path OR a shared group with the target's
+  // shareWishlist grant (shareWishlist's first-ever read path).
+  const sharesWishlistGroup = access.sharedActiveGroups.some(
+    (g) => g.shareWishlist,
+  );
+  const canViewWishlist =
+    sharesWishlistGroup || (await canViewWishlistOf(userId, targetUser.id));
+
+  const profileData = await loadProfilePageData(userId, targetUser.id);
+  // Mutual friends are friends-only — a groupmate can't enumerate the graph.
+  // Per §12.1 the section is simply absent (empty array → not rendered).
+  const mutualFriends = access.isFriend ? profileData.mutualFriends : [];
+  // Mutual groups shown are the active shared groups (aligned with the gate).
+  const mutualGroups = access.sharedActiveGroups.map((g) => ({
+    id: g.id,
+    name: g.name,
+  }));
+  const wishlistPreview = canViewWishlist
+    ? profileData.wishlistPreview
+    : { items: [], totalCount: 0 };
+
   return {
-    canViewProfile,
+    unlocked: true,
     user,
     userJoinedDisplay: user.createdAt.toLocaleDateString(),
     relationship,
-    profileData,
+    isFriend: access.isFriend,
     birthdayVisible,
+    canViewWishlist,
+    mutualGroups,
+    mutualFriends,
+    wishlistPreview,
   } as const;
 }
 
@@ -317,7 +354,7 @@ const ProfileRoute = () => {
   const userDisplayName = data.user.name ?? data.user.username;
   const relationship = data.relationship;
 
-  if (!data.canViewProfile) {
+  if (!data.unlocked) {
     return (
       <FriendGateCard
         context="profile"
@@ -335,8 +372,11 @@ const ProfileRoute = () => {
       user={data.user}
       userJoinedDisplay={data.userJoinedDisplay}
       relationship={relationship}
-      profileData={data.profileData}
       birthdayVisible={data.birthdayVisible}
+      canViewWishlist={data.canViewWishlist}
+      mutualGroups={data.mutualGroups}
+      mutualFriends={data.mutualFriends}
+      wishlistPreview={data.wishlistPreview}
     />
   );
 };
@@ -353,16 +393,22 @@ type FriendProfileViewProps = Readonly<{
   };
   userJoinedDisplay: string;
   relationship: Relationship;
-  profileData: ProfilePageData;
   birthdayVisible: boolean;
+  canViewWishlist: boolean;
+  mutualGroups: ProfilePageData['mutualGroups'];
+  mutualFriends: ProfilePageData['mutualFriends'];
+  wishlistPreview: ProfilePageData['wishlistPreview'];
 }>;
 
 function FriendProfileView({
   user,
   userJoinedDisplay,
   relationship,
-  profileData,
   birthdayVisible,
+  canViewWishlist,
+  mutualGroups,
+  mutualFriends,
+  wishlistPreview,
 }: FriendProfileViewProps) {
   const userDisplayName = user.name ?? user.username;
   // Visibility is decided server-side by `canViewBirthday` (single source of
@@ -381,33 +427,41 @@ function FriendProfileView({
         birthdayLabel={birthdayLabel}
         joinedDisplay={userJoinedDisplay}
         actions={
-          <>
-            <Button asChild>
-              <Link to="wishlist" prefetch="intent">
-                {userDisplayName}'s wishlist
-              </Link>
-            </Button>
+          canViewWishlist ? (
+            <>
+              <Button asChild>
+                <Link to="wishlist" prefetch="intent">
+                  {userDisplayName}'s wishlist
+                </Link>
+              </Button>
+              <FriendActionButton
+                targetUserId={user.id}
+                targetUserName={userDisplayName}
+                relationship={relationship}
+                variant="compact"
+              />
+            </>
+          ) : (
             <FriendActionButton
               targetUserId={user.id}
               targetUserName={userDisplayName}
               relationship={relationship}
               variant="compact"
             />
-          </>
+          )
         }
       />
 
-      <MutualStrip
-        groups={profileData.mutualGroups}
-        friends={profileData.mutualFriends}
-      />
+      <MutualStrip groups={mutualGroups} friends={mutualFriends} />
 
-      <WishlistPreviewCard
-        items={profileData.wishlistPreview.items}
-        totalCount={profileData.wishlistPreview.totalCount}
-        fullListTo="wishlist"
-        ownerName={userDisplayName}
-      />
+      {canViewWishlist ? (
+        <WishlistPreviewCard
+          items={wishlistPreview.items}
+          totalCount={wishlistPreview.totalCount}
+          fullListTo="wishlist"
+          ownerName={userDisplayName}
+        />
+      ) : null}
     </div>
   );
 }

--- a/app/routes/users+/$username_+/index.tsx
+++ b/app/routes/users+/$username_+/index.tsx
@@ -36,7 +36,11 @@ import {
   declineOccasion,
   getOccasionYear,
   getPersonSurfaceAccess,
+  loadOpenPoolsForRecipient,
+  loadPersonIdeation,
+  loadPersonWishlistSource,
   PERSON_SURFACE_OCCASION_TYPE,
+  proposeToPool,
   recordPoolOutcome,
   recordWishlistPurchaseOutcome,
   requirePersonSurfaceUnlock,
@@ -156,9 +160,6 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
     id: g.id,
     name: g.name,
   }));
-  const wishlistPreview = canViewWishlist
-    ? profileData.wishlistPreview
-    : { items: [], totalCount: 0 };
 
   // ── Temporal state (spec §4) ──
   const upcoming = birthdayVisible ? getUpcomingBirthday(user.birthday) : null;
@@ -206,6 +207,24 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
     budgetCents: circleBudgetCents(g, user.id),
   }));
 
+  // Budget line: the highest recipient-excluded circle ceiling, if any is > 0.
+  // Suppressed at 0 (earned-not-scaffolded — never "~$0").
+  const topBudget = [...organizeGroups]
+    .filter((g) => g.budgetCents > 0)
+    .sort((a, b) => b.budgetCents - a.budgetCents)[0];
+  const budgetLine = topBudget
+    ? { groupName: topBudget.name, cents: topBudget.budgetCents }
+    : null;
+
+  // ── Ideation block (circle-keyed reads, §7) ──
+  const [ideation, wishlistSource, openPools] = await Promise.all([
+    loadPersonIdeation(userId, user.id),
+    canViewWishlist
+      ? loadPersonWishlistSource(userId, user.id)
+      : Promise.resolve([]),
+    loadOpenPoolsForRecipient(userId, user.id),
+  ]);
+
   return {
     unlocked: true,
     user,
@@ -216,11 +235,14 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
     canViewWishlist,
     mutualGroups,
     mutualFriends,
-    wishlistPreview,
     temporalState,
     occasion,
     declined,
     organizeGroups,
+    budgetLine,
+    wishlistSource,
+    ideation,
+    openPools,
   } as const;
 }
 
@@ -233,6 +255,7 @@ enum PersonIntent {
   UndoDecline = 'undo-decline',
   SoloCommit = 'solo-commit',
   RecordOutcome = 'record-outcome',
+  ProposeToPool = 'propose-to-pool',
 }
 
 const OptionalDollarAmountSchema = z.preprocess(
@@ -275,6 +298,16 @@ const RecordOutcomeSchema = z
     message: 'Missing target for outcome.',
   });
 
+const ProposeToPoolSchema = z.object({
+  intent: z.literal(PersonIntent.ProposeToPool),
+  poolId: z.string(),
+  name: z.string().min(1).max(200),
+  wishlistItemId: z.string().optional(),
+  giftListItemId: z.string().optional(),
+  url: z.string().optional(),
+  priceCents: OptionalDollarAmountSchema,
+});
+
 const PersonActionSchema = z.union([
   SaveIdeaSchema,
   AddNoteSchema,
@@ -282,6 +315,7 @@ const PersonActionSchema = z.union([
   UndoDeclineSchema,
   SoloCommitSchema,
   RecordOutcomeSchema,
+  ProposeToPoolSchema,
 ]);
 
 export async function action({ params, request }: ActionFunctionArgs) {
@@ -390,6 +424,21 @@ export async function action({ params, request }: ActionFunctionArgs) {
       }
       return data(submission.reply());
     }
+    case PersonIntent.ProposeToPool: {
+      await requirePersonSurfaceUnlock(userId, target.id);
+      await proposeToPool({
+        userId,
+        poolId: v.poolId,
+        targetUserId: target.id,
+        name: v.name,
+        wishlistItemId: v.wishlistItemId || null,
+        giftListItemId: v.giftListItemId || null,
+        url: v.url || null,
+        priceCents: v.priceCents ?? null,
+        requestId,
+      });
+      return data(submission.reply());
+    }
     default: {
       return data(submission.reply(), { status: 400 });
     }
@@ -424,11 +473,14 @@ const ProfileRoute = () => {
       canViewWishlist={data.canViewWishlist}
       mutualGroups={data.mutualGroups}
       mutualFriends={data.mutualFriends}
-      wishlistPreview={data.wishlistPreview}
       temporalState={data.temporalState}
       occasion={data.occasion}
       declined={data.declined}
       organizeGroups={data.organizeGroups}
+      budgetLine={data.budgetLine}
+      wishlistSource={data.wishlistSource}
+      ideation={data.ideation}
+      openPools={data.openPools}
     />
   );
 };

--- a/app/routes/users+/$username_+/index.tsx
+++ b/app/routes/users+/$username_+/index.tsx
@@ -39,6 +39,7 @@ import {
   loadOpenPoolsForRecipient,
   loadPersonIdeation,
   loadPersonWishlistSource,
+  loadPostOccasion,
   PERSON_SURFACE_OCCASION_TYPE,
   proposeToPool,
   recordPoolOutcome,
@@ -191,8 +192,15 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
       select: { id: true },
     })) != null;
 
-  const temporalState: TemporalState =
-    occasionNear && declined
+  // Post-occasion (within 14 days after, only with an unconfirmed solo intent)
+  // takes precedence — it's the memory-write moment.
+  const postOccasion = birthdayVisible
+    ? await loadPostOccasion(userId, user.id, user.birthday)
+    : null;
+
+  const temporalState: TemporalState = postOccasion
+    ? 'post-occasion'
+    : occasionNear && declined
       ? 'declined'
       : occasionNear
         ? 'occasion-near'
@@ -243,6 +251,7 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
     wishlistSource,
     ideation,
     openPools,
+    postOccasion,
   } as const;
 }
 
@@ -481,6 +490,7 @@ const ProfileRoute = () => {
       wishlistSource={data.wishlistSource}
       ideation={data.ideation}
       openPools={data.openPools}
+      postOccasion={data.postOccasion}
     />
   );
 };

--- a/app/routes/users+/$username_+/index.tsx
+++ b/app/routes/users+/$username_+/index.tsx
@@ -446,7 +446,9 @@ export async function action({ params, request }: ActionFunctionArgs) {
         priceCents: v.priceCents ?? null,
         requestId,
       });
-      return data(submission.reply());
+      // Land the user in the pool so they see their idea took; a bare reply
+      // gives no feedback and reads as "nothing happened".
+      return redirect(`/pools/${v.poolId}`);
     }
     default: {
       return data(submission.reply(), { status: 400 });

--- a/app/utils/analytics.ts
+++ b/app/utils/analytics.ts
@@ -84,6 +84,15 @@ export const ANALYTIC_EVENT_NAMES = [
   // between wishlist_share_viewed and signup_submitted in the share-reach
   // funnel; anonymous visitors fire it, so NOT user-required.
   'share_cta_clicked',
+  // Person surface — circle-private memory write paths. All require an acting
+  // user (the viewer), so all are user-required below.
+  'gift_list_item_saved',
+  'person_note_created',
+  'occasion_declined',
+  'occasion_decline_undone',
+  'solo_gift_committed',
+  'gift_outcome_recorded',
+  'saved_idea_promoted',
   // Browser/device/PWA environment snapshot. Anonymous-capable and deduped
   // daily by visitor id in analytics.server.ts.
   CLIENT_ENVIRONMENT_EVENT_NAME,
@@ -190,4 +199,12 @@ export const USER_REQUIRED_EVENTS: Set<AnalyticEventName> = new Set([
   // Joining a group and opening the wishlist editor require a session.
   'group_joined',
   'wishlist_editor_opened',
+  // Person-surface memory writes all have a known acting viewer.
+  'gift_list_item_saved',
+  'person_note_created',
+  'occasion_declined',
+  'occasion_decline_undone',
+  'solo_gift_committed',
+  'gift_outcome_recorded',
+  'saved_idea_promoted',
 ]);

--- a/app/utils/birthday.ts
+++ b/app/utils/birthday.ts
@@ -42,6 +42,41 @@ export function getUpcomingBirthday(
   return { date: candidate, daysUntil };
 }
 
+export type RecentBirthday = {
+  date: Date;
+  daysSince: number;
+};
+
+// The most recent PAST occurrence of this birthday's month/day, if it fell
+// within the last `withinDays` days. Mirror of `getUpcomingBirthday` for the
+// post-occasion window. Returns null when missing/unparseable or outside the
+// window. Uses the same UTC month/day reading so the calendar date is
+// timezone-invariant. `daysSince === 0` means the birthday is today.
+export function getRecentBirthday(
+  birthday: Date | string | null | undefined,
+  withinDays: number,
+): RecentBirthday | null {
+  if (!birthday) return null;
+  const parsed = birthday instanceof Date ? birthday : new Date(birthday);
+  if (Number.isNaN(parsed.getTime())) return null;
+  const now = new Date();
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const candidate = new Date(
+    today.getFullYear(),
+    parsed.getUTCMonth(),
+    parsed.getUTCDate(),
+  );
+  // If this year's occurrence hasn't happened yet, step back to last year's.
+  if (candidate.getTime() > today.getTime()) {
+    candidate.setFullYear(candidate.getFullYear() - 1);
+  }
+  const daysSince = Math.round(
+    (today.getTime() - candidate.getTime()) / MS_PER_DAY,
+  );
+  if (daysSince < 0 || daysSince > withinDays) return null;
+  return { date: candidate, daysSince };
+}
+
 // Short human label — "Today!", "Tomorrow", or "Sep 12". The Date passed
 // in is already the local-timezone candidate constructed by
 // `getUpcomingBirthday`, so local-time formatting is correct here.

--- a/app/utils/person-surface.server.ts
+++ b/app/utils/person-surface.server.ts
@@ -1,0 +1,338 @@
+import { data } from 'react-router';
+import { queueLogEvent } from '#app/utils/analytics.server.ts';
+import { getUpcomingBirthday } from '#app/utils/birthday.ts';
+import { prisma } from '#app/utils/db.server.ts';
+import { getRelationshipDetails } from '#app/utils/friends.server.ts';
+import { createPool } from '#app/utils/pool.server.ts';
+
+// The person surface is circle-private memory keyed to a viewer↔target pair.
+// This module owns the access gate, the write paths (Commit 1), and the
+// circle-keyed read queries (Commit 4). Every write re-verifies the unlock
+// server-side — the UI gate is never the authority.
+
+export const PERSON_SURFACE_OCCASION_TYPE = 'BIRTHDAY';
+
+export type SharedActiveGroup = {
+  id: string;
+  name: string;
+  // The target's per-group share toggles (their affirmative grants to the
+  // group). This surface is the first-ever reader of shareWishlist.
+  shareWishlist: boolean;
+  shareBirthday: boolean;
+  // Active members (removedAt: null) with their group contribution defaults —
+  // used for the budget line and Organize routing.
+  members: Array<{ userId: string; contributionCents: number }>;
+};
+
+export type PersonSurfaceAccess = {
+  isFriend: boolean;
+  sharedActiveGroups: SharedActiveGroup[];
+  unlocked: boolean;
+};
+
+// Unlock rule (spec §6): FRIENDS or ≥1 shared active group (removedAt: null on
+// BOTH memberships). Also returns the shared groups (with the target's per-group
+// share flags + members) that the loader needs for visibility and Organize.
+export async function getPersonSurfaceAccess(
+  viewerId: string,
+  targetUserId: string,
+): Promise<PersonSurfaceAccess> {
+  const relationship = await getRelationshipDetails(viewerId, targetUserId);
+  const isFriend = relationship.state === 'FRIENDS';
+
+  const viewerMemberships = await prisma.usersInGiftGroups.findMany({
+    where: { userId: viewerId, removedAt: null },
+    select: { giftGroupId: true },
+  });
+  const viewerGroupIds = viewerMemberships.map((m) => m.giftGroupId);
+
+  let sharedActiveGroups: SharedActiveGroup[] = [];
+  if (viewerGroupIds.length > 0) {
+    const targetMemberships = await prisma.usersInGiftGroups.findMany({
+      where: {
+        userId: targetUserId,
+        removedAt: null,
+        giftGroupId: { in: viewerGroupIds },
+      },
+      select: {
+        shareWishlist: true,
+        shareBirthday: true,
+        giftGroup: {
+          select: {
+            id: true,
+            name: true,
+            groupMembers: {
+              where: { removedAt: null },
+              select: { userId: true, contributionCents: true },
+            },
+          },
+        },
+      },
+    });
+    sharedActiveGroups = targetMemberships.map((m) => ({
+      id: m.giftGroup.id,
+      name: m.giftGroup.name,
+      shareWishlist: m.shareWishlist,
+      shareBirthday: m.shareBirthday,
+      members: m.giftGroup.groupMembers.map((gm) => ({
+        userId: gm.userId,
+        contributionCents: gm.contributionCents,
+      })),
+    }));
+  }
+
+  const unlocked = isFriend || sharedActiveGroups.length > 0;
+  return { isFriend, sharedActiveGroups, unlocked };
+}
+
+// Guard for every write action. Throws a 403 when the target is not unlocked
+// for the viewer; returns the access so callers can reuse the shared groups.
+export async function requirePersonSurfaceUnlock(
+  viewerId: string,
+  targetUserId: string,
+): Promise<PersonSurfaceAccess> {
+  const access = await getPersonSurfaceAccess(viewerId, targetUserId);
+  if (!access.unlocked) {
+    throw data(
+      { error: 'You do not have access to this person.' },
+      { status: 403 },
+    );
+  }
+  return access;
+}
+
+// Sum of a circle's active member contribution defaults, EXCLUDING the
+// recipient (spec §12.4). Returns 0 when nobody has a default — callers must
+// suppress the budget line at 0 (earned-not-scaffolded).
+export function circleBudgetCents(
+  group: SharedActiveGroup,
+  recipientUserId: string,
+): number {
+  return group.members
+    .filter((m) => m.userId !== recipientUserId)
+    .reduce((sum, m) => sum + (m.contributionCents ?? 0), 0);
+}
+
+// The occasion instance a viewer is acting on for decline: the upcoming
+// birthday's calendar year. When the birthday passes, the upcoming occurrence
+// rolls to next year, so the decline unique-key no longer matches — the decline
+// auto-resets next cycle (spec §6).
+export function getOccasionYear(
+  birthday: Date | string | null | undefined,
+): number | null {
+  const upcoming = getUpcomingBirthday(birthday);
+  return upcoming ? upcoming.date.getFullYear() : null;
+}
+
+// ─── Write paths (Commit 1) ─────────────────────────────────────────────────
+
+type WriteContext = { requestId?: string | null };
+
+export async function saveGiftListItem(input: {
+  ownerId: string;
+  targetUserId: string;
+  name: string;
+  url?: string | null;
+  priceCents?: number | null;
+  currency?: string | null;
+  requestId?: string | null;
+}) {
+  const { ownerId, targetUserId, name, url = null, priceCents = null } = input;
+  // Currency is only ever stored alongside a price (matches WishlistItem).
+  const currency = priceCents != null ? (input.currency ?? null) : null;
+
+  const item = await prisma.giftListItem.create({
+    data: { ownerId, targetUserId, name, url, priceCents, currency },
+    select: { id: true },
+  });
+
+  queueLogEvent({
+    name: 'gift_list_item_saved',
+    userId: ownerId,
+    source: 'server',
+    requestId: input.requestId,
+    properties: {
+      targetUserId,
+      hasUrl: url != null,
+      hasPrice: priceCents != null,
+    },
+  });
+  return item;
+}
+
+export async function createPersonNote(input: {
+  authorId: string;
+  subjectUserId: string;
+  body: string;
+  requestId?: string | null;
+}) {
+  const { authorId, subjectUserId, body } = input;
+  const note = await prisma.personNote.create({
+    data: { authorId, subjectUserId, body },
+    select: { id: true },
+  });
+
+  queueLogEvent({
+    name: 'person_note_created',
+    userId: authorId,
+    source: 'server',
+    requestId: input.requestId,
+    properties: { subjectUserId, length: body.length },
+  });
+  return note;
+}
+
+export async function declineOccasion(input: {
+  userId: string;
+  targetUserId: string;
+  occasionYear: number;
+  requestId?: string | null;
+}) {
+  const { userId, targetUserId, occasionYear } = input;
+  const decline = await prisma.occasionDecline.upsert({
+    where: {
+      userId_targetUserId_occasionType_occasionYear: {
+        userId,
+        targetUserId,
+        occasionType: PERSON_SURFACE_OCCASION_TYPE,
+        occasionYear,
+      },
+    },
+    create: {
+      userId,
+      targetUserId,
+      occasionType: PERSON_SURFACE_OCCASION_TYPE,
+      occasionYear,
+    },
+    update: {},
+    select: { id: true },
+  });
+
+  queueLogEvent({
+    name: 'occasion_declined',
+    userId,
+    source: 'server',
+    requestId: input.requestId,
+    properties: { targetUserId, occasionYear },
+  });
+  return decline;
+}
+
+export async function undoOccasionDecline(input: {
+  userId: string;
+  targetUserId: string;
+  occasionYear: number;
+  requestId?: string | null;
+}) {
+  const { userId, targetUserId, occasionYear } = input;
+  await prisma.occasionDecline.deleteMany({
+    where: {
+      userId,
+      targetUserId,
+      occasionType: PERSON_SURFACE_OCCASION_TYPE,
+      occasionYear,
+    },
+  });
+
+  queueLogEvent({
+    name: 'occasion_decline_undone',
+    userId,
+    source: 'server',
+    requestId: input.requestId,
+    properties: { targetUserId, occasionYear },
+  });
+}
+
+// Off-wishlist solo gift = a pool-of-one. Never surfaced with pool ceremony;
+// the gift `name` becomes the pool title / display name (a nameless solo gift
+// is not allowed — enforced by the action schema).
+export async function commitSoloGift(input: {
+  organizerId: string;
+  recipientUserId: string;
+  name: string;
+  eventDate?: Date | null;
+  requestId?: string | null;
+}) {
+  const { organizerId, recipientUserId, name, eventDate = null } = input;
+  const pool = await createPool({
+    title: name,
+    occasionType: PERSON_SURFACE_OCCASION_TYPE,
+    eventDate,
+    recipientUserId,
+    organizerId,
+    giftGroupId: null,
+  });
+
+  queueLogEvent({
+    name: 'solo_gift_committed',
+    userId: organizerId,
+    source: 'server',
+    requestId: input.requestId,
+    properties: { poolId: pool.id, recipientUserId },
+  });
+  return pool;
+}
+
+export type OutcomeFeedback = 'LOVED' | 'OKAY' | 'SKIPPED';
+
+// Records "did it land" on a pool-of-one. Authorized to the pool organizer
+// (the solo giver) only.
+export async function recordPoolOutcome(input: {
+  userId: string;
+  poolId: string;
+  feedback: OutcomeFeedback;
+  requestId?: string | null;
+}) {
+  const { userId, poolId, feedback } = input;
+  const pool = await prisma.pool.findUnique({
+    where: { id: poolId },
+    select: { id: true, organizerId: true },
+  });
+  if (!pool || pool.organizerId !== userId) {
+    throw data({ error: 'Pool not found.' }, { status: 404 });
+  }
+  await prisma.pool.update({
+    where: { id: poolId },
+    data: { outcomeFeedback: feedback },
+  });
+
+  queueLogEvent({
+    name: 'gift_outcome_recorded',
+    userId,
+    source: 'server',
+    requestId: input.requestId,
+    properties: { kind: 'pool', poolId, feedback },
+  });
+}
+
+// Records "did it land" on a wishlist-claim solo intent. Authorized to the
+// claimer (purchasedById) only.
+export async function recordWishlistPurchaseOutcome(input: {
+  userId: string;
+  wishlistItemId: string;
+  feedback: OutcomeFeedback;
+  requestId?: string | null;
+}) {
+  const { userId, wishlistItemId, feedback } = input;
+  const purchase = await prisma.wishlistPurchase.findUnique({
+    where: { wishlistItemId },
+    select: { purchasedById: true },
+  });
+  if (!purchase || purchase.purchasedById !== userId) {
+    throw data({ error: 'Claim not found.' }, { status: 404 });
+  }
+  await prisma.wishlistPurchase.update({
+    where: { wishlistItemId },
+    data: { outcomeFeedback: feedback },
+  });
+
+  queueLogEvent({
+    name: 'gift_outcome_recorded',
+    userId,
+    source: 'server',
+    requestId: input.requestId,
+    properties: { kind: 'wishlist', wishlistItemId, feedback },
+  });
+}
+
+export type { WriteContext };

--- a/app/utils/person-surface.server.ts
+++ b/app/utils/person-surface.server.ts
@@ -1,10 +1,17 @@
 import { data } from 'react-router';
 import { queueLogEvent } from '#app/utils/analytics.server.ts';
-import { getUpcomingBirthday } from '#app/utils/birthday.ts';
+import {
+  formatBirthdayLabel,
+  getRecentBirthday,
+  getUpcomingBirthday,
+} from '#app/utils/birthday.ts';
 import { prisma } from '#app/utils/db.server.ts';
 import { getRelationshipDetails } from '#app/utils/friends.server.ts';
 import { POOL_STATUS } from '#app/utils/pool-constants.ts';
 import { createPool, proposeIdea } from '#app/utils/pool.server.ts';
+
+// Post-occasion detection window (spec §4): 14 days after the occasion.
+export const POST_OCCASION_WINDOW_DAYS = 14;
 
 // The person surface is circle-private memory keyed to a viewer↔target pair.
 // This module owns the access gate, the write paths (Commit 1), and the
@@ -547,6 +554,102 @@ export async function proposeToPool(input: {
     },
   });
   return idea;
+}
+
+// ─── Post-occasion detection (Commit 5, spec §4) ─────────────────────────────
+
+export type PostOccasion = {
+  occasionLabel: string;
+  // The viewer's unconfirmed solo intent that needs a "did it land" answer.
+  gift: { kind: 'pool' | 'wishlist'; id: string; name: string };
+  // Set when a group pool for this recipient recorded automatically this cycle.
+  recordedGroupPoolName: string | null;
+};
+
+// Within 14 days after the occasion, only if the viewer has an unconfirmed
+// solo intent for it (pool-of-one or wishlist claim). Group pools record
+// automatically at their DECIDED transition; we only surface that note. Once a
+// solo intent is answered OR skipped (outcomeFeedback set), it's never
+// re-detected — no re-nag.
+export async function loadPostOccasion(
+  viewerId: string,
+  targetUserId: string,
+  birthday: Date | string | null | undefined,
+): Promise<PostOccasion | null> {
+  const recent = getRecentBirthday(birthday, POST_OCCASION_WINDOW_DAYS);
+  if (!recent) return null;
+
+  // Unconfirmed solo intents. Pool-of-one = organizer-solo pool (exactly one
+  // contributor) with no recorded outcome.
+  const soloPools = await prisma.pool.findMany({
+    where: {
+      organizerId: viewerId,
+      recipientUserId: targetUserId,
+      outcomeFeedback: null,
+    },
+    select: {
+      id: true,
+      title: true,
+      _count: { select: { contributors: true } },
+    },
+    orderBy: { createdAt: 'desc' },
+  });
+  const soloPool = soloPools.find((p) => p._count.contributors === 1);
+
+  let gift: PostOccasion['gift'] | null = null;
+  if (soloPool) {
+    gift = { kind: 'pool', id: soloPool.id, name: soloPool.title };
+  } else {
+    const claim = await prisma.wishlistPurchase.findFirst({
+      where: {
+        purchasedById: viewerId,
+        outcomeFeedback: null,
+        wishlistItem: { ownerId: targetUserId },
+      },
+      select: {
+        wishlistItemId: true,
+        wishlistItem: { select: { title: true } },
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+    if (claim) {
+      gift = {
+        kind: 'wishlist',
+        id: claim.wishlistItemId,
+        name: claim.wishlistItem.title,
+      };
+    }
+  }
+  if (!gift) return null;
+
+  // Group pool (more than one contributor) decided for the just-passed cycle.
+  const windowStart = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+  const groupPools = await prisma.pool.findMany({
+    where: {
+      recipientUserId: targetUserId,
+      chosenIdeaId: { not: null },
+      contributors: { some: { userId: viewerId } },
+      eventDate: { gte: windowStart, lt: new Date() },
+    },
+    select: {
+      chosenIdea: { select: { name: true } },
+      _count: { select: { contributors: true } },
+    },
+  });
+  const groupPool = groupPools.find((p) => p._count.contributors > 1);
+
+  const occasionLabel =
+    recent.daysSince === 0
+      ? 'was today'
+      : recent.daysSince === 1
+        ? 'was yesterday'
+        : `was ${formatBirthdayLabel(recent.date, -1)} · ${recent.daysSince} days ago`;
+
+  return {
+    occasionLabel,
+    gift,
+    recordedGroupPoolName: groupPool?.chosenIdea?.name ?? null,
+  };
 }
 
 export type { WriteContext };

--- a/app/utils/person-surface.server.ts
+++ b/app/utils/person-surface.server.ts
@@ -3,7 +3,8 @@ import { queueLogEvent } from '#app/utils/analytics.server.ts';
 import { getUpcomingBirthday } from '#app/utils/birthday.ts';
 import { prisma } from '#app/utils/db.server.ts';
 import { getRelationshipDetails } from '#app/utils/friends.server.ts';
-import { createPool } from '#app/utils/pool.server.ts';
+import { POOL_STATUS } from '#app/utils/pool-constants.ts';
+import { createPool, proposeIdea } from '#app/utils/pool.server.ts';
 
 // The person surface is circle-private memory keyed to a viewer↔target pair.
 // This module owns the access gate, the write paths (Commit 1), and the
@@ -333,6 +334,219 @@ export async function recordWishlistPurchaseOutcome(input: {
     requestId: input.requestId,
     properties: { kind: 'wishlist', wishlistItemId, feedback },
   });
+}
+
+// ─── Ideation reads (Commit 4 — circle-keyed) ────────────────────────────────
+
+export type PersonIdeation = {
+  giftHistory: Array<{
+    id: string;
+    name: string;
+    year: number;
+    contributorCount: number;
+    priceCents: number | null;
+  }>;
+  proposedUnused: Array<{ id: string; name: string; year: number }>;
+  notes: Array<{ id: string; body: string }>;
+  savedIdeas: Array<{
+    id: string;
+    name: string;
+    url: string | null;
+    priceCents: number | null;
+    currency: string | null;
+  }>;
+};
+
+// Gift history + proposed-but-unused are visible only to a viewer who was in
+// the circle the memory came from (a contributor of the pool). Gift history is
+// PAST occasions only — the active cycle's pool must never show as "given" the
+// moment an idea is chosen: guard on eventDate < now, or (undated) a terminal
+// PURCHASED/DELIVERED status. Notes + saved ideas are private to the viewer.
+export async function loadPersonIdeation(
+  viewerId: string,
+  targetUserId: string,
+): Promise<PersonIdeation> {
+  const now = new Date();
+  const [historyPools, notes, savedIdeas] = await Promise.all([
+    prisma.pool.findMany({
+      where: {
+        recipientUserId: targetUserId,
+        chosenIdeaId: { not: null },
+        contributors: { some: { userId: viewerId } },
+        OR: [
+          { eventDate: { lt: now } },
+          {
+            eventDate: null,
+            status: { in: [POOL_STATUS.PURCHASED, POOL_STATUS.DELIVERED] },
+          },
+        ],
+      },
+      select: {
+        id: true,
+        eventDate: true,
+        createdAt: true,
+        finalPriceCents: true,
+        chosenIdeaId: true,
+        chosenIdea: { select: { name: true } },
+        _count: { select: { contributors: true } },
+        ideas: { select: { id: true, name: true } },
+      },
+      orderBy: { createdAt: 'desc' },
+    }),
+    prisma.personNote.findMany({
+      where: { authorId: viewerId, subjectUserId: targetUserId },
+      select: { id: true, body: true },
+      orderBy: { createdAt: 'desc' },
+    }),
+    prisma.giftListItem.findMany({
+      where: { ownerId: viewerId, targetUserId },
+      select: {
+        id: true,
+        name: true,
+        url: true,
+        priceCents: true,
+        currency: true,
+      },
+      orderBy: { createdAt: 'desc' },
+    }),
+  ]);
+
+  const giftHistory = historyPools.map((p) => ({
+    id: p.id,
+    name: p.chosenIdea?.name ?? 'Gift',
+    year: (p.eventDate ?? p.createdAt).getFullYear(),
+    contributorCount: p._count.contributors,
+    priceCents: p.finalPriceCents,
+  }));
+
+  const proposedUnused = historyPools.flatMap((p) =>
+    p.ideas
+      .filter((i) => i.id !== p.chosenIdeaId)
+      .map((i) => ({
+        id: i.id,
+        name: i.name,
+        year: (p.eventDate ?? p.createdAt).getFullYear(),
+      })),
+  );
+
+  return { giftHistory, proposedUnused, notes, savedIdeas };
+}
+
+export type PersonWishlistItem = {
+  id: string;
+  title: string;
+  url: string | null;
+  priceCents: number | null;
+  currency: string | null;
+  claimed: boolean;
+  claimedByViewer: boolean;
+};
+
+// The target's active wishlist as a gift source. Claim identity is never
+// exposed — only whether the item is claimed, and whether the VIEWER is the
+// claimer (for the self "I'm getting this" toggle).
+export async function loadPersonWishlistSource(
+  viewerId: string,
+  targetUserId: string,
+): Promise<PersonWishlistItem[]> {
+  const items = await prisma.wishlistItem.findMany({
+    where: { ownerId: targetUserId, status: 'ACTIVE' },
+    select: {
+      id: true,
+      title: true,
+      url: true,
+      priceCents: true,
+      currency: true,
+      purchase: { select: { purchasedById: true } },
+    },
+    orderBy: [{ sortOrder: 'asc' }, { updatedAt: 'desc' }],
+  });
+  return items.map((i) => ({
+    id: i.id,
+    title: i.title,
+    url: i.url,
+    priceCents: i.priceCents,
+    currency: i.currency,
+    claimed: i.purchase != null,
+    claimedByViewer: i.purchase?.purchasedById === viewerId,
+  }));
+}
+
+// Open pools for this recipient that the viewer is a contributor of — the
+// "Propose to pool" resolver. 0 → route into Organize; 1 → propose directly;
+// 2+ → picker. Never dead-ends.
+export async function loadOpenPoolsForRecipient(
+  viewerId: string,
+  targetUserId: string,
+): Promise<Array<{ id: string; title: string }>> {
+  return prisma.pool.findMany({
+    where: {
+      recipientUserId: targetUserId,
+      status: POOL_STATUS.OPEN,
+      contributors: { some: { userId: viewerId } },
+    },
+    select: { id: true, title: true },
+    orderBy: { createdAt: 'desc' },
+  });
+}
+
+// Propose an idea (from the wishlist or a saved GiftListItem) into an existing
+// open pool. Authorized: the pool must be OPEN, for this recipient, and the
+// viewer must be a contributor. Promoting a saved idea links it (giftListItemId)
+// rather than copying.
+export async function proposeToPool(input: {
+  userId: string;
+  poolId: string;
+  targetUserId: string;
+  name: string;
+  wishlistItemId?: string | null;
+  giftListItemId?: string | null;
+  url?: string | null;
+  priceCents?: number | null;
+  requestId?: string | null;
+}) {
+  const { userId, poolId, targetUserId, name } = input;
+  const pool = await prisma.pool.findUnique({
+    where: { id: poolId },
+    select: {
+      id: true,
+      status: true,
+      recipientUserId: true,
+      contributors: { where: { userId }, select: { userId: true } },
+    },
+  });
+  if (
+    !pool ||
+    pool.status !== POOL_STATUS.OPEN ||
+    pool.recipientUserId !== targetUserId ||
+    pool.contributors.length === 0
+  ) {
+    throw data({ error: 'Pool not found.' }, { status: 404 });
+  }
+
+  const idea = await proposeIdea({
+    poolId,
+    proposedById: userId,
+    name,
+    url: input.url ?? null,
+    estimatedPriceCents: input.priceCents ?? null,
+    wishlistItemId: input.wishlistItemId ?? null,
+    giftListItemId: input.giftListItemId ?? null,
+  });
+
+  queueLogEvent({
+    name: input.giftListItemId ? 'saved_idea_promoted' : 'pool_idea_proposed',
+    userId,
+    source: 'server',
+    requestId: input.requestId,
+    properties: {
+      poolId,
+      ideaId: idea.id,
+      fromWishlist: input.wishlistItemId != null,
+      fromSavedIdea: input.giftListItemId != null,
+    },
+  });
+  return idea;
 }
 
 export type { WriteContext };

--- a/app/utils/pool.server.test.ts
+++ b/app/utils/pool.server.test.ts
@@ -358,6 +358,7 @@ describe('pool server utilities', () => {
         proposedById: 'user-1',
         url: 'https://example.com',
         wishlistItemId: null,
+        giftListItemId: null,
       },
       select: { id: true, name: true },
     });

--- a/app/utils/pool.server.ts
+++ b/app/utils/pool.server.ts
@@ -342,6 +342,9 @@ export type ProposeIdeaInput = {
 	url?: string | null
 	estimatedPriceCents?: number | null
 	wishlistItemId?: string | null
+	// Promotion link — set when this idea was promoted from a private
+	// GiftListItem (person surface). Links, never copy-orphans.
+	giftListItemId?: string | null
 }
 
 export async function proposeIdea(input: ProposeIdeaInput) {
@@ -354,6 +357,7 @@ export async function proposeIdea(input: ProposeIdeaInput) {
 			url: input.url ?? null,
 			estimatedPriceCents: input.estimatedPriceCents ?? null,
 			wishlistItemId: input.wishlistItemId ?? null,
+			giftListItemId: input.giftListItemId ?? null,
 		},
 		select: { id: true, name: true },
 	})

--- a/docs/giftpool-person-surface-action-model.md
+++ b/docs/giftpool-person-surface-action-model.md
@@ -1,0 +1,277 @@
+# GiftPool — Person Surface: Action-Model Spec (v1 draft)
+
+*Paper-first artifact. Resolves the action model for the person-centric / gift-occasion
+surface. Input to Claude Design; nothing here goes to Claude Code until the layout is
+resolved there. Companion to `giftpool-vision-spine.md` and
+`giftpool-state-of-reality.md`.*
+
+*Standing caveat, kept deliberately at the top: this model derives from one founder
+rehearsal (Cacho's August birthday) plus the vision docs. It is a hypothesis with good
+posture, not a validated loop. Designing this surface is not evidence anyone returns.
+The first real test fixture is the actual Cacho pool in August.*
+
+---
+
+## 1. Purpose — one sentence
+
+The page for a person answers **"what should we get them, and who's in?"** — powered by
+circle-private memory, with the pool as *output*, not centerpiece.
+
+The old page answered "who is this person?" (a record). This one answers "a gift
+occasion is coming — what do I do?" (a launchpad).
+
+## 2. Positioning
+
+- **The competitor is the minus-one splinter thread, not WhatsApp.** The chat
+  conversation stays in WhatsApp; GiftPool is where the durable artifacts land — ideas,
+  decisions, coverage, history. A minus-one thread covers exactly one recipient;
+  GiftPool is one group, N hidden pools.
+- **Circle-private memory only.** GiftPool cannot and must not compete with Google on
+  gift inspiration. Every ideation source on this page must be something Google cannot
+  know: what this circle gave, proposed, rejected, learned, noticed. Any feature idea
+  for this page that is not circle-private memory is out of scope by rule.
+- **Insider consults (e.g. recipient's spouse) are not mediated.** The consult happens
+  in WhatsApp; the surface captures the *output* as a note. (A no-account "ask link" is
+  a parked future organizer-pull mechanic — not v1.)
+
+## 3. Page identity — DECIDED
+
+**This is `/users/:handle` restructured, not a new page.**
+
+Reasoning: every raw ingredient (wishlist, birthday, mutual groups, mutual friends) is
+already on the profile; a second person-page splits identity ("profile or gift page?");
+and the future occasion reminder needs exactly one canonical landing URL per person.
+The profile stops being a record and becomes this surface.
+
+## 4. Temporal states (what the page leads with)
+
+| State | Trigger | Page leads with |
+|---|---|---|
+| **Occasion near** | occasion within reminder window (existing 60-day birthday logic, or tighter) | Occasion header ("Cacho's birthday · Aug 14 · in 6 weeks") + primary actions |
+| **Cold** (no occasion near) | default | Dossier + capture ("save an idea," notes). Year-round capture lives here. |
+| **Post-occasion** | an occasion just passed with a pool or solo intent attached | Memory write: confirm what was given / whether it landed |
+
+Post-occasion detail: pool gifts write memory automatically from pool completion. Only
+solo gifts need a manual confirm. Never nag for memory writes on occasions where the
+viewer did nothing.
+
+Occasion scope v1: **birthday only** (the only occasion the data model knows). The
+header is designed occasion-generic so Christmas / custom occasions slot in later
+without redesign.
+
+## 5. Terminal states of a visit
+
+A visit "worked" if it ends in one of:
+
+1. **Organized** — a pool for this person exists.
+2. **Committed solo** — a private solo gift intent exists.
+3. **Idea saved** — a gift-list entry for this person exists (the lightweight
+   non-commitment; this is the "deferred with a trace" state).
+4. **Declined** — explicitly sitting this occasion out.
+
+Leaving without action is permitted and undesigned — the occasion persists and the
+(future) reminder fires again. **No snooze mechanism.** Snooze is reminder-*delivery*
+logic; building it now smuggles scheduling infrastructure into a surface PR. When beat-2
+delivery exists, snooze becomes its concern, not this page's.
+
+## 6. Action model × relationship context
+
+### Access gate — RESOLVED (verified against code, 2026-07-02)
+
+**Unlock rule:** the surface unlocks for `FRIENDS` **or** ≥1 shared active group
+(`removedAt: null`). All other viewers keep the existing `FriendGateCard` stub
+(verified to expose identity only: id, name, username, avatar).
+
+**Visibility model — union of grants, with one absolute override.**
+`birthdayVisibility` (global, relationship-scoped: EVERYONE / FRIENDS_OF_FRIENDS /
+FRIENDS / NOBODY) and `shareBirthday` (per-member-per-group, default true, backfilled
+true) are independent *grant channels*, not layers:
+
+> Birthday visible to viewer ⟺
+> [relationship satisfies `birthdayVisibility`] OR
+> [∃ shared group with target's `shareBirthday = true`]
+> — EXCEPT `birthdayVisibility = NOBODY`, which wins over everything.
+
+Reasoning: an AND/ceiling model would hide birthdays from non-friend groupmates under
+the default global setting (`FRIENDS`), silently gutting the group product's core use.
+The per-group toggle's copy ("Share my birthday with this group") is an explicit
+affirmative grant and should behave like one. But NOBODY is the user screaming "hide
+it" and must be absolute — accepting the rare loss of "hidden from friends, visible to
+one group."
+
+**Implementation prerequisite: extract a single `canViewBirthday(viewer, target)`
+server helper** implementing the rule above, consumed by ALL birthday surfaces: home
+panel (today checks only `birthdayVisibility`), group overview (today checks only
+`shareBirthday` — the live NOBODY inconsistency), friend row, profile, and this
+surface's occasion header. This mirrors the planned `canView` helper extraction from
+the address-visibility workstream. No birthday surface may embed its own gate logic.
+
+**Wishlist:** visible ⟺ `FRIENDS` (today's behavior) OR [shared group with
+`shareWishlist = true`] — giving `shareWishlist` its first-ever reader. Claim state
+travels with wishlist visibility. Consulting both toggles for the first time only
+*adds* visibility for groupmates (who currently see nothing), so no regression; the
+defaults-true backfill is acceptable because joining a gift group is contextual
+consent for exactly this, and the toggle is prominent and editable.
+
+**Mutual friends: friends-only.** A groupmate enumerating your friend graph leaks more
+than either toggle governs. Mutual groups: visible to both (shared by definition).
+**Person notes: private to author in v1** (shared-scope notes deferred — needs a
+write-time visibility picker; pool idea proposals already cover collaborative
+pitch-in). Circle memory (gift history, idea archive): keyed to the circle — visible
+iff the viewer was in the pool/group the memory came from, regardless of friendship.
+Actions (organize / save idea / decline): available to anyone past the unlock.
+
+Terminal states are context-invariant. Only the route to **Organized** varies, via one
+variable: the candidate contributor set.
+
+| Context | Organize | Solo | Save idea | Decline |
+|---|---|---|---|---|
+| Groupmate, one shared group | Pool in that group | ✓ | ✓ | ✓ |
+| Groupmate, multiple shared groups | **Picker — always ask, never default.** Wrong-default in a secrecy product = worst bug class; picker friction is recoverable, a visibility leak isn't. | ✓ | ✓ | ✓ |
+| Friend only, no shared group | Standalone pool. **PHASED (2026-07-03):** v1 = create pool + existing share-link flow (organizer sends the link). The select-mutual-friends flow (design frame 2b) is **PR 2: pool invitations** — consent-based invite→accept, reusing the friend-request pattern and the `GroupInvitation` precedent. Direct-add of contributors is REJECTED: it drops a financial expectation on someone without consent, and with zero pool notification events they'd never know (ghost contributors). The bridge framing ("you share Cacho — organize together") stays as v1 copy on the entry card. | ✓ | ✓ | ✓ |
+| No mutuals | Not offered | ✓ | ✓ | ✓ |
+
+### Decline semantics — DECIDED
+- Per occasion instance ("Cacho's birthday 2026"), auto-resets next cycle.
+- **Private to the decliner.** Never visible to the group — visible declines are social
+  surveillance and poison the warmth. Suppresses my reminders; converts my occasion
+  header to a quiet "sitting this one out — undo" state.
+
+### Solo gift — DECIDED, now verified viable
+- Under the hood: a pool of one. **Verified clean in code**: no minimum-contributor
+  constraint; `calculateContributions` handles N=1; `createPool` already seeds the
+  organizer as sole first contributor; no group-only cap assumptions.
+- In the UI: **never called a pool.** No organizer/cap/contributor ceremony. Language
+  like "I've got this one covered."
+- **v1 shortcut (verified):** for wishlist items, `WishlistPurchase` (claim = purchase,
+  one per item) already functions as a solo commitment with dedupe. v1 solo-for-wishlist
+  may be *presentation only* over existing claims; pool-of-one is needed only for
+  off-wishlist solo gifts. Decide the split in design — but do not build a third
+  intent record.
+
+## 7. The ideation block — the body of the page
+
+The center of gravity. Not the pool button. Sources, ranked by defensibility:
+
+1. **Their wishlist** (exists) — re-presented as a gift *source* with per-item actions
+   ("I'm getting this" / "propose to pool"), not a read-only list.
+2. **What this circle gave before** — gift history per recipient. Written automatically
+   by pool completion (+ solo confirm). Never manually curated.
+3. **Proposed-but-unused ideas** from past pools — auto-archived. Prevents re-treading
+   rejected ground and resurfaces near-misses ("we almost got him X").
+4. **Notes about the person** — durable ("buys everything he wants himself → go for
+   novelty") and fresh ("started running," "wife says he needs gear"). The only fully
+   manual memory write besides saved ideas. Author-visible + circle-visible; never
+   recipient-visible. Exact visibility rule to resolve in design.
+5. **My saved ideas for them** (gift-lists) — the year-round capture habit,
+   promotable to a pool proposal or solo intent when an occasion arrives.
+6. **Budget context** — "this circle can cover ~$X." Verified: `Pool` has no cap/goal
+   field; the number is the sum of per-member defaults (`groupMemberDefaults`) for the
+   chosen circle, minus the recipient. Shown as ideation constraint only. Cap
+   inheritance/freeze mechanics are pool-domain (see §10).
+
+### Empty-state rule — DECIDED
+**Memory sections are earned, not scaffolded.** A section renders only when it has
+content. Day-one page = occasion header (if near) + wishlist + capture actions. No
+empty museum boxes. Every dossier — including the founder's — starts at zero and cannot
+be backfilled; therefore **write paths ship first, read views inherit.**
+
+## 8. What existing page elements become
+
+| Today (fact) | Becomes (entry point) |
+|---|---|
+| Wishlist | Gift source with claim/propose actions |
+| Birthday | Occasion header + its countdown state |
+| Mutual groups | Contributor-circle candidates for Organize |
+| Mutual friends | Contributor candidates for standalone pool (bridge seed) |
+| Avatar/handle | Unchanged identity block |
+
+## 9. Schema reality — VERIFIED against code
+
+Genuinely greenfield (migrations required):
+- **Gift-list item** — idea saved for a person, no pool attached. (`GiftIdea` is
+  pool-bound; confirmed no standalone concept.)
+- **Person note** — durable/fresh notes, circle-visibility, never recipient-visible.
+- **Occasion decline** — per viewer × occasion instance.
+- **"Did it land" feedback** — the only missing piece of gift outcome.
+
+Exists already (build on, don't duplicate):
+- **Gift outcome core**: `Pool.chosenIdeaId` + `Pool.finalPriceCents`, set at `DECIDED`.
+  Gift history = query over completed pools by `recipientUserId`.
+- **Solo intent for wishlist items**: `WishlistPurchase` (claim = purchase, unique per
+  item). Off-wishlist solo = pool-of-one (verified clean, §6).
+- **Idea archive is a view, not a table — CONFIRMED**: `GiftIdea where
+  pool.recipientUserId = X` (exclude `chosenIdeaId`). Unindexed but irrelevant at
+  current scale. Caveats: free-text (`recipientName`) pools can't attach to a person
+  page; and see the cascade risk in §10.
+- Occasion data: birthdays only. `GroupReminder` is just `offsetDays` per group — a
+  reminder *setting*, not occasion data. Confirms §4's birthday-only v1.
+
+## 10. Filed elsewhere (explicitly not this surface)
+
+- **Recipient-exclusion invariant — VERIFIED single-layer, fix specced.** The normal
+  group flow is safe (route filters recipient out of `groupMemberDefaults`), but the
+  invariant lives only in the one caller; `createPool` itself does no recipient
+  filtering and doesn't guard organizer===recipient (tamperable). Since this spec adds
+  new `createPool` callers (solo pool-of-one, standalone pools), the invariant moves
+  into `createPool` + regression tests BEFORE surface work multiplies callers.
+  Standalone fix PR; prompt already written.
+- **Live consent inconsistency (pre-existing, production):** group-overview birthday
+  list checks only `shareBirthday`; home panel checks only `birthdayVisibility`. A
+  `NOBODY` user is still surfaced on group overview today. Resolved by the
+  `canViewBirthday` helper unification (see §6 access gate) — can ship as its own
+  small PR ahead of the surface.
+- **Pool deletion destroys memory:** `GiftIdea` has `onDelete: Cascade` from Pool. Once
+  gift history/idea archive matter, deleting a pool erases circle memory. Direction:
+  pools should end in `CANCELLED`, not row deletion (mirrors the existing soft-delete
+  asymmetry note). File with the memory workstream.
+- **`GiftGroup.createdById` migration never landed** (decided in a prior session,
+  confirmed absent — exists only on `GroupInvitation`/`GroupReminder`). The pool→group
+  bridge remains unmeasurable. Small migration, do it regardless of this surface.
+- **Cap freeze semantics** — "contributions inherited from group at pool creation,
+  frozen at some moment" is unresolved spec. Pool-domain. Do not let it ride into any
+  implementation as vibes. (PR-3 lesson.)
+- Reminder delivery: scheduler, cron, VAPID, notification consent — beat-2 infra.
+- Pool-created-in-group notifications to members (needed for "everybody gets notified"
+  — currently zero pool/group events feed notifications). Adjacent PR, not this page.
+- WhatsApp integration — parked, named, far.
+- App-wide mobile visual overhaul — separate workstream; do not leak in.
+
+## 11. Codebase verification — DONE (2026-07-02)
+
+All eight original questions answered against code; findings folded into §§4, 6, 9, 10.
+One check remains open:
+
+> Read-only — do not modify. In the `pools+/new` action (and any other `createPool`
+> caller): when a group pool has a `recipientUserId` who is a member of that group, is
+> the recipient excluded from the seeded `groupMemberDefaults` contributors? Show the
+> exact filter. Also check: can the recipient end up notified or listed via any
+> contributor-facing query if seeded? Report, don't fix yet.
+
+## 12. Design-audit deltas (2026-07-03 — overrides to the Claude Design mock)
+
+The mock (`Person Surface (Mobile).dc.html`) passed audit with these binding overrides:
+
+1. **Gated = absent.** Do NOT implement 3b's "Mutual friends hidden" box. Sections a
+   viewer can't see simply don't render — no placeholder, no explanation.
+2. **Frame 2b is PR 2, not this PR** (see §6 phasing). v1 friends-only Organize =
+   standalone pool + share link. No picker UI implying direct-add.
+3. **Notes are private-to-author in v1.** Section title must say so ("Your notes ·
+   private" pattern, matching "Your saved ideas · private"). Mock's bare "Notes" title
+   is ambiguous — do not implement circle-visible notes.
+4. **Copy fixes:** drop "We won't remind you about this one" (2c) until reminder
+   delivery exists — the decline record still suppresses future reminders when built.
+   Drop "comfortably" from budget copy — the number is a ceiling (sum of caps), not
+   comfort. Every budget figure (header, picker rows) excludes the recipient.
+5. **Action row is a function of temporal state, not memory richness:** day-one (3a)
+   in occasion-near state gets the same Just me / Save idea / Not this time row as 1a.
+
+## 13. Suggested build order (after design, after verification)
+
+1. Write paths: save-idea, person-note, decline, solo intent. (Memory starts accruing.)
+2. Page restructure: temporal states + occasion header + action row.
+3. Ideation block read views (inherit from writes + existing wishlist).
+4. Post-occasion memory write (pool completion hook + solo confirm).
+
+Rationale: the compounding asset can't be backfilled — every week without write paths
+is a week of memory lost. Reads without writes are an empty museum.

--- a/prisma/migrations/20260703165325_add_person_surface_memory/migration.sql
+++ b/prisma/migrations/20260703165325_add_person_surface_memory/migration.sql
@@ -1,0 +1,81 @@
+-- AlterTable
+ALTER TABLE "Pool" ADD COLUMN "outcomeFeedback" TEXT;
+
+-- AlterTable
+ALTER TABLE "WishlistPurchase" ADD COLUMN "outcomeFeedback" TEXT;
+
+-- CreateTable
+CREATE TABLE "GiftListItem" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "ownerId" TEXT NOT NULL,
+    "targetUserId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "url" TEXT,
+    "priceCents" INTEGER,
+    "currency" TEXT,
+    CONSTRAINT "GiftListItem_ownerId_fkey" FOREIGN KEY ("ownerId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "GiftListItem_targetUserId_fkey" FOREIGN KEY ("targetUserId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "PersonNote" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "authorId" TEXT NOT NULL,
+    "subjectUserId" TEXT NOT NULL,
+    "body" TEXT NOT NULL,
+    CONSTRAINT "PersonNote_authorId_fkey" FOREIGN KEY ("authorId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "PersonNote_subjectUserId_fkey" FOREIGN KEY ("subjectUserId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "OccasionDecline" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "userId" TEXT NOT NULL,
+    "targetUserId" TEXT NOT NULL,
+    "occasionType" TEXT NOT NULL DEFAULT 'BIRTHDAY',
+    "occasionYear" INTEGER NOT NULL,
+    CONSTRAINT "OccasionDecline_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "OccasionDecline_targetUserId_fkey" FOREIGN KEY ("targetUserId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_GiftIdea" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    "poolId" TEXT NOT NULL,
+    "proposedById" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "url" TEXT,
+    "estimatedPriceCents" INTEGER,
+    "wishlistItemId" TEXT,
+    "giftListItemId" TEXT,
+    CONSTRAINT "GiftIdea_poolId_fkey" FOREIGN KEY ("poolId") REFERENCES "Pool" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "GiftIdea_proposedById_fkey" FOREIGN KEY ("proposedById") REFERENCES "User" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "GiftIdea_wishlistItemId_fkey" FOREIGN KEY ("wishlistItemId") REFERENCES "WishlistItem" ("id") ON DELETE SET NULL ON UPDATE CASCADE,
+    CONSTRAINT "GiftIdea_giftListItemId_fkey" FOREIGN KEY ("giftListItemId") REFERENCES "GiftListItem" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+INSERT INTO "new_GiftIdea" ("createdAt", "description", "estimatedPriceCents", "id", "name", "poolId", "proposedById", "updatedAt", "url", "wishlistItemId") SELECT "createdAt", "description", "estimatedPriceCents", "id", "name", "poolId", "proposedById", "updatedAt", "url", "wishlistItemId" FROM "GiftIdea";
+DROP TABLE "GiftIdea";
+ALTER TABLE "new_GiftIdea" RENAME TO "GiftIdea";
+CREATE INDEX "GiftIdea_poolId_idx" ON "GiftIdea"("poolId");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;
+
+-- CreateIndex
+CREATE INDEX "GiftListItem_ownerId_targetUserId_idx" ON "GiftListItem"("ownerId", "targetUserId");
+
+-- CreateIndex
+CREATE INDEX "PersonNote_authorId_subjectUserId_idx" ON "PersonNote"("authorId", "subjectUserId");
+
+-- CreateIndex
+CREATE INDEX "OccasionDecline_userId_idx" ON "OccasionDecline"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "OccasionDecline_userId_targetUserId_occasionType_occasionYear_key" ON "OccasionDecline"("userId", "targetUserId", "occasionType", "occasionYear");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -64,6 +64,13 @@ model User {
   poolMessages                 PoolMessage[]
   feedback                     Feedback[]
   consents                     Consent[]
+  // Person-surface memory relations
+  giftListItemsOwned           GiftListItem[]                @relation("GiftListItem_Owner")
+  giftListItemsAbout           GiftListItem[]                @relation("GiftListItem_Target")
+  personNotesAuthored          PersonNote[]                  @relation("PersonNote_Author")
+  personNotesAbout             PersonNote[]                  @relation("PersonNote_Subject")
+  occasionDeclines             OccasionDecline[]             @relation("OccasionDecline_User")
+  occasionDeclinesAbout        OccasionDecline[]             @relation("OccasionDecline_Target")
 }
 
 model Friendship {
@@ -321,6 +328,11 @@ model Pool {
   chosenIdeaId    String?  @unique
   finalPriceCents Int?
 
+  // Post-occasion "did it land" feedback. Valid values: LOVED | OKAY | SKIPPED
+  // (null = unanswered). SKIPPED records "never re-nag". Applies to group pools
+  // and solo pool-of-one alike.
+  outcomeFeedback String?
+
   // Invite code — for standalone pools or supplemental invites within a group
   inviteCode      String?  @unique
 
@@ -385,9 +397,14 @@ model GiftIdea {
   // Smart link — references a WishlistItem owned by the recipient
   wishlistItemId       String?
 
+  // Promotion link — set when this idea was promoted from a viewer's private
+  // GiftListItem. Links the promotion rather than copy-orphaning the item.
+  giftListItemId       String?
+
   pool                 Pool          @relation("Pool_Ideas", fields: [poolId], references: [id], onDelete: Cascade)
   proposedBy           User          @relation(fields: [proposedById], references: [id])
   wishlistItem         WishlistItem? @relation(fields: [wishlistItemId], references: [id], onDelete: SetNull)
+  giftListItem         GiftListItem? @relation(fields: [giftListItemId], references: [id], onDelete: SetNull)
 
   // Back-references
   chosenForPool        Pool?         @relation("Pool_ChosenIdea")
@@ -536,6 +553,9 @@ model WishlistPurchase {
   wishlistItemId String       @unique
   purchasedById  String
   createdAt      DateTime     @default(now())
+  // Post-occasion "did it land" feedback for a wishlist-claim solo intent.
+  // Valid values: LOVED | OKAY | SKIPPED (null = unanswered).
+  outcomeFeedback String?
   wishlistItem   WishlistItem @relation(fields: [wishlistItemId], references: [id], onDelete: Cascade)
   purchasedBy    User         @relation(fields: [purchasedById], references: [id], onDelete: Cascade)
 
@@ -549,6 +569,61 @@ model WishlistPublicShare {
   tokenHash String   @unique
   createdAt DateTime @default(now())
   owner     User     @relation(fields: [ownerId], references: [id], onDelete: Cascade)
+}
+
+// -----------------------------------------------------------------------------
+// Person surface — circle-private memory (see docs/giftpool-person-surface-*.md)
+// -----------------------------------------------------------------------------
+
+// A gift idea saved for a person, with no pool attached. Private to the owner;
+// NEVER visible to targetUser. Promotable to a pool GiftIdea (which links back
+// via GiftIdea.giftListItemId rather than copying).
+model GiftListItem {
+  id           String     @id @default(cuid())
+  createdAt    DateTime   @default(now())
+  ownerId      String
+  targetUserId String
+  name         String
+  url          String?
+  priceCents   Int?
+  currency     String? // ISO-4217; only ever stored alongside a price
+  owner        User       @relation("GiftListItem_Owner", fields: [ownerId], references: [id], onDelete: Cascade)
+  targetUser   User       @relation("GiftListItem_Target", fields: [targetUserId], references: [id], onDelete: Cascade)
+  giftIdeas    GiftIdea[]
+
+  @@index([ownerId, targetUserId])
+}
+
+// A durable/fresh note the author keeps about a person. Private to the author
+// in v1; NEVER visible to subjectUser under any rule.
+model PersonNote {
+  id            String   @id @default(cuid())
+  createdAt     DateTime @default(now())
+  authorId      String
+  subjectUserId String
+  body          String
+  author        User     @relation("PersonNote_Author", fields: [authorId], references: [id], onDelete: Cascade)
+  subjectUser   User     @relation("PersonNote_Subject", fields: [subjectUserId], references: [id], onDelete: Cascade)
+
+  @@index([authorId, subjectUserId])
+}
+
+// A viewer explicitly sitting out one occasion instance. Private to the
+// decliner. Keyed per occasion instance (occasionType + year) so it
+// auto-resets next cycle. Never visible to any other user.
+model OccasionDecline {
+  id           String   @id @default(cuid())
+  createdAt    DateTime @default(now())
+  userId       String
+  targetUserId String
+  // Valid values: BIRTHDAY (v1 only)
+  occasionType String   @default("BIRTHDAY")
+  occasionYear Int
+  user         User     @relation("OccasionDecline_User", fields: [userId], references: [id], onDelete: Cascade)
+  targetUser   User     @relation("OccasionDecline_Target", fields: [targetUserId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, targetUserId, occasionType, occasionYear])
+  @@index([userId])
 }
 
 // -----------------------------------------------------------------------------

--- a/tests/e2e/user-profile.test.ts
+++ b/tests/e2e/user-profile.test.ts
@@ -84,18 +84,14 @@ test('friend profile view shows header, birthday pill, wishlist preview, and out
     await expect(page.getByText(`@${friend.username}`)).toBeVisible();
 
     // Birthday pill visible (we set it 30 days out, inside the window).
-    await expect(
-      page.getByLabel(/^Birthday /i).first(),
-    ).toBeVisible();
+    await expect(page.getByLabel(/^Birthday /i).first()).toBeVisible();
 
     // Wishlist preview card renders the seeded item.
+    await expect(page.getByText('Vintage espresso machine')).toBeVisible();
     await expect(
-      page.getByText('Vintage espresso machine'),
-    ).toBeVisible();
-    await expect(
-      page
-        .getByRole('link', { name: /see.*full wishlist/i })
-        .or(page.getByRole('link', { name: /see all/i })),
+      page.getByRole('link', {
+        name: `${friend.name ?? friend.username}'s wishlist`,
+      }),
     ).toBeVisible();
 
     // Stranger profile should show the new NONE-state gate copy.


### PR DESCRIPTION
## Summary

Reworks `/users/:username` into the person-surface gift occasion launchpad described in the action-model spec.

- Adds person-surface memory write paths, access gating, temporal states, ideation reads, and post-occasion outcome capture.
- Adds the action-model spec under `docs/` for review context.
- Fixes the `Propose to pool` path so proposing an item into an existing pool navigates to that pool instead of looking like a no-op.

## Root Cause

`Propose to pool` previously used a background fetcher submit and the route returned only form data, so the idea could be created without any visible user feedback.

## Validation

- `npm test -- --run 'app/routes/users+/$username_+/index.authz.test.ts' 'app/routes/users+/$username.test.tsx'`
- `npm run typecheck`
- `npm run lint` (exits 0 with existing warnings)

## Notes

Do not merge until checks and review feedback have been addressed.