### PR TITLE
fix(avatar): load profile avatars at an allowed image size

### DIFF
--- a/app/components/ui/avatar.tsx
+++ b/app/components/ui/avatar.tsx
@@ -34,9 +34,18 @@ export const Avatar = ({
   loading = 'lazy',
   ariaLabel,
 }: AvatarProps) => {
+  // Numeric sizes are rendered via inline styles (Tailwind's N * 0.25rem scale)
+  // rather than `h-${size} w-${size}` classes — interpolated class names can't
+  // be seen by Tailwind's JIT scanner and get purged, leaving the img with no
+  // dimensions.
+  const numericSizeStyle =
+    typeof size === 'number'
+      ? { height: `${size * 0.25}rem`, width: `${size * 0.25}rem` }
+      : undefined;
+
   const sizeClass = (() => {
     if (typeof size === 'number') {
-      return `h-${size} w-${size}`;
+      return '';
     }
     switch (size) {
       case 's':
@@ -85,7 +94,7 @@ export const Avatar = ({
         src={src}
         alt={imageAlt}
         className={imgClasses}
-        style={style}
+        style={{ ...numericSizeStyle, ...style }}
         onClick={onClick}
         loading={loading}
         aria-label={ariaLabel ?? imageAlt}

--- a/app/components/ui/avatar.tsx
+++ b/app/components/ui/avatar.tsx
@@ -1,5 +1,5 @@
 import { type User, type UserImage } from '@prisma/client';
-import { getUserImgSrc } from '#app/utils/misc.tsx';
+import { getUserImgSrc, snapToUserImageSize } from '#app/utils/misc.tsx';
 
 type AvatarSize = 's' | 'm' | 'l' | number;
 type AvatarShape = 'circle' | 'rounded' | 'square';
@@ -61,9 +61,12 @@ export const Avatar = ({
     }
   })();
 
+  // Snap to a bucket the image route actually serves — an off-list size (e.g.
+  // 160 from size={20}) is a 400 and a broken avatar. size is a Tailwind unit
+  // (× 4px); request 2× for retina, then snap up.
   const requestedImageSize =
     typeof size === 'number'
-      ? Math.min(512, Math.max(32, size * 8))
+      ? snapToUserImageSize(size * 8)
       : size === 's'
         ? 64
         : size === 'l'

--- a/app/routes/resources+/user-images.$imageId.tsx
+++ b/app/routes/resources+/user-images.$imageId.tsx
@@ -3,8 +3,9 @@ import sharp from 'sharp';
 import { type LoaderFunctionArgs } from 'react-router';
 import { requireUserId } from '#app/utils/auth.server.ts';
 import { prisma } from '#app/utils/db.server.ts';
+import { USER_IMAGE_SIZES } from '#app/utils/misc.tsx';
 
-const ALLOWED_IMAGE_SIZES = new Set([32, 48, 64, 96, 128, 256, 512]);
+const ALLOWED_IMAGE_SIZES = new Set<number>(USER_IMAGE_SIZES);
 
 function parseRequestedSize(request: Request) {
   const sizeParam = new URL(request.url).searchParams.get('size');

--- a/app/utils/misc.tsx
+++ b/app/utils/misc.tsx
@@ -5,6 +5,18 @@ import { useSpinDelay } from 'spin-delay';
 import { extendTailwindMerge } from 'tailwind-merge';
 import { extendedTheme } from './extended-theme.ts';
 
+// The only sizes the /resources/user-images route will resize to — any other
+// value is rejected with a 400. Keep this in sync with that route (it imports
+// this constant) and snap requested pixel dimensions to a bucket before asking.
+export const USER_IMAGE_SIZES = [32, 48, 64, 96, 128, 256, 512] as const;
+
+export function snapToUserImageSize(px: number) {
+  for (const size of USER_IMAGE_SIZES) {
+    if (px <= size) return size;
+  }
+  return USER_IMAGE_SIZES[USER_IMAGE_SIZES.length - 1];
+}
+
 export function getUserImgSrc(
   imageId?: string | null,
   options?: { size?: number },

--- a/app/utils/misc.tsx
+++ b/app/utils/misc.tsx
@@ -11,10 +11,11 @@ import { extendedTheme } from './extended-theme.ts';
 export const USER_IMAGE_SIZES = [32, 48, 64, 96, 128, 256, 512] as const;
 
 export function snapToUserImageSize(px: number) {
-  for (const size of USER_IMAGE_SIZES) {
-    if (px <= size) return size;
-  }
-  return USER_IMAGE_SIZES[USER_IMAGE_SIZES.length - 1];
+  return (
+    USER_IMAGE_SIZES.find((size) => px <= size) ??
+    USER_IMAGE_SIZES.at(-1) ??
+    512
+  );
 }
 
 export function getUserImgSrc(


### PR DESCRIPTION
## Problem

On the person surface (profile), the user's avatar rendered as a **broken image** (showing alt text like "Marco Rodrígu"), while the same user's wishlist avatar loaded fine.

## Root cause

The `/resources/user-images/:id` route only resizes to a fixed allow-set — `{32, 48, 64, 96, 128, 256, 512}` — and returns **400** for anything else. The person surface introduced *numeric* `Avatar` sizes, and the Avatar computed the requested pixel size as `size * 8`:

- `size={20}` (hero) → `?size=160` → not in the set → **400 → broken image**
- `size={14}` → `?size=112` → 400

The wishlist avatar requests `size: 64` (allowed), which is exactly why it worked there but not on the profile.

## Fix (two atomic commits)

1. **`request an image size the resource route serves`** — snap the requested size to an allowed bucket via a shared `USER_IMAGE_SIZES` constant, and have the resource route derive its allow-set from that same constant so they can't drift.
2. **`render numeric sizes via inline style`** — a latent, secondary bug: numeric sizes built dimensions as `h-${size} w-${size}`, interpolated class names Tailwind's JIT scanner can't see and purges. Emit dimensions as an inline style instead.

## Verification

- Snap math: 12→96, 14→128, 20→256 — all in the allow-set.
- `npm run lint` (0 errors), `npm run typecheck`, `npx prettier --check`, and the affected unit tests all pass. e2e runs in CI.

https://claude.ai/code/session_012huiwEszwwGn3bzDJzLVoq