### PR TITLE
fix(groups): repair Member Actions mobile layout + empty Transfer Ownership dropdown

### DIFF
--- a/app/routes/groups+/$giftGroupId_+/settings.component.test.tsx
+++ b/app/routes/groups+/$giftGroupId_+/settings.component.test.tsx
@@ -130,4 +130,63 @@ describe('group settings route', () => {
     expect(checkbox).not.toBeChecked();
     expect(readHidden()).toBe('false');
   });
+
+  const asOwnerViewing = (
+    members: Array<{ userId: string; role: string; username: string }>,
+  ) => {
+    loaderDataSnapshot.canManageSettings = true;
+    loaderDataSnapshot.viewerMember.role = 'OWNER';
+    loaderDataSnapshot.giftGroup.groupMembers = members.map((m) => ({
+      userId: m.userId,
+      role: m.role,
+      user: {
+        id: m.userId,
+        username: m.username,
+        name: m.username,
+        image: null,
+      },
+    }));
+  };
+
+  it('offers every non-owner member (not just admins) in Transfer Ownership', () => {
+    // A group with no admins — the owner and two plain members. The dropdown
+    // used to filter to ADMIN only and render empty; every member is eligible.
+    asOwnerViewing([
+      { userId: 'viewer-1', role: 'OWNER', username: 'wade' },
+      { userId: 'm2', role: 'MEMBER', username: 'np' },
+    ]);
+    renderRoute();
+    expect(screen.getByText('Transfer Ownership')).toBeInTheDocument();
+    // Non-empty branch: the select + Transfer button render.
+    expect(screen.getByText('Select member')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Transfer' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/invite another member/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows a guidance message instead of an empty Transfer dropdown when the owner is alone', () => {
+    asOwnerViewing([{ userId: 'viewer-1', role: 'OWNER', username: 'wade' }]);
+    renderRoute();
+    expect(screen.getByText(/invite another member/i)).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Transfer' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders the shared actions menu per manageable member row', () => {
+    asOwnerViewing([
+      { userId: 'viewer-1', role: 'OWNER', username: 'wade' },
+      { userId: 'm2', role: 'MEMBER', username: 'np' },
+    ]);
+    renderRoute();
+    // A manageable member gets the three-dot menu (desktop + mobile triggers).
+    expect(screen.getAllByLabelText('Actions for np').length).toBeGreaterThan(
+      0,
+    );
+    // The owner's own row has no actions available, so no menu renders.
+    expect(screen.queryByLabelText('Actions for wade')).not.toBeInTheDocument();
+  });
 });

--- a/app/routes/groups+/$giftGroupId_+/settings.tsx
+++ b/app/routes/groups+/$giftGroupId_+/settings.tsx
@@ -23,6 +23,7 @@ import {
   useExitOnSubmitSuccess,
 } from '#app/components/editable-section.tsx';
 import { ErrorList } from '#app/components/forms.tsx';
+import { MemberActionsMenu } from '#app/components/groups/member-actions-menu.tsx';
 import { RoleBadge } from '#app/components/groups/RoleBadge.tsx';
 import { Avatar } from '#app/components/ui/avatar.tsx';
 import { Button } from '#app/components/ui/button.tsx';
@@ -436,7 +437,6 @@ const GroupSettingsRoute = () => {
     useLoaderData<typeof loader>();
   const actionData = useActionData<typeof action>();
   const fetchers = useFetchers();
-  const memberActionFetcher = useFetcher<typeof action>();
   const settingsAction = `/groups/${giftGroup.id}/settings`;
   const optimisticMembers = React.useMemo(
     () =>
@@ -455,10 +455,6 @@ const GroupSettingsRoute = () => {
     viewerMember?.role ??
     'MEMBER';
   const canTransfer = optimisticViewerRole === 'OWNER';
-  const canPromote = optimisticViewerRole === 'OWNER';
-  const canDemote = optimisticViewerRole === 'OWNER';
-  const canRemove =
-    optimisticViewerRole === 'OWNER' || optimisticViewerRole === 'ADMIN';
   return (
     <div className="space-y-6">
       {/* Your preferences — visible & editable by every member (P7.5) */}
@@ -516,10 +512,7 @@ const GroupSettingsRoute = () => {
               {optimisticMembers.map((m: any) => {
                 const isViewer = m.userId === viewerMember?.userId;
                 return (
-                  <li
-                    key={m.userId}
-                    className="flex flex-wrap items-center gap-3 p-3 sm:flex-nowrap"
-                  >
+                  <li key={m.userId} className="flex items-center gap-3 p-3">
                     <div className="flex min-w-0 flex-1 items-center gap-3">
                       <Avatar size="s" image={m.user.image} user={m.user} />
                       <div className="min-w-0">
@@ -532,63 +525,19 @@ const GroupSettingsRoute = () => {
                         </div>
                       </div>
                     </div>
-                    <div className="flex flex-wrap items-center gap-2">
-                      {/* Promote / Demote (owner only) */}
-                      {canPromote && m.role === 'MEMBER' && !isViewer ? (
-                        <memberActionFetcher.Form
-                          method="post"
-                          action={settingsAction}
-                        >
-                          <input
-                            type="hidden"
-                            name="giftGroupId"
-                            value={giftGroup.id}
-                          />
-                          <input
-                            type="hidden"
-                            name="memberUserId"
-                            value={m.userId}
-                          />
-                          <Button
-                            size="sm"
-                            variant="secondary"
-                            name="intent"
-                            value={SettingsIntent.MemberPromoteAdmin}
-                          >
-                            Promote to Admin
-                          </Button>
-                        </memberActionFetcher.Form>
-                      ) : null}
-                      {canDemote && m.role === 'ADMIN' && !isViewer ? (
-                        <memberActionFetcher.Form
-                          method="post"
-                          action={settingsAction}
-                        >
-                          <input
-                            type="hidden"
-                            name="giftGroupId"
-                            value={giftGroup.id}
-                          />
-                          <input
-                            type="hidden"
-                            name="memberUserId"
-                            value={m.userId}
-                          />
-                          <Button
-                            size="sm"
-                            variant="secondary"
-                            name="intent"
-                            value={SettingsIntent.MemberDemoteMember}
-                          >
-                            Demote to Member
-                          </Button>
-                        </memberActionFetcher.Form>
-                      ) : null}
-
-                      <MemberActions
+                    {/*
+                     * Same three-dot menu the Members tab uses
+                     * (MemberActionsMenu → dropdown on desktop, bottom sheet on
+                     * mobile). It derives the allowed promote/demote/remove
+                     * actions from the viewer's role, so the row no longer packs
+                     * multiple wide buttons that overlapped on small screens.
+                     */}
+                    <div className="flex-none">
+                      <MemberActionsMenu
                         giftGroupId={giftGroup.id}
-                        memberUserId={m.userId}
-                        canRemove={canRemove && !isViewer}
+                        viewerRole={optimisticViewerRole}
+                        member={{ user: m.user, role: m.role }}
+                        isViewer={isViewer}
                       />
                     </div>
                   </li>
@@ -761,35 +710,6 @@ const SettingsCard = ({
         <ErrorList errors={form.errors} id={form.errorId} />
       </fetcher.Form>
     </EditableSection>
-  );
-};
-const MemberActions = ({
-  giftGroupId,
-  memberUserId,
-  canRemove,
-}: {
-  giftGroupId: string;
-  memberUserId: string;
-  canRemove: boolean;
-}) => {
-  const fetcher = useFetcher<typeof action>();
-  const settingsAction = `/groups/${giftGroupId}/settings`;
-  return (
-    <div className="flex items-center gap-2">
-      {canRemove && (
-        <fetcher.Form method="post" action={settingsAction}>
-          <input type="hidden" name="giftGroupId" value={giftGroupId} />
-          <input type="hidden" name="memberUserId" value={memberUserId} />
-          <Button
-            name="intent"
-            value={SettingsIntent.MemberRemove}
-            variant="destructive"
-          >
-            Remove
-          </Button>
-        </fetcher.Form>
-      )}
-    </div>
   );
 };
 const RemindersSection = ({ giftGroup }: { giftGroup: any }) => {

--- a/app/routes/groups+/$giftGroupId_+/settings.tsx
+++ b/app/routes/groups+/$giftGroupId_+/settings.tsx
@@ -493,7 +493,7 @@ const GroupSettingsRoute = () => {
                 Transfer Ownership
               </div>
               <div className="mb-4 text-sm text-muted-foreground">
-                Make another admin the owner of this group
+                Make another member the owner of this group
               </div>
               <TransferOwnershipForm
                 giftGroupId={giftGroup.id}
@@ -932,7 +932,11 @@ const TransferOwnershipForm = ({
   const [form] = useForm({
     id: 'transfer-owner',
   });
-  const admins = members.filter((m) => m.role === 'ADMIN');
+  // Any non-owner member can receive ownership. transferOwnership() on the
+  // server promotes the target (ADMIN *or* MEMBER) straight to OWNER, so
+  // filtering to ADMIN-only here left an empty, dead-end dropdown in groups
+  // that have no admins.
+  const eligible = members.filter((m) => m.role !== 'OWNER');
   return (
     <fetcher.Form
       method="post"
@@ -941,21 +945,29 @@ const TransferOwnershipForm = ({
       className="flex items-center gap-2"
     >
       <input type="hidden" name="giftGroupId" value={giftGroupId} />
-      <Select name="newOwnerUserId">
-        <SelectTrigger>
-          <SelectValue placeholder="Select admin" />
-        </SelectTrigger>
-        <SelectContent>
-          {admins.map((m: any) => (
-            <SelectItem key={m.userId} value={m.userId}>
-              {m.user.username}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-      <Button name="intent" value={SettingsIntent.OwnershipTransfer}>
-        Transfer
-      </Button>
+      {eligible.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          Invite another member to this group before you can transfer ownership.
+        </p>
+      ) : (
+        <>
+          <Select name="newOwnerUserId">
+            <SelectTrigger>
+              <SelectValue placeholder="Select member" />
+            </SelectTrigger>
+            <SelectContent>
+              {eligible.map((m: any) => (
+                <SelectItem key={m.userId} value={m.userId}>
+                  {m.user.username}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Button name="intent" value={SettingsIntent.OwnershipTransfer}>
+            Transfer
+          </Button>
+        </>
+      )}
     </fetcher.Form>
   );
 };


### PR DESCRIPTION
Two group-settings bugs.

## 1. Member Actions rows unusable on mobile

The settings "Member Actions" list rendered Promote / Demote / Remove as separate wide buttons inline in each row. On mobile they wrapped and overlapped the member's name, role badge, and avatar.

**Fix:** reuse `MemberActionsMenu` — the same three-dot menu the group **Members** tab already uses (anchored dropdown on desktop, bottom sheet on mobile, with a confirmation step). It derives the allowed actions from the viewer's role, so this also removes the duplicated `canPromote`/`canDemote`/`canRemove` logic and the local `MemberActions` component.

## 2. Transfer Ownership dropdown is empty

The dropdown filtered members to `role === 'ADMIN'`, so a group with no admins showed an empty, dead-end select on both mobile and desktop.

**Root cause:** the client filter was stricter than the server. `transferOwnership()` accepts any member (ADMIN *or* MEMBER) and promotes them straight to OWNER.

**Fix:** offer every non-owner member as an eligible target, and show a helpful message instead of an empty select when the owner is the only member. Copy updated ("Make another member the owner").

## Commits (atomic)

1. `collapse member-actions row into the shared actions menu`
2. `allow ownership transfer to any non-owner member`

## Verification

`npm run typecheck` (0), `npx prettier --check`, ESLint (clean), and the settings + member-actions-menu unit tests (14 tests) all pass. e2e runs in CI.

https://claude.ai/code/session_012huiwEszwwGn3bzDJzLVoq