### PR TITLE
fix(groups): members page back nav + role-aware rail label

### DIFF
--- a/app/routes/groups+/$giftGroupId_+/_layout.tsx
+++ b/app/routes/groups+/$giftGroupId_+/_layout.tsx
@@ -26,6 +26,10 @@ const GroupLayout = () => {
   // back affordance to the group, and never shows the Overview/Members tab bar.
   const isSettings =
     location.pathname === `/groups/${giftGroup.id}/settings`;
+  // Members is a tab under this same header. Its back should climb to the parent
+  // group, not skip past it to the groups index (which is correct for Overview).
+  const isMembers =
+    location.pathname === `/groups/${giftGroup.id}/members`;
 
   return (
     // min-w-0: this is a grid item in the app shell; without it the default
@@ -47,7 +51,11 @@ const GroupLayout = () => {
       ) : (
         <PageHeader
           variant="detail"
-          back={{ label: 'Groups', href: '/groups' }}
+          back={
+            isMembers
+              ? { label: giftGroup.name, href: `/groups/${giftGroup.id}` }
+              : { label: 'Groups', href: '/groups' }
+          }
           icon={<LuUsers size={24} className="text-primary" />}
           title={giftGroup.name}
           subtitle={`${giftGroup.groupMembers.length} ${giftGroup.groupMembers.length === 1 ? 'member' : 'members'}`}

--- a/app/routes/groups+/$giftGroupId_+/index.tsx
+++ b/app/routes/groups+/$giftGroupId_+/index.tsx
@@ -194,7 +194,7 @@ const MembersRailCard = ({
           to={`/groups/${giftGroupId}/members`}
           className="text-xs text-primary hover:underline"
         >
-          Manage
+          {viewerRole === 'MEMBER' ? 'View all' : 'Manage'}
         </Link>
       }
     />


### PR DESCRIPTION
Two small fixes to the group members surface.

## 1. Back navigation → parent group
The members tab renders inside the shared group layout, whose header back control pointed at `/groups` (the groups index), skipping past the group itself. The back destination is now scoped to the parent group (`/groups/{id}`) for the members path — mirroring the settings sub-page — while Overview keeps its back at the groups index. Since the members page has no header of its own, this fixes both the mobile header back button and the desktop back control; there is no separate breadcrumb.

## 2. Role-aware Members rail label
The desktop group page's Members rail card labeled its link "Manage" for every viewer, but plain MEMBERs can only view profiles there (management actions are already role-gated away). The label now reads **"View all"** for MEMBER and stays **"Manage"** for OWNER/ADMIN, derived from the `viewerRole` prop the card already receives.

## Not changed (verified)
Management affordances on the members page are already gated — `memberMenuActions` returns an empty list for a MEMBER viewer, so `MemberActionsMenu` renders `null` and plain members see no promote/demote/remove controls.

## Verification
- `npm run typecheck` — no errors
- `npm run lint` — only pre-existing warnings (0 errors)

https://claude.ai/code/session_012huiwEszwwGn3bzDJzLVoq