### PR TITLE
fix(pools): guard hard delete against destroying gift memory

### DIFF
--- a/app/routes/pools+/$poolId+/settings.test.tsx
+++ b/app/routes/pools+/$poolId+/settings.test.tsx
@@ -8,7 +8,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const loaderDataSnapshot = {
   inviteUrl: 'https://giftpool.app/pools/join/invite-1' as string | null,
-  isOrganizer: true,
+  // True only for an empty "mistake" pool the organizer may hard-delete;
+  // anything with memory shows Cancel instead. See settings loader.
+  canHardDelete: true,
   pool: {
     id: 'pool-1',
     title: 'Alex Birthday Pool',
@@ -49,7 +51,7 @@ function renderRoute() {
 describe('app/routes/pools+/$poolId+/settings.tsx', () => {
   beforeEach(() => {
     loaderDataSnapshot.pool.status = 'OPEN';
-    loaderDataSnapshot.isOrganizer = true;
+    loaderDataSnapshot.canHardDelete = true;
     loaderDataSnapshot.inviteUrl = 'https://giftpool.app/pools/join/invite-1';
   });
 
@@ -102,8 +104,10 @@ describe('app/routes/pools+/$poolId+/settings.tsx', () => {
     expect(method.disabled).toBe(true);
   });
 
-  it('hides the delete action from non-organizer managers', () => {
-    loaderDataSnapshot.isOrganizer = false;
+  it('hides the delete action when the pool cannot be hard-deleted', () => {
+    // canHardDelete is false for non-organizer managers AND for any pool that
+    // holds memory (gift ideas / other contributors) — both collapse to Cancel.
+    loaderDataSnapshot.canHardDelete = false;
     renderRoute();
     expect(
       screen.queryByRole('button', { name: 'Delete pool' }),

--- a/app/routes/pools+/$poolId+/settings.tsx
+++ b/app/routes/pools+/$poolId+/settings.tsx
@@ -41,6 +41,7 @@ import {
 	isPoolOrganizer,
 	type PoolForPermissions,
 } from '#app/utils/pool-permissions.server.ts';
+import { isPoolEmptyForDeletion } from '#app/utils/pool.server.ts';
 
 // Reuse the shared pool action so cancel/delete/generate-invite/update-details
 // all flow through one place.
@@ -93,10 +94,15 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 		? `${new URL(request.url).origin}/pools/join/${pool.inviteCode}`
 		: null;
 
+	const isOrganizer = isPoolOrganizer(userId, poolForPerms);
+
 	return {
 		pool,
 		inviteUrl,
-		isOrganizer: isPoolOrganizer(userId, poolForPerms),
+		isOrganizer,
+		// Hard delete is only offered for an empty "mistake" pool (no ideas, no
+		// contributors beyond the organizer). Anything with memory shows Cancel.
+		canHardDelete: isOrganizer && (await isPoolEmptyForDeletion(pool.id)),
 	};
 }
 
@@ -119,7 +125,7 @@ function toDateInputValue(value: Date | string | null | undefined) {
 }
 
 const PoolSettings = () => {
-	const { pool, inviteUrl, isOrganizer } = useLoaderData<typeof loader>();
+	const { pool, inviteUrl, canHardDelete } = useLoaderData<typeof loader>();
 	const isClosed =
 		pool.status === POOL_STATUS.DELIVERED ||
 		pool.status === POOL_STATUS.CANCELLED;
@@ -141,7 +147,7 @@ const PoolSettings = () => {
 			{!isClosed && (
 				<DangerZone
 					poolId={pool.id}
-					isOrganizer={isOrganizer}
+					canHardDelete={canHardDelete}
 					canCancel={pool.status !== POOL_STATUS.DELIVERED}
 				/>
 			)}
@@ -382,11 +388,11 @@ const InviteSection = ({
 
 const DangerZone = ({
 	poolId,
-	isOrganizer,
+	canHardDelete,
 	canCancel,
 }: {
 	poolId: string;
-	isOrganizer: boolean;
+	canHardDelete: boolean;
 	canCancel: boolean;
 }) => {
 	const cancelFetcher = useFetcher();
@@ -429,7 +435,7 @@ const DangerZone = ({
 							</Button>
 						</ConfirmDialog>
 					)}
-					{isOrganizer && (
+					{canHardDelete && (
 						<ConfirmDialog
 							title="Delete this pool?"
 							description="This permanently deletes the pool and everything in it."

--- a/app/utils/pool.server.test.ts
+++ b/app/utils/pool.server.test.ts
@@ -542,6 +542,14 @@ describe('pool server utilities', () => {
   });
 
   it('marks purchased, delivered, cancelled, and deleted pools', async () => {
+    // deletePool now guards on an empty "mistake" pool — seed the empty state so
+    // the guard passes and the hard delete proceeds.
+    poolFindUnique.mockResolvedValue({
+      organizerId: 'user-1',
+      _count: { ideas: 0 },
+      contributors: [{ userId: 'user-1' }],
+    });
+
     await markPurchased('pool-1', 'user-1');
     await markDelivered('pool-1', 'user-1');
     await cancelPool('pool-1', 'user-1');
@@ -572,6 +580,63 @@ describe('pool server utilities', () => {
     expect(logPoolActivity).toHaveBeenNthCalledWith(4, 'pool-1', 'pool.deleted', {
       actorId: 'user-1',
     });
+  });
+
+  it('deletePool rejects a pool that has gift ideas', async () => {
+    poolFindUnique.mockResolvedValue({
+      organizerId: 'user-1',
+      _count: { ideas: 1 },
+      contributors: [{ userId: 'user-1' }],
+    });
+
+    await expect(deletePool('pool-1', 'user-1')).rejects.toMatchObject({
+      init: { status: 409 },
+    });
+    expect(poolDelete).not.toHaveBeenCalled();
+    expect(logPoolActivity).not.toHaveBeenCalled();
+  });
+
+  it('deletePool rejects a pool with contributors beyond the organizer', async () => {
+    poolFindUnique.mockResolvedValue({
+      organizerId: 'user-1',
+      _count: { ideas: 0 },
+      contributors: [{ userId: 'user-1' }, { userId: 'user-2' }],
+    });
+
+    await expect(deletePool('pool-1', 'user-1')).rejects.toMatchObject({
+      init: { status: 409 },
+    });
+    expect(poolDelete).not.toHaveBeenCalled();
+    expect(logPoolActivity).not.toHaveBeenCalled();
+  });
+
+  it('deletePool hard-deletes an empty "mistake" pool', async () => {
+    poolFindUnique.mockResolvedValue({
+      organizerId: 'user-1',
+      _count: { ideas: 0 },
+      contributors: [{ userId: 'user-1' }],
+    });
+
+    await deletePool('pool-1', 'user-1');
+
+    expect(poolDelete).toHaveBeenCalledWith({ where: { id: 'pool-1' } });
+    expect(logPoolActivity).toHaveBeenCalledWith('pool-1', 'pool.deleted', {
+      actorId: 'user-1',
+    });
+  });
+
+  it('cancelPool preserves gift ideas (no destructive delete)', async () => {
+    // Cancellation only flips status — GiftIdea rows are preserved for future
+    // queries (distinct from display: the person surface reads only completed
+    // pools, so a cancelled pool's ideas are preserved, not shown).
+    await cancelPool('pool-1', 'user-1');
+
+    expect(poolUpdate).toHaveBeenCalledWith({
+      data: { status: 'CANCELLED' },
+      where: { id: 'pool-1' },
+    });
+    expect(poolDelete).not.toHaveBeenCalled();
+    expect(giftIdeaDelete).not.toHaveBeenCalled();
   });
 
   it('getContributionBreakdown returns null without a confirmed final price', async () => {

--- a/app/utils/pool.server.test.ts
+++ b/app/utils/pool.server.test.ts
@@ -625,6 +625,15 @@ describe('pool server utilities', () => {
     });
   });
 
+  it('deletePool rejects when the pool no longer exists', async () => {
+    poolFindUnique.mockResolvedValue(null);
+
+    await expect(deletePool('pool-1', 'user-1')).rejects.toMatchObject({
+      init: { status: 409 },
+    });
+    expect(poolDelete).not.toHaveBeenCalled();
+  });
+
   it('cancelPool preserves gift ideas (no destructive delete)', async () => {
     // Cancellation only flips status — GiftIdea rows are preserved for future
     // queries (distinct from display: the person surface reads only completed

--- a/app/utils/pool.server.ts
+++ b/app/utils/pool.server.ts
@@ -623,7 +623,39 @@ export async function cancelPool(poolId: string, actorId: string) {
 	})
 }
 
+// Returns whether the pool is an empty "mistake" (safe to hard-delete):
+// no gift ideas and no contributors beyond the organizer. The organizer is
+// always seeded as a contributor at creation, so we exclude them from the count.
+export async function isPoolEmptyForDeletion(poolId: string): Promise<boolean> {
+	const pool = await prisma.pool.findUnique({
+		where: { id: poolId },
+		select: {
+			organizerId: true,
+			_count: { select: { ideas: true } },
+			contributors: { select: { userId: true } },
+		},
+	})
+	if (!pool) return false
+	const otherContributors = pool.contributors.filter(
+		c => c.userId !== pool.organizerId,
+	).length
+	return pool._count.ideas === 0 && otherContributors === 0
+}
+
 export async function deletePool(poolId: string, actorId: string) {
+	// Hard delete is allowed only for a pool that is genuinely a mistake — no
+	// gift ideas and no contributors beyond the organizer. Anything with memory
+	// must be cancelled instead, so its GiftIdea/contributor rows survive for the
+	// recipient's gift history. Enforced here (throw), not just hidden in the UI.
+	if (!(await isPoolEmptyForDeletion(poolId))) {
+		throw data(
+			{
+				error:
+					'This pool has gift ideas or other contributors. Cancel it instead of deleting.',
+			},
+			{ status: 409 },
+		)
+	}
 	await logPoolActivity(poolId, POOL_ACTIVITY_TYPE.POOL_DELETED, { actorId })
 	await prisma.pool.delete({ where: { id: poolId } })
 }


### PR DESCRIPTION
## Context

`deletePool` (`app/utils/pool.server.ts`) hard-deleted a pool with `prisma.pool.delete`, which cascades away `GiftIdea` (`onDelete: Cascade`), `PoolContributor`, and `IdeaVote`. The person surface (`loadPersonIdeation`) now reads those rows as a recipient's **gift history** ("What this circle gave before") and **proposed-but-unused ideas** ("We almost got them…"). A hard delete therefore silently destroyed real memory.

`cancelPool` already exists and is non-destructive — it only sets `status: CANCELLED`, leaving those rows intact.

**New rule:** hard delete is allowed ONLY for a pool that is genuinely a *mistake* — no gift ideas and no contributors beyond the organizer. Everything else must be cancelled. Enforced server-side (throw, not just hidden in the UI).

Note: the organizer is always seeded as a contributor at creation, so "empty" means 0 gift ideas AND 0 contributors other than the organizer. Group-created pools auto-add member contributors and are thus never hard-deletable.

## Changes

- **`isPoolEmptyForDeletion(poolId)`** helper — 0 ideas AND 0 contributors beyond the organizer.
- **`deletePool`** throws `data(..., { status: 409 })` when the pool isn't empty, before the destructive delete.
- **Pool settings Danger zone** — the loader computes `canHardDelete = isOrganizer && isPoolEmptyForDeletion(...)`; the **Delete pool** button is gated on it. Pools with memory show only **Cancel pool**. The `Intent.DeletePool` action keeps organizer-only auth and now propagates the 409 for direct/forged requests.
- **Tests** — delete rejected for a pool with ideas; rejected with an extra contributor; empty-pool delete still works; cancel preserves gift-idea rows (no destructive delete). Existing combined happy-path test seeded to pass the guard.

## Finding to flag (confirmed, not fixed here)

`PoolActivity` has `onDelete: Cascade` (`prisma/schema.prisma:446`). `deletePool` logs `POOL_DELETED` immediately **before** `prisma.pool.delete`, so that activity row is cascaded away by the same delete — the "pool deleted" log erases itself and never survives. Pre-existing and out of scope here (only affects genuinely-empty mistake pools now). Follow-up should either drop the self-defeating log or record it on a non-cascading audit surface.

## Verification

- `npm test -- --run pool.server.test.ts` → 35 passed
- `npm run typecheck` → clean
- ESLint on changed files → 0 errors

https://claude.ai/code/session_012huiwEszwwGn3bzDJzLVoq