### PR TITLE
chore: untrack Claude Code scheduled_tasks.lock

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"3e82b2fd-003f-45ff-a624-25a1e055d5fd","pid":95067,"acquiredAt":1775865903301}

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ storybook-static
 *.har
 *profile.json.gz
 *profile.json
+
+# Claude Code runtime state (machine-local, never commit)
+.claude/scheduled_tasks.lock


### PR DESCRIPTION
## What

Untracks `.claude/scheduled_tasks.lock` and adds a `.gitignore` rule for it.

## Why

The file is Claude Code runtime lock state — a `sessionId`/`pid`/`timestamp` blob that every session rewrites:

```json
{"sessionId":"…","pid":95067,"acquiredAt":1775865903301}
```

It was committed by accident in `5b0f434` (its only history is that single commit) and is meaningless outside the machine/session that wrote it — like a PID file. Because it wasn't ignored, it kept showing up as modified in `git status` on every session.

## Changes

- `git rm --cached .claude/scheduled_tasks.lock`
- Add `.claude/scheduled_tasks.lock` to `.gitignore`

Leaves the other tracked `.claude/` files (`profile-revamp-plan.md`, `skills/ci-green/SKILL.md`) untouched — those are intentional.