### PR TITLE
docs: workflow conventions + /ship skill

### DIFF
--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: ship
+description: Ship the current changes end-to-end — dedicated branch, atomic commits, PR against main, and CI monitored to green. Use when the user wants a change landed cleanly through the full PR workflow.
+---
+
+# ship
+
+Create a dedicated branch (never commit to main). Make atomic commits. Open a PR against main. Monitor CI: fix coverage gaps, Playwright flakes, and Sonar findings. Report status when all checks are green; do not merge without confirmation.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Gift Pool is a full-stack web application for managing wishlists and coordinating gifts within groups. Built with React Router v7, React, TypeScript, Prisma (SQLite), and Tailwind CSS. Deployed on Fly.io with LiteFS for distributed SQLite.
 
+## Git Workflow
+
+Always ship changes via a dedicated PR branch — never commit directly to main. Follow the atomic-commit PR workflow and monitor CI to green before considering work done.
+
 ## Commands
 
 ### Development
@@ -229,3 +233,11 @@ Optional:
 - `SENTRY_DSN` - Error tracking
 
 See `app/utils/env.server.ts` for full list.
+
+## Mobile UI Conventions
+
+On mobile surfaces, use bottom-sheet patterns (not centered modals), and ensure every interactive control provides visible feedback or redirect after action. See the "Modals are sheets on mobile — HARD RULE" convention above for the `ResponsiveDialog` mechanics.
+
+## Debugging & Testing
+
+When a test or CI check fails, run the specific test type the user requested (jest/unit vs. e2e). If a fix isn't working after two attempts, stop and step back to re-diagnose the root cause rather than iterating on throwaway diagnostics.


### PR DESCRIPTION
Codifies recurring workflow expectations surfaced by the `/insights` usage report.

## Changes

- **`CLAUDE.md`** — three new convention sections:
  - **Git Workflow**: always ship via a dedicated PR branch, never commit to main; atomic commits, CI to green before done.
  - **Mobile UI Conventions**: bottom sheets not centered modals; every interactive control gives visible feedback/redirect (cross-refs the existing `ResponsiveDialog` hard rule).
  - **Debugging & Testing**: run the specific test type requested (unit vs e2e); step back and re-diagnose after two failed fix attempts instead of iterating on throwaway diagnostics.
- **`.claude/skills/ship/SKILL.md`** — new `/ship` skill encoding the branch → atomic commits → PR → CI-green loop.

Docs/tooling only — no runtime code touched.