### PR TITLE
test(person-surface): cover action-flow wiring + resurrect privacy test

### DIFF
--- a/app/components/users/person-surface.test.tsx
+++ b/app/components/users/person-surface.test.tsx
@@ -1,0 +1,249 @@
+/** @vitest-environment jsdom */
+/**
+ * Form-emission regression net for the person surface — the direct guard for
+ * the "button rendered but did nothing" class of bug. Each action's form must
+ * actually SUBMIT its intent and required fields.
+ *
+ * We render the real (exported) PersonSurface and mock react-router's `Form`
+ * (and `useFetcher().Form`) to a plain <form> that captures the submitted
+ * FormData on submit — no network, no data router. A form whose button emits
+ * the wrong intent, or drops a required field, fails here. ResponsiveDialog is
+ * mocked to pass-through elements so dialog-wrapped forms render inline.
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { MemoryRouter } from 'react-router';
+import type * as ReactRouter from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  PersonSurface,
+  type PersonSurfaceViewData,
+} from './person-surface.tsx';
+
+// Shared capture slot — the mocked <form> writes the submitted FormData here.
+const captured = vi.hoisted(() => ({ formData: undefined as FormData | undefined }));
+
+vi.mock('react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof ReactRouter>();
+  const react = await import('react');
+  const Form = ({
+    children,
+    className,
+  }: {
+    children?: React.ReactNode;
+    className?: string;
+    method?: string;
+  }) =>
+    react.createElement(
+      'form',
+      {
+        className,
+        onSubmit: (e: React.FormEvent<HTMLFormElement>) => {
+          e.preventDefault();
+          captured.formData = new FormData(e.currentTarget);
+        },
+      },
+      children,
+    );
+  return {
+    ...actual,
+    Form,
+    useFetcher: () => ({
+      Form,
+      submit: () => {},
+      state: 'idle' as const,
+      data: undefined,
+    }),
+  };
+});
+
+vi.mock('#app/components/ui/responsive-dialog.tsx', () => {
+  const Pass = ({ children }: { children?: React.ReactNode }) => <>{children}</>;
+  return {
+    ResponsiveDialog: Pass,
+    ResponsiveDialogContent: ({ children }: { children?: React.ReactNode }) => (
+      <div>{children}</div>
+    ),
+    ResponsiveDialogHeader: Pass,
+    ResponsiveDialogFooter: Pass,
+    ResponsiveDialogTitle: ({ children }: { children?: React.ReactNode }) => (
+      <h2>{children}</h2>
+    ),
+    ResponsiveDialogDescription: ({
+      children,
+    }: {
+      children?: React.ReactNode;
+    }) => <p>{children}</p>,
+    ResponsiveDialogTrigger: Pass,
+    ResponsiveDialogClose: Pass,
+  };
+});
+
+const emptyIdeation: PersonSurfaceViewData['ideation'] = {
+  giftHistory: [],
+  proposedUnused: [],
+  notes: [],
+  savedIdeas: [],
+};
+
+function baseData(
+  overrides: Partial<PersonSurfaceViewData> = {},
+): PersonSurfaceViewData {
+  return {
+    user: {
+      id: 'target-1',
+      username: 'casey',
+      name: 'Casey Jones',
+      bio: null,
+      birthday: null,
+      image: null,
+    },
+    userJoinedDisplay: 'Jan 2024',
+    relationship: {
+      state: 'FRIENDS',
+      friendshipId: 'f1',
+      incomingRequestId: null,
+      outgoingRequestId: null,
+    },
+    isFriend: true,
+    birthdayVisible: true,
+    canViewWishlist: true,
+    mutualGroups: [],
+    mutualFriends: [],
+    // occasion-near renders the ActionRow (Save idea / Just me / Not this time)
+    // and the OccasionHeader (no FriendActionButton to stub out).
+    temporalState: 'occasion-near',
+    occasion: { label: 'Tomorrow', daysUntil: 1 },
+    declined: false,
+    organizeGroups: [],
+    budgetLine: null,
+    wishlistSource: [],
+    ideation: emptyIdeation,
+    openPools: [],
+    postOccasion: null,
+    ...overrides,
+  };
+}
+
+function renderSurface(data: PersonSurfaceViewData) {
+  render(
+    <MemoryRouter initialEntries={['/users/casey']}>
+      <PersonSurface {...data} />
+    </MemoryRouter>,
+  );
+}
+
+function submitButton(name: RegExp | string) {
+  const submit = screen
+    .getAllByRole('button', { name })
+    .find((b) => (b as HTMLButtonElement).type === 'submit');
+  if (!submit) throw new Error(`No submit button matching ${name}`);
+  return submit;
+}
+
+describe('PersonSurface form emission', () => {
+  beforeEach(() => {
+    captured.formData = undefined;
+  });
+
+  it('propose from a saved idea emits propose-to-pool with giftListItemId', async () => {
+    const user = userEvent.setup();
+    renderSurface(
+      baseData({
+        ideation: {
+          ...emptyIdeation,
+          savedIdeas: [
+            {
+              id: 'gli1',
+              name: 'Ceramics class',
+              url: null,
+              priceCents: null,
+              currency: null,
+            },
+          ],
+        },
+        openPools: [{ id: 'p1', title: 'Pool' }],
+      }),
+    );
+
+    await user.click(screen.getByRole('button', { name: /propose to pool/i }));
+
+    const fd = captured.formData!;
+    expect(fd).toBeDefined();
+    expect(fd.get('intent')).toBe('propose-to-pool');
+    expect(fd.get('poolId')).toBe('p1');
+    expect(fd.get('name')).toBe('Ceramics class');
+    expect(fd.get('giftListItemId')).toBe('gli1');
+    expect(fd.get('wishlistItemId')).toBeNull();
+  });
+
+  it('propose from a wishlist item emits propose-to-pool with wishlistItemId', async () => {
+    const user = userEvent.setup();
+    renderSurface(
+      baseData({
+        wishlistSource: [
+          {
+            id: 'w1',
+            title: 'Immersion blender',
+            url: null,
+            priceCents: null,
+            currency: null,
+            claimed: false,
+            claimedByViewer: false,
+          },
+        ],
+        openPools: [{ id: 'p1', title: 'Pool' }],
+      }),
+    );
+
+    await user.click(screen.getByRole('button', { name: /propose to pool/i }));
+
+    const fd = captured.formData!;
+    expect(fd).toBeDefined();
+    expect(fd.get('intent')).toBe('propose-to-pool');
+    expect(fd.get('poolId')).toBe('p1');
+    expect(fd.get('name')).toBe('Immersion blender');
+    expect(fd.get('wishlistItemId')).toBe('w1');
+    expect(fd.get('giftListItemId')).toBeNull();
+  });
+
+  it('save-idea emits its intent and name', async () => {
+    const user = userEvent.setup();
+    renderSurface(baseData());
+
+    await user.type(screen.getByLabelText('Idea'), 'Handmade journal');
+    await user.click(submitButton('Save idea'));
+
+    const fd = captured.formData!;
+    expect(fd).toBeDefined();
+    expect(fd.get('intent')).toBe('save-idea');
+    expect(fd.get('name')).toBe('Handmade journal');
+  });
+
+  it('decline-occasion emits its intent', async () => {
+    const user = userEvent.setup();
+    renderSurface(baseData());
+
+    await user.click(screen.getByRole('button', { name: 'Not this time' }));
+
+    expect(captured.formData).toBeDefined();
+    expect(captured.formData!.get('intent')).toBe('decline-occasion');
+  });
+
+  it('solo-commit emits its intent and required name', async () => {
+    const user = userEvent.setup();
+    renderSurface(baseData());
+
+    await user.type(
+      screen.getByLabelText('What are you getting them?'),
+      'Handmade mug',
+    );
+    await user.click(submitButton("I've got this"));
+
+    const fd = captured.formData!;
+    expect(fd).toBeDefined();
+    expect(fd.get('intent')).toBe('solo-commit');
+    expect(fd.get('name')).toBe('Handmade mug');
+  });
+});

--- a/app/components/users/person-surface.test.tsx
+++ b/app/components/users/person-surface.test.tsx
@@ -210,7 +210,13 @@ describe('PersonSurface form emission', () => {
 
   it('save-idea emits its intent and name', async () => {
     const user = userEvent.setup();
-    renderSurface(baseData());
+    // A note gives the surface memory, suppressing DayOneCapture — otherwise it
+    // renders a second SaveIdeaDialog and the "Idea" control is ambiguous.
+    renderSurface(
+      baseData({
+        ideation: { ...emptyIdeation, notes: [{ id: 'n1', body: 'Likes tea' }] },
+      }),
+    );
 
     await user.type(screen.getByLabelText('Idea'), 'Handmade journal');
     await user.click(submitButton('Save idea'));

--- a/tests/e2e/person-surface.test.ts
+++ b/tests/e2e/person-surface.test.ts
@@ -1,0 +1,617 @@
+/**
+ * Person-surface action-flow coverage.
+ *
+ * The person surface (`/users/:username`) had 1174 unit tests covering server
+ * actions and loaders, yet shipped a bug where "Propose to pool" rendered but
+ * did nothing — the click-to-action wiring was never exercised. These tests
+ * drive the real buttons and assert each one *visibly does something*
+ * (navigation or a rendered/persisted result), never merely "no error".
+ *
+ * Levers the surface exposes (see app/routes/users+/$username_+/index.tsx):
+ *  - unlock: FRIENDS or ≥1 shared active group (removedAt: null on both).
+ *  - occasion-near (ActionRow: Organize / Just me / Save idea / Not this time):
+ *    birthday visible AND 0 ≤ daysUntil ≤ 60.
+ *  - post-occasion (PostOccasionFlow): birthday within 14 days past AND an
+ *    unconfirmed solo intent (pool-of-one, outcomeFeedback: null).
+ *  - IdeationBlock (wishlist source + saved ideas, each carrying ProposeControl)
+ *    renders in every state except post-occasion.
+ */
+
+import { type Page } from '@playwright/test';
+import { prisma } from '#app/utils/db.server.ts';
+import { createPool } from '#app/utils/pool.server.ts';
+import { createPassword, createUser } from '#tests/db-utils.ts';
+import { expect, loginWithPassword, test, waitFor } from '#tests/playwright-utils.ts';
+
+type SeededUser = {
+  id: string;
+  username: string;
+  name: string;
+  email: string;
+  password: string;
+};
+
+/** Create a user with a known password (password === username). */
+async function seedUser(overrides?: { birthday?: Date }): Promise<SeededUser> {
+  const userData = createUser();
+  const user = await prisma.user.create({
+    select: { id: true, username: true, name: true, email: true },
+    data: {
+      ...userData,
+      birthday: overrides?.birthday,
+      roles: { connect: { name: 'user' } },
+      password: { create: createPassword(userData.username) },
+    },
+  });
+  return { ...user, name: user.name ?? userData.name, password: userData.username };
+}
+
+/** viewer ↔ target friendship (canonical sorted pair for the @@unique). */
+async function makeFriendship(aId: string, bId: string) {
+  const pair =
+    aId < bId ? { userAId: aId, userBId: bId } : { userAId: bId, userBId: aId };
+  await prisma.friendship.create({ data: pair });
+}
+
+/** An active group whose members are all the given user ids (first is OWNER). */
+async function makeGroup(name: string, memberIds: string[]): Promise<string> {
+  const group = await prisma.giftGroup.create({
+    select: { id: true },
+    data: {
+      name,
+      groupMembers: {
+        create: memberIds.map((userId, i) => ({
+          userId,
+          role: i === 0 ? 'OWNER' : 'MEMBER',
+        })),
+      },
+    },
+  });
+  return group.id;
+}
+
+/** A birthday `days` in the future (negative = past), à la user-profile.test.ts. */
+function birthdayOffset(days: number): Date {
+  const d = new Date();
+  d.setDate(d.getDate() + days);
+  return d;
+}
+
+/**
+ * Remove everything the seeded users own, in FK-safe order. The e2e DB is
+ * shared and never reset between tests, so each test cleans up exactly what it
+ * created.
+ */
+async function cleanup(userIds: string[]) {
+  const inUsers = { in: userIds };
+  // Pools (cascade ideas / contributors / votes) referencing these users.
+  await prisma.pool.deleteMany({
+    where: { OR: [{ organizerId: inUsers }, { recipientUserId: inUsers }] },
+  });
+  await prisma.giftListItem.deleteMany({
+    where: { OR: [{ ownerId: inUsers }, { targetUserId: inUsers }] },
+  });
+  await prisma.wishlistItem.deleteMany({ where: { ownerId: inUsers } });
+  await prisma.occasionDecline.deleteMany({
+    where: { OR: [{ userId: inUsers }, { targetUserId: inUsers }] },
+  });
+  await prisma.friendship.deleteMany({
+    where: { OR: [{ userAId: inUsers }, { userBId: inUsers }] },
+  });
+  await prisma.giftGroup.deleteMany({
+    where: { groupMembers: { some: { userId: inUsers } } },
+  });
+  await prisma.user.deleteMany({ where: { id: inUsers } });
+}
+
+/**
+ * Log in, clearing any prior session first. A persisted cookie makes /login
+ * redirect straight past the form, so user-switches within a test need a clean
+ * slate before loginWithPassword.
+ */
+async function login(page: Page, user: { username: string; password: string }) {
+  await page.context().clearCookies();
+  await loginWithPassword(page, {
+    username: user.username,
+    password: user.password,
+  });
+}
+
+// ─── 1. Organize routing ─────────────────────────────────────────────────────
+
+test.describe('Organize routing', () => {
+  test('exactly 1 shared group → prefilled group creation', async ({ page }) => {
+    const viewer = await seedUser();
+    const target = await seedUser({ birthday: birthdayOffset(30) });
+    const groupId = await makeGroup('Weekend Crew', [viewer.id, target.id]);
+    try {
+      await login(page, viewer);
+      await page.goto(`/users/${target.username}`);
+
+      // No picker for a single group — the button names the circle directly.
+      await page
+        .getByRole('button', { name: 'Organize with Weekend Crew' })
+        .click();
+
+      await expect(page).toHaveURL(/\/pools\/new/);
+      const url = new URL(page.url());
+      expect(url.searchParams.get('groupId')).toBe(groupId);
+      expect(url.searchParams.get('recipientId')).toBe(target.id);
+      // The group-context creation page renders with group + recipient prefilled.
+      // ("Weekend Crew" appears in both the back-link and this card, so anchor
+      // on the card's unambiguous sentence.)
+      await expect(page.getByText(/Creating a pool in/)).toBeVisible();
+      await expect(page.getByText(target.name)).toBeVisible();
+    } finally {
+      await cleanup([viewer.id, target.id]);
+    }
+  });
+
+  test('2+ shared groups → picker (never a default), then prefilled creation', async ({
+    page,
+  }) => {
+    const viewer = await seedUser();
+    const target = await seedUser({ birthday: birthdayOffset(30) });
+    const groupA = await makeGroup('Book Club', [viewer.id, target.id]);
+    await makeGroup('Hiking Buddies', [viewer.id, target.id]);
+    try {
+      await login(page, viewer);
+      await page.goto(`/users/${target.username}`);
+
+      // Generic label — clicking must NOT auto-navigate; it opens a chooser.
+      await page.getByRole('button', { name: 'Organize a gift' }).click();
+      await expect(
+        page.getByRole('heading', { name: 'Organize with which circle?' }),
+      ).toBeVisible();
+      await expect(page).toHaveURL(new RegExp(`/users/${target.username}`));
+
+      await page.getByRole('button', { name: /Book Club/ }).click();
+
+      await expect(page).toHaveURL(/\/pools\/new/);
+      const url = new URL(page.url());
+      expect(url.searchParams.get('groupId')).toBe(groupA);
+      expect(url.searchParams.get('recipientId')).toBe(target.id);
+      await expect(page.getByText(/Creating a pool in/)).toBeVisible();
+    } finally {
+      await cleanup([viewer.id, target.id]);
+    }
+  });
+
+  test('friend with no shared group → standalone creation (recipientId, no group)', async ({
+    page,
+  }) => {
+    const viewer = await seedUser();
+    const target = await seedUser({ birthday: birthdayOffset(30) });
+    await makeFriendship(viewer.id, target.id);
+    try {
+      await login(page, viewer);
+      await page.goto(`/users/${target.username}`);
+
+      await page.getByRole('button', { name: 'Organize a gift' }).click();
+
+      await expect(page).toHaveURL(/\/pools\/new/);
+      const url = new URL(page.url());
+      expect(url.searchParams.get('recipientId')).toBe(target.id);
+      expect(url.searchParams.get('groupId')).toBeNull();
+      // Standalone flow: recipient preselected, share-link copy reachable.
+      await expect(page.getByText('Who is this for?')).toBeVisible();
+      await expect(page.getByText(target.name)).toBeVisible();
+      await expect(
+        page.getByText(/They'll never see this pool/i),
+      ).toBeVisible();
+    } finally {
+      await cleanup([viewer.id, target.id]);
+    }
+  });
+
+  test('neither friend nor shared group never reaches the surface (gate stub)', async ({
+    page,
+  }) => {
+    const viewer = await seedUser();
+    const target = await seedUser({ birthday: birthdayOffset(30) });
+    try {
+      await login(page, viewer);
+      await page.goto(`/users/${target.username}`);
+
+      // FriendGateCard, not the person surface.
+      await expect(
+        page.getByRole('heading', {
+          name: new RegExp(`See ${target.name}'s profile`, 'i'),
+        }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole('button', { name: /Organize/ }),
+      ).toHaveCount(0);
+    } finally {
+      await cleanup([viewer.id, target.id]);
+    }
+  });
+});
+
+// ─── 2. Propose-to-pool resolver ─────────────────────────────────────────────
+
+test.describe('Propose-to-pool resolver', () => {
+  test('0 open pools, from a saved idea → routes into Organize carrying the idea', async ({
+    page,
+  }) => {
+    const viewer = await seedUser();
+    const target = await seedUser();
+    await makeFriendship(viewer.id, target.id);
+    await prisma.giftListItem.create({
+      data: { ownerId: viewer.id, targetUserId: target.id, name: 'Ceramics class' },
+    });
+    try {
+      await login(page, viewer);
+      await page.goto(`/users/${target.username}`);
+
+      await expect(
+        page.getByText('Your saved ideas · private'),
+      ).toBeVisible();
+      await page.getByRole('button', { name: 'Propose to pool' }).click();
+
+      await expect(page).toHaveURL(/\/pools\/new/);
+      const url = new URL(page.url());
+      expect(url.searchParams.get('recipientId')).toBe(target.id);
+      expect(url.searchParams.get('title')).toBe('Ceramics class');
+      // The idea name arrives prefilled in the pool title field.
+      await expect(page.getByLabel('Pool title')).toHaveValue('Ceramics class');
+    } finally {
+      await cleanup([viewer.id, target.id]);
+    }
+  });
+
+  test('0 open pools, from a wishlist item → routes into Organize carrying the idea', async ({
+    page,
+  }) => {
+    const viewer = await seedUser();
+    const target = await seedUser();
+    await makeFriendship(viewer.id, target.id);
+    await prisma.wishlistItem.create({
+      data: {
+        ownerId: target.id,
+        title: 'Cast iron skillet',
+        type: 'ITEM',
+        status: 'ACTIVE',
+        sortOrder: 0,
+      },
+    });
+    try {
+      await login(page, viewer);
+      await page.goto(`/users/${target.username}`);
+
+      await expect(page.getByText('Cast iron skillet')).toBeVisible();
+      await page.getByRole('button', { name: 'Propose to pool' }).click();
+
+      await expect(page).toHaveURL(/\/pools\/new/);
+      const url = new URL(page.url());
+      expect(url.searchParams.get('recipientId')).toBe(target.id);
+      expect(url.searchParams.get('title')).toBe('Cast iron skillet');
+      await expect(page.getByLabel('Pool title')).toHaveValue('Cast iron skillet');
+    } finally {
+      await cleanup([viewer.id, target.id]);
+    }
+  });
+
+  test('exactly 1 open pool, from a saved idea → proposes directly + links giftListItemId', async ({
+    page,
+  }) => {
+    const viewer = await seedUser();
+    const target = await seedUser();
+    await makeFriendship(viewer.id, target.id);
+    const savedIdea = await prisma.giftListItem.create({
+      select: { id: true },
+      data: { ownerId: viewer.id, targetUserId: target.id, name: 'Trail shoes' },
+    });
+    const pool = await createPool({
+      title: 'Open Pool',
+      organizerId: viewer.id,
+      recipientUserId: target.id,
+    });
+    try {
+      await login(page, viewer);
+      await page.goto(`/users/${target.username}`);
+
+      await page.getByRole('button', { name: 'Propose to pool' }).click();
+
+      // Lands the viewer in the pool (a bare reply reads as "nothing happened").
+      await expect(page).toHaveURL(new RegExp(`/pools/${pool.id}`));
+
+      const idea = await waitFor(async () => {
+        const row = await prisma.giftIdea.findFirst({
+          where: { poolId: pool.id, name: 'Trail shoes' },
+          select: { id: true, giftListItemId: true },
+        });
+        expect(row).not.toBeNull();
+        return row;
+      });
+      // Promoting a saved idea LINKS it, not copies it.
+      expect(idea?.giftListItemId).toBe(savedIdea.id);
+    } finally {
+      await cleanup([viewer.id, target.id]);
+    }
+  });
+
+  test('exactly 1 open pool, from a wishlist item → proposes directly + links wishlistItemId', async ({
+    page,
+  }) => {
+    const viewer = await seedUser();
+    const target = await seedUser();
+    await makeFriendship(viewer.id, target.id);
+    const item = await prisma.wishlistItem.create({
+      select: { id: true },
+      data: {
+        ownerId: target.id,
+        title: 'Immersion blender',
+        type: 'ITEM',
+        status: 'ACTIVE',
+        sortOrder: 0,
+      },
+    });
+    const pool = await createPool({
+      title: 'Open Pool',
+      organizerId: viewer.id,
+      recipientUserId: target.id,
+    });
+    try {
+      await login(page, viewer);
+      await page.goto(`/users/${target.username}`);
+
+      await page.getByRole('button', { name: 'Propose to pool' }).click();
+
+      await expect(page).toHaveURL(new RegExp(`/pools/${pool.id}`));
+
+      const idea = await waitFor(async () => {
+        const row = await prisma.giftIdea.findFirst({
+          where: { poolId: pool.id, name: 'Immersion blender' },
+          select: { id: true, wishlistItemId: true },
+        });
+        expect(row).not.toBeNull();
+        return row;
+      });
+      expect(idea?.wishlistItemId).toBe(item.id);
+    } finally {
+      await cleanup([viewer.id, target.id]);
+    }
+  });
+
+  test('2+ open pools → picker, and the chosen pool receives the idea', async ({
+    page,
+  }) => {
+    const viewer = await seedUser();
+    const target = await seedUser();
+    await makeFriendship(viewer.id, target.id);
+    await prisma.giftListItem.create({
+      data: { ownerId: viewer.id, targetUserId: target.id, name: 'Camera strap' },
+    });
+    await createPool({
+      title: 'Pool One',
+      organizerId: viewer.id,
+      recipientUserId: target.id,
+    });
+    const poolTwo = await createPool({
+      title: 'Pool Two',
+      organizerId: viewer.id,
+      recipientUserId: target.id,
+    });
+    try {
+      await login(page, viewer);
+      await page.goto(`/users/${target.username}`);
+
+      await page.getByRole('button', { name: 'Propose to pool' }).click();
+      await expect(
+        page.getByRole('heading', { name: 'Propose to which pool?' }),
+      ).toBeVisible();
+      await page.getByRole('button', { name: 'Pool Two' }).click();
+
+      await expect(page).toHaveURL(new RegExp(`/pools/${poolTwo.id}`));
+      await waitFor(async () => {
+        const row = await prisma.giftIdea.findFirst({
+          where: { poolId: poolTwo.id, name: 'Camera strap' },
+          select: { id: true },
+        });
+        expect(row).not.toBeNull();
+        return row;
+      });
+    } finally {
+      await cleanup([viewer.id, target.id]);
+    }
+  });
+});
+
+// ─── 3. Action row flows ─────────────────────────────────────────────────────
+
+test.describe('Action row', () => {
+  test('Save idea → appears under "Your saved ideas · private", private to owner', async ({
+    page,
+  }) => {
+    const viewer = await seedUser();
+    const target = await seedUser({ birthday: birthdayOffset(30) });
+    const third = await seedUser();
+    await makeFriendship(viewer.id, target.id);
+    await makeFriendship(third.id, target.id);
+    try {
+      await login(page, viewer);
+      await page.goto(`/users/${target.username}`);
+
+      await page.getByRole('button', { name: 'Save idea' }).click();
+      const saveDialog = page.getByRole('dialog');
+      await saveDialog.getByLabel('Idea').fill('Handmade journal');
+      await saveDialog.getByRole('button', { name: 'Save idea' }).click();
+
+      // Visible to the author on reload, under the private section.
+      await waitFor(async () => {
+        const row = await prisma.giftListItem.findFirst({
+          where: { ownerId: viewer.id, targetUserId: target.id, name: 'Handmade journal' },
+          select: { id: true },
+        });
+        expect(row).not.toBeNull();
+        return row;
+      });
+      await page.goto(`/users/${target.username}`);
+      await expect(page.getByText('Your saved ideas · private')).toBeVisible();
+      await expect(page.getByText('Handmade journal')).toBeVisible();
+
+      // NOT visible to a third viewer looking at the same target.
+      await login(page, third);
+      await page.goto(`/users/${target.username}`);
+      await expect(page.getByText('Handmade journal')).toHaveCount(0);
+
+      // NOT visible to the target viewing the author's profile.
+      await login(page, target);
+      await page.goto(`/users/${viewer.username}`);
+      await expect(page.getByText('Handmade journal')).toHaveCount(0);
+    } finally {
+      await cleanup([viewer.id, target.id, third.id]);
+    }
+  });
+
+  test('Not this time → declined header + Undo, invisible to another viewer', async ({
+    page,
+  }) => {
+    const viewer = await seedUser();
+    const target = await seedUser({ birthday: birthdayOffset(30) });
+    const other = await seedUser();
+    await makeFriendship(viewer.id, target.id);
+    await makeFriendship(other.id, target.id);
+    try {
+      await login(page, viewer);
+      await page.goto(`/users/${target.username}`);
+
+      await page.getByRole('button', { name: 'Not this time' }).click();
+      await expect(
+        page.getByText("You're sitting this one out"),
+      ).toBeVisible();
+      const undo = page.getByRole('button', { name: 'Undo' });
+      await expect(undo).toBeVisible();
+
+      // The decline is per-viewer — another viewer sees the normal occasion.
+      await login(page, other);
+      await page.goto(`/users/${target.username}`);
+      await expect(page.getByText("You're sitting this one out")).toHaveCount(0);
+      await expect(page.getByText(/Birthday ·/)).toBeVisible();
+
+      // Undo restores the occasion header for the original viewer.
+      await login(page, viewer);
+      await page.goto(`/users/${target.username}`);
+      await page.getByRole('button', { name: 'Undo' }).click();
+      await expect(page.getByText("You're sitting this one out")).toHaveCount(0);
+      await expect(page.getByText(/Birthday ·/)).toBeVisible();
+      await expect(
+        page.getByRole('button', { name: 'Not this time' }),
+      ).toBeVisible();
+    } finally {
+      await cleanup([viewer.id, target.id, other.id]);
+    }
+  });
+
+  test('Just me → requires a gift name, creates a pool-of-one without pool ceremony', async ({
+    page,
+  }) => {
+    const viewer = await seedUser();
+    const target = await seedUser({ birthday: birthdayOffset(30) });
+    await makeFriendship(viewer.id, target.id);
+    try {
+      await login(page, viewer);
+      await page.goto(`/users/${target.username}`);
+
+      await page.getByRole('button', { name: 'Just me' }).click();
+      const dialogTitle = page.getByText("I've got this one");
+      await expect(dialogTitle).toBeVisible();
+
+      // Empty submit is blocked (name required) — dialog stays open, no pool.
+      await page.getByRole('button', { name: "I've got this" }).click();
+      await expect(dialogTitle).toBeVisible();
+
+      await page.getByLabel('What are you getting them?').fill('Handmade mug');
+      await page.getByRole('button', { name: "I've got this" }).click();
+
+      const pool = await waitFor(async () => {
+        const row = await prisma.pool.findFirst({
+          where: { organizerId: viewer.id, recipientUserId: target.id, title: 'Handmade mug' },
+          select: { id: true, _count: { select: { contributors: true } } },
+        });
+        expect(row).not.toBeNull();
+        return row;
+      });
+      // Pool-of-one: exactly one contributor, and no pool page in the UI flow.
+      expect(pool?._count.contributors).toBe(1);
+      await expect(page).toHaveURL(new RegExp(`/users/${target.username}`));
+    } finally {
+      await cleanup([viewer.id, target.id]);
+    }
+  });
+});
+
+// ─── 4. Post-occasion UI wiring ──────────────────────────────────────────────
+
+test.describe('Post-occasion "Did it land?"', () => {
+  test('"They loved it" records the outcome and clears the prompt', async ({
+    page,
+  }) => {
+    const viewer = await seedUser();
+    const target = await seedUser({ birthday: birthdayOffset(-3) });
+    await makeFriendship(viewer.id, target.id);
+    // Unconfirmed solo intent = a pool-of-one for this recipient.
+    const pool = await createPool({
+      title: 'Vinyl record',
+      organizerId: viewer.id,
+      recipientUserId: target.id,
+    });
+    try {
+      await login(page, viewer);
+      await page.goto(`/users/${target.username}`);
+
+      await expect(page.getByText('Did it land?')).toBeVisible();
+      await expect(page.getByText('Your gift · Vinyl record')).toBeVisible();
+
+      await page.getByRole('button', { name: 'They loved it' }).click();
+
+      await waitFor(async () => {
+        const row = await prisma.pool.findUnique({
+          where: { id: pool.id },
+          select: { outcomeFeedback: true },
+        });
+        expect(row?.outcomeFeedback).toBe('LOVED');
+        return row;
+      });
+
+      // Answered once → never re-nagged.
+      await page.goto(`/users/${target.username}`);
+      await expect(page.getByText('Did it land?')).toHaveCount(0);
+    } finally {
+      await cleanup([viewer.id, target.id]);
+    }
+  });
+
+  test('"Skip for now" suppresses the prompt permanently', async ({ page }) => {
+    const viewer = await seedUser();
+    const target = await seedUser({ birthday: birthdayOffset(-3) });
+    await makeFriendship(viewer.id, target.id);
+    const pool = await createPool({
+      title: 'Wool scarf',
+      organizerId: viewer.id,
+      recipientUserId: target.id,
+    });
+    try {
+      await login(page, viewer);
+      await page.goto(`/users/${target.username}`);
+
+      await expect(page.getByText('Did it land?')).toBeVisible();
+      await page.getByRole('button', { name: 'Skip for now' }).click();
+
+      await waitFor(async () => {
+        const row = await prisma.pool.findUnique({
+          where: { id: pool.id },
+          select: { outcomeFeedback: true },
+        });
+        expect(row?.outcomeFeedback).toBe('SKIPPED');
+        return row;
+      });
+
+      await page.goto(`/users/${target.username}`);
+      await expect(page.getByText('Did it land?')).toHaveCount(0);
+    } finally {
+      await cleanup([viewer.id, target.id]);
+    }
+  });
+});

--- a/tests/e2e/recipient-privacy.test.ts
+++ b/tests/e2e/recipient-privacy.test.ts
@@ -13,7 +13,7 @@
 
 import { getPasswordHash } from '#app/utils/auth.server.ts';
 import { prisma } from '#app/utils/db.server.ts';
-import { createPool } from '#app/utils/pool.server.ts';
+import { createPool, generatePoolInviteCode } from '#app/utils/pool.server.ts';
 import { createUser } from '#tests/db-utils.ts';
 import { readEmail } from '#tests/mocks/utils.ts';
 import { expect, loginWithPassword, test } from '#tests/playwright-utils.ts';
@@ -79,6 +79,9 @@ test.describe('recipient privacy', () => {
       groupMemberDefaults: [{ userId: other.id, contributionCents: 0 }],
     });
     poolId = pool.id;
+    // Give the pool a real invite code so the recipient-invite-link test can
+    // actually navigate the join flow (createPool never sets one).
+    await generatePoolInviteCode(poolId);
   });
 
   test.afterAll(async () => {
@@ -204,16 +207,14 @@ test.describe('recipient privacy', () => {
       where: { id: poolId },
       select: { inviteCode: true },
     });
-    if (!invite?.inviteCode) {
-      test.skip(true, 'pool has no invite code in seed — skip');
-      return;
-    }
+    const inviteCode = invite?.inviteCode;
+    expect(inviteCode).toBeTruthy();
 
     await loginWithPassword(page, {
       username: recipient.username,
       password: recipient.password,
     });
-    await page.goto(`/pools/join/${invite.inviteCode}`);
+    await page.goto(`/pools/join/${inviteCode}`);
 
     // Landing on the pool detail would be a leak.
     await expect(page).not.toHaveURL(new RegExp(`/pools/${poolId}`));


### PR DESCRIPTION
## Why

The person surface (`/users/:username`) had 1174 unit tests over its server actions and loaders, yet shipped a bug where **"Propose to pool" rendered but did nothing** — no test exercised the click-to-action wiring. This adds the coverage that catches that class, and resurrects a permanently-skipped recipient-privacy test.

**Test-only changes** — no app code touched. No real bug surfaced, so there are no `.fixme`s.

## What

**`tests/e2e/person-surface.test.ts`** (new) — browser-level, every assertion checks a positive outcome (navigation / rendered content / persisted row), never just absence of error:
- **Organize routing** — 1 shared group → prefilled `/pools/new?groupId&recipientId`; 2+ groups → picker (asserted it does *not* auto-navigate), then prefilled creation; friend-only → standalone `?recipientId` (no group); gate stub (no relationship → `FriendGateCard`).
- **Propose resolver** — 0 pools → routes into Organize carrying the idea as `title`; 1 pool → redirect to `/pools/:id` + `GiftIdea` persisted with `giftListItemId`/`wishlistItemId` link; 2+ → picker → idea lands in the chosen pool. From both a saved idea and a wishlist item.
- **Action row** — Save idea (persisted + invisible to target and a third viewer); Not this time (declined header + Undo, invisible to another viewer, Undo restores); Just me (name required, 1-contributor pool-of-one, no pool ceremony).
- **Post-occasion** — "They loved it" records `LOVED` and clears the prompt; "Skip for now" records `SKIPPED` and suppresses permanently.

**`app/components/users/person-surface.test.tsx`** (new) — renders the exported `PersonSurface` with `Form`/`useFetcher` mocked to capture submitted `FormData`; asserts propose / save-idea / decline / solo-commit each emit their intent + required fields. The direct regression net for the dead-button class.

**`tests/e2e/recipient-privacy.test.ts`** — the invite-link test self-skipped because `createPool` never sets an `inviteCode`. Populated via the production `generatePoolInviteCode` helper and un-skipped. It passes: the recipient hitting `/pools/join/:code` gets a `404` and is not added as a contributor — **no privacy bug**.

## Verification
- `npm run test:e2e:run` (full): 105 passed, 6 skipped (pre-existing), 0 failed.
- Component test: 5 passed. `typecheck` + `eslint`: clean.
- No `.only`, no `.fixme` anywhere in the new/edited files.

https://claude.ai/code/session_013vPd3LA9T9rHLhCpsBxaJy