### PR TITLE
fix: resolve Sentry crashes — tampered honeypot payloads and pre-Chrome-84 getAnimations

### DIFF
--- a/app/components/progress-bar.test.tsx
+++ b/app/components/progress-bar.test.tsx
@@ -1,0 +1,20 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import { createRoutesStub } from 'react-router';
+import { describe, expect, it } from 'vitest';
+
+import { EpicProgress } from './progress-bar';
+
+describe('EpicProgress', () => {
+  // jsdom, like pre-Chrome-84 browsers, has no Element.getAnimations —
+  // this render doubles as the regression test for that crash.
+  it('renders without Element.getAnimations support', () => {
+    const App = createRoutesStub([
+      { path: '/', Component: () => <EpicProgress /> },
+    ]);
+    render(<App />);
+    expect(screen.getByRole('progressbar', { hidden: true })).toBeInTheDocument();
+  });
+});

--- a/app/components/progress-bar.tsx
+++ b/app/components/progress-bar.tsx
@@ -18,9 +18,12 @@ const EpicProgress = () => {
     if (!ref.current) return;
     if (delayedPending) setAnimationComplete(false);
 
-    const animationPromises = ref.current
-      .getAnimations()
-      .map(({ finished }) => finished);
+    // Element.getAnimations() is missing on older browsers (pre-Chrome 84);
+    // fall back to resolving immediately so the bar still hides.
+    const animationPromises =
+      typeof ref.current.getAnimations === 'function'
+        ? ref.current.getAnimations().map(({ finished }) => finished)
+        : [];
 
     void Promise.allSettled(animationPromises).then(() => {
       if (!delayedPending) setAnimationComplete(true);

--- a/app/utils/honeypot.server.test.ts
+++ b/app/utils/honeypot.server.test.ts
@@ -1,0 +1,65 @@
+/**
+ * @vitest-environment node
+ */
+import { SpamError } from 'remix-utils/honeypot/server';
+import { describe, expect, it } from 'vitest';
+
+import { checkHoneypot, GuardedHoneypot } from './honeypot.server.ts';
+
+// The exported `honeypot` instance disables the valid-from field under
+// NODE_ENV=test, so the decrypt path is exercised through a dedicated
+// instance configured like production.
+function makeHoneypot() {
+  return new GuardedHoneypot({ encryptionSeed: 'test-seed' });
+}
+
+function makeFormData(validFrom: string) {
+  const formData = new FormData();
+  formData.set('name__confirm', '');
+  formData.set('from__confirm', validFrom);
+  return formData;
+}
+
+describe('GuardedHoneypot', () => {
+  it('treats a non-base64 valid-from value as spam instead of throwing InvalidCharacterError', async () => {
+    const formData = makeFormData('%%%not-base64%%%');
+    await expect(makeHoneypot().check(formData)).rejects.toBeInstanceOf(
+      SpamError,
+    );
+  });
+
+  it('treats a truncated ciphertext as spam instead of throwing OperationError', async () => {
+    // Valid base64, but decodes to fewer bytes than the AES-GCM IV + tag.
+    const formData = makeFormData('AAAA');
+    await expect(makeHoneypot().check(formData)).rejects.toBeInstanceOf(
+      SpamError,
+    );
+  });
+
+  it('treats a forged ciphertext (wrong key/tag) as spam', async () => {
+    const forged = Buffer.from(new Uint8Array(32).fill(7)).toString('base64');
+    const formData = makeFormData(forged);
+    await expect(makeHoneypot().check(formData)).rejects.toBeInstanceOf(
+      SpamError,
+    );
+  });
+
+  it('accepts a legit getInputProps round-trip', async () => {
+    const hp = makeHoneypot();
+    const props = await hp.getInputProps();
+    const formData = new FormData();
+    formData.set(props.nameFieldName, '');
+    formData.set(props.validFromFieldName!, props.encryptedValidFrom);
+    await expect(hp.check(formData)).resolves.toBeUndefined();
+  });
+});
+
+describe('checkHoneypot', () => {
+  it('rejects a filled honeypot field with a 400 Response', async () => {
+    const formData = new FormData();
+    formData.set('name__confirm', 'bot text');
+    await expect(checkHoneypot(formData)).rejects.toSatisfy(
+      (thrown) => thrown instanceof Response && thrown.status === 400,
+    );
+  });
+});

--- a/app/utils/honeypot.server.ts
+++ b/app/utils/honeypot.server.ts
@@ -1,6 +1,20 @@
 import { Honeypot, SpamError } from 'remix-utils/honeypot/server';
 
-export const honeypot = new Honeypot({
+// remix-utils' Honeypot.check() maps a falsy decrypt result to SpamError, but
+// its decrypt() lets raw atob/WebCrypto errors escape when a bot tampers with
+// the from__confirm field (still unguarded as of remix-utils 10.0.0).
+// Normalize decrypt failures to the falsy path check() already handles.
+export class GuardedHoneypot extends Honeypot {
+  protected override async decrypt(value: string) {
+    try {
+      return await super.decrypt(value);
+    } catch {
+      return '';
+    }
+  }
+}
+
+export const honeypot = new GuardedHoneypot({
   validFromFieldName: process.env.NODE_ENV === 'test' ? null : undefined,
   encryptionSeed: process.env.HONEYPOT_SECRET,
 });


### PR DESCRIPTION
## Context

Diagnosing recent Sentry issues surfaced two production defects:

- **GIFTPOOL-UI-1D / GIFTPOOL-UI-1E** (`POST /api/feedback`, but the same guard protects login/signup/verify/forgot-password/onboarding): remix-utils' `Honeypot.check()` intends decrypt failures to become `SpamError` (`if (!time) throw new SpamError(...)`), but its `decrypt()` has no try/catch — verified still unguarded in remix-utils 10.0.0, so upgrading doesn't help. Bot-tampered `from__confirm` values threw raw `InvalidCharacterError` (bad base64) / `OperationError` (truncated ciphertext) that escaped `checkHoneypot`'s `SpamError`-only catch as unhandled 500s.
- **GIFTPOOL-UI-1G** (escalating, plus GIFTPOOL-UI-1F as a suspected downstream symptom): `EpicProgress` — rendered globally from `root.tsx` — called `ref.current.getAnimations()` unconditionally. The API shipped in Chrome 84; all events are Chrome Mobile 83 / Opera Mobile on Android 10, where every route render crashed.

## Approach

- **Honeypot**: subclass `Honeypot` and override the `protected decrypt()` hook (an intended extension point per the library's types) to return `''` on throw, restoring the library's own falsy-→-`SpamError` semantics. Deliberately *not* a blanket catch in `checkHoneypot` — genuinely unexpected errors still propagate to Sentry.
- **Progress bar**: feature-detect `getAnimations` and fall back to an empty promise list; `Promise.allSettled([])` resolves immediately so the hide-state machine still works, minus fade-completion tracking on ancient browsers.

## Tests

- `honeypot.server.test.ts`: garbage base64, truncated ciphertext, and forged ciphertext all yield `SpamError` (not raw crypto errors); legit `getInputProps()` round-trip still passes; `checkHoneypot` converts to a 400 `Response`.
- `progress-bar.test.tsx`: jsdom lacks `getAnimations` just like pre-Chrome-84 browsers, so a plain render doubles as the regression test — confirmed it fails on `main` and passes with the guard.

## Verification

- Full unit suite: 193 files / 1197 tests green; `feedback.test.ts` e2e green; typecheck + lint clean (0 errors, warnings pre-existing).
- Manual: dev server `POST /api/feedback` with `from__confirm=%%%garbage` and `from__confirm=AAAA` both return **400** (previously 500).

Fixes GIFTPOOL-UI-1D, GIFTPOOL-UI-1E, GIFTPOOL-UI-1G. GIFTPOOL-UI-1F will be resolved manually and watched for regression.