### PR TITLE
feat(notifications): add scoped preference infrastructure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -245,12 +245,18 @@ Cache tiering: short-TTL admin queries (≤5 min) use `lruCache`; long-TTL aggre
 
 ### Notification preferences
 
-Hot/cold path split — reads tolerate missing rows, writes don't.
+Preferences are sparse and resolved through the notification policy seam. Reads
+never create rows, including signup and the settings loader.
 
-- **Cold path (settings loader)**: `app/routes/settings+/profile.notifications.tsx` calls `ensureNotificationPreferencesForUser` to materialize a row per `NOTIFICATION_TYPES`. This is the only place that upserts on read, and the e2e rollback tests rely on the rows existing afterwards.
-- **Hot path (friend-request fanout)**: `getNotificationPreferences` / `getNotificationPreferenceForChannels` fall back to `DEFAULT_NOTIFICATION_PREFERENCES` when rows are missing — no upsert in the fanout.
-- **Signup**: `auth.server.ts` seeds one row per type via nested-create so new users never hit the fallback.
-- `disableEmailForAll` collapses to one `findMany` + one transactional `updateMany` + audit `createMany` (not an O(N) loop).
+- Central precedence is global channel gate → topic override → category override → catalog default. Context activity filters the result and can never re-enable a centrally disabled channel/topic.
+- `notification-catalog.ts` maps concrete events to stable user-facing topics and categories. Adding an event to an existing topic must not add another preference row or toggle.
+- The current settings screen still submits concrete event types for compatibility; `setNotificationPreference` deliberately maps them to their shared topic. The scoped settings UI arrives in the next milestone.
+- `disableEmailForAll` writes one durable `EMAIL` global gate, so future topics remain disabled. Topic choices changed while that gate is off are retained for a later re-enable.
+- Context activity uses sparse `GroupNotificationPreference` and `PoolNotificationPreference` rows. Explicit pool settings override the parent group; otherwise group settings inherit to child pools; otherwise the default is `IMPORTANT_ONLY`.
+- Context preference reads/writes require current group membership or pool contribution. Dispatcher policy reads use `requireAccess: false` only after the owning domain has selected an eligible audience.
+- A null context activity level means inherit and may coexist with `noticeDismissedAt`, which is required to dismiss awareness of an inherited group mute on one pool.
+- Category bulk writes are transactional and clear more-specific topic rows for that channel so the selected category value actually applies to every child topic.
+- Admin notification reporting resolves effective choices for the full user denominator; it must not count sparse rows as if they were the user population.
 
 ### Occasion reminders (the scheduler)
 

--- a/app/routes/admin+/users_.$userId.tsx
+++ b/app/routes/admin+/users_.$userId.tsx
@@ -65,9 +65,7 @@ export async function action({
         ok: true,
         intent: 'toggle_admin',
         message:
-          target === 'grant'
-            ? 'Granted admin role.'
-            : 'Revoked admin role.',
+          target === 'grant' ? 'Granted admin role.' : 'Revoked admin role.',
       };
     }
 
@@ -90,7 +88,8 @@ export async function action({
       if (err.code === 'CANNOT_DEMOTE_SELF') {
         message = 'You cannot revoke your own admin role.';
       } else if (err.code === 'LAST_ADMIN') {
-        message = 'Cannot revoke the last admin. Grant admin to another user first.';
+        message =
+          'Cannot revoke the last admin. Grant admin to another user first.';
       } else {
         message = 'User not found.';
       }
@@ -100,11 +99,9 @@ export async function action({
   }
 }
 
-const formatDate = (date: Date | string) =>
-  new Date(date).toLocaleDateString();
+const formatDate = (date: Date | string) => new Date(date).toLocaleDateString();
 
-const formatDateTime = (date: Date | string) =>
-  new Date(date).toLocaleString();
+const formatDateTime = (date: Date | string) => new Date(date).toLocaleString();
 
 const AdminUserDetailRoute = () => {
   const { user } = useLoaderData<typeof loader>();
@@ -123,19 +120,17 @@ const AdminUserDetailRoute = () => {
           >
             ← Back to users
           </Link>
-          <h1 className="text-xl font-semibold">{user.name ?? user.username}</h1>
+          <h1 className="text-xl font-semibold">
+            {user.name ?? user.username}
+          </h1>
           <p className="text-muted-foreground">
             @{user.username} · {user.email}
           </p>
         </div>
       </div>
 
-      {toggleFetcher.data ? (
-        <ActionBanner data={toggleFetcher.data} />
-      ) : null}
-      {revokeFetcher.data ? (
-        <ActionBanner data={revokeFetcher.data} />
-      ) : null}
+      {toggleFetcher.data ? <ActionBanner data={toggleFetcher.data} /> : null}
+      {revokeFetcher.data ? <ActionBanner data={revokeFetcher.data} /> : null}
 
       <section className="grid gap-4 lg:grid-cols-2">
         {/* --- profile --- */}
@@ -261,15 +256,9 @@ const AdminUserDetailRoute = () => {
         </SectionCard>
 
         {/* --- wishlist --- */}
-        <SectionCard
-          title="Wishlist"
-          description="Items owned by this user."
-        >
+        <SectionCard title="Wishlist" description="Items owned by this user.">
           <dl className="grid grid-cols-[auto,1fr] gap-x-4 gap-y-2 text-sm">
-            <DLRow
-              label="Items"
-              value={user.counts.wishlistItems.toString()}
-            />
+            <DLRow label="Items" value={user.counts.wishlistItems.toString()} />
             <DLRow
               label="View public profile"
               value={
@@ -304,7 +293,7 @@ const AdminUserDetailRoute = () => {
       {/* --- notification prefs --- */}
       <SectionCard
         title="Notification preferences"
-        description="Per-type in-app + email toggles from UserNotificationPreference."
+        description="Effective per-type choices after global, category, topic, and catalog inheritance."
       >
         {user.notificationPreferences.length === 0 ? (
           <EmptyRow>No preferences recorded (using defaults).</EmptyRow>

--- a/app/routes/settings+/profile.notifications.test.tsx
+++ b/app/routes/settings+/profile.notifications.test.tsx
@@ -16,7 +16,6 @@ import {
 const getUserId = vi.fn();
 const requireUserId = vi.fn();
 const verifyPreferenceToken = vi.fn();
-const ensureNotificationPreferencesForUser = vi.fn();
 const getNotificationPreferences = vi.fn();
 const setNotificationPreference = vi.fn();
 const disableEmailForAll = vi.fn();
@@ -63,7 +62,10 @@ vi.mock('react-router', async () => {
     ...actual,
     useFetcher: () => {
       useFetcherCallCount += 1;
-      const state = useFetcherCallCount % 2 === 1 ? toggleFetcherState : disableFetcherState;
+      const state =
+        useFetcherCallCount % 2 === 1
+          ? toggleFetcherState
+          : disableFetcherState;
       return {
         Form: (props: React.ComponentProps<'form'>) => <form {...props} />,
         data: state.data,
@@ -94,13 +96,12 @@ vi.mock('#app/utils/auth.server.ts', () => ({
 }));
 
 vi.mock('#app/utils/notification-preference-token.server.ts', () => ({
-  verifyPreferenceToken: (...args: Array<unknown>) => verifyPreferenceToken(...args),
+  verifyPreferenceToken: (...args: Array<unknown>) =>
+    verifyPreferenceToken(...args),
 }));
 
 vi.mock('#app/utils/notification-preferences.server.ts', () => ({
   disableEmailForAll: (...args: Array<unknown>) => disableEmailForAll(...args),
-  ensureNotificationPreferencesForUser: (...args: Array<unknown>) =>
-    ensureNotificationPreferencesForUser(...args),
   getNotificationPreferences: (...args: Array<unknown>) =>
     getNotificationPreferences(...args),
   setNotificationPreference: (...args: Array<unknown>) =>
@@ -143,8 +144,6 @@ beforeEach(() => {
   getUserId.mockReset();
   requireUserId.mockReset();
   verifyPreferenceToken.mockReset();
-  ensureNotificationPreferencesForUser.mockReset();
-  ensureNotificationPreferencesForUser.mockResolvedValue(undefined);
   getNotificationPreferences.mockReset();
   setNotificationPreference.mockReset();
   disableEmailForAll.mockReset();
@@ -189,7 +188,9 @@ describe('settings notifications route module', () => {
         toLoaderArgs({
           context: {},
           params: {},
-          request: new Request('https://giftpool.app/settings/profile/notifications'),
+          request: new Request(
+            'https://giftpool.app/settings/profile/notifications',
+          ),
         }),
       ),
     ).rejects.toMatchObject({
@@ -207,7 +208,9 @@ describe('settings notifications route module', () => {
       toLoaderArgs({
         context: {},
         params: {},
-        request: new Request('https://giftpool.app/settings/profile/notifications'),
+        request: new Request(
+          'https://giftpool.app/settings/profile/notifications',
+        ),
       }),
     );
 
@@ -263,10 +266,12 @@ describe('settings notifications route module', () => {
     requireUserId.mockResolvedValue('user-1');
 
     const toggleResult = await action(
-        toActionArgs({
-          context: {},
-          params: {},
-          request: new Request('https://giftpool.app/settings/profile/notifications', {
+      toActionArgs({
+        context: {},
+        params: {},
+        request: new Request(
+          'https://giftpool.app/settings/profile/notifications',
+          {
             body: new URLSearchParams({
               channel: 'EMAIL',
               enabled: 'false',
@@ -277,8 +282,9 @@ describe('settings notifications route module', () => {
             headers: {
               'content-type': 'application/x-www-form-urlencoded',
             },
-          method: 'POST',
-        }),
+            method: 'POST',
+          },
+        ),
       }),
     );
 
@@ -295,10 +301,12 @@ describe('settings notifications route module', () => {
     });
 
     const disableResult = await action(
-        toActionArgs({
-          context: {},
-          params: {},
-          request: new Request('https://giftpool.app/settings/profile/notifications', {
+      toActionArgs({
+        context: {},
+        params: {},
+        request: new Request(
+          'https://giftpool.app/settings/profile/notifications',
+          {
             body: new URLSearchParams({
               intent: 'disable-email',
               requestId: 'disable-1',
@@ -306,8 +314,9 @@ describe('settings notifications route module', () => {
             headers: {
               'content-type': 'application/x-www-form-urlencoded',
             },
-          method: 'POST',
-        }),
+            method: 'POST',
+          },
+        ),
       }),
     );
 
@@ -321,10 +330,12 @@ describe('settings notifications route module', () => {
     });
 
     const invalidIntent = await action(
-        toActionArgs({
-          context: {},
-          params: {},
-          request: new Request('https://giftpool.app/settings/profile/notifications', {
+      toActionArgs({
+        context: {},
+        params: {},
+        request: new Request(
+          'https://giftpool.app/settings/profile/notifications',
+          {
             body: new URLSearchParams({
               intent: 'unknown',
               requestId: 'invalid-1',
@@ -332,8 +343,9 @@ describe('settings notifications route module', () => {
             headers: {
               'content-type': 'application/x-www-form-urlencoded',
             },
-          method: 'POST',
-        }),
+            method: 'POST',
+          },
+        ),
       }),
     );
 
@@ -380,16 +392,23 @@ describe('settings notifications route component', () => {
     renderRoute();
 
     expect(
-      screen.getByText('You are viewing notification preferences with a one-time link.'),
+      screen.getByText(
+        'You are viewing notification preferences with a one-time link.',
+      ),
     ).toBeInTheDocument();
     expect(
       screen.getByRole('link', { name: /sign in to update your preferences/i }),
-    ).toHaveAttribute('href', '/login?redirectTo=/settings/profile/notifications');
+    ).toHaveAttribute(
+      'href',
+      '/login?redirectTo=/settings/profile/notifications',
+    );
     expect(
       screen.getAllByRole('checkbox', { name: /enable email/i })[0],
     ).toBeDisabled();
     expect(
-      screen.queryByRole('button', { name: /turn off all email notifications/i }),
+      screen.queryByRole('button', {
+        name: /turn off all email notifications/i,
+      }),
     ).not.toBeInTheDocument();
   });
 
@@ -423,7 +442,9 @@ describe('settings notifications route component', () => {
     toggleFetcherState.data = {
       ok: false,
       requestId:
-        typeof toggleRequestId === 'string' ? toggleRequestId : 'toggle-request',
+        typeof toggleRequestId === 'string'
+          ? toggleRequestId
+          : 'toggle-request',
     };
     useFetcherCallCount = 0;
     rerender(
@@ -433,7 +454,9 @@ describe('settings notifications route component', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getAllByRole('checkbox', { name: /enable email/i })[0]).toBeChecked();
+      expect(
+        screen.getAllByRole('checkbox', { name: /enable email/i })[0],
+      ).toBeChecked();
     });
     expect(toggleFetcherState.submit).toHaveBeenCalledTimes(1);
   });
@@ -446,9 +469,9 @@ describe('settings notifications route component', () => {
     );
 
     expect(
-      screen.getAllByRole('checkbox', { name: /enable email/i }).every(
-        (checkbox) => !(checkbox as HTMLInputElement).checked,
-      ),
+      screen
+        .getAllByRole('checkbox', { name: /enable email/i })
+        .every((checkbox) => !(checkbox as HTMLInputElement).checked),
     ).toBe(true);
     const disableFormData = disableFetcherState.submit.mock.calls[0]?.[0] as
       | FormData
@@ -480,9 +503,9 @@ describe('settings notifications route component', () => {
 
     await waitFor(() => {
       expect(
-        screen.getAllByRole('checkbox', { name: /enable email/i }).every(
-          (checkbox) => !(checkbox as HTMLInputElement).checked,
-        ),
+        screen
+          .getAllByRole('checkbox', { name: /enable email/i })
+          .every((checkbox) => !(checkbox as HTMLInputElement).checked),
       ).toBe(true);
     });
     expect(disableFetcherState.submit).toHaveBeenCalledTimes(1);

--- a/app/routes/settings+/profile.notifications.tsx
+++ b/app/routes/settings+/profile.notifications.tsx
@@ -29,7 +29,6 @@ import {
 import { verifyPreferenceToken } from '#app/utils/notification-preference-token.server.ts';
 import {
   disableEmailForAll,
-  ensureNotificationPreferencesForUser,
   getNotificationPreferences,
   setNotificationPreference,
 } from '#app/utils/notification-preferences.server.ts';
@@ -88,15 +87,6 @@ export async function loader({ request }: LoaderFunctionArgs) {
   }
   const canReadPreferences =
     (userId && userId === targetUserId) || tokenPayload?.uid === targetUserId;
-  // Settings page is the only place users directly manage their preferences.
-  // Materialize rows here so downstream writes (`setNotificationPreference`,
-  // `disableEmailForAll`) always see persisted rows, and so UI optimistic
-  // rollback tests can assert against a stable DB state. This is a cold
-  // path — the hot notification fanout reads still tolerate missing rows
-  // via the in-memory defaults fallback.
-  if (canReadPreferences) {
-    await ensureNotificationPreferencesForUser(targetUserId);
-  }
   const preferencesMap = canReadPreferences
     ? await getNotificationPreferences(targetUserId)
     : null;

--- a/app/utils/admin.server.ts
+++ b/app/utils/admin.server.ts
@@ -2,6 +2,8 @@ import { queueLogEvent } from './analytics.server.ts';
 import { cache, cachified, lruCache } from './cache.server.ts';
 import { prisma } from './db.server.ts';
 import { type FeedbackStatus } from './feedback-validation.ts';
+import { NOTIFICATION_TYPE_VALUES } from './notification-catalog.ts';
+import { getNotificationPreferencesForUsers } from './notification-preferences.server.ts';
 import { POOL_STATUS, type PoolStatus } from './pool-constants.ts';
 
 const SIXTY_SECONDS = 60 * 1000;
@@ -951,61 +953,59 @@ export type AdminUserDetail = {
 export async function getAdminUserDetail(
   userId: string,
 ): Promise<AdminUserDetail | null> {
-  const [identity, contributorGroups, recentEvents] = await Promise.all([
-    prisma.user.findUnique({
-      where: { id: userId },
-      select: {
-        id: true,
-        email: true,
-        username: true,
-        name: true,
-        bio: true,
-        birthday: true,
-        createdAt: true,
-        image: { select: { id: true } },
-        roles: { select: { name: true }, orderBy: { name: 'asc' } },
-        sessions: {
-          select: { id: true, createdAt: true, expirationDate: true },
-          orderBy: { createdAt: 'desc' },
-          take: 10,
-        },
-        notificationPreferences: {
-          select: { type: true, inAppEnabled: true, emailEnabled: true },
-          orderBy: { type: 'asc' },
-        },
-        _count: {
-          select: {
-            wishlistItems: true,
-            friendshipsA: true,
-            friendshipsB: true,
-            poolsOrganized: true,
-            poolsAsPurchaser: true,
-            poolsAsDeliverer: true,
-            poolsAsRecipient: true,
-            poolContributions: true,
-            notifications: { where: { status: 'UNREAD' } },
+  const [identity, contributorGroups, recentEvents, preferenceMaps] =
+    await Promise.all([
+      prisma.user.findUnique({
+        where: { id: userId },
+        select: {
+          id: true,
+          email: true,
+          username: true,
+          name: true,
+          bio: true,
+          birthday: true,
+          createdAt: true,
+          image: { select: { id: true } },
+          roles: { select: { name: true }, orderBy: { name: 'asc' } },
+          sessions: {
+            select: { id: true, createdAt: true, expirationDate: true },
+            orderBy: { createdAt: 'desc' },
+            take: 10,
+          },
+          _count: {
+            select: {
+              wishlistItems: true,
+              friendshipsA: true,
+              friendshipsB: true,
+              poolsOrganized: true,
+              poolsAsPurchaser: true,
+              poolsAsDeliverer: true,
+              poolsAsRecipient: true,
+              poolContributions: true,
+              notifications: { where: { status: 'UNREAD' } },
+            },
           },
         },
-      },
-    }),
-    prisma.poolContributor.groupBy({
-      by: ['hasPaid'],
-      where: { userId },
-      _count: { _all: true },
-    }),
-    prisma.analyticsEvent.findMany({
-      where: { userId },
-      orderBy: { createdAt: 'desc' },
-      take: 20,
-      select: {
-        id: true,
-        name: true,
-        createdAt: true,
-        source: true,
-        properties: true,
-      },
-    }),
-  ]);
+      }),
+      prisma.poolContributor.groupBy({
+        by: ['hasPaid'],
+        where: { userId },
+        _count: { _all: true },
+      }),
+      prisma.analyticsEvent.findMany({
+        where: { userId },
+        orderBy: { createdAt: 'desc' },
+        take: 20,
+        select: {
+          id: true,
+          name: true,
+          createdAt: true,
+          source: true,
+          properties: true,
+        },
+      }),
+      getNotificationPreferencesForUsers([userId]),
+    ]);
 
   if (!identity) return null;
 
@@ -1025,7 +1025,13 @@ export async function getAdminUserDetail(
     image: identity.image,
     roles: identity.roles,
     sessions: identity.sessions,
-    notificationPreferences: identity.notificationPreferences,
+    notificationPreferences: Array.from(
+      preferenceMaps.get(userId)?.entries() ?? [],
+    ).map(([type, preference]) => ({
+      type,
+      inAppEnabled: preference.inAppEnabled,
+      emailEnabled: preference.emailEnabled,
+    })),
     counts: {
       wishlistItems: identity._count.wishlistItems,
       friendships: identity._count.friendshipsA + identity._count.friendshipsB,
@@ -1562,29 +1568,21 @@ export type NotificationOptOutRow = {
 export async function getNotificationOptOutMatrix(): Promise<
   NotificationOptOutRow[]
 > {
-  const rows = await prisma.$queryRaw<
-    Array<{
-      type: string;
-      inApp_off: bigint | null;
-      email_off: bigint | null;
-      total: bigint;
-    }>
-  >`
-    SELECT
-      type,
-      SUM(CASE WHEN inAppEnabled = 0 THEN 1 ELSE 0 END) AS inApp_off,
-      SUM(CASE WHEN emailEnabled = 0 THEN 1 ELSE 0 END) AS email_off,
-      COUNT(*) AS total
-    FROM UserNotificationPreference
-    GROUP BY type
-  `;
-
-  return rows.map((row) => {
-    const total = Number(row.total);
-    const inAppOff = Number(row.inApp_off ?? 0);
-    const emailOff = Number(row.email_off ?? 0);
+  const users = await prisma.user.findMany({ select: { id: true } });
+  const preferences = await getNotificationPreferencesForUsers(
+    users.map((user) => user.id),
+  );
+  return NOTIFICATION_TYPE_VALUES.map((type) => {
+    const total = users.length;
+    let inAppOff = 0;
+    let emailOff = 0;
+    for (const user of users) {
+      const preference = preferences.get(user.id)?.get(type);
+      if (!preference?.inAppEnabled) inAppOff += 1;
+      if (!preference?.emailEnabled) emailOff += 1;
+    }
     return {
-      type: row.type,
+      type,
       inAppOptOutPercent: total > 0 ? Math.round((inAppOff / total) * 100) : 0,
       emailOptOutPercent: total > 0 ? Math.round((emailOff / total) * 100) : 0,
       total,

--- a/app/utils/auth.server.test.ts
+++ b/app/utils/auth.server.test.ts
@@ -6,7 +6,11 @@ import {
   CURRENT_LEGAL_VERSION,
   LEGAL_DOCUMENT_TYPE,
 } from '#app/utils/legal.ts';
-import { NOTIFICATION_TYPES } from '#app/utils/notification-catalog.ts';
+import {
+  DEFAULT_NOTIFICATION_PREFERENCES,
+  NOTIFICATION_TYPES,
+} from '#app/utils/notification-catalog.ts';
+import { getNotificationPreferences } from '#app/utils/notification-preferences.server.ts';
 
 const testConsent = {
   version: CURRENT_LEGAL_VERSION,
@@ -16,7 +20,6 @@ const testConsent = {
 
 describe('auth.server', () => {
   beforeEach(async () => {
-    await prisma.userNotificationPreference.deleteMany();
     await prisma.session.deleteMany({
       where: { user: { email: { contains: '@signup-test.com' } } },
     });
@@ -25,7 +28,7 @@ describe('auth.server', () => {
     });
   });
 
-  it('signup seeds a notification preference row for every registered type', async () => {
+  it('signup inherits sparse notification defaults without materializing rows', async () => {
     await prisma.role.upsert({
       where: { name: 'user' },
       update: {},
@@ -43,15 +46,15 @@ describe('auth.server', () => {
       consent: testConsent,
     });
 
-    const prefs = await prisma.userNotificationPreference.findMany({
-      where: { userId: session.userId },
-      select: { type: true, inAppEnabled: true, emailEnabled: true },
-    });
-
-    const seededTypes = new Set(prefs.map((p) => p.type));
+    const prefs = await getNotificationPreferences(session.userId);
     for (const type of Object.values(NOTIFICATION_TYPES)) {
-      expect(seededTypes.has(type)).toBe(true);
+      expect(prefs.get(type)).toEqual(DEFAULT_NOTIFICATION_PREFERENCES[type]);
     }
+    await expect(
+      prisma.notificationTopicPreference.count({
+        where: { userId: session.userId },
+      }),
+    ).resolves.toBe(0);
   });
 
   it('signup writes a consent row with the current legal version and age affirmation', async () => {

--- a/app/utils/auth.server.ts
+++ b/app/utils/auth.server.ts
@@ -5,24 +5,7 @@ import { safeRedirect } from 'remix-utils/safe-redirect';
 import { prisma } from './db.server.ts';
 import { LEGAL_DOCUMENT_TYPE } from './legal.ts';
 import { combineHeaders } from './misc.tsx';
-import {
-  DEFAULT_NOTIFICATION_PREFERENCES,
-  NOTIFICATION_TYPES,
-} from './notification-catalog.ts';
 import { authSessionStorage } from './session.server.ts';
-
-// Seed a row per notification type at user creation so we don't have to run
-// N upserts on the hot read/write path later. Reads still tolerate missing
-// rows (they fall back to defaults), so this is strictly an optimization for
-// the common case.
-const defaultNotificationPreferenceRows = Object.values(NOTIFICATION_TYPES).map(
-  (type) => ({
-    type,
-    inAppEnabled: DEFAULT_NOTIFICATION_PREFERENCES[type].inAppEnabled,
-    emailEnabled: DEFAULT_NOTIFICATION_PREFERENCES[type].emailEnabled,
-    pushEnabled: DEFAULT_NOTIFICATION_PREFERENCES[type].pushEnabled,
-  }),
-);
 
 export const SESSION_EXPIRATION_TIME = 1000 * 60 * 60 * 24 * 30;
 export const getSessionExpirationDate = () =>
@@ -151,9 +134,6 @@ export async function signup({
             create: {
               hash: hashedPassword,
             },
-          },
-          notificationPreferences: {
-            create: defaultNotificationPreferenceRows,
           },
           consents: {
             create: {

--- a/app/utils/notification-catalog.test.ts
+++ b/app/utils/notification-catalog.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from 'vitest';
 import {
   getNotificationEventDefinition,
   isNotificationType,
+  matchesNotificationContext,
   NOTIFICATION_CHANNELS,
   NOTIFICATION_EVENT_CATALOG,
+  NOTIFICATION_TOPIC_CATALOG,
   NOTIFICATION_TOPICS,
   NOTIFICATION_TYPES,
 } from '#app/utils/notification-catalog.ts';
@@ -20,19 +22,20 @@ describe('notification catalog', () => {
     ).toBe(NOTIFICATION_TOPICS.FRIEND_REQUESTS);
   });
 
-  it('keeps email opt-in for new events except grandfathered friend defaults', () => {
+  it('keeps email opt-in for new topics except grandfathered friend defaults', () => {
     const grandfatheredEmailDefaults = new Set<string>([
-      NOTIFICATION_TYPES.FRIEND_REQUEST_RECEIVED,
-      NOTIFICATION_TYPES.FRIEND_REQUEST_ACCEPTED,
+      NOTIFICATION_TOPICS.FRIEND_REQUESTS,
     ]);
 
-    for (const [type, definition] of Object.entries(
-      NOTIFICATION_EVENT_CATALOG,
+    for (const [topic, definition] of Object.entries(
+      NOTIFICATION_TOPIC_CATALOG,
     )) {
-      if (!grandfatheredEmailDefaults.has(type)) {
+      if (!grandfatheredEmailDefaults.has(topic)) {
         expect(definition.defaults.emailEnabled).toBe(false);
       }
       expect(definition.defaults.pushEnabled).toBe(false);
+    }
+    for (const definition of Object.values(NOTIFICATION_EVENT_CATALOG)) {
       expect(definition.supportedChannels).toContain(
         NOTIFICATION_CHANNELS.IN_APP,
       );
@@ -43,5 +46,16 @@ describe('notification catalog', () => {
     expect(isNotificationType(NOTIFICATION_TYPES.UPCOMING_BIRTHDAY)).toBe(true);
     expect(isNotificationType('SOMETHING_NEW')).toBe(false);
     expect(isNotificationType(null)).toBe(false);
+  });
+
+  it('requires the context kind declared by an event', () => {
+    const groupContext = { kind: 'GROUP', groupId: 'group-1' } as const;
+    const poolContext = { kind: 'POOL', poolId: 'pool-1' } as const;
+
+    expect(matchesNotificationContext('NONE')).toBe(true);
+    expect(matchesNotificationContext('NONE', groupContext)).toBe(false);
+    expect(matchesNotificationContext('GROUP', groupContext)).toBe(true);
+    expect(matchesNotificationContext('GROUP')).toBe(false);
+    expect(matchesNotificationContext('GROUP', poolContext)).toBe(false);
   });
 });

--- a/app/utils/notification-catalog.ts
+++ b/app/utils/notification-catalog.ts
@@ -26,6 +26,10 @@ export const NOTIFICATION_CATEGORIES = {
 export type NotificationCategory =
   (typeof NOTIFICATION_CATEGORIES)[keyof typeof NOTIFICATION_CATEGORIES];
 
+export const NOTIFICATION_CATEGORY_VALUES = Object.values(
+  NOTIFICATION_CATEGORIES,
+);
+
 export const NOTIFICATION_TOPICS = {
   FRIEND_REQUESTS: 'FRIEND_REQUESTS',
   BIRTHDAY_REMINDERS: 'BIRTHDAY_REMINDERS',
@@ -34,9 +38,15 @@ export const NOTIFICATION_TOPICS = {
 export type NotificationTopic =
   (typeof NOTIFICATION_TOPICS)[keyof typeof NOTIFICATION_TOPICS];
 
+export const NOTIFICATION_TOPIC_VALUES = Object.values(NOTIFICATION_TOPICS);
+
 export type NotificationImportance = 'IMPORTANT' | 'ROUTINE';
 export type NotificationContextKind = 'NONE' | 'GROUP' | 'POOL';
 export type NotificationDeliveryStrategy = 'ONE_SHOT' | 'PER_CHANNEL_LEDGER';
+
+export type NotificationContext =
+  | { kind: 'GROUP'; groupId: string }
+  | { kind: 'POOL'; poolId: string };
 
 export type NotificationPreferenceDefaults = {
   inAppEnabled: boolean;
@@ -46,15 +56,38 @@ export type NotificationPreferenceDefaults = {
 
 type NotificationEventDefinition = {
   topic: NotificationTopic;
-  category: NotificationCategory;
   importance: NotificationImportance;
   context: NotificationContextKind;
   supportedChannels: ReadonlyArray<NotificationChannel>;
-  defaults: NotificationPreferenceDefaults;
   deliveryStrategy: NotificationDeliveryStrategy;
 };
 
+type NotificationTopicDefinition = {
+  category: NotificationCategory;
+  defaults: NotificationPreferenceDefaults;
+};
+
 const allChannels = NOTIFICATION_CHANNEL_VALUES;
+
+/** Topic policy is stable even when several concrete events map to one row. */
+export const NOTIFICATION_TOPIC_CATALOG = {
+  [NOTIFICATION_TOPICS.FRIEND_REQUESTS]: {
+    category: NOTIFICATION_CATEGORIES.SOCIAL,
+    defaults: {
+      inAppEnabled: true,
+      emailEnabled: true,
+      pushEnabled: false,
+    },
+  },
+  [NOTIFICATION_TOPICS.BIRTHDAY_REMINDERS]: {
+    category: NOTIFICATION_CATEGORIES.OCCASIONS,
+    defaults: {
+      inAppEnabled: true,
+      emailEnabled: false,
+      pushEnabled: false,
+    },
+  },
+} as const satisfies Record<NotificationTopic, NotificationTopicDefinition>;
 
 /**
  * Typed source of truth for event policy. User-facing topic/category copy will
@@ -64,41 +97,23 @@ const allChannels = NOTIFICATION_CHANNEL_VALUES;
 export const NOTIFICATION_EVENT_CATALOG = {
   [NOTIFICATION_TYPES.FRIEND_REQUEST_RECEIVED]: {
     topic: NOTIFICATION_TOPICS.FRIEND_REQUESTS,
-    category: NOTIFICATION_CATEGORIES.SOCIAL,
     importance: 'IMPORTANT',
     context: 'NONE',
     supportedChannels: allChannels,
-    defaults: {
-      inAppEnabled: true,
-      emailEnabled: true,
-      pushEnabled: false,
-    },
     deliveryStrategy: 'ONE_SHOT',
   },
   [NOTIFICATION_TYPES.FRIEND_REQUEST_ACCEPTED]: {
     topic: NOTIFICATION_TOPICS.FRIEND_REQUESTS,
-    category: NOTIFICATION_CATEGORIES.SOCIAL,
     importance: 'IMPORTANT',
     context: 'NONE',
     supportedChannels: allChannels,
-    defaults: {
-      inAppEnabled: true,
-      emailEnabled: true,
-      pushEnabled: false,
-    },
     deliveryStrategy: 'ONE_SHOT',
   },
   [NOTIFICATION_TYPES.UPCOMING_BIRTHDAY]: {
     topic: NOTIFICATION_TOPICS.BIRTHDAY_REMINDERS,
-    category: NOTIFICATION_CATEGORIES.OCCASIONS,
     importance: 'IMPORTANT',
     context: 'NONE',
     supportedChannels: allChannels,
-    defaults: {
-      inAppEnabled: true,
-      emailEnabled: false,
-      pushEnabled: false,
-    },
     deliveryStrategy: 'PER_CHANNEL_LEDGER',
   },
 } as const satisfies Record<NotificationType, NotificationEventDefinition>;
@@ -108,7 +123,10 @@ export const NOTIFICATION_TYPE_VALUES = Object.values(NOTIFICATION_TYPES);
 export const DEFAULT_NOTIFICATION_PREFERENCES = Object.fromEntries(
   NOTIFICATION_TYPE_VALUES.map((type) => [
     type,
-    { ...NOTIFICATION_EVENT_CATALOG[type].defaults },
+    {
+      ...NOTIFICATION_TOPIC_CATALOG[NOTIFICATION_EVENT_CATALOG[type].topic]
+        .defaults,
+    },
   ]),
 ) as Record<NotificationType, NotificationPreferenceDefaults>;
 
@@ -116,10 +134,51 @@ export function getNotificationEventDefinition(type: NotificationType) {
   return NOTIFICATION_EVENT_CATALOG[type];
 }
 
+export function getNotificationTopicDefinition(topic: NotificationTopic) {
+  return NOTIFICATION_TOPIC_CATALOG[topic];
+}
+
+export function getNotificationCategoryTopics(
+  category: NotificationCategory,
+): Array<NotificationTopic> {
+  return NOTIFICATION_TOPIC_VALUES.filter(
+    (topic) => NOTIFICATION_TOPIC_CATALOG[topic].category === category,
+  );
+}
+
+export function matchesNotificationContext(
+  expected: NotificationContextKind,
+  context?: NotificationContext,
+) {
+  return expected === 'NONE'
+    ? context === undefined
+    : context?.kind === expected;
+}
+
 export function isNotificationType(value: unknown): value is NotificationType {
   return (
     typeof value === 'string' &&
     Object.hasOwn(NOTIFICATION_EVENT_CATALOG, value)
+  );
+}
+
+export function isNotificationTopic(
+  value: unknown,
+): value is NotificationTopic {
+  return (
+    typeof value === 'string' &&
+    Object.hasOwn(NOTIFICATION_TOPIC_CATALOG, value)
+  );
+}
+
+export function isNotificationCategory(
+  value: unknown,
+): value is NotificationCategory {
+  return (
+    typeof value === 'string' &&
+    Object.values(NOTIFICATION_CATEGORIES).includes(
+      value as NotificationCategory,
+    )
   );
 }
 
@@ -173,6 +232,7 @@ export type NotificationIntent<T extends NotificationType = NotificationType> =
         userId: string;
         type: T;
         payload: NotificationPayload<T>;
+        context?: NotificationContext;
         sourceIdentifier?: string;
       }
     : never;

--- a/app/utils/notification-dispatcher.server.test.tsx
+++ b/app/utils/notification-dispatcher.server.test.tsx
@@ -7,10 +7,7 @@ import {
   NOTIFICATION_TYPES,
 } from '#app/utils/notification-catalog.ts';
 import { dispatchNotification } from '#app/utils/notification-dispatcher.server.ts';
-import {
-  ensureNotificationPreferencesForUser,
-  setNotificationPreference,
-} from '#app/utils/notification-preferences.server.ts';
+import { setNotificationPreference } from '#app/utils/notification-preferences.server.ts';
 
 vi.mock('#app/utils/email.server.ts', () => ({
   sendEmail: vi
@@ -106,7 +103,9 @@ describe('notification dispatcher', () => {
     captureException.mockClear();
     await prisma.notificationDelivery.deleteMany();
     await prisma.notificationPreferenceAudit.deleteMany();
-    await prisma.userNotificationPreference.deleteMany();
+    await prisma.notificationTopicPreference.deleteMany();
+    await prisma.notificationCategoryPreference.deleteMany();
+    await prisma.notificationChannelPreference.deleteMany();
     await prisma.notification.deleteMany();
     await prisma.friendRequest.deleteMany();
     await prisma.friendship.deleteMany();
@@ -118,7 +117,6 @@ describe('notification dispatcher', () => {
   it('creates in-app notification and sends email by default', async () => {
     const recipient = await createUser();
     const actor = await createUser();
-    await ensureNotificationPreferencesForUser(recipient.id);
     const friendRequest = await prisma.friendRequest.create({
       data: {
         fromUserId: actor.id,
@@ -155,7 +153,6 @@ describe('notification dispatcher', () => {
   it('respects email preference toggles', async () => {
     const recipient = await createUser();
     const actor = await createUser();
-    await ensureNotificationPreferencesForUser(recipient.id);
 
     await setNotificationPreference(
       recipient.id,
@@ -194,7 +191,6 @@ describe('notification dispatcher', () => {
   it('sends a web push when the push preference is enabled', async () => {
     const recipient = await createUser();
     const actor = await createUser();
-    await ensureNotificationPreferencesForUser(recipient.id);
 
     await setNotificationPreference(
       recipient.id,
@@ -233,7 +229,6 @@ describe('notification dispatcher', () => {
   it('does not send a web push when the push preference is off (default)', async () => {
     const recipient = await createUser();
     const actor = await createUser();
-    await ensureNotificationPreferencesForUser(recipient.id);
 
     const friendRequest = await prisma.friendRequest.create({
       data: { fromUserId: actor.id, toUserId: recipient.id, status: 'PENDING' },
@@ -260,7 +255,6 @@ describe('notification dispatcher', () => {
   it('creates an in-app UPCOMING_BIRTHDAY notification without email by default', async () => {
     const viewer = await createUser();
     const birthdayOwner = await createUser({ name: 'Birthday Person' });
-    await ensureNotificationPreferencesForUser(viewer.id);
 
     await dispatchNotification({
       userId: viewer.id,
@@ -282,7 +276,6 @@ describe('notification dispatcher', () => {
   it('is idempotent per sourceIdentifier for UPCOMING_BIRTHDAY', async () => {
     const viewer = await createUser();
     const birthdayOwner = await createUser();
-    await ensureNotificationPreferencesForUser(viewer.id);
 
     const notify = () =>
       dispatchNotification({
@@ -304,7 +297,6 @@ describe('notification dispatcher', () => {
   it('sends birthday email when the user has opted in', async () => {
     const viewer = await createUser();
     const birthdayOwner = await createUser();
-    await ensureNotificationPreferencesForUser(viewer.id);
     await setNotificationPreference(
       viewer.id,
       NOTIFICATION_TYPES.UPCOMING_BIRTHDAY,
@@ -326,7 +318,6 @@ describe('notification dispatcher', () => {
   it('sends the birthday email only once across repeated calls — the delivery ledger gates every channel', async () => {
     const viewer = await createUser();
     const birthdayOwner = await createUser();
-    await ensureNotificationPreferencesForUser(viewer.id);
     await setNotificationPreference(
       viewer.id,
       NOTIFICATION_TYPES.UPCOMING_BIRTHDAY,
@@ -360,7 +351,6 @@ describe('notification dispatcher', () => {
   it('dedupes email for an email-only user with the in-app channel disabled', async () => {
     const viewer = await createUser();
     const birthdayOwner = await createUser();
-    await ensureNotificationPreferencesForUser(viewer.id);
     await setNotificationPreference(
       viewer.id,
       NOTIFICATION_TYPES.UPCOMING_BIRTHDAY,
@@ -398,7 +388,6 @@ describe('notification dispatcher', () => {
   it('sends the birthday push only once across repeated calls', async () => {
     const viewer = await createUser();
     const birthdayOwner = await createUser();
-    await ensureNotificationPreferencesForUser(viewer.id);
     await setNotificationPreference(
       viewer.id,
       NOTIFICATION_TYPES.UPCOMING_BIRTHDAY,
@@ -424,7 +413,6 @@ describe('notification dispatcher', () => {
   it('does not claim a recurring channel when delivery capability is unavailable', async () => {
     const viewer = await createUser();
     const birthdayOwner = await createUser();
-    await ensureNotificationPreferencesForUser(viewer.id);
     await setNotificationPreference(
       viewer.id,
       NOTIFICATION_TYPES.UPCOMING_BIRTHDAY,
@@ -462,7 +450,6 @@ describe('notification dispatcher', () => {
   it('derives a window-stable default sourceIdentifier — the birthday date, not the sweep day', async () => {
     const viewer = await createUser();
     const birthdayOwner = await createUser();
-    await ensureNotificationPreferencesForUser(viewer.id);
 
     // No sourceIdentifier passed: the event handler derives it from the birthday's
     // calendar date (now + daysUntil). Simulate the daily sweep advancing
@@ -495,7 +482,6 @@ describe('notification dispatcher', () => {
   it('re-notifies when the owner edits their birthday to a different date', async () => {
     const viewer = await createUser();
     const birthdayOwner = await createUser();
-    await ensureNotificationPreferencesForUser(viewer.id);
 
     const notify = (daysUntil: number) =>
       dispatchNotification({
@@ -521,7 +507,6 @@ describe('notification dispatcher', () => {
 
   it('renders a date-based message that cannot go stale in the bell', async () => {
     const viewer = await createUser();
-    await ensureNotificationPreferencesForUser(viewer.id);
 
     const notifyFor = async (daysUntil: number) => {
       const birthdayOwner = await createUser({ name: 'Birthday Person' });
@@ -553,7 +538,6 @@ describe('notification dispatcher', () => {
   it('claims nothing while all channels are disabled, so enabling one later in the window still delivers', async () => {
     const viewer = await createUser();
     const birthdayOwner = await createUser();
-    await ensureNotificationPreferencesForUser(viewer.id);
     await setNotificationPreference(
       viewer.id,
       NOTIFICATION_TYPES.UPCOMING_BIRTHDAY,
@@ -595,7 +579,6 @@ describe('notification dispatcher', () => {
   it('delivers to a channel enabled mid-window without repeating the others', async () => {
     const viewer = await createUser();
     const birthdayOwner = await createUser();
-    await ensureNotificationPreferencesForUser(viewer.id);
 
     const notify = () =>
       dispatchNotification({
@@ -629,7 +612,6 @@ describe('notification dispatcher', () => {
   it('isolates channel failures — a failing email does not block push', async () => {
     const viewer = await createUser();
     const birthdayOwner = await createUser();
-    await ensureNotificationPreferencesForUser(viewer.id);
     await setNotificationPreference(
       viewer.id,
       NOTIFICATION_TYPES.UPCOMING_BIRTHDAY,
@@ -667,7 +649,6 @@ describe('notification dispatcher', () => {
   it('treats a sendEmail error status (no throw) as a failed channel', async () => {
     const viewer = await createUser();
     const birthdayOwner = await createUser();
-    await ensureNotificationPreferencesForUser(viewer.id);
     await setNotificationPreference(
       viewer.id,
       NOTIFICATION_TYPES.UPCOMING_BIRTHDAY,
@@ -699,7 +680,6 @@ describe('notification dispatcher', () => {
   it('fires occasion_reminder_sent once per delivery, never on no-op re-runs', async () => {
     const viewer = await createUser();
     const birthdayOwner = await createUser();
-    await ensureNotificationPreferencesForUser(viewer.id);
 
     const notify = () =>
       dispatchNotification({

--- a/app/utils/notification-dispatcher.server.ts
+++ b/app/utils/notification-dispatcher.server.ts
@@ -48,7 +48,11 @@ export async function dispatchNotification(
   intent: NotificationIntent,
 ): Promise<NotificationDispatchResult> {
   const [policy, occurrenceKey] = await Promise.all([
-    resolveNotificationPolicy({ userId: intent.userId, type: intent.type }),
+    resolveNotificationPolicy({
+      userId: intent.userId,
+      type: intent.type,
+      context: intent.context,
+    }),
     Promise.resolve(getNotificationOccurrenceKey(intent)),
   ]);
   const definition = getNotificationEventDefinition(intent.type);

--- a/app/utils/notification-policy.server.test.ts
+++ b/app/utils/notification-policy.server.test.ts
@@ -3,10 +3,14 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { prisma } from '#app/utils/db.server.ts';
 import {
   NOTIFICATION_CHANNELS,
+  NOTIFICATION_TOPICS,
   NOTIFICATION_TYPES,
 } from '#app/utils/notification-catalog.ts';
 import { resolveNotificationPolicy } from '#app/utils/notification-policy.server.ts';
-import { setNotificationPreference } from '#app/utils/notification-preferences.server.ts';
+import {
+  setGlobalChannelPreference,
+  setTopicChannelPreference,
+} from '#app/utils/notification-preferences.server.ts';
 
 async function createUser() {
   return prisma.user.create({
@@ -27,50 +31,87 @@ async function createUser() {
 describe('resolveNotificationPolicy', () => {
   beforeEach(async () => {
     await prisma.notificationPreferenceAudit.deleteMany();
-    await prisma.userNotificationPreference.deleteMany();
+    await prisma.notificationTopicPreference.deleteMany();
+    await prisma.notificationCategoryPreference.deleteMany();
+    await prisma.notificationChannelPreference.deleteMany();
     await prisma.user.deleteMany({
       where: { email: { contains: '@example.com' } },
     });
   });
 
-  it('explains catalog defaults when legacy rows are missing', async () => {
+  it('explains catalog defaults when sparse rows are missing', async () => {
     const user = await createUser();
-
     const policy = await resolveNotificationPolicy({
       userId: user.id,
       type: NOTIFICATION_TYPES.UPCOMING_BIRTHDAY,
     });
 
-    expect(policy.channels[NOTIFICATION_CHANNELS.IN_APP]).toMatchObject({
+    expect(policy.channels[NOTIFICATION_CHANNELS.IN_APP]).toEqual({
+      channel: NOTIFICATION_CHANNELS.IN_APP,
       allowed: true,
       reason: 'allowed',
+      source: 'catalog_default',
     });
-    expect(policy.channels[NOTIFICATION_CHANNELS.EMAIL]).toMatchObject({
+    expect(policy.channels[NOTIFICATION_CHANNELS.EMAIL]).toEqual({
+      channel: NOTIFICATION_CHANNELS.EMAIL,
       allowed: false,
       reason: 'preference_disabled',
+      source: 'catalog_default',
     });
   });
 
-  it('reflects an explicit legacy event preference', async () => {
+  it('reflects a topic override shared by concrete events', async () => {
     const user = await createUser();
-    await setNotificationPreference(
-      user.id,
-      NOTIFICATION_TYPES.UPCOMING_BIRTHDAY,
-      NOTIFICATION_CHANNELS.EMAIL,
-      true,
-      'policy-test',
-    );
+    await setTopicChannelPreference({
+      userId: user.id,
+      topic: NOTIFICATION_TOPICS.FRIEND_REQUESTS,
+      channel: NOTIFICATION_CHANNELS.EMAIL,
+      enabled: false,
+      source: 'policy-test',
+    });
 
+    for (const type of [
+      NOTIFICATION_TYPES.FRIEND_REQUEST_RECEIVED,
+      NOTIFICATION_TYPES.FRIEND_REQUEST_ACCEPTED,
+    ]) {
+      const policy = await resolveNotificationPolicy({ userId: user.id, type });
+      expect(policy.channels[NOTIFICATION_CHANNELS.EMAIL]).toEqual({
+        channel: NOTIFICATION_CHANNELS.EMAIL,
+        allowed: false,
+        reason: 'preference_disabled',
+        source: 'topic_override',
+      });
+    }
+  });
+
+  it('applies a disabled global channel gate before topic choices', async () => {
+    const user = await createUser();
+    await setGlobalChannelPreference({
+      userId: user.id,
+      channel: NOTIFICATION_CHANNELS.IN_APP,
+      enabled: false,
+      source: 'policy-test',
+    });
     const policy = await resolveNotificationPolicy({
       userId: user.id,
-      type: NOTIFICATION_TYPES.UPCOMING_BIRTHDAY,
+      type: NOTIFICATION_TYPES.FRIEND_REQUEST_RECEIVED,
     });
+    expect(policy.channels[NOTIFICATION_CHANNELS.IN_APP]).toMatchObject({
+      allowed: false,
+      reason: 'preference_disabled',
+      source: 'global_channel',
+    });
+  });
 
-    expect(policy.channels[NOTIFICATION_CHANNELS.EMAIL]).toEqual({
-      channel: NOTIFICATION_CHANNELS.EMAIL,
-      allowed: true,
-      reason: 'allowed',
-      source: 'legacy_event_preference',
-    });
+  it('fails closed when an event receives the wrong context kind', async () => {
+    const user = await createUser();
+
+    await expect(
+      resolveNotificationPolicy({
+        userId: user.id,
+        type: NOTIFICATION_TYPES.FRIEND_REQUEST_RECEIVED,
+        context: { kind: 'POOL', poolId: 'pool-1' },
+      }),
+    ).rejects.toThrow('requires context kind NONE');
   });
 });

--- a/app/utils/notification-policy.server.ts
+++ b/app/utils/notification-policy.server.ts
@@ -1,22 +1,35 @@
 import {
-  channelToColumn,
   getNotificationEventDefinition,
+  matchesNotificationContext,
   NOTIFICATION_CHANNEL_VALUES,
   type NotificationChannel,
+  type NotificationContext,
   type NotificationType,
 } from '#app/utils/notification-catalog.ts';
-import { getNotificationPreferenceForChannels } from '#app/utils/notification-preferences.server.ts';
+import {
+  allowsContextActivity,
+  getContextNotificationPreference,
+  resolveCentralNotificationPreferences,
+  type CentralPreferenceSource,
+} from '#app/utils/notification-preferences.server.ts';
 
 export type NotificationPolicyReason =
   | 'allowed'
   | 'preference_disabled'
+  | 'context_muted'
+  | 'context_filtered'
   | 'unsupported';
 
 export type NotificationChannelPolicy = {
   channel: NotificationChannel;
   allowed: boolean;
   reason: NotificationPolicyReason;
-  source: 'catalog' | 'legacy_event_preference';
+  source:
+    | 'catalog'
+    | CentralPreferenceSource
+    | 'application_default'
+    | 'group_override'
+    | 'pool_override';
 };
 
 export type ResolvedNotificationPolicy = {
@@ -25,20 +38,34 @@ export type ResolvedNotificationPolicy = {
 };
 
 /**
- * The policy seam already returns explainable per-channel decisions even
- * though milestone 4 reads the legacy per-event rows underneath it. Scoped
- * preference storage can replace that implementation without widening the
- * dispatcher's interface.
+ * The policy seam owns central precedence and contextual filtering. The
+ * dispatcher submits the same typed intent and remains unaware of storage.
  */
 export async function resolveNotificationPolicy({
   userId,
   type,
+  context,
 }: {
   userId: string;
   type: NotificationType;
+  context?: NotificationContext;
 }): Promise<ResolvedNotificationPolicy> {
   const definition = getNotificationEventDefinition(type);
-  const preferences = await getNotificationPreferenceForChannels(userId, type);
+  if (!matchesNotificationContext(definition.context, context)) {
+    throw new Error(
+      `Notification ${type} requires context kind ${definition.context}.`,
+    );
+  }
+  const [central, contextual] = await Promise.all([
+    resolveCentralNotificationPreferences({ userId, type }),
+    definition.context !== 'NONE' && context
+      ? getContextNotificationPreference({
+          userId,
+          context,
+          requireAccess: false,
+        })
+      : null,
+  ]);
 
   const entries = NOTIFICATION_CHANNEL_VALUES.map((channel) => {
     if (!definition.supportedChannels.includes(channel)) {
@@ -53,14 +80,44 @@ export async function resolveNotificationPolicy({
       ] as const;
     }
 
-    const allowed = preferences[channelToColumn(channel)];
+    const preference = central.channels[channel];
+    if (!preference.enabled) {
+      return [
+        channel,
+        {
+          channel,
+          allowed: false,
+          reason: 'preference_disabled',
+          source: preference.source,
+        },
+      ] as const;
+    }
+
+    if (
+      contextual &&
+      !allowsContextActivity(contextual, central.topic, definition.importance)
+    ) {
+      return [
+        channel,
+        {
+          channel,
+          allowed: false,
+          reason:
+            contextual.activityLevel === 'MUTED'
+              ? 'context_muted'
+              : 'context_filtered',
+          source: contextual.source,
+        },
+      ] as const;
+    }
+
     return [
       channel,
       {
         channel,
-        allowed,
-        reason: allowed ? 'allowed' : 'preference_disabled',
-        source: 'legacy_event_preference',
+        allowed: true,
+        reason: 'allowed',
+        source: preference.source,
       },
     ] as const;
   });

--- a/app/utils/notification-preference-migration.test.ts
+++ b/app/utils/notification-preference-migration.test.ts
@@ -1,0 +1,137 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const migrationPath = path.join(
+  process.cwd(),
+  'prisma/migrations/20260714032000_scoped_notification_preferences/migration.sql',
+);
+
+describe('scoped notification preference migration', () => {
+  let db: Database.Database | null = null;
+
+  afterEach(() => {
+    db?.close();
+    db = null;
+  });
+
+  it('preserves defaults, derives the email gate, and consolidates conflicts conservatively', () => {
+    db = new Database(':memory:');
+    db.exec(`
+      PRAGMA foreign_keys = ON;
+      CREATE TABLE "User" ("id" TEXT NOT NULL PRIMARY KEY);
+      CREATE TABLE "UserNotificationPreference" (
+        "userId" TEXT NOT NULL,
+        "type" TEXT NOT NULL,
+        "inAppEnabled" BOOLEAN NOT NULL,
+        "emailEnabled" BOOLEAN NOT NULL,
+        "pushEnabled" BOOLEAN NOT NULL,
+        "createdAt" DATETIME NOT NULL,
+        "updatedAt" DATETIME NOT NULL,
+        PRIMARY KEY ("userId", "type")
+      );
+      CREATE TABLE "NotificationPreferenceAudit" (
+        "id" TEXT NOT NULL PRIMARY KEY,
+        "userId" TEXT NOT NULL,
+        "type" TEXT NOT NULL,
+        "channel" TEXT NOT NULL,
+        "previousValue" BOOLEAN NOT NULL,
+        "newValue" BOOLEAN NOT NULL,
+        "source" TEXT NOT NULL,
+        "createdAt" DATETIME NOT NULL
+      );
+    `);
+
+    const users = ['defaults', 'all-off', 'conflict', 'birthday-opt-in'];
+    const insertUser = db.prepare('INSERT INTO "User" ("id") VALUES (?)');
+    const insertPreference = db.prepare(`
+      INSERT INTO "UserNotificationPreference" (
+        "userId", "type", "inAppEnabled", "emailEnabled", "pushEnabled",
+        "createdAt", "updatedAt"
+      ) VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+    `);
+    for (const userId of users) insertUser.run(userId);
+    for (const userId of users) {
+      insertPreference.run(
+        userId,
+        'FRIEND_REQUEST_RECEIVED',
+        1,
+        userId === 'all-off' || userId === 'conflict' ? 0 : 1,
+        0,
+      );
+      insertPreference.run(
+        userId,
+        'FRIEND_REQUEST_ACCEPTED',
+        1,
+        userId === 'all-off' ? 0 : 1,
+        0,
+      );
+      insertPreference.run(
+        userId,
+        'UPCOMING_BIRTHDAY',
+        1,
+        userId === 'birthday-opt-in' ? 1 : 0,
+        0,
+      );
+    }
+    db.prepare(
+      `
+      INSERT INTO "NotificationPreferenceAudit" VALUES (
+        'audit-1', 'conflict', 'FRIEND_REQUEST_RECEIVED', 'EMAIL',
+        1, 0, 'legacy-settings', CURRENT_TIMESTAMP
+      )
+    `,
+    ).run();
+
+    db.exec(fs.readFileSync(migrationPath, 'utf8'));
+
+    expect(
+      db
+        .prepare(
+          'SELECT * FROM "NotificationChannelPreference" WHERE "userId" = ? AND "channel" = ?',
+        )
+        .get('all-off', 'EMAIL'),
+    ).toMatchObject({ enabled: 0 });
+    expect(
+      db
+        .prepare(
+          'SELECT * FROM "NotificationTopicPreference" WHERE "userId" = ?',
+        )
+        .all('defaults'),
+    ).toEqual([]);
+    expect(
+      db
+        .prepare(
+          'SELECT * FROM "NotificationTopicPreference" WHERE "userId" = ? AND "topic" = ? AND "channel" = ?',
+        )
+        .get('conflict', 'FRIEND_REQUESTS', 'EMAIL'),
+    ).toMatchObject({ enabled: 0 });
+    expect(
+      db
+        .prepare(
+          'SELECT * FROM "NotificationTopicPreference" WHERE "userId" = ? AND "topic" = ? AND "channel" = ?',
+        )
+        .get('birthday-opt-in', 'BIRTHDAY_REMINDERS', 'EMAIL'),
+    ).toMatchObject({ enabled: 1 });
+    expect(
+      db
+        .prepare(
+          'SELECT "kind", "preferenceKey", "previousValue", "newValue" FROM "NotificationPreferenceAudit" WHERE "id" = ?',
+        )
+        .get('audit-1'),
+    ).toEqual({
+      kind: 'LEGACY_EVENT',
+      preferenceKey: 'FRIEND_REQUEST_RECEIVED',
+      previousValue: 'true',
+      newValue: 'false',
+    });
+    expect(
+      db
+        .prepare(
+          "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'UserNotificationPreference'",
+        )
+        .get(),
+    ).toBeUndefined();
+  });
+});

--- a/app/utils/notification-preferences.server.test.ts
+++ b/app/utils/notification-preferences.server.test.ts
@@ -1,19 +1,28 @@
 import { randomUUID } from 'node:crypto';
-import { describe, expect, it, beforeEach } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { prisma } from '#app/utils/db.server.ts';
 import {
   DEFAULT_NOTIFICATION_PREFERENCES,
+  NOTIFICATION_CATEGORIES,
   NOTIFICATION_CHANNELS,
+  NOTIFICATION_TOPICS,
   NOTIFICATION_TYPES,
-  type NotificationType,
 } from '#app/utils/notification-catalog.ts';
 import {
+  allowsContextActivity,
+  clearContextActivityPreference,
   disableEmailForAll,
-  ensureNotificationPreferencesForUser,
+  dismissContextMutedNotice,
+  getContextNotificationPreference,
   getNotificationPreferenceForChannels,
   getNotificationPreferences,
-  notificationPreferenceDefaultsFor,
+  NOTIFICATION_ACTIVITY_LEVELS,
+  resolveCentralNotificationPreferences,
+  setCategoryChannelPreference,
+  setContextActivityPreference,
+  setGlobalChannelPreference,
   setNotificationPreference,
+  setTopicChannelPreference,
 } from '#app/utils/notification-preferences.server.ts';
 
 async function createUser() {
@@ -32,10 +41,39 @@ async function createUser() {
   });
 }
 
+async function createGroupPool(userId: string) {
+  const group = await prisma.giftGroup.create({
+    data: {
+      name: `Group ${randomUUID()}`,
+      groupMembers: { create: { userId } },
+    },
+    select: { id: true },
+  });
+  const pool = await prisma.pool.create({
+    data: {
+      title: `Pool ${randomUUID()}`,
+      organizerId: userId,
+      giftGroupId: group.id,
+      contributors: { create: { userId } },
+    },
+    select: { id: true },
+  });
+  return { group, pool };
+}
+
 describe('notification preferences', () => {
   beforeEach(async () => {
+    vi.useRealTimers();
     await prisma.notificationPreferenceAudit.deleteMany();
-    await prisma.userNotificationPreference.deleteMany();
+    await prisma.poolNotificationPreference.deleteMany();
+    await prisma.groupNotificationPreference.deleteMany();
+    await prisma.notificationTopicPreference.deleteMany();
+    await prisma.notificationCategoryPreference.deleteMany();
+    await prisma.notificationChannelPreference.deleteMany();
+    await prisma.poolContributor.deleteMany();
+    await prisma.pool.deleteMany();
+    await prisma.usersInGiftGroups.deleteMany();
+    await prisma.giftGroup.deleteMany();
     await prisma.friendRequest.deleteMany();
     await prisma.friendship.deleteMany();
     await prisma.user.deleteMany({
@@ -43,24 +81,22 @@ describe('notification preferences', () => {
     });
   });
 
-  it('seeds defaults when ensuring preferences', async () => {
+  it('inherits catalog defaults without materializing rows', async () => {
     const user = await createUser();
-    await ensureNotificationPreferencesForUser(user.id);
-    const preference = await getNotificationPreferenceForChannels(
-      user.id,
-      NOTIFICATION_TYPES.FRIEND_REQUEST_RECEIVED,
-    );
-    expect(preference).toEqual({
-      inAppEnabled: true,
-      emailEnabled: true,
-      pushEnabled: false,
-    });
+    const preferences = await getNotificationPreferences(user.id);
+
+    for (const type of Object.values(NOTIFICATION_TYPES)) {
+      expect(preferences.get(type)).toEqual(
+        DEFAULT_NOTIFICATION_PREFERENCES[type],
+      );
+    }
+    await expect(
+      prisma.notificationTopicPreference.count({ where: { userId: user.id } }),
+    ).resolves.toBe(0);
   });
 
-  it('persists preference changes with audit log entries', async () => {
+  it('maps both friend events to one sparse topic override', async () => {
     const user = await createUser();
-    await ensureNotificationPreferencesForUser(user.id);
-
     await setNotificationPreference(
       user.id,
       NOTIFICATION_TYPES.FRIEND_REQUEST_RECEIVED,
@@ -69,198 +105,337 @@ describe('notification preferences', () => {
       'test',
     );
 
-    const preference = await getNotificationPreferenceForChannels(
-      user.id,
+    for (const type of [
       NOTIFICATION_TYPES.FRIEND_REQUEST_RECEIVED,
-    );
-    expect(preference.emailEnabled).toBe(false);
-
-    const audit = await prisma.notificationPreferenceAudit.findFirst({
-      where: {
-        userId: user.id,
-        type: NOTIFICATION_TYPES.FRIEND_REQUEST_RECEIVED,
-      },
-    });
-    expect(audit).not.toBeNull();
-    expect(audit?.previousValue).toBe(true);
-    expect(audit?.newValue).toBe(false);
-    expect(audit?.channel).toBe(NOTIFICATION_CHANNELS.EMAIL);
-  });
-
-  it('disables email for all types', async () => {
-    const user = await createUser();
-    await ensureNotificationPreferencesForUser(user.id);
-
-    await disableEmailForAll(user.id, 'test');
-
-    for (const type of Object.values(NOTIFICATION_TYPES)) {
-      const pref = await getNotificationPreferenceForChannels(user.id, type);
-      if (type === NOTIFICATION_TYPES.UPCOMING_BIRTHDAY) {
-        expect(pref.emailEnabled).toBe(false);
-      } else {
-        expect(pref.emailEnabled).toBe(false);
-      }
+      NOTIFICATION_TYPES.FRIEND_REQUEST_ACCEPTED,
+    ]) {
+      await expect(
+        getNotificationPreferenceForChannels(user.id, type),
+      ).resolves.toMatchObject({ emailEnabled: false });
     }
-  });
-
-  it('disableEmailForAll is a no-op when no email rows are enabled', async () => {
-    const user = await createUser();
-    await ensureNotificationPreferencesForUser(user.id);
-    // Flip all email prefs off ahead of time.
-    await prisma.userNotificationPreference.updateMany({
-      where: { userId: user.id },
-      data: { emailEnabled: false },
-    });
-    const beforeAudit = await prisma.notificationPreferenceAudit.count({
-      where: { userId: user.id },
-    });
-
-    await disableEmailForAll(user.id, 'test-noop');
-
-    const afterAudit = await prisma.notificationPreferenceAudit.count({
-      where: { userId: user.id },
-    });
-    expect(afterAudit).toBe(beforeAudit);
-  });
-
-  it('disableEmailForAll only audits the rows that actually transitioned', async () => {
-    const user = await createUser();
-    await ensureNotificationPreferencesForUser(user.id);
-    // Pre-disable one email pref so only one row transitions.
-    await prisma.userNotificationPreference.updateMany({
-      where: {
-        userId: user.id,
-        type: NOTIFICATION_TYPES.FRIEND_REQUEST_ACCEPTED,
-      },
-      data: { emailEnabled: false },
-    });
-
-    await disableEmailForAll(user.id, 'test-partial');
-
-    const audits = await prisma.notificationPreferenceAudit.findMany({
-      where: { userId: user.id, source: 'test-partial' },
-      select: { type: true, previousValue: true, newValue: true },
-    });
-    // FRIEND_REQUEST_RECEIVED was true → false (and so was UPCOMING_BIRTHDAY
-    // if its default is true). Defaults live in notification-catalog; we
-    // assert we only audited rows whose previous value was true.
-    expect(audits.every((a) => a.previousValue === true)).toBe(true);
-    expect(audits.every((a) => a.newValue === false)).toBe(true);
-    // FRIEND_REQUEST_ACCEPTED was already off, so there should be no audit.
-    expect(
-      audits.find((a) => a.type === NOTIFICATION_TYPES.FRIEND_REQUEST_ACCEPTED),
-    ).toBeUndefined();
-  });
-
-  it('setNotificationPreference creates a row for users without one', async () => {
-    const user = await createUser();
-    // No ensure call — mimic a pre-bootstrap user visiting the toggle path.
-
-    const result = await setNotificationPreference(
-      user.id,
-      NOTIFICATION_TYPES.FRIEND_REQUEST_RECEIVED,
-      NOTIFICATION_CHANNELS.EMAIL,
-      false,
-      'test-fresh',
-    );
-
-    expect(result.emailEnabled).toBe(false);
-    const stored = await prisma.userNotificationPreference.findUnique({
-      where: {
-        userId_type: {
-          userId: user.id,
-          type: NOTIFICATION_TYPES.FRIEND_REQUEST_RECEIVED,
+    await expect(
+      prisma.notificationTopicPreference.findUnique({
+        where: {
+          userId_topic_channel: {
+            userId: user.id,
+            topic: NOTIFICATION_TOPICS.FRIEND_REQUESTS,
+            channel: NOTIFICATION_CHANNELS.EMAIL,
+          },
         },
-      },
-      select: { emailEnabled: true, inAppEnabled: true },
+      }),
+    ).resolves.toMatchObject({ enabled: false });
+    await expect(
+      prisma.notificationPreferenceAudit.findFirst({
+        where: { userId: user.id, source: 'test' },
+      }),
+    ).resolves.toMatchObject({
+      kind: 'TOPIC',
+      preferenceKey: NOTIFICATION_TOPICS.FRIEND_REQUESTS,
+      previousValue: 'true',
+      newValue: 'false',
     });
-    expect(stored?.emailEnabled).toBe(false);
-    // The other channel defaults to the registry value.
-    expect(stored?.inAppEnabled).toBe(
-      DEFAULT_NOTIFICATION_PREFERENCES[
-        NOTIFICATION_TYPES.FRIEND_REQUEST_RECEIVED
-      ].inAppEnabled,
-    );
-    // An audit row is written because the effective value moved from
-    // "default true" → "explicit false".
-    const audit = await prisma.notificationPreferenceAudit.findFirst({
-      where: { userId: user.id, source: 'test-fresh' },
-    });
-    expect(audit).not.toBeNull();
-    expect(audit?.previousValue).toBe(true);
-    expect(audit?.newValue).toBe(false);
   });
 
-  it('setNotificationPreference returns the existing row when the value is unchanged', async () => {
+  it('resolves topic over category over catalog, with the global gate absolute', async () => {
     const user = await createUser();
-    await ensureNotificationPreferencesForUser(user.id);
-
-    // Idempotent call: try to "set" to the current default.
-    const result = await setNotificationPreference(
-      user.id,
-      NOTIFICATION_TYPES.FRIEND_REQUEST_RECEIVED,
-      NOTIFICATION_CHANNELS.EMAIL,
-      DEFAULT_NOTIFICATION_PREFERENCES[
-        NOTIFICATION_TYPES.FRIEND_REQUEST_RECEIVED
-      ].emailEnabled,
-      'test-idempotent',
-    );
-
-    expect(result.emailEnabled).toBe(
-      DEFAULT_NOTIFICATION_PREFERENCES[
-        NOTIFICATION_TYPES.FRIEND_REQUEST_RECEIVED
-      ].emailEnabled,
-    );
-    // No audit row for no-op.
-    const audit = await prisma.notificationPreferenceAudit.findFirst({
-      where: { userId: user.id, source: 'test-idempotent' },
+    await setCategoryChannelPreference({
+      userId: user.id,
+      category: NOTIFICATION_CATEGORIES.OCCASIONS,
+      channel: NOTIFICATION_CHANNELS.EMAIL,
+      enabled: true,
+      source: 'test-category',
     });
-    expect(audit).toBeNull();
+    let resolved = await resolveCentralNotificationPreferences({
+      userId: user.id,
+      type: NOTIFICATION_TYPES.UPCOMING_BIRTHDAY,
+    });
+    expect(resolved.channels.EMAIL).toEqual({
+      enabled: true,
+      source: 'category_override',
+    });
+
+    await setTopicChannelPreference({
+      userId: user.id,
+      topic: NOTIFICATION_TOPICS.BIRTHDAY_REMINDERS,
+      channel: NOTIFICATION_CHANNELS.EMAIL,
+      enabled: false,
+      source: 'test-topic',
+    });
+    resolved = await resolveCentralNotificationPreferences({
+      userId: user.id,
+      type: NOTIFICATION_TYPES.UPCOMING_BIRTHDAY,
+    });
+    expect(resolved.channels.EMAIL).toEqual({
+      enabled: false,
+      source: 'topic_override',
+    });
+
+    await setGlobalChannelPreference({
+      userId: user.id,
+      channel: NOTIFICATION_CHANNELS.EMAIL,
+      enabled: false,
+      source: 'test-global',
+    });
+    resolved = await resolveCentralNotificationPreferences({
+      userId: user.id,
+      type: NOTIFICATION_TYPES.UPCOMING_BIRTHDAY,
+    });
+    expect(resolved.channels.EMAIL).toEqual({
+      enabled: false,
+      source: 'global_channel',
+    });
+
+    await setTopicChannelPreference({
+      userId: user.id,
+      topic: NOTIFICATION_TOPICS.BIRTHDAY_REMINDERS,
+      channel: NOTIFICATION_CHANNELS.EMAIL,
+      enabled: true,
+      source: 'test-topic-while-gated',
+    });
+    await setGlobalChannelPreference({
+      userId: user.id,
+      channel: NOTIFICATION_CHANNELS.EMAIL,
+      enabled: true,
+      source: 'test-global-enable',
+    });
+    resolved = await resolveCentralNotificationPreferences({
+      userId: user.id,
+      type: NOTIFICATION_TYPES.UPCOMING_BIRTHDAY,
+    });
+    expect(resolved.channels.EMAIL).toEqual({
+      enabled: true,
+      source: 'topic_override',
+    });
   });
 
-  it('getNotificationPreferences fills in defaults for types without a row', async () => {
+  it('applies category bulk changes atomically and clears narrower overrides', async () => {
     const user = await createUser();
-    // Seed exactly one row so we can verify the fill-in merges with stored.
-    await prisma.userNotificationPreference.create({
-      data: {
-        userId: user.id,
-        type: NOTIFICATION_TYPES.FRIEND_REQUEST_RECEIVED,
-        inAppEnabled: false,
-        emailEnabled: false,
-      },
+    await setTopicChannelPreference({
+      userId: user.id,
+      topic: NOTIFICATION_TOPICS.FRIEND_REQUESTS,
+      channel: NOTIFICATION_CHANNELS.EMAIL,
+      enabled: false,
+      source: 'test-topic',
+    });
+    await setCategoryChannelPreference({
+      userId: user.id,
+      category: NOTIFICATION_CATEGORIES.SOCIAL,
+      channel: NOTIFICATION_CHANNELS.EMAIL,
+      enabled: true,
+      source: 'test-bulk',
     });
 
-    const prefs = await getNotificationPreferences(user.id);
-
-    // The stored row comes back as-is.
-    expect(prefs.get(NOTIFICATION_TYPES.FRIEND_REQUEST_RECEIVED)).toEqual({
-      inAppEnabled: false,
-      emailEnabled: false,
-      pushEnabled: false,
+    await expect(
+      prisma.notificationTopicPreference.count({
+        where: {
+          userId: user.id,
+          topic: NOTIFICATION_TOPICS.FRIEND_REQUESTS,
+          channel: NOTIFICATION_CHANNELS.EMAIL,
+        },
+      }),
+    ).resolves.toBe(0);
+    const resolved = await resolveCentralNotificationPreferences({
+      userId: user.id,
+      type: NOTIFICATION_TYPES.FRIEND_REQUEST_RECEIVED,
     });
-    // Missing types come back with registry defaults.
-    for (const type of Object.values(NOTIFICATION_TYPES)) {
-      if (type === NOTIFICATION_TYPES.FRIEND_REQUEST_RECEIVED) continue;
-      expect(prefs.get(type)).toEqual(DEFAULT_NOTIFICATION_PREFERENCES[type]);
-    }
+    expect(resolved.channels.EMAIL).toEqual({
+      enabled: true,
+      source: 'category_override',
+    });
   });
 
-  it('notificationPreferenceDefaultsFor produces one row per registered type', () => {
-    const rows = notificationPreferenceDefaultsFor('user-xyz');
-    const types = new Set(rows.map((r) => r.type as NotificationType));
-    for (const type of Object.values(NOTIFICATION_TYPES)) {
-      expect(types.has(type)).toBe(true);
-    }
-    for (const row of rows) {
-      expect(row.userId).toBe('user-xyz');
-      expect(row.inAppEnabled).toBe(
-        DEFAULT_NOTIFICATION_PREFERENCES[row.type as NotificationType]
-          .inAppEnabled,
-      );
-      expect(row.emailEnabled).toBe(
-        DEFAULT_NOTIFICATION_PREFERENCES[row.type as NotificationType]
-          .emailEnabled,
-      );
-    }
+  it('rolls back a category operation when its user does not exist', async () => {
+    await expect(
+      setCategoryChannelPreference({
+        userId: 'missing-user',
+        category: NOTIFICATION_CATEGORIES.SOCIAL,
+        channel: NOTIFICATION_CHANNELS.EMAIL,
+        enabled: false,
+        source: 'test-rollback',
+      }),
+    ).rejects.toBeDefined();
+    await expect(
+      prisma.notificationCategoryPreference.count({
+        where: { userId: 'missing-user' },
+      }),
+    ).resolves.toBe(0);
+  });
+
+  it('disableEmailForAll creates one durable gate and is idempotent', async () => {
+    const user = await createUser();
+    await disableEmailForAll(user.id, 'test-disable');
+    await disableEmailForAll(user.id, 'test-disable-again');
+
+    await expect(
+      prisma.notificationChannelPreference.findUnique({
+        where: {
+          userId_channel: {
+            userId: user.id,
+            channel: NOTIFICATION_CHANNELS.EMAIL,
+          },
+        },
+      }),
+    ).resolves.toMatchObject({ enabled: false });
+    await expect(
+      prisma.notificationPreferenceAudit.count({
+        where: { userId: user.id, kind: 'GLOBAL_CHANNEL' },
+      }),
+    ).resolves.toBe(1);
+  });
+
+  it('inherits a group activity setting and permits an explicit child-pool override', async () => {
+    const user = await createUser();
+    const { group, pool } = await createGroupPool(user.id);
+    await setContextActivityPreference({
+      userId: user.id,
+      context: { kind: 'GROUP', groupId: group.id },
+      activityLevel: NOTIFICATION_ACTIVITY_LEVELS.MUTED,
+      source: 'test-group',
+    });
+
+    let resolved = await getContextNotificationPreference({
+      userId: user.id,
+      context: { kind: 'POOL', poolId: pool.id },
+    });
+    expect(resolved).toMatchObject({
+      activityLevel: NOTIFICATION_ACTIVITY_LEVELS.MUTED,
+      source: 'group_override',
+      controllingContext: { kind: 'GROUP', groupId: group.id },
+      noticeVisible: true,
+    });
+
+    await setContextActivityPreference({
+      userId: user.id,
+      context: { kind: 'POOL', poolId: pool.id },
+      activityLevel: NOTIFICATION_ACTIVITY_LEVELS.ALL_ACTIVITY,
+      source: 'test-pool',
+    });
+    resolved = await getContextNotificationPreference({
+      userId: user.id,
+      context: { kind: 'POOL', poolId: pool.id },
+    });
+    expect(resolved).toMatchObject({
+      activityLevel: NOTIFICATION_ACTIVITY_LEVELS.ALL_ACTIVITY,
+      source: 'pool_override',
+    });
+
+    await clearContextActivityPreference({
+      userId: user.id,
+      context: { kind: 'POOL', poolId: pool.id },
+      source: 'test-clear',
+    });
+    resolved = await getContextNotificationPreference({
+      userId: user.id,
+      context: { kind: 'POOL', poolId: pool.id },
+    });
+    expect(resolved.activityLevel).toBe(NOTIFICATION_ACTIVITY_LEVELS.MUTED);
+  });
+
+  it('normalizes empty Custom to Muted and filters populated Custom by topic', async () => {
+    const user = await createUser();
+    const { pool } = await createGroupPool(user.id);
+    const context = { kind: 'POOL', poolId: pool.id } as const;
+    await setContextActivityPreference({
+      userId: user.id,
+      context,
+      activityLevel: NOTIFICATION_ACTIVITY_LEVELS.CUSTOM,
+      customTopics: [],
+      source: 'test-empty',
+    });
+    let resolved = await getContextNotificationPreference({
+      userId: user.id,
+      context,
+    });
+    expect(resolved.activityLevel).toBe(NOTIFICATION_ACTIVITY_LEVELS.MUTED);
+
+    await setContextActivityPreference({
+      userId: user.id,
+      context,
+      activityLevel: NOTIFICATION_ACTIVITY_LEVELS.CUSTOM,
+      customTopics: [NOTIFICATION_TOPICS.FRIEND_REQUESTS],
+      source: 'test-custom',
+    });
+    resolved = await getContextNotificationPreference({
+      userId: user.id,
+      context,
+    });
+    expect(
+      allowsContextActivity(
+        resolved,
+        NOTIFICATION_TOPICS.FRIEND_REQUESTS,
+        'ROUTINE',
+      ),
+    ).toBe(true);
+    expect(
+      allowsContextActivity(
+        resolved,
+        NOTIFICATION_TOPICS.BIRTHDAY_REMINDERS,
+        'IMPORTANT',
+      ),
+    ).toBe(false);
+  });
+
+  it('dismisses one mute cycle and shows the notice after a later re-mute', async () => {
+    vi.useFakeTimers();
+    const user = await createUser();
+    const { group } = await createGroupPool(user.id);
+    const context = { kind: 'GROUP', groupId: group.id } as const;
+    vi.setSystemTime(new Date('2026-07-13T12:00:00Z'));
+    await setContextActivityPreference({
+      userId: user.id,
+      context,
+      activityLevel: NOTIFICATION_ACTIVITY_LEVELS.MUTED,
+      source: 'test-mute',
+    });
+    await dismissContextMutedNotice({
+      userId: user.id,
+      context,
+      source: 'test-dismiss',
+    });
+    let resolved = await getContextNotificationPreference({
+      userId: user.id,
+      context,
+    });
+    expect(resolved.noticeVisible).toBe(false);
+
+    vi.setSystemTime(new Date('2026-07-14T12:00:00Z'));
+    await setContextActivityPreference({
+      userId: user.id,
+      context,
+      activityLevel: NOTIFICATION_ACTIVITY_LEVELS.ALL_ACTIVITY,
+      source: 'test-unmute',
+    });
+    vi.setSystemTime(new Date('2026-07-15T12:00:00Z'));
+    await setContextActivityPreference({
+      userId: user.id,
+      context,
+      activityLevel: NOTIFICATION_ACTIVITY_LEVELS.MUTED,
+      source: 'test-remute',
+    });
+    resolved = await getContextNotificationPreference({
+      userId: user.id,
+      context,
+    });
+    expect(resolved.noticeVisible).toBe(true);
+    expect(resolved.noticeDismissedAt).toBeNull();
+  });
+
+  it('rejects context writes for non-members without persisting state', async () => {
+    const member = await createUser();
+    const outsider = await createUser();
+    const { group } = await createGroupPool(member.id);
+    await expect(
+      setContextActivityPreference({
+        userId: outsider.id,
+        context: { kind: 'GROUP', groupId: group.id },
+        activityLevel: NOTIFICATION_ACTIVITY_LEVELS.MUTED,
+        source: 'test-unauthorized',
+      }),
+    ).rejects.toMatchObject({ init: { status: 404 } });
+    await expect(
+      prisma.groupNotificationPreference.count({
+        where: { userId: outsider.id },
+      }),
+    ).resolves.toBe(0);
   });
 });

--- a/app/utils/notification-preferences.server.ts
+++ b/app/utils/notification-preferences.server.ts
@@ -1,115 +1,129 @@
+import { Prisma } from '@prisma/client';
+import { data } from 'react-router';
 import { prisma } from '#app/utils/db.server.ts';
 import {
   channelToColumn,
-  DEFAULT_NOTIFICATION_PREFERENCES,
+  getNotificationCategoryTopics,
+  getNotificationEventDefinition,
+  getNotificationTopicDefinition,
+  isNotificationTopic,
   NOTIFICATION_CHANNELS,
-  NOTIFICATION_TYPES,
+  NOTIFICATION_CHANNEL_VALUES,
+  NOTIFICATION_TOPIC_VALUES,
+  NOTIFICATION_TYPE_VALUES,
+  type NotificationCategory,
   type NotificationChannel,
+  type NotificationContext,
+  type NotificationImportance,
+  type NotificationPreferenceDefaults,
+  type NotificationTopic,
   type NotificationType,
 } from '#app/utils/notification-catalog.ts';
 
-const preferenceTypes = Object.values(NOTIFICATION_TYPES);
+export const NOTIFICATION_ACTIVITY_LEVELS = {
+  ALL_ACTIVITY: 'ALL_ACTIVITY',
+  IMPORTANT_ONLY: 'IMPORTANT_ONLY',
+  MUTED: 'MUTED',
+  CUSTOM: 'CUSTOM',
+} as const;
 
-function defaultForType(type: NotificationType) {
-  return DEFAULT_NOTIFICATION_PREFERENCES[type];
-}
+export type NotificationActivityLevel =
+  (typeof NOTIFICATION_ACTIVITY_LEVELS)[keyof typeof NOTIFICATION_ACTIVITY_LEVELS];
 
-// Shape used for `createMany` / nested `create` when bootstrapping a new user.
-// Kept as a plain data builder so callers can either pass it to signup's
-// nested-create or hand it to a standalone createMany.
-export function notificationPreferenceDefaultsFor(userId: string) {
-  const now = new Date();
-  return preferenceTypes.map((type) => ({
-    userId,
+export type CentralPreferenceSource =
+  | 'catalog_default'
+  | 'category_override'
+  | 'topic_override'
+  | 'global_channel';
+
+export type CentralChannelPreference = {
+  enabled: boolean;
+  source: CentralPreferenceSource;
+};
+
+export type ResolvedCentralNotificationPreferences = {
+  type: NotificationType;
+  topic: NotificationTopic;
+  category: NotificationCategory;
+  channels: Record<NotificationChannel, CentralChannelPreference>;
+};
+
+export type ResolvedContextNotificationPreference = {
+  context: NotificationContext;
+  activityLevel: NotificationActivityLevel;
+  source: 'application_default' | 'group_override' | 'pool_override';
+  customTopics: Array<NotificationTopic>;
+  mutedAt: Date | null;
+  noticeDismissedAt: Date | null;
+  noticeVisible: boolean;
+  controllingContext: NotificationContext | null;
+};
+
+const DEFAULT_GLOBAL_CHANNEL_PREFERENCES: Record<NotificationChannel, boolean> =
+  {
+    [NOTIFICATION_CHANNELS.IN_APP]: true,
+    [NOTIFICATION_CHANNELS.EMAIL]: true,
+    [NOTIFICATION_CHANNELS.WEB_PUSH]: true,
+  };
+
+type CentralPreferenceState = {
+  gates: Map<NotificationChannel, boolean>;
+  categories: Map<string, boolean>;
+  topics: Map<string, boolean>;
+};
+
+export async function resolveCentralNotificationPreferences({
+  userId,
+  type,
+}: {
+  userId: string;
+  type: NotificationType;
+}): Promise<ResolvedCentralNotificationPreferences> {
+  return resolveCentralFromState(
     type,
-    inAppEnabled: defaultForType(type).inAppEnabled,
-    emailEnabled: defaultForType(type).emailEnabled,
-    pushEnabled: defaultForType(type).pushEnabled,
-    createdAt: now,
-    updatedAt: now,
-  }));
-}
-
-// Legacy bootstrap: upserts one row per notification type. Still exported for
-// tests and for the settings route's "heal missing rows" paths, but it should
-// NOT be called on the hot read path — reads tolerate missing rows by falling
-// back to `DEFAULT_NOTIFICATION_PREFERENCES`, and new users get their rows
-// via `createMany` in the signup flow.
-export async function ensureNotificationPreferencesForUser(
-  userId: string,
-  tx = prisma,
-) {
-  const now = new Date();
-  await Promise.all(
-    preferenceTypes.map((type) =>
-      tx.userNotificationPreference.upsert({
-        where: {
-          userId_type: {
-            userId,
-            type,
-          },
-        },
-        update: {},
-        create: {
-          userId,
-          type,
-          inAppEnabled: defaultForType(type).inAppEnabled,
-          emailEnabled: defaultForType(type).emailEnabled,
-          pushEnabled: defaultForType(type).pushEnabled,
-          createdAt: now,
-          updatedAt: now,
-        },
-      }),
-    ),
+    await loadCentralPreferenceState(userId),
   );
 }
 
 export async function getNotificationPreferences(userId: string) {
-  const prefs = await prisma.userNotificationPreference.findMany({
-    where: { userId },
-    select: {
-      type: true,
-      inAppEnabled: true,
-      emailEnabled: true,
-      pushEnabled: true,
-    },
-  });
-  const map = new Map<
-    NotificationType,
-    { inAppEnabled: boolean; emailEnabled: boolean; pushEnabled: boolean }
-  >();
-  for (const pref of prefs) {
-    map.set(pref.type as NotificationType, {
-      inAppEnabled: pref.inAppEnabled,
-      emailEnabled: pref.emailEnabled,
-      pushEnabled: pref.pushEnabled,
-    });
-  }
-  // Fill in defaults for any type that doesn't yet have a row. This replaces
-  // the old "ensure upsert" pattern that ran N writes on every read.
-  for (const type of preferenceTypes) {
-    if (!map.has(type)) {
-      map.set(type, { ...defaultForType(type) });
-    }
-  }
-  return map;
+  return (await getNotificationPreferencesForUsers([userId])).get(
+    userId,
+  ) as Map<NotificationType, NotificationPreferenceDefaults>;
+}
+
+/** Bulk resolved read for admin/operations surfaces without N×3 queries. */
+export async function getNotificationPreferencesForUsers(userIds: string[]) {
+  const states = await loadCentralPreferenceStates(userIds);
+  return new Map(
+    userIds.map((userId) => {
+      const state = states.get(userId) ?? emptyCentralPreferenceState();
+      return [
+        userId,
+        new Map(
+          NOTIFICATION_TYPE_VALUES.map((type) => [
+            type,
+            channelsToLegacyShape(
+              resolveCentralFromState(type, state).channels,
+            ),
+          ]),
+        ),
+      ];
+    }),
+  );
 }
 
 export async function getNotificationPreferenceForChannels(
   userId: string,
   type: NotificationType,
 ) {
-  const pref = await prisma.userNotificationPreference.findUnique({
-    where: { userId_type: { userId, type } },
-    select: { inAppEnabled: true, emailEnabled: true, pushEnabled: true },
+  const resolved = await resolveCentralNotificationPreferences({
+    userId,
+    type,
   });
-  if (!pref) {
-    const defaults = defaultForType(type);
-    return { ...defaults };
-  }
-  return pref;
+  return channelsToLegacyShape(resolved.channels);
 }
 
+/** Compatibility interface for the current per-event settings screen. */
 export async function setNotificationPreference(
   userId: string,
   type: NotificationType,
@@ -117,81 +131,735 @@ export async function setNotificationPreference(
   enabled: boolean,
   source: string,
 ) {
-  const column = channelToColumn(channel);
-  const existing = await prisma.userNotificationPreference.findUnique({
-    where: { userId_type: { userId, type } },
-    select: { inAppEnabled: true, emailEnabled: true, pushEnabled: true },
+  const topic = getNotificationEventDefinition(type).topic;
+  await setTopicChannelPreference({
+    userId,
+    topic,
+    channel,
+    enabled,
+    source,
   });
-  const defaults = defaultForType(type);
-  const previousValue = existing?.[column] ?? defaults[column];
-  if (existing && previousValue === enabled) {
-    return existing;
-  }
+  return getNotificationPreferenceForChannels(userId, type);
+}
 
-  const result = await prisma.$transaction(async (tx) => {
-    const updated = await tx.userNotificationPreference.upsert({
-      where: { userId_type: { userId, type } },
-      update: {
-        [column]: enabled,
-      },
-      create: {
-        userId,
-        type,
-        inAppEnabled:
-          column === 'inAppEnabled' ? enabled : defaults.inAppEnabled,
-        emailEnabled:
-          column === 'emailEnabled' ? enabled : defaults.emailEnabled,
-        pushEnabled: column === 'pushEnabled' ? enabled : defaults.pushEnabled,
-      },
+export async function setGlobalChannelPreference({
+  userId,
+  channel,
+  enabled,
+  source,
+}: {
+  userId: string;
+  channel: NotificationChannel;
+  enabled: boolean;
+  source: string;
+}) {
+  const defaultValue = DEFAULT_GLOBAL_CHANNEL_PREFERENCES[channel];
+  await prisma.$transaction(async (tx) => {
+    const existing = await tx.notificationChannelPreference.findUnique({
+      where: { userId_channel: { userId, channel } },
+      select: { enabled: true },
     });
+    const previousValue = existing?.enabled ?? defaultValue;
+    if (previousValue === enabled) return;
 
-    // Only emit an audit row when the flag actually moved. Upserting a fresh
-    // row with the default value (equal to `enabled`) is a no-op audit-wise.
-    if (previousValue !== enabled) {
-      await tx.notificationPreferenceAudit.create({
-        data: {
-          userId,
-          type,
-          channel,
-          previousValue,
-          newValue: enabled,
-          source,
-        },
+    if (enabled === defaultValue) {
+      await tx.notificationChannelPreference.deleteMany({
+        where: { userId, channel },
+      });
+    } else {
+      await tx.notificationChannelPreference.upsert({
+        where: { userId_channel: { userId, channel } },
+        create: { userId, channel, enabled },
+        update: { enabled },
       });
     }
-
-    return updated;
+    await auditPreferenceChange(tx, {
+      userId,
+      kind: 'GLOBAL_CHANNEL',
+      preferenceKey: channel,
+      channel,
+      previousValue,
+      newValue: enabled,
+      source,
+    });
   });
+}
 
-  return result;
+export async function setTopicChannelPreference({
+  userId,
+  topic,
+  channel,
+  enabled,
+  source,
+}: {
+  userId: string;
+  topic: NotificationTopic;
+  channel: NotificationChannel;
+  enabled: boolean;
+  source: string;
+}) {
+  await prisma.$transaction(async (tx) => {
+    const previousValue = await resolveTopicChannelInTransaction(tx, {
+      userId,
+      topic,
+      channel,
+    });
+    if (previousValue === enabled) return;
+
+    await tx.notificationTopicPreference.upsert({
+      where: { userId_topic_channel: { userId, topic, channel } },
+      create: { userId, topic, channel, enabled },
+      update: { enabled },
+    });
+    await auditPreferenceChange(tx, {
+      userId,
+      kind: 'TOPIC',
+      preferenceKey: topic,
+      channel,
+      previousValue,
+      newValue: enabled,
+      source,
+    });
+  });
+}
+
+export async function clearTopicChannelPreference({
+  userId,
+  topic,
+  channel,
+  source,
+}: {
+  userId: string;
+  topic: NotificationTopic;
+  channel: NotificationChannel;
+  source: string;
+}) {
+  await prisma.$transaction(async (tx) => {
+    const existing = await tx.notificationTopicPreference.findUnique({
+      where: { userId_topic_channel: { userId, topic, channel } },
+      select: { enabled: true },
+    });
+    if (!existing) return;
+    await tx.notificationTopicPreference.delete({
+      where: { userId_topic_channel: { userId, topic, channel } },
+    });
+    const inheritedValue = await resolveTopicChannelInTransaction(tx, {
+      userId,
+      topic,
+      channel,
+    });
+    await auditPreferenceChange(tx, {
+      userId,
+      kind: 'TOPIC',
+      preferenceKey: topic,
+      channel,
+      previousValue: existing.enabled,
+      newValue: inheritedValue,
+      source,
+    });
+  });
+}
+
+/**
+ * A category bulk change is atomic and clears more-specific topic rows for the
+ * same channel so every topic actually adopts the selected category value.
+ */
+export async function setCategoryChannelPreference({
+  userId,
+  category,
+  channel,
+  enabled,
+  source,
+}: {
+  userId: string;
+  category: NotificationCategory;
+  channel: NotificationChannel;
+  enabled: boolean;
+  source: string;
+}) {
+  const topics = getNotificationCategoryTopics(category);
+  await prisma.$transaction(async (tx) => {
+    const existing = await tx.notificationCategoryPreference.findUnique({
+      where: { userId_category_channel: { userId, category, channel } },
+      select: { enabled: true },
+    });
+    await tx.notificationCategoryPreference.upsert({
+      where: { userId_category_channel: { userId, category, channel } },
+      create: { userId, category, channel, enabled },
+      update: { enabled },
+    });
+    const clearedTopics = await tx.notificationTopicPreference.deleteMany({
+      where: { userId, channel, topic: { in: topics } },
+    });
+    if (existing?.enabled === enabled && clearedTopics.count === 0) return;
+    await auditPreferenceChange(tx, {
+      userId,
+      kind: 'CATEGORY',
+      preferenceKey: category,
+      channel,
+      previousValue: existing?.enabled ?? null,
+      newValue: enabled,
+      source,
+    });
+  });
 }
 
 export async function disableEmailForAll(userId: string, source: string) {
-  // Previously this function iterated each preference row inside a transaction
-  // and issued one UPDATE + one INSERT per type. Even on 3 types that was 6
-  // round-trips. Now we do one findMany to capture the "which rows were
-  // actually ON" set (for audit), then a single updateMany + a single
-  // createMany inside one transaction.
-  const previouslyEnabled = await prisma.userNotificationPreference.findMany({
-    where: { userId, emailEnabled: true },
-    select: { type: true },
+  await setGlobalChannelPreference({
+    userId,
+    channel: NOTIFICATION_CHANNELS.EMAIL,
+    enabled: false,
+    source,
   });
-  if (previouslyEnabled.length === 0) return;
+}
 
-  await prisma.$transaction([
-    prisma.userNotificationPreference.updateMany({
-      where: { userId, emailEnabled: true },
-      data: { emailEnabled: false },
+export async function setContextActivityPreference({
+  userId,
+  context,
+  activityLevel,
+  customTopics = [],
+  source,
+}: {
+  userId: string;
+  context: NotificationContext;
+  activityLevel: NotificationActivityLevel;
+  customTopics?: Array<NotificationTopic>;
+  source: string;
+}) {
+  const normalizedTopics = normalizeCustomTopics(customTopics);
+  const normalizedLevel =
+    activityLevel === NOTIFICATION_ACTIVITY_LEVELS.CUSTOM &&
+    normalizedTopics.length === 0
+      ? NOTIFICATION_ACTIVITY_LEVELS.MUTED
+      : activityLevel;
+
+  await prisma.$transaction(async (tx) => {
+    await requireContextAccess(tx, userId, context);
+    const existing = await findContextPreference(tx, userId, context);
+    const wasMuted =
+      existing?.activityLevel === NOTIFICATION_ACTIVITY_LEVELS.MUTED;
+    const isMuted = normalizedLevel === NOTIFICATION_ACTIVITY_LEVELS.MUTED;
+    let mutedAt: Date | null = null;
+    if (isMuted) {
+      mutedAt = wasMuted ? (existing?.mutedAt ?? new Date()) : new Date();
+    }
+    const nextTopics =
+      normalizedLevel === NOTIFICATION_ACTIVITY_LEVELS.CUSTOM
+        ? normalizedTopics
+        : [];
+    const previousActivity = serializeActivity(existing);
+    const nextActivity = serializeActivity({
+      activityLevel: normalizedLevel,
+      customTopics: serializeTopics(nextTopics),
+    });
+    if (previousActivity === nextActivity) return;
+
+    await upsertContextPreference(tx, userId, context, {
+      activityLevel: normalizedLevel,
+      customTopics: serializeTopics(nextTopics),
+      mutedAt,
+      noticeDismissedAt:
+        isMuted && wasMuted ? existing?.noticeDismissedAt : null,
+    });
+    await auditPreferenceChange(tx, {
+      userId,
+      kind: 'CONTEXT_ACTIVITY',
+      contextKind: context.kind,
+      contextId: contextId(context),
+      previousValue: previousActivity,
+      newValue: nextActivity,
+      source,
+    });
+  });
+}
+
+export async function clearContextActivityPreference({
+  userId,
+  context,
+  source,
+}: {
+  userId: string;
+  context: NotificationContext;
+  source: string;
+}) {
+  await prisma.$transaction(async (tx) => {
+    await requireContextAccess(tx, userId, context);
+    const existing = await findContextPreference(tx, userId, context);
+    if (!existing?.activityLevel) return;
+    await upsertContextPreference(tx, userId, context, {
+      activityLevel: null,
+      customTopics: null,
+      mutedAt: null,
+      noticeDismissedAt: null,
+    });
+    await auditPreferenceChange(tx, {
+      userId,
+      kind: 'CONTEXT_ACTIVITY',
+      contextKind: context.kind,
+      contextId: contextId(context),
+      previousValue: serializeActivity(existing),
+      newValue: null,
+      source,
+    });
+  });
+}
+
+export async function dismissContextMutedNotice({
+  userId,
+  context,
+  source,
+}: {
+  userId: string;
+  context: NotificationContext;
+  source: string;
+}) {
+  await prisma.$transaction(async (tx) => {
+    await requireContextAccess(tx, userId, context);
+    const resolved = await resolveContextInTransaction(tx, userId, context);
+    if (!resolved.mutedAt || !resolved.noticeVisible) return;
+    const dismissedAt = new Date();
+    const existing = await findContextPreference(tx, userId, context);
+    await upsertContextPreference(tx, userId, context, {
+      activityLevel: existing?.activityLevel ?? null,
+      customTopics: existing?.customTopics ?? null,
+      mutedAt: existing?.mutedAt ?? null,
+      noticeDismissedAt: dismissedAt,
+    });
+    await auditPreferenceChange(tx, {
+      userId,
+      kind: 'MUTED_NOTICE',
+      contextKind: context.kind,
+      contextId: contextId(context),
+      previousValue: resolved.noticeDismissedAt?.toISOString() ?? null,
+      newValue: dismissedAt.toISOString(),
+      source,
+    });
+  });
+}
+
+export async function getContextNotificationPreference({
+  userId,
+  context,
+  requireAccess = true,
+}: {
+  userId: string;
+  context: NotificationContext;
+  requireAccess?: boolean;
+}): Promise<ResolvedContextNotificationPreference> {
+  return prisma.$transaction(async (tx) => {
+    if (requireAccess) await requireContextAccess(tx, userId, context);
+    return resolveContextInTransaction(tx, userId, context);
+  });
+}
+
+export function allowsContextActivity(
+  preference: ResolvedContextNotificationPreference,
+  topic: NotificationTopic,
+  importance: NotificationImportance,
+) {
+  switch (preference.activityLevel) {
+    case NOTIFICATION_ACTIVITY_LEVELS.ALL_ACTIVITY:
+      return true;
+    case NOTIFICATION_ACTIVITY_LEVELS.IMPORTANT_ONLY:
+      return importance === 'IMPORTANT';
+    case NOTIFICATION_ACTIVITY_LEVELS.MUTED:
+      return false;
+    case NOTIFICATION_ACTIVITY_LEVELS.CUSTOM:
+      return preference.customTopics.includes(topic);
+  }
+}
+
+async function loadCentralPreferenceState(
+  userId: string,
+): Promise<CentralPreferenceState> {
+  return (await loadCentralPreferenceStates([userId])).get(
+    userId,
+  ) as CentralPreferenceState;
+}
+
+async function loadCentralPreferenceStates(userIds: string[]) {
+  if (userIds.length === 0) return new Map<string, CentralPreferenceState>();
+  const [gates, categories, topics] = await prisma.$transaction([
+    prisma.notificationChannelPreference.findMany({
+      where: { userId: { in: userIds } },
+      select: { userId: true, channel: true, enabled: true },
     }),
-    prisma.notificationPreferenceAudit.createMany({
-      data: previouslyEnabled.map((pref) => ({
-        userId,
-        type: pref.type,
-        channel: NOTIFICATION_CHANNELS.EMAIL,
-        previousValue: true,
-        newValue: false,
-        source,
-      })),
+    prisma.notificationCategoryPreference.findMany({
+      where: { userId: { in: userIds } },
+      select: { userId: true, category: true, channel: true, enabled: true },
+    }),
+    prisma.notificationTopicPreference.findMany({
+      where: { userId: { in: userIds } },
+      select: { userId: true, topic: true, channel: true, enabled: true },
     }),
   ]);
+  const states = new Map(
+    userIds.map((id) => [id, emptyCentralPreferenceState()]),
+  );
+  for (const row of gates) {
+    states
+      .get(row.userId)
+      ?.gates.set(row.channel as NotificationChannel, row.enabled);
+  }
+  for (const row of categories) {
+    states
+      .get(row.userId)
+      ?.categories.set(preferenceKey(row.category, row.channel), row.enabled);
+  }
+  for (const row of topics) {
+    states
+      .get(row.userId)
+      ?.topics.set(preferenceKey(row.topic, row.channel), row.enabled);
+  }
+  return states;
+}
+
+function emptyCentralPreferenceState(): CentralPreferenceState {
+  return { gates: new Map(), categories: new Map(), topics: new Map() };
+}
+
+function resolveCentralFromState(
+  type: NotificationType,
+  state: CentralPreferenceState,
+): ResolvedCentralNotificationPreferences {
+  const event = getNotificationEventDefinition(type);
+  const topicDefinition = getNotificationTopicDefinition(event.topic);
+  const entries = NOTIFICATION_CHANNEL_VALUES.map((channel) => {
+    const gate =
+      state.gates.get(channel) ?? DEFAULT_GLOBAL_CHANNEL_PREFERENCES[channel];
+    if (!gate) {
+      return [
+        channel,
+        { enabled: false, source: 'global_channel' as const },
+      ] as const;
+    }
+    const topicValue = state.topics.get(preferenceKey(event.topic, channel));
+    if (topicValue !== undefined) {
+      return [
+        channel,
+        { enabled: topicValue, source: 'topic_override' as const },
+      ] as const;
+    }
+    const categoryValue = state.categories.get(
+      preferenceKey(topicDefinition.category, channel),
+    );
+    if (categoryValue !== undefined) {
+      return [
+        channel,
+        { enabled: categoryValue, source: 'category_override' as const },
+      ] as const;
+    }
+    return [
+      channel,
+      {
+        enabled: topicDefinition.defaults[channelToColumn(channel)],
+        source: 'catalog_default' as const,
+      },
+    ] as const;
+  });
+  return {
+    type,
+    topic: event.topic,
+    category: topicDefinition.category,
+    channels: Object.fromEntries(entries) as Record<
+      NotificationChannel,
+      CentralChannelPreference
+    >,
+  };
+}
+
+function channelsToLegacyShape(
+  channels: Record<NotificationChannel, CentralChannelPreference>,
+): NotificationPreferenceDefaults {
+  return {
+    inAppEnabled: channels[NOTIFICATION_CHANNELS.IN_APP].enabled,
+    emailEnabled: channels[NOTIFICATION_CHANNELS.EMAIL].enabled,
+    pushEnabled: channels[NOTIFICATION_CHANNELS.WEB_PUSH].enabled,
+  };
+}
+
+async function resolveTopicChannelInTransaction(
+  tx: Prisma.TransactionClient,
+  {
+    userId,
+    topic,
+    channel,
+  }: {
+    userId: string;
+    topic: NotificationTopic;
+    channel: NotificationChannel;
+  },
+) {
+  const definition = getNotificationTopicDefinition(topic);
+  const [topicOverride, categoryOverride] = await Promise.all([
+    tx.notificationTopicPreference.findUnique({
+      where: { userId_topic_channel: { userId, topic, channel } },
+      select: { enabled: true },
+    }),
+    tx.notificationCategoryPreference.findUnique({
+      where: {
+        userId_category_channel: {
+          userId,
+          category: definition.category,
+          channel,
+        },
+      },
+      select: { enabled: true },
+    }),
+  ]);
+  return (
+    topicOverride?.enabled ??
+    categoryOverride?.enabled ??
+    definition.defaults[channelToColumn(channel)]
+  );
+}
+
+async function requireContextAccess(
+  tx: Prisma.TransactionClient,
+  userId: string,
+  context: NotificationContext,
+) {
+  const accessible =
+    context.kind === 'GROUP'
+      ? await tx.usersInGiftGroups.findFirst({
+          where: { userId, giftGroupId: context.groupId, removedAt: null },
+          select: { userId: true },
+        })
+      : await tx.poolContributor.findUnique({
+          where: { poolId_userId: { poolId: context.poolId, userId } },
+          select: { userId: true },
+        });
+  if (!accessible) {
+    throw data({ error: 'Notification context not found.' }, { status: 404 });
+  }
+}
+
+async function resolveContextInTransaction(
+  tx: Prisma.TransactionClient,
+  userId: string,
+  context: NotificationContext,
+): Promise<ResolvedContextNotificationPreference> {
+  if (context.kind === 'GROUP') {
+    const row = await tx.groupNotificationPreference.findUnique({
+      where: { userId_giftGroupId: { userId, giftGroupId: context.groupId } },
+    });
+    return resolvedContext({
+      context,
+      row,
+      source: row?.activityLevel ? 'group_override' : 'application_default',
+      controllingContext: row?.activityLevel ? context : null,
+      noticeDismissedAt: row?.noticeDismissedAt ?? null,
+    });
+  }
+
+  const [pool, poolRow] = await Promise.all([
+    tx.pool.findUnique({
+      where: { id: context.poolId },
+      select: { giftGroupId: true },
+    }),
+    tx.poolNotificationPreference.findUnique({
+      where: { userId_poolId: { userId, poolId: context.poolId } },
+    }),
+  ]);
+  if (!pool) {
+    throw data({ error: 'Notification context not found.' }, { status: 404 });
+  }
+  if (poolRow?.activityLevel) {
+    return resolvedContext({
+      context,
+      row: poolRow,
+      source: 'pool_override',
+      controllingContext: context,
+      noticeDismissedAt: poolRow.noticeDismissedAt,
+    });
+  }
+  const groupContext = pool.giftGroupId
+    ? ({ kind: 'GROUP', groupId: pool.giftGroupId } as const)
+    : null;
+  const groupRow = groupContext
+    ? await tx.groupNotificationPreference.findUnique({
+        where: {
+          userId_giftGroupId: {
+            userId,
+            giftGroupId: groupContext.groupId,
+          },
+        },
+      })
+    : null;
+  return resolvedContext({
+    context,
+    row: groupRow,
+    source: groupRow?.activityLevel ? 'group_override' : 'application_default',
+    controllingContext: groupRow?.activityLevel ? groupContext : null,
+    noticeDismissedAt: poolRow?.noticeDismissedAt ?? null,
+  });
+}
+
+function resolvedContext({
+  context,
+  row,
+  source,
+  controllingContext,
+  noticeDismissedAt,
+}: {
+  context: NotificationContext;
+  row: {
+    activityLevel: string | null;
+    customTopics: string | null;
+    mutedAt: Date | null;
+  } | null;
+  source: ResolvedContextNotificationPreference['source'];
+  controllingContext: NotificationContext | null;
+  noticeDismissedAt: Date | null;
+}): ResolvedContextNotificationPreference {
+  const activityLevel = isActivityLevel(row?.activityLevel)
+    ? row.activityLevel
+    : NOTIFICATION_ACTIVITY_LEVELS.IMPORTANT_ONLY;
+  const customTopics = deserializeTopics(row?.customTopics);
+  const mutedAt =
+    activityLevel === NOTIFICATION_ACTIVITY_LEVELS.MUTED
+      ? (row?.mutedAt ?? null)
+      : null;
+  return {
+    context,
+    activityLevel,
+    source,
+    customTopics,
+    mutedAt,
+    noticeDismissedAt,
+    noticeVisible: Boolean(
+      mutedAt && (!noticeDismissedAt || mutedAt > noticeDismissedAt),
+    ),
+    controllingContext,
+  };
+}
+
+async function findContextPreference(
+  tx: Prisma.TransactionClient,
+  userId: string,
+  context: NotificationContext,
+) {
+  return context.kind === 'GROUP'
+    ? tx.groupNotificationPreference.findUnique({
+        where: {
+          userId_giftGroupId: { userId, giftGroupId: context.groupId },
+        },
+      })
+    : tx.poolNotificationPreference.findUnique({
+        where: { userId_poolId: { userId, poolId: context.poolId } },
+      });
+}
+
+async function upsertContextPreference(
+  tx: Prisma.TransactionClient,
+  userId: string,
+  context: NotificationContext,
+  values: {
+    activityLevel: string | null;
+    customTopics: string | null;
+    mutedAt: Date | null;
+    noticeDismissedAt: Date | null | undefined;
+  },
+) {
+  const data = {
+    activityLevel: values.activityLevel,
+    customTopics: values.customTopics,
+    mutedAt: values.mutedAt,
+    noticeDismissedAt: values.noticeDismissedAt ?? null,
+  };
+  if (context.kind === 'GROUP') {
+    return tx.groupNotificationPreference.upsert({
+      where: { userId_giftGroupId: { userId, giftGroupId: context.groupId } },
+      create: { userId, giftGroupId: context.groupId, ...data },
+      update: data,
+    });
+  }
+  return tx.poolNotificationPreference.upsert({
+    where: { userId_poolId: { userId, poolId: context.poolId } },
+    create: { userId, poolId: context.poolId, ...data },
+    update: data,
+  });
+}
+
+function normalizeCustomTopics(topics: Array<NotificationTopic>) {
+  return [...new Set(topics)].filter((topic) =>
+    NOTIFICATION_TOPIC_VALUES.includes(topic),
+  );
+}
+
+function serializeTopics(topics: Array<NotificationTopic>) {
+  return topics.length ? JSON.stringify(topics) : null;
+}
+
+function deserializeTopics(value: string | null | undefined) {
+  if (!value) return [];
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed.filter(isNotificationTopic) : [];
+  } catch {
+    return [];
+  }
+}
+
+function isActivityLevel(value: unknown): value is NotificationActivityLevel {
+  return (
+    typeof value === 'string' &&
+    Object.values(NOTIFICATION_ACTIVITY_LEVELS).includes(
+      value as NotificationActivityLevel,
+    )
+  );
+}
+
+function contextId(context: NotificationContext) {
+  return context.kind === 'GROUP' ? context.groupId : context.poolId;
+}
+
+function preferenceKey(key: string, channel: string) {
+  return `${key}:${channel}`;
+}
+
+function serializeActivity(
+  value:
+    | { activityLevel: string | null; customTopics: string | null }
+    | null
+    | undefined,
+) {
+  if (!value?.activityLevel) return null;
+  return JSON.stringify({
+    activityLevel: value.activityLevel,
+    customTopics: deserializeTopics(value.customTopics),
+  });
+}
+
+async function auditPreferenceChange(
+  tx: Prisma.TransactionClient,
+  input: {
+    userId: string;
+    kind: string;
+    preferenceKey?: string | null;
+    channel?: string | null;
+    contextKind?: string | null;
+    contextId?: string | null;
+    previousValue: string | boolean | null;
+    newValue: string | boolean | null;
+    source: string;
+  },
+) {
+  await tx.notificationPreferenceAudit.create({
+    data: {
+      userId: input.userId,
+      kind: input.kind,
+      preferenceKey: input.preferenceKey ?? null,
+      channel: input.channel ?? null,
+      contextKind: input.contextKind ?? null,
+      contextId: input.contextId ?? null,
+      previousValue: serializeAuditValue(input.previousValue),
+      newValue: serializeAuditValue(input.newValue),
+      source: input.source,
+    },
+  });
+}
+
+function serializeAuditValue(value: string | boolean | null) {
+  return typeof value === 'boolean' ? String(value) : value;
 }

--- a/app/utils/notification-preferences.server.ts
+++ b/app/utils/notification-preferences.server.ts
@@ -831,6 +831,8 @@ function serializeActivity(
   });
 }
 
+type PreferenceAuditValue = string | boolean | null;
+
 async function auditPreferenceChange(
   tx: Prisma.TransactionClient,
   input: {
@@ -840,8 +842,8 @@ async function auditPreferenceChange(
     channel?: string | null;
     contextKind?: string | null;
     contextId?: string | null;
-    previousValue: string | boolean | null;
-    newValue: string | boolean | null;
+    previousValue: PreferenceAuditValue;
+    newValue: PreferenceAuditValue;
     source: string;
   },
 ) {
@@ -860,6 +862,6 @@ async function auditPreferenceChange(
   });
 }
 
-function serializeAuditValue(value: string | boolean | null) {
+function serializeAuditValue(value: PreferenceAuditValue) {
   return typeof value === 'boolean' ? String(value) : value;
 }

--- a/app/utils/occasion-reminders.server.test.ts
+++ b/app/utils/occasion-reminders.server.test.ts
@@ -36,10 +36,7 @@ import {
   NOTIFICATION_CHANNELS,
   NOTIFICATION_TYPES,
 } from '#app/utils/notification-catalog.ts';
-import {
-  ensureNotificationPreferencesForUser,
-  setNotificationPreference,
-} from '#app/utils/notification-preferences.server.ts';
+import { setNotificationPreference } from '#app/utils/notification-preferences.server.ts';
 import {
   findUpcomingBirthdayOwners,
   getBirthdayReminderRecipientIds,
@@ -102,7 +99,6 @@ async function makeFriends(userAId: string, userBId: string) {
 }
 
 async function optIntoEmail(userId: string) {
-  await ensureNotificationPreferencesForUser(userId);
   await setNotificationPreference(
     userId,
     NOTIFICATION_TYPES.UPCOMING_BIRTHDAY,
@@ -116,7 +112,9 @@ async function cleanup() {
   await prisma.notificationDelivery.deleteMany();
   await prisma.notification.deleteMany();
   await prisma.notificationPreferenceAudit.deleteMany();
-  await prisma.userNotificationPreference.deleteMany();
+  await prisma.notificationTopicPreference.deleteMany();
+  await prisma.notificationCategoryPreference.deleteMany();
+  await prisma.notificationChannelPreference.deleteMany();
   await prisma.usersInGiftGroups.deleteMany();
   await prisma.giftGroup.deleteMany();
   await prisma.friendship.deleteMany();

--- a/docs/product/notification-coordination-architecture.md
+++ b/docs/product/notification-coordination-architecture.md
@@ -1,6 +1,6 @@
 # Notification coordination architecture
 
-Status: Accepted; milestone 4 runtime architecture implemented
+Status: Accepted; runtime and scoped-preference architecture implemented
 
 Last updated: 2026-07-13
 
@@ -54,11 +54,14 @@ and been measured. General messaging and free-form broadcasts are out of scope.
   push adapters. Web push returns structured delivered, unavailable, or failed
   outcomes and checks capability before a recurring claim.
 - `notification-policy.server.ts` returns explainable per-channel decisions.
-  It deliberately reads the legacy per-event rows until scoped preferences
-  replace its implementation in milestone 5.
-- `UserNotificationPreference` stores one row per user and concrete type.
-  Settings-page reads materialize missing rows; hot-path reads inherit catalog
-  defaults without writing.
+  It resolves global gates, sparse topic/category choices, and contextual
+  activity without exposing persistence details to the dispatcher.
+- `notification-preferences.server.ts` owns sparse central and context storage,
+  precedence, inheritance, access checks, mute-awareness state, and audit rows.
+  Reads and signup never materialize catalog defaults.
+- `NotificationChannelPreference`, `NotificationCategoryPreference`, and
+  `NotificationTopicPreference` store sparse central choices. Group and pool
+  context tables store activity overrides and mute-awareness timestamps.
 - `NotificationDelivery` is the recurring-delivery ledger. Birthday reminders
   use a channel-specific source identifier and claim before sending.
 - `Notification` is the visible in-app read model. Users can mark rows read or
@@ -82,12 +85,13 @@ detail to users and make the dispatcher wider with each feature.
 Remaining gaps belong to later milestones:
 
 - Category labels live in the settings route rather than the catalog.
-- “Disable all email” updates current type rows but is not a durable channel
-  gate; a future type can inherit an enabled email default.
 - One-shot friend notifications dedupe only the in-app row and use a
   check-then-create flow. Email and push have no common delivery claim.
-- The admin opt-out matrix counts persisted rows rather than effective choices,
-  so missing default rows and context modes can produce misleading percentages.
+- The central settings screen still presents concrete events. Its compatibility
+  action maps those events to shared topics until the approved scoped UI ships.
+- No current catalog event has a group or pool context yet, so context policy is
+  covered at the resolver interface but will first be exercised by automatic
+  pool updates.
 - `GroupReminder` settings are persisted and presented as functional, but the
   birthday sweep does not consume them. Occasion schedule policy must not be
   confused with recipient delivery preference.
@@ -288,10 +292,10 @@ Email and push defaults for new topics are always off. A proposal to enable a
 new email or push default requires an explicit product decision and migration,
 not merely a catalog edit.
 
-## Persistence direction
+## Persistence
 
-The exact Prisma names can be chosen during implementation, but the data model
-must express these concepts without overloading the visible `Notification` row:
+The data model expresses these concepts without overloading the visible
+`Notification` row:
 
 - global user/channel gates;
 - sparse category/channel overrides;
@@ -300,17 +304,19 @@ must express these concepts without overloading the visible `Notification` row:
 - custom context-topic selections;
 - mute timestamp and notice-dismissal timestamp;
 - per-channel delivery claims and outcomes;
-- organizer-nudge audit and cooldown history.
+- organizer-nudge audit and cooldown history (deferred until nudges ship).
 
-Prefer real group and pool relations over an unconstrained polymorphic string.
-If a shared context-preference table uses nullable group and pool foreign keys,
-the migration must enforce exactly one context and unique user/context pairs.
+`GroupNotificationPreference` and `PoolNotificationPreference` use real foreign
+keys and unique user/context pairs rather than an unconstrained polymorphic
+identifier. A null activity level means inheritance and allows a child-pool row
+to retain its dismissal of an inherited group-mute notice.
 
-Existing `UserNotificationPreference` rows must migrate without changing current
-friend or birthday behavior. Default-equivalent rows may collapse to inheritance;
-non-default rows become explicit topic overrides. The migration must also derive
-the initial global email gate so an existing “disable all” choice is not undone
-by future topics.
+The legacy per-event rows migrate to sparse topic choices. Because the two
+friend-request events now share one topic, conflicting legacy choices collapse
+to the more restrictive value to avoid surprise delivery. Default-equivalent
+rows collapse to inheritance, and a legacy all-email-off choice becomes one
+durable global gate. Historical audit rows remain available as `LEGACY_EVENT`
+entries in the generalized audit table.
 
 ## Delivery, idempotency, and failure semantics
 
@@ -453,10 +459,10 @@ Required invariant coverage:
 
 ## Implementation sequence
 
-1. Refactor the catalog, policy resolver, dispatcher, delivery ledger, and
-   adapters while preserving existing behavior.
-2. Add central sparse overrides, durable channel gates, context activity
-   persistence, and resolver tests.
+1. **Complete:** Refactor the catalog, policy resolver, dispatcher, delivery
+   ledger, and adapters while preserving existing behavior.
+2. **Complete:** Add central sparse overrides, durable channel gates, context
+   activity persistence, migration coverage, and resolver tests.
 3. Complete the Claude Design checkpoint and implement approved settings and
    muted-awareness surfaces.
 4. Add the selected automatic pool events and measure delivery/suppression.

--- a/prisma/migrations/20260714032000_scoped_notification_preferences/migration.sql
+++ b/prisma/migrations/20260714032000_scoped_notification_preferences/migration.sql
@@ -1,0 +1,205 @@
+-- Create the sparse central preference tables.
+CREATE TABLE "NotificationChannelPreference" (
+    "userId" TEXT NOT NULL,
+    "channel" TEXT NOT NULL,
+    "enabled" BOOLEAN NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    PRIMARY KEY ("userId", "channel"),
+    CONSTRAINT "NotificationChannelPreference_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE TABLE "NotificationCategoryPreference" (
+    "userId" TEXT NOT NULL,
+    "category" TEXT NOT NULL,
+    "channel" TEXT NOT NULL,
+    "enabled" BOOLEAN NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    PRIMARY KEY ("userId", "category", "channel"),
+    CONSTRAINT "NotificationCategoryPreference_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE TABLE "NotificationTopicPreference" (
+    "userId" TEXT NOT NULL,
+    "topic" TEXT NOT NULL,
+    "channel" TEXT NOT NULL,
+    "enabled" BOOLEAN NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    PRIMARY KEY ("userId", "topic", "channel"),
+    CONSTRAINT "NotificationTopicPreference_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- Context preferences use real group/pool foreign keys rather than a free-form
+-- polymorphic identifier. A null activityLevel means "inherit" and permits a
+-- row to retain notice-dismissal state for an inherited group mute.
+CREATE TABLE "GroupNotificationPreference" (
+    "userId" TEXT NOT NULL,
+    "giftGroupId" TEXT NOT NULL,
+    "activityLevel" TEXT,
+    "customTopics" TEXT,
+    "mutedAt" DATETIME,
+    "noticeDismissedAt" DATETIME,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    PRIMARY KEY ("userId", "giftGroupId"),
+    CONSTRAINT "GroupNotificationPreference_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "GroupNotificationPreference_giftGroupId_fkey" FOREIGN KEY ("giftGroupId") REFERENCES "Group" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE TABLE "PoolNotificationPreference" (
+    "userId" TEXT NOT NULL,
+    "poolId" TEXT NOT NULL,
+    "activityLevel" TEXT,
+    "customTopics" TEXT,
+    "mutedAt" DATETIME,
+    "noticeDismissedAt" DATETIME,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    PRIMARY KEY ("userId", "poolId"),
+    CONSTRAINT "PoolNotificationPreference_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "PoolNotificationPreference_poolId_fkey" FOREIGN KEY ("poolId") REFERENCES "Pool" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE INDEX "NotificationChannelPreference_channel_idx" ON "NotificationChannelPreference"("channel");
+CREATE INDEX "NotificationCategoryPreference_category_channel_idx" ON "NotificationCategoryPreference"("category", "channel");
+CREATE INDEX "NotificationTopicPreference_topic_channel_idx" ON "NotificationTopicPreference"("topic", "channel");
+CREATE INDEX "GroupNotificationPreference_giftGroupId_idx" ON "GroupNotificationPreference"("giftGroupId");
+CREATE INDEX "PoolNotificationPreference_poolId_idx" ON "PoolNotificationPreference"("poolId");
+
+-- Preserve the legacy "turn off all email" choice as a durable channel gate.
+-- Require all three registered legacy rows so a partial historical row set
+-- cannot accidentally disable future email topics.
+INSERT INTO "NotificationChannelPreference" (
+    "userId", "channel", "enabled", "createdAt", "updatedAt"
+)
+SELECT
+    "userId", 'EMAIL', false, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM "UserNotificationPreference"
+WHERE "type" IN (
+    'FRIEND_REQUEST_RECEIVED',
+    'FRIEND_REQUEST_ACCEPTED',
+    'UPCOMING_BIRTHDAY'
+)
+GROUP BY "userId"
+HAVING COUNT(DISTINCT "type") = 3 AND MAX("emailEnabled") = 0;
+
+-- Both friend-request events intentionally share one user-facing topic. When
+-- legacy rows conflict, MIN chooses the more restrictive value so migration
+-- never creates surprise delivery. Missing rows contribute the catalog default.
+WITH "FriendValues" AS (
+    SELECT
+        "User"."id" AS "userId",
+        MIN(
+            COALESCE((
+                SELECT "inAppEnabled" FROM "UserNotificationPreference"
+                WHERE "userId" = "User"."id" AND "type" = 'FRIEND_REQUEST_RECEIVED'
+            ), true),
+            COALESCE((
+                SELECT "inAppEnabled" FROM "UserNotificationPreference"
+                WHERE "userId" = "User"."id" AND "type" = 'FRIEND_REQUEST_ACCEPTED'
+            ), true)
+        ) AS "inAppEnabled",
+        MIN(
+            COALESCE((
+                SELECT "emailEnabled" FROM "UserNotificationPreference"
+                WHERE "userId" = "User"."id" AND "type" = 'FRIEND_REQUEST_RECEIVED'
+            ), true),
+            COALESCE((
+                SELECT "emailEnabled" FROM "UserNotificationPreference"
+                WHERE "userId" = "User"."id" AND "type" = 'FRIEND_REQUEST_ACCEPTED'
+            ), true)
+        ) AS "emailEnabled",
+        MIN(
+            COALESCE((
+                SELECT "pushEnabled" FROM "UserNotificationPreference"
+                WHERE "userId" = "User"."id" AND "type" = 'FRIEND_REQUEST_RECEIVED'
+            ), false),
+            COALESCE((
+                SELECT "pushEnabled" FROM "UserNotificationPreference"
+                WHERE "userId" = "User"."id" AND "type" = 'FRIEND_REQUEST_ACCEPTED'
+            ), false)
+        ) AS "pushEnabled"
+    FROM "User"
+)
+INSERT INTO "NotificationTopicPreference" (
+    "userId", "topic", "channel", "enabled", "createdAt", "updatedAt"
+)
+SELECT "userId", 'FRIEND_REQUESTS', 'IN_APP', "inAppEnabled", CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM "FriendValues" WHERE "inAppEnabled" != true
+UNION ALL
+SELECT "userId", 'FRIEND_REQUESTS', 'EMAIL', "emailEnabled", CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM "FriendValues"
+WHERE "emailEnabled" != true
+  AND NOT EXISTS (
+      SELECT 1 FROM "NotificationChannelPreference" AS "gate"
+      WHERE "gate"."userId" = "FriendValues"."userId"
+        AND "gate"."channel" = 'EMAIL'
+        AND "gate"."enabled" = false
+  )
+UNION ALL
+SELECT "userId", 'FRIEND_REQUESTS', 'WEB_PUSH', "pushEnabled", CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM "FriendValues" WHERE "pushEnabled" != false;
+
+-- Birthday reminders map one-to-one to their topic, so every non-default value
+-- can migrate directly. Email rows covered by the global gate remain inherited.
+INSERT INTO "NotificationTopicPreference" (
+    "userId", "topic", "channel", "enabled", "createdAt", "updatedAt"
+)
+SELECT "userId", 'BIRTHDAY_REMINDERS', 'IN_APP', "inAppEnabled", CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM "UserNotificationPreference"
+WHERE "type" = 'UPCOMING_BIRTHDAY' AND "inAppEnabled" != true
+UNION ALL
+SELECT "userId", 'BIRTHDAY_REMINDERS', 'EMAIL', "emailEnabled", CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM "UserNotificationPreference" AS "legacy"
+WHERE "type" = 'UPCOMING_BIRTHDAY'
+  AND "emailEnabled" != false
+  AND NOT EXISTS (
+      SELECT 1 FROM "NotificationChannelPreference" AS "gate"
+      WHERE "gate"."userId" = "legacy"."userId"
+        AND "gate"."channel" = 'EMAIL'
+        AND "gate"."enabled" = false
+  )
+UNION ALL
+SELECT "userId", 'BIRTHDAY_REMINDERS', 'WEB_PUSH', "pushEnabled", CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM "UserNotificationPreference"
+WHERE "type" = 'UPCOMING_BIRTHDAY' AND "pushEnabled" != false;
+
+DROP TABLE "UserNotificationPreference";
+
+-- Generalize the audit log so channel, category, topic, group, and pool changes
+-- share one history without boolean-only or concrete-event-only columns.
+ALTER TABLE "NotificationPreferenceAudit" RENAME TO "LegacyNotificationPreferenceAudit";
+
+CREATE TABLE "NotificationPreferenceAudit" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "userId" TEXT NOT NULL,
+    "kind" TEXT NOT NULL,
+    "preferenceKey" TEXT,
+    "channel" TEXT,
+    "contextKind" TEXT,
+    "contextId" TEXT,
+    "previousValue" TEXT,
+    "newValue" TEXT,
+    "source" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "NotificationPreferenceAudit_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+INSERT INTO "NotificationPreferenceAudit" (
+    "id", "userId", "kind", "preferenceKey", "channel",
+    "previousValue", "newValue", "source", "createdAt"
+)
+SELECT
+    "id", "userId", 'LEGACY_EVENT', "type", "channel",
+    CASE WHEN "previousValue" THEN 'true' ELSE 'false' END,
+    CASE WHEN "newValue" THEN 'true' ELSE 'false' END,
+    "source", "createdAt"
+FROM "LegacyNotificationPreferenceAudit";
+
+DROP TABLE "LegacyNotificationPreferenceAudit";
+
+CREATE INDEX "NotificationPreferenceAudit_userId_createdAt_idx" ON "NotificationPreferenceAudit"("userId", "createdAt");
+CREATE INDEX "NotificationPreferenceAudit_kind_preferenceKey_idx" ON "NotificationPreferenceAudit"("kind", "preferenceKey");
+CREATE INDEX "NotificationPreferenceAudit_channel_idx" ON "NotificationPreferenceAudit"("channel");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -44,8 +44,12 @@ model User {
   friendRequestsReceived       FriendRequest[]               @relation("FriendRequestToUser")
   friendshipsA                 Friendship[]                  @relation("FriendshipUserA")
   friendshipsB                 Friendship[]                  @relation("FriendshipUserB")
-  notificationPreferences      UserNotificationPreference[]
-  notificationPreferenceAudits NotificationPreferenceAudit[]
+  notificationChannelPreferences  NotificationChannelPreference[]
+  notificationCategoryPreferences NotificationCategoryPreference[]
+  notificationTopicPreferences    NotificationTopicPreference[]
+  groupNotificationPreferences    GroupNotificationPreference[]
+  poolNotificationPreferences     PoolNotificationPreference[]
+  notificationPreferenceAudits    NotificationPreferenceAudit[]
   notificationDeliveries       NotificationDelivery[]
   pushSubscriptions            PushSubscription[]
   friendInvitationsCreated     FriendInvitation[]            @relation("FriendInvitation_CreatedBy")
@@ -157,20 +161,45 @@ model NotificationDelivery {
   @@id([userId, sourceIdentifier])
 }
 
-model UserNotificationPreference {
-  userId       String
-  type         String
-  inAppEnabled Boolean  @default(true)
-  emailEnabled Boolean  @default(true)
-  // Web Push defaults OFF — unlike in-app/email it requires an explicit opt-in
-  // plus browser permission, so it can never be on by default.
-  pushEnabled  Boolean  @default(false)
-  createdAt    DateTime @default(now())
-  updatedAt    DateTime @updatedAt
-  user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+// Sparse central notification preferences. Missing rows inherit the catalog
+// defaults; global channel gates are absolute ceilings over category/topic
+// choices. Channel/category/topic strings are validated against the catalog.
+model NotificationChannelPreference {
+  userId    String
+  channel   String
+  enabled   Boolean
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 
-  @@id([userId, type])
-  @@index([type])
+  @@id([userId, channel])
+  @@index([channel])
+}
+
+model NotificationCategoryPreference {
+  userId    String
+  category  String
+  channel   String
+  enabled   Boolean
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@id([userId, category, channel])
+  @@index([category, channel])
+}
+
+model NotificationTopicPreference {
+  userId    String
+  topic     String
+  channel   String
+  enabled   Boolean
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@id([userId, topic, channel])
+  @@index([topic, channel])
 }
 
 model PushSubscription {
@@ -191,16 +220,19 @@ model PushSubscription {
 model NotificationPreferenceAudit {
   id            String   @id @default(cuid())
   userId        String
-  type          String
-  channel       String
-  previousValue Boolean
-  newValue      Boolean
+  kind          String
+  preferenceKey String?
+  channel       String?
+  contextKind   String?
+  contextId     String?
+  previousValue String?
+  newValue      String?
   source        String
   createdAt     DateTime @default(now())
   user          User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@index([userId, createdAt])
-  @@index([type])
+  @@index([kind, preferenceKey])
   @@index([channel])
 }
 
@@ -222,6 +254,7 @@ model GiftGroup {
   reminders        GroupReminder[]
   joinRequests     JoinRequest[]
   groupMembers     UsersInGiftGroups[]
+  notificationPreferences GroupNotificationPreference[]
 
   @@index([createdById])
   @@map("Group")
@@ -368,11 +401,47 @@ model Pool {
   votes         IdeaVote[]
   activities    PoolActivity[]
   messages      PoolMessage[]
+  notificationPreferences PoolNotificationPreference[]
 
   @@index([giftGroupId])
   @@index([organizerId])
   @@index([recipientUserId])
   @@index([status])
+}
+
+// Context rows are also sparse. A null activityLevel means "inherit" and lets
+// the row retain a notice dismissal for an inherited group mute. customTopics
+// is a validated JSON array of stable notification-topic identifiers.
+model GroupNotificationPreference {
+  userId            String
+  giftGroupId       String
+  activityLevel     String?
+  customTopics      String?
+  mutedAt           DateTime?
+  noticeDismissedAt DateTime?
+  createdAt         DateTime  @default(now())
+  updatedAt         DateTime  @updatedAt
+  user              User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  giftGroup         GiftGroup @relation(fields: [giftGroupId], references: [id], onDelete: Cascade)
+
+  @@id([userId, giftGroupId])
+  @@index([giftGroupId])
+}
+
+model PoolNotificationPreference {
+  userId            String
+  poolId            String
+  activityLevel     String?
+  customTopics      String?
+  mutedAt           DateTime?
+  noticeDismissedAt DateTime?
+  createdAt         DateTime  @default(now())
+  updatedAt         DateTime  @updatedAt
+  user              User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  pool              Pool      @relation(fields: [poolId], references: [id], onDelete: Cascade)
+
+  @@id([userId, poolId])
+  @@index([poolId])
 }
 
 // One record per contributor per pool.

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -6,7 +6,6 @@ import {
 	getUserImages,
 	img,
 } from '#tests/db-utils.ts'
-import { ensureNotificationPreferencesForUser } from '#app/utils/notification-preferences.server.ts'
 import {
 	POOL_STATUS,
 	DECISION_MODE,
@@ -136,7 +135,6 @@ async function seed() {
 			},
 		},
 	})
-	await ensureNotificationPreferencesForUser(wade.id)
 
 	// Marco — birthday in +22 days. Lives in Book Club with Wade (see below),
 	// but intentionally NOT in The Crew because that's his birthday pool.
@@ -153,7 +151,6 @@ async function seed() {
 			birthday: birthdayInDays(22, 31),
 		},
 	})
-	await ensureNotificationPreferencesForUser(marco.id)
 
 	// NP — The Crew member. Birthday in +37 days.
 	const np = await prisma.user.create({
@@ -170,7 +167,6 @@ async function seed() {
 			birthday: birthdayInDays(37, 28),
 		},
 	})
-	await ensureNotificationPreferencesForUser(np.id)
 
 	// Alvaro — The Crew member. Birthday in +54 days (edge: just inside window).
 	const alvaro = await prisma.user.create({
@@ -186,7 +182,6 @@ async function seed() {
 			birthday: birthdayInDays(54, 29),
 		},
 	})
-	await ensureNotificationPreferencesForUser(alvaro.id)
 
 	// Sofia — The Crew member. Birthday in +88 days (edge: OUTSIDE 60-day
 	// window). This is deliberate — we want at least one friend whose birthday
@@ -203,7 +198,6 @@ async function seed() {
 			birthday: birthdayInDays(88, 32),
 		},
 	})
-	await ensureNotificationPreferencesForUser(sofia.id)
 
 	// Hana — Book Club. Birthday TOMORROW (imminent edge case).
 	// Wade's friend. Rich wishlist + past items.
@@ -223,7 +217,6 @@ async function seed() {
 			birthday: birthdayInDays(1, 27),
 		},
 	})
-	await ensureNotificationPreferencesForUser(hana.id)
 
 	// Leo — Wade's friend, deliberately empty wishlist (edge case). Book Club.
 	// Birthday in +25 days.
@@ -239,7 +232,6 @@ async function seed() {
 			birthday: birthdayInDays(25, 33),
 		},
 	})
-	await ensureNotificationPreferencesForUser(leo.id)
 
 	// Zoe — NOT Wade's friend. Has sent Wade a pending friend request.
 	// Has a small wishlist which Wade should NOT be able to see until accept.
@@ -255,7 +247,6 @@ async function seed() {
 			birthday: birthdayInDays(200, 26),
 		},
 	})
-	await ensureNotificationPreferencesForUser(zoe.id)
 
 	// Ben — NOT Wade's friend. Wade has sent them a pending friend request.
 	const ben = await prisma.user.create({
@@ -270,7 +261,6 @@ async function seed() {
 			birthday: birthdayInDays(150, 36),
 		},
 	})
-	await ensureNotificationPreferencesForUser(ben.id)
 
 	console.timeEnd('👤 Created named users...')
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -15,6 +15,16 @@ sonar.test.inclusions=app/**/*.test.*,app/**/*.spec.*,app/**/__tests__/**,tests/
 # analyzed as source files.
 sonar.exclusions=app/components/ui/icons/**
 
+# Prisma migrations are immutable SQLite history. Sonar analyzes SQL files with
+# PL/SQL rules, where repeated migration identifiers and explicit comparisons
+# against Prisma's boolean columns are intentional and clearer than emulating
+# constants or dialect-specific truthiness. Keep every other SQL rule active.
+sonar.issue.ignore.multicriteria=e1,e2
+sonar.issue.ignore.multicriteria.e1.ruleKey=plsql:S1192
+sonar.issue.ignore.multicriteria.e1.resourceKey=prisma/migrations/**/*.sql
+sonar.issue.ignore.multicriteria.e2.ruleKey=plsql:BooleanLiteralComparisonCheck
+sonar.issue.ignore.multicriteria.e2.resourceKey=prisma/migrations/**/*.sql
+
 # Vitest only produces LCOV for app/* today. Keep infrastructure and script
 # code in Sonar's static analysis scope, but do not require app-style line
 # coverage for those paths. `app/root.tsx` is the framework root route — it

--- a/tests/e2e/settings-notifications.test.ts
+++ b/tests/e2e/settings-notifications.test.ts
@@ -1,6 +1,9 @@
 import { type Page } from '@playwright/test';
 import { prisma } from '#app/utils/db.server.ts';
-import { NOTIFICATION_TYPES } from '#app/utils/notification-catalog.ts';
+import {
+  NOTIFICATION_CHANNELS,
+  NOTIFICATION_TOPICS,
+} from '#app/utils/notification-catalog.ts';
 import {
   expect,
   singleFetchActionBody,
@@ -14,9 +17,6 @@ const dismissInstallPrompt = async (page: Page) => {
     await notNow.click();
   }
 };
-
-const friendRequestReceivedType = NOTIFICATION_TYPES.FRIEND_REQUEST_RECEIVED;
-const friendRequestAcceptedType = NOTIFICATION_TYPES.FRIEND_REQUEST_ACCEPTED;
 
 const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -58,16 +58,17 @@ test('users can optimistically toggle notification channels while request is pen
   await waitFor(
     async () => {
       const updatedPreference =
-        await prisma.userNotificationPreference.findUnique({
+        await prisma.notificationTopicPreference.findUnique({
           where: {
-            userId_type: {
+            userId_topic_channel: {
               userId: user.id,
-              type: friendRequestReceivedType,
+              topic: NOTIFICATION_TOPICS.FRIEND_REQUESTS,
+              channel: NOTIFICATION_CHANNELS.EMAIL,
             },
           },
-          select: { emailEnabled: true },
+          select: { enabled: true },
         });
-      if (updatedPreference?.emailEnabled !== false) {
+      if (updatedPreference?.enabled !== false) {
         throw new Error('Preference not updated yet');
       }
       return updatedPreference;
@@ -148,16 +149,17 @@ test('failed toggle requests rollback optimistic notification channel updates', 
   );
 
   const unchangedPreference =
-    await prisma.userNotificationPreference.findUnique({
+    await prisma.notificationTopicPreference.findUnique({
       where: {
-        userId_type: {
+        userId_topic_channel: {
           userId: user.id,
-          type: friendRequestReceivedType,
+          topic: NOTIFICATION_TOPICS.FRIEND_REQUESTS,
+          channel: NOTIFICATION_CHANNELS.EMAIL,
         },
       },
-      select: { emailEnabled: true },
+      select: { enabled: true },
     });
-  expect(unchangedPreference?.emailEnabled).toBe(initiallyChecked);
+  expect(unchangedPreference?.enabled ?? true).toBe(initiallyChecked);
 
   await page.unroute('**/settings/profile/notifications*');
 });
@@ -184,33 +186,26 @@ test('users can disable all email notifications at once', async ({
   await expect(friendActivityEmailToggles.first()).not.toBeChecked();
   await expect(friendActivityEmailToggles.nth(1)).not.toBeChecked();
 
-  const updatedPreferences = await waitFor(
+  const updatedPreference = await waitFor(
     async () => {
-      const preferences = await prisma.userNotificationPreference.findMany({
+      const preference = await prisma.notificationChannelPreference.findUnique({
         where: {
-          userId: user.id,
-          type: {
-            in: [friendRequestReceivedType, friendRequestAcceptedType],
+          userId_channel: {
+            userId: user.id,
+            channel: NOTIFICATION_CHANNELS.EMAIL,
           },
         },
-        select: { type: true, emailEnabled: true },
+        select: { enabled: true },
       });
 
-      if (preferences.length !== 2) {
-        throw new Error('Preferences not updated yet');
+      if (preference?.enabled !== false) {
+        throw new Error('Email channel gate not disabled yet');
       }
 
-      if (preferences.some((pref) => pref.emailEnabled !== false)) {
-        throw new Error('Email preferences not disabled yet');
-      }
-
-      return preferences;
+      return preference;
     },
     { timeout: 8000 },
   );
 
-  expect(updatedPreferences).toHaveLength(2);
-  for (const pref of updatedPreferences) {
-    expect(pref.emailEnabled).toBe(false);
-  }
+  expect(updatedPreference.enabled).toBe(false);
 });


### PR DESCRIPTION
## Summary

- replace materialized per-event preferences with sparse global-channel, category, and shared-topic overrides
- add group/pool activity inheritance, Custom filtering, mute-awareness state, access checks, and generalized preference audits
- migrate legacy choices conservatively, preserve the durable all-email-off choice, and keep the current settings UI working through a shared-topic compatibility adapter
- resolve effective preferences in the dispatcher policy and admin reporting without widening the delivery interface

## Migration and environment

- adds `20260714032000_scoped_notification_preferences`
- removes `UserNotificationPreference` after migrating non-default values
- conflicting received/accepted friend-request choices migrate to the more restrictive shared-topic value to avoid surprise delivery
- no environment-variable changes

## Test plan

- [x] Prisma schema validate and client generation
- [x] TypeScript and quiet ESLint
- [x] full Vitest suite: 198 files / 1,241 tests
- [x] migration reset and focused migration assertions
- [x] notification preference/policy/dispatcher/admin/auth/occasion-reminder coverage
- [x] Playwright `settings-notifications.test.ts`: 3 Chromium scenarios
- [x] production build (Playwright preflight)

## UI

- no new UI in this milestone; the accepted scoped-preference and muted-awareness UI remains the next PR
- no screenshots required
