### PR TITLE
feat(notifications): add preference awareness UI

### DIFF
--- a/app/components/notifications/context-notification-controls.test.tsx
+++ b/app/components/notifications/context-notification-controls.test.tsx
@@ -1,0 +1,188 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const submit = vi.fn();
+
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual('react-router');
+  return {
+    ...actual,
+    useFetcher: () => ({
+      data: undefined,
+      formData: undefined,
+      state: 'idle',
+      submit,
+    }),
+  };
+});
+
+vi.mock('#app/components/ui/responsive-dialog.tsx', () => ({
+  ResponsiveDialog: ({ children }: { children: React.ReactNode }) => children,
+  ResponsiveDialogContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  ResponsiveDialogDescription: ({
+    children,
+  }: {
+    children: React.ReactNode;
+  }) => <p>{children}</p>,
+  ResponsiveDialogHeader: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  ResponsiveDialogTitle: ({ children }: { children: React.ReactNode }) => (
+    <h2>{children}</h2>
+  ),
+  ResponsiveDialogTrigger: ({ children }: { children: React.ReactNode }) =>
+    children,
+}));
+
+import {
+  ContextNotificationAwarenessNotice,
+  ContextNotificationControl,
+} from './context-notification-controls.tsx';
+
+const baseAwareness = {
+  notificationOff: false,
+  reason: null,
+  noticeVisible: false,
+  preference: {
+    activityLevel: 'IMPORTANT_ONLY' as const,
+    source: 'application_default' as const,
+    customTopics: [],
+  },
+};
+
+beforeEach(() => {
+  submit.mockReset();
+});
+
+describe('context notification controls', () => {
+  it('shows a personal activity control and hides Custom with no contextual topics', () => {
+    render(
+      <MemoryRouter>
+        <ContextNotificationControl
+          context={{ kind: 'GROUP', groupId: 'group-1' }}
+          contextLabel="Family"
+          awareness={baseAwareness}
+          availableTopics={[]}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Notifications for Family: Important',
+      }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Custom topics')).not.toBeInTheDocument();
+  });
+
+  it('explains inherited pool settings and allows a local important override', async () => {
+    render(
+      <MemoryRouter>
+        <ContextNotificationControl
+          context={{ kind: 'POOL', poolId: 'pool-1' }}
+          contextLabel="Birthday pool"
+          inheritedFromLabel="Family"
+          awareness={{
+            notificationOff: true,
+            reason: 'inherited_mute',
+            noticeVisible: true,
+            preference: {
+              activityLevel: 'MUTED',
+              source: 'group_override',
+              customTopics: [],
+            },
+          }}
+          availableTopics={[]}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.getByText(/using the notification setting from/i),
+    ).toHaveTextContent('Family');
+    await userEvent.click(
+      screen.getByRole('radio', { name: /important only/i }),
+    );
+    const formData = submit.mock.calls[0]?.[0] as FormData;
+    expect(Object.fromEntries(formData)).toMatchObject({
+      intent: 'set-activity',
+      contextKind: 'POOL',
+      contextId: 'pool-1',
+      activityLevel: 'IMPORTANT_ONLY',
+    });
+  });
+
+  it('keeps the muted indicator while letting the reason notice be dismissed', async () => {
+    const awareness = {
+      notificationOff: true,
+      reason: 'explicit_mute' as const,
+      noticeVisible: true,
+      preference: {
+        activityLevel: 'MUTED' as const,
+        source: 'group_override' as const,
+        customTopics: [],
+      },
+    };
+    render(
+      <MemoryRouter>
+        <ContextNotificationControl
+          context={{ kind: 'GROUP', groupId: 'group-1' }}
+          contextLabel="Family"
+          awareness={awareness}
+          availableTopics={[]}
+        />
+        <ContextNotificationAwarenessNotice
+          context={{ kind: 'GROUP', groupId: 'group-1' }}
+          contextLabel="Family"
+          awareness={awareness}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Notifications for Family: Muted' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('You muted Family')).toBeInTheDocument();
+    await userEvent.click(
+      screen.getByRole('button', {
+        name: /dismiss notification settings notice/i,
+      }),
+    );
+    const formData = submit.mock.calls.at(-1)?.[0] as FormData;
+    expect(Object.fromEntries(formData)).toMatchObject({
+      intent: 'dismiss-notice',
+      contextKind: 'GROUP',
+      contextId: 'group-1',
+    });
+  });
+
+  it('labels a context Off when every account delivery channel is disabled', () => {
+    render(
+      <MemoryRouter>
+        <ContextNotificationControl
+          context={{ kind: 'GROUP', groupId: 'group-1' }}
+          contextLabel="Family"
+          awareness={{
+            ...baseAwareness,
+            notificationOff: true,
+            reason: 'no_channels',
+            noticeVisible: true,
+          }}
+          availableTopics={[]}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Notifications for Family: Off' }),
+    ).toBeInTheDocument();
+  });
+});

--- a/app/components/notifications/context-notification-controls.tsx
+++ b/app/components/notifications/context-notification-controls.tsx
@@ -1,0 +1,423 @@
+import React from 'react';
+import {
+  LuBell,
+  LuBellOff,
+  LuCheck,
+  LuChevronRight,
+  LuX,
+} from 'react-icons/lu';
+import { Link, useFetcher } from 'react-router';
+import { Button } from '#app/components/ui/button.tsx';
+import {
+  ResponsiveDialog,
+  ResponsiveDialogContent,
+  ResponsiveDialogDescription,
+  ResponsiveDialogHeader,
+  ResponsiveDialogTitle,
+  ResponsiveDialogTrigger,
+} from '#app/components/ui/responsive-dialog.tsx';
+import { cn } from '#app/utils/misc.tsx';
+import {
+  type NotificationContext,
+  type NotificationTopic,
+} from '#app/utils/notification-catalog.ts';
+import {
+  isNotificationActivityLevel,
+  NOTIFICATION_ACTIVITY_LEVELS,
+  type ContextNotificationAwarenessReason,
+  type NotificationActivityLevel,
+} from '#app/utils/notification-context.ts';
+
+type SerializableContextPreference = {
+  activityLevel: NotificationActivityLevel;
+  source: 'application_default' | 'group_override' | 'pool_override';
+  customTopics: Array<NotificationTopic>;
+};
+
+export type SerializableContextAwareness = {
+  notificationOff: boolean;
+  reason: ContextNotificationAwarenessReason | null;
+  noticeVisible: boolean;
+  preference: SerializableContextPreference;
+};
+
+export type ContextTopicOption = {
+  topic: NotificationTopic;
+  label: string;
+  description: string;
+};
+
+const activityOptions = [
+  {
+    value: NOTIFICATION_ACTIVITY_LEVELS.ALL_ACTIVITY,
+    label: 'All activity',
+    description: 'Every update from this space, within your channel choices.',
+  },
+  {
+    value: NOTIFICATION_ACTIVITY_LEVELS.IMPORTANT_ONLY,
+    label: 'Important only',
+    description: 'Only key moments — decisions, assignments, and milestones.',
+  },
+  {
+    value: NOTIFICATION_ACTIVITY_LEVELS.MUTED,
+    label: 'Muted',
+    description:
+      'Silence optional updates and organizer nudges. Account and security messages are separate.',
+  },
+] as const;
+
+export function ContextNotificationControl({
+  context,
+  contextLabel,
+  awareness,
+  availableTopics,
+  inheritedFromLabel,
+}: Readonly<{
+  context: NotificationContext;
+  contextLabel: string;
+  awareness: SerializableContextAwareness;
+  availableTopics: Array<ContextTopicOption>;
+  inheritedFromLabel?: string | null;
+}>) {
+  const [open, setOpen] = React.useState(false);
+  const fetcher = useFetcher<{ ok: boolean }>();
+  const pendingLevel = fetcher.formData?.get('activityLevel');
+  const level = isNotificationActivityLevel(pendingLevel)
+    ? pendingLevel
+    : awareness.preference.activityLevel;
+  const inherited =
+    context.kind === 'POOL' && awareness.preference.source === 'group_override';
+  const hasPoolOverride =
+    context.kind === 'POOL' && awareness.preference.source === 'pool_override';
+  const displayLabel =
+    awareness.reason === 'no_channels' ? 'Off' : activityLabel(level);
+  const Icon = awareness.notificationOff ? LuBellOff : LuBell;
+
+  const setActivity = (
+    activityLevel: NotificationActivityLevel,
+    topics: Array<NotificationTopic> = [],
+  ) => {
+    const formData = contextFormData(context, 'set-activity');
+    formData.set('activityLevel', activityLevel);
+    for (const topic of topics) formData.append('customTopic', topic);
+    void fetcher.submit(formData, {
+      action: '/api/notification-preferences/context',
+      method: 'post',
+    });
+  };
+
+  return (
+    <ResponsiveDialog open={open} onOpenChange={setOpen}>
+      <ResponsiveDialogTrigger asChild>
+        <button
+          type="button"
+          className={cn(
+            'inline-flex min-h-11 items-center gap-1.5 rounded-full border px-3 text-sm font-medium outline-none ring-ring focus-visible:ring-2',
+            awareness.notificationOff
+              ? 'border-amber-300 bg-amber-50 text-amber-900 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-100'
+              : 'border-border bg-background text-foreground hover:bg-muted',
+          )}
+          aria-label={`Notifications for ${contextLabel}: ${displayLabel}`}
+        >
+          <Icon className="h-4 w-4" aria-hidden="true" />
+          <span className="hidden sm:inline">{displayLabel}</span>
+        </button>
+      </ResponsiveDialogTrigger>
+      <ResponsiveDialogContent className="sm:max-w-lg">
+        <ResponsiveDialogHeader>
+          <ResponsiveDialogTitle>Notifications</ResponsiveDialogTitle>
+          <ResponsiveDialogDescription>
+            Choose how much activity you want from {contextLabel}. Your delivery
+            channels still apply.
+          </ResponsiveDialogDescription>
+        </ResponsiveDialogHeader>
+
+        <div className="space-y-4 py-2">
+          {inherited ? (
+            <div className="rounded-lg border border-border bg-muted/50 px-3 py-2 text-sm text-muted-foreground">
+              Using the notification setting from{' '}
+              <span className="font-medium text-foreground">
+                {inheritedFromLabel ?? 'this group'}
+              </span>
+              . Choosing an option below changes only this pool.
+            </div>
+          ) : null}
+
+          <div
+            className="space-y-2"
+            role="radiogroup"
+            aria-label="Activity level"
+          >
+            {activityOptions.map((option) => (
+              <ActivityOption
+                key={option.value}
+                selected={level === option.value}
+                disabled={fetcher.state !== 'idle'}
+                label={option.label}
+                description={option.description}
+                onSelect={() => setActivity(option.value)}
+              />
+            ))}
+          </div>
+
+          {availableTopics.length > 0 ? (
+            <CustomTopicOptions
+              topics={availableTopics}
+              selected={awareness.preference.customTopics}
+              active={level === NOTIFICATION_ACTIVITY_LEVELS.CUSTOM}
+              disabled={fetcher.state !== 'idle'}
+              onChange={(topics) =>
+                setActivity(NOTIFICATION_ACTIVITY_LEVELS.CUSTOM, topics)
+              }
+            />
+          ) : null}
+
+          {hasPoolOverride ? (
+            <Button
+              type="button"
+              variant="outline"
+              className="w-full"
+              disabled={fetcher.state !== 'idle'}
+              onClick={() => {
+                void fetcher.submit(
+                  contextFormData(context, 'clear-activity'),
+                  {
+                    action: '/api/notification-preferences/context',
+                    method: 'post',
+                  },
+                );
+              }}
+            >
+              Use group setting
+            </Button>
+          ) : null}
+
+          <Button asChild variant="link" className="w-full">
+            <Link to="/settings/profile/notifications">
+              Manage delivery channels and all topics
+              <LuChevronRight className="ml-1 h-4 w-4" aria-hidden="true" />
+            </Link>
+          </Button>
+        </div>
+      </ResponsiveDialogContent>
+    </ResponsiveDialog>
+  );
+}
+
+function ActivityOption({
+  selected,
+  disabled,
+  label,
+  description,
+  onSelect,
+}: Readonly<{
+  selected: boolean;
+  disabled: boolean;
+  label: string;
+  description: string;
+  onSelect: () => void;
+}>) {
+  return (
+    <button
+      type="button"
+      role="radio"
+      aria-checked={selected}
+      disabled={disabled}
+      onClick={onSelect}
+      className={cn(
+        'flex min-h-16 w-full items-center gap-3 rounded-xl border px-3 py-2 text-left outline-none ring-ring focus-visible:ring-2 disabled:opacity-60',
+        selected
+          ? 'border-primary bg-primary/5'
+          : 'border-border hover:bg-muted',
+      )}
+    >
+      <span className="min-w-0 flex-1">
+        <span className="block font-medium">{label}</span>
+        <span className="block text-sm text-muted-foreground">
+          {description}
+        </span>
+      </span>
+      {selected ? (
+        <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-primary text-primary-foreground">
+          <LuCheck className="h-4 w-4" aria-hidden="true" />
+        </span>
+      ) : null}
+    </button>
+  );
+}
+
+function CustomTopicOptions({
+  topics,
+  selected,
+  active,
+  disabled,
+  onChange,
+}: Readonly<{
+  topics: Array<ContextTopicOption>;
+  selected: Array<NotificationTopic>;
+  active: boolean;
+  disabled: boolean;
+  onChange: (topics: Array<NotificationTopic>) => void;
+}>) {
+  return (
+    <fieldset className="rounded-xl border border-border p-3">
+      <legend className="px-1 text-sm font-medium">Custom topics</legend>
+      <p className="mb-2 text-sm text-muted-foreground">
+        Pick exactly which topics reach you.
+      </p>
+      <div className="space-y-2">
+        {topics.map((topic) => {
+          const checked = active && selected.includes(topic.topic);
+          return (
+            <label
+              key={topic.topic}
+              className="flex min-h-11 cursor-pointer items-center gap-3 rounded-lg px-2 hover:bg-muted"
+            >
+              <input
+                type="checkbox"
+                checked={checked}
+                disabled={disabled}
+                onChange={() => {
+                  const next = checked
+                    ? selected.filter((value) => value !== topic.topic)
+                    : [...selected, topic.topic];
+                  onChange(next);
+                }}
+              />
+              <span>
+                <span className="block text-sm font-medium">{topic.label}</span>
+                <span className="block text-xs text-muted-foreground">
+                  {topic.description}
+                </span>
+              </span>
+            </label>
+          );
+        })}
+      </div>
+    </fieldset>
+  );
+}
+
+export function ContextNotificationAwarenessNotice({
+  context,
+  contextLabel,
+  awareness,
+  inheritedFromLabel,
+}: Readonly<{
+  context: NotificationContext;
+  contextLabel: string;
+  awareness: SerializableContextAwareness;
+  inheritedFromLabel?: string | null;
+}>) {
+  const fetcher = useFetcher<{ ok: boolean }>();
+  if (!awareness.noticeVisible || !awareness.reason) return null;
+
+  const copy = awarenessCopy(
+    awareness.reason,
+    contextLabel,
+    inheritedFromLabel,
+  );
+  return (
+    <div className="flex gap-3 rounded-xl border border-amber-300 bg-amber-50 px-3 py-3 text-amber-950 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-100">
+      <LuBellOff className="mt-1 h-5 w-5 shrink-0" aria-hidden="true" />
+      <div className="min-w-0 flex-1">
+        <p className="font-medium">{copy.title}</p>
+        <p className="mt-0.5 text-sm opacity-80">{copy.description}</p>
+        {awareness.reason === 'no_channels' ? (
+          <Button
+            asChild
+            variant="link"
+            className="mt-1 h-auto p-0 text-current"
+          >
+            <Link to="/settings/profile/notifications">Turn on a channel</Link>
+          </Button>
+        ) : (
+          <button
+            type="button"
+            className="mt-2 min-h-11 text-sm font-medium underline underline-offset-4"
+            disabled={fetcher.state !== 'idle'}
+            onClick={() => {
+              const formData = contextFormData(context, 'set-activity');
+              formData.set(
+                'activityLevel',
+                NOTIFICATION_ACTIVITY_LEVELS.IMPORTANT_ONLY,
+              );
+              void fetcher.submit(formData, {
+                action: '/api/notification-preferences/context',
+                method: 'post',
+              });
+            }}
+          >
+            Turn on important updates
+            {awareness.reason === 'inherited_mute' ? ' here' : ''}
+          </button>
+        )}
+      </div>
+      <button
+        type="button"
+        aria-label="Dismiss notification settings notice"
+        className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full hover:bg-black/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        disabled={fetcher.state !== 'idle'}
+        onClick={() => {
+          void fetcher.submit(contextFormData(context, 'dismiss-notice'), {
+            action: '/api/notification-preferences/context',
+            method: 'post',
+          });
+        }}
+      >
+        <LuX className="h-5 w-5" aria-hidden="true" />
+      </button>
+    </div>
+  );
+}
+
+function contextFormData(
+  context: NotificationContext,
+  intent: 'set-activity' | 'clear-activity' | 'dismiss-notice',
+) {
+  const formData = new FormData();
+  formData.set('intent', intent);
+  formData.set('contextKind', context.kind);
+  formData.set(
+    'contextId',
+    context.kind === 'GROUP' ? context.groupId : context.poolId,
+  );
+  return formData;
+}
+
+function activityLabel(level: NotificationActivityLevel) {
+  switch (level) {
+    case NOTIFICATION_ACTIVITY_LEVELS.ALL_ACTIVITY:
+      return 'All activity';
+    case NOTIFICATION_ACTIVITY_LEVELS.IMPORTANT_ONLY:
+      return 'Important';
+    case NOTIFICATION_ACTIVITY_LEVELS.MUTED:
+      return 'Muted';
+    case NOTIFICATION_ACTIVITY_LEVELS.CUSTOM:
+      return 'Custom';
+  }
+}
+
+function awarenessCopy(
+  reason: ContextNotificationAwarenessReason,
+  contextLabel: string,
+  inheritedFromLabel?: string | null,
+) {
+  if (reason === 'inherited_mute') {
+    return {
+      title: 'Notifications are muted by the group setting',
+      description: `${inheritedFromLabel ?? 'The parent group'} is muted, so ${contextLabel} inherits that choice.`,
+    };
+  }
+  if (reason === 'no_channels') {
+    return {
+      title: 'No delivery channel is on',
+      description: `Updates from ${contextLabel} cannot reach you until you turn on in-app, email, or push.`,
+    };
+  }
+  return {
+    title: `You muted ${contextLabel}`,
+    description:
+      'Optional updates are off. You can still change this from the notification control above.',
+  };
+}

--- a/app/components/notifications/context-notification-controls.tsx
+++ b/app/components/notifications/context-notification-controls.tsx
@@ -135,11 +135,11 @@ export function ContextNotificationControl({
         <div className="space-y-4 py-2">
           {inherited ? (
             <div className="rounded-lg border border-border bg-muted/50 px-3 py-2 text-sm text-muted-foreground">
-              Using the notification setting from{' '}
+              {'Using the notification setting from '}
               <span className="font-medium text-foreground">
                 {inheritedFromLabel ?? 'this group'}
               </span>
-              . Choosing an option below changes only this pool.
+              {'. Choosing an option below changes only this pool.'}
             </div>
           ) : null}
 
@@ -271,6 +271,7 @@ function CustomTopicOptions({
           return (
             <label
               key={topic.topic}
+              aria-label={`${topic.label}: ${topic.description}`}
               className="flex min-h-11 cursor-pointer items-center gap-3 rounded-lg px-2 hover:bg-muted"
             >
               <input

--- a/app/components/notifications/preference-switch.tsx
+++ b/app/components/notifications/preference-switch.tsx
@@ -1,0 +1,42 @@
+import { cn } from '#app/utils/misc.tsx';
+
+export function PreferenceSwitch({
+  checked,
+  disabled,
+  label,
+  onCheckedChange,
+}: Readonly<{
+  checked: boolean;
+  disabled?: boolean;
+  label: string;
+  onCheckedChange: (checked: boolean) => void;
+}>) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={label}
+      disabled={disabled}
+      onClick={() => onCheckedChange(!checked)}
+      className="inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-full outline-none ring-ring focus-visible:ring-2 disabled:cursor-not-allowed disabled:opacity-50"
+    >
+      <span
+        aria-hidden="true"
+        className={cn(
+          'relative h-6 w-10 rounded-full border transition-colors',
+          checked
+            ? 'border-primary bg-primary'
+            : 'border-input bg-muted-foreground/20',
+        )}
+      >
+        <span
+          className={cn(
+            'absolute top-0.5 h-[18px] w-[18px] rounded-full bg-background shadow-sm transition-transform',
+            checked ? 'translate-x-[18px]' : 'translate-x-0.5',
+          )}
+        />
+      </span>
+    </button>
+  );
+}

--- a/app/routes/api.notification-preferences.context.test.ts
+++ b/app/routes/api.notification-preferences.context.test.ts
@@ -1,0 +1,110 @@
+/**
+ * @vitest-environment node
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { toActionArgs } from '#tests/route-module-test-utils.ts';
+
+const requireUserId = vi.fn();
+const setContextActivityPreference = vi.fn();
+const clearContextActivityPreference = vi.fn();
+const dismissContextNotificationNotice = vi.fn();
+
+vi.mock('#app/utils/auth.server.ts', () => ({
+  requireUserId: (...args: Array<unknown>) => requireUserId(...args),
+}));
+
+vi.mock('#app/utils/notification-preferences.server.ts', () => ({
+  setContextActivityPreference: (...args: Array<unknown>) =>
+    setContextActivityPreference(...args),
+  clearContextActivityPreference: (...args: Array<unknown>) =>
+    clearContextActivityPreference(...args),
+  dismissContextNotificationNotice: (...args: Array<unknown>) =>
+    dismissContextNotificationNotice(...args),
+}));
+
+import { action } from './api.notification-preferences.context.ts';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  requireUserId.mockResolvedValue('user-1');
+});
+
+describe('context notification preference action', () => {
+  it('sets a validated pool activity preference', async () => {
+    await action(
+      toActionArgs({
+        context: {},
+        params: {},
+        request: formRequest({
+          intent: 'set-activity',
+          contextKind: 'POOL',
+          contextId: 'pool-1',
+          activityLevel: 'IMPORTANT_ONLY',
+        }),
+      }),
+    );
+
+    expect(setContextActivityPreference).toHaveBeenCalledWith({
+      userId: 'user-1',
+      context: { kind: 'POOL', poolId: 'pool-1' },
+      activityLevel: 'IMPORTANT_ONLY',
+      customTopics: [],
+      source: 'context:notification-settings',
+    });
+  });
+
+  it('clears overrides and dismisses awareness for group contexts', async () => {
+    for (const intent of ['clear-activity', 'dismiss-notice'] as const) {
+      await action(
+        toActionArgs({
+          context: {},
+          params: {},
+          request: formRequest({
+            intent,
+            contextKind: 'GROUP',
+            contextId: 'group-1',
+          }),
+        }),
+      );
+    }
+
+    expect(clearContextActivityPreference).toHaveBeenCalledWith({
+      userId: 'user-1',
+      context: { kind: 'GROUP', groupId: 'group-1' },
+      source: 'context:notification-settings',
+    });
+    expect(dismissContextNotificationNotice).toHaveBeenCalledWith({
+      userId: 'user-1',
+      context: { kind: 'GROUP', groupId: 'group-1' },
+      source: 'context:notification-settings',
+    });
+  });
+
+  it('rejects invalid contexts before calling the preference module', async () => {
+    await expect(
+      action(
+        toActionArgs({
+          context: {},
+          params: {},
+          request: formRequest({
+            intent: 'dismiss-notice',
+            contextKind: 'ACCOUNT',
+            contextId: 'user-1',
+          }),
+        }),
+      ),
+    ).rejects.toMatchObject({ status: 400 });
+    expect(dismissContextNotificationNotice).not.toHaveBeenCalled();
+  });
+});
+
+function formRequest(values: Record<string, string>) {
+  return new Request(
+    'https://giftpool.app/api/notification-preferences/context',
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams(values).toString(),
+    },
+  );
+}

--- a/app/routes/api.notification-preferences.context.ts
+++ b/app/routes/api.notification-preferences.context.ts
@@ -1,0 +1,65 @@
+import { invariantResponse } from '@epic-web/invariant';
+import { data, type ActionFunctionArgs } from 'react-router';
+import { requireUserId } from '#app/utils/auth.server.ts';
+import {
+  isNotificationTopic,
+  type NotificationContext,
+} from '#app/utils/notification-catalog.ts';
+import { isNotificationActivityLevel } from '#app/utils/notification-context.ts';
+import {
+  clearContextActivityPreference,
+  dismissContextNotificationNotice,
+  setContextActivityPreference,
+} from '#app/utils/notification-preferences.server.ts';
+
+const SOURCE = 'context:notification-settings';
+
+export async function action({ request }: ActionFunctionArgs) {
+  const userId = await requireUserId(request);
+  const formData = await request.formData();
+  const intent = formData.get('intent');
+  const context = parseContext(formData);
+
+  if (intent === 'set-activity') {
+    const activityLevel = formData.get('activityLevel');
+    invariantResponse(
+      isNotificationActivityLevel(activityLevel),
+      'Invalid notification activity level',
+    );
+    const customTopics = formData
+      .getAll('customTopic')
+      .filter(isNotificationTopic);
+    await setContextActivityPreference({
+      userId,
+      context,
+      activityLevel,
+      customTopics,
+      source: SOURCE,
+    });
+    return { ok: true };
+  }
+
+  if (intent === 'clear-activity') {
+    await clearContextActivityPreference({ userId, context, source: SOURCE });
+    return { ok: true };
+  }
+
+  if (intent === 'dismiss-notice') {
+    await dismissContextNotificationNotice({
+      userId,
+      context,
+      source: SOURCE,
+    });
+    return { ok: true };
+  }
+
+  return data({ ok: false }, { status: 400 });
+}
+
+function parseContext(formData: FormData): NotificationContext {
+  const kind = formData.get('contextKind');
+  const id = formData.get('contextId');
+  invariantResponse(typeof id === 'string' && id.length > 0, 'Invalid context');
+  invariantResponse(kind === 'GROUP' || kind === 'POOL', 'Invalid context');
+  return kind === 'GROUP' ? { kind, groupId: id } : { kind, poolId: id };
+}

--- a/app/routes/groups+/$giftGroupId_+/__route.server.test.ts
+++ b/app/routes/groups+/$giftGroupId_+/__route.server.test.ts
@@ -26,6 +26,7 @@ const friendshipFindMany = vi.fn();
 const friendRequestFindMany = vi.fn();
 const viewerMembershipFindUnique = vi.fn();
 const groupInvitationFindFirst = vi.fn();
+const getContextNotificationAwareness = vi.fn();
 
 vi.mock('#app/utils/auth.server.ts', () => ({
   requireUserId: (...args: Array<unknown>) => requireUserId(...args),
@@ -53,7 +54,8 @@ vi.mock('#app/utils/db.server.ts', () => ({
       findFirst: (...args: Array<unknown>) => groupInvitationFindFirst(...args),
     },
     usersInGiftGroups: {
-      findUnique: (...args: Array<unknown>) => viewerMembershipFindUnique(...args),
+      findUnique: (...args: Array<unknown>) =>
+        viewerMembershipFindUnique(...args),
     },
   },
 }));
@@ -72,6 +74,11 @@ vi.mock('#app/utils/group-invitations.server.ts', () => ({
 vi.mock('#app/utils/toast.server.ts', () => ({
   createToastHeaders: (...args: Array<unknown>) => createToastHeaders(...args),
   redirectWithToast: (...args: Array<unknown>) => redirectWithToast(...args),
+}));
+
+vi.mock('#app/utils/notification-preferences.server.ts', () => ({
+  getContextNotificationAwareness: (...args: Array<unknown>) =>
+    getContextNotificationAwareness(...args),
 }));
 
 import { action, loader } from './__route.server.ts';
@@ -107,6 +114,12 @@ beforeEach(() => {
   friendRequestFindMany.mockReset();
   viewerMembershipFindUnique.mockReset();
   groupInvitationFindFirst.mockReset();
+  getContextNotificationAwareness.mockReset().mockResolvedValue({
+    notificationOff: false,
+    noticeVisible: false,
+    reason: null,
+    preference: { activityLevel: 'IMPORTANT_ONLY' },
+  });
 
   createToastHeaders.mockResolvedValue(new Headers({ 'x-toast': 'ok' }));
   redirectWithToast.mockImplementation(
@@ -183,7 +196,9 @@ describe('groups detail route server module', () => {
       code: 'invite-code',
       id: 'invite-1',
     });
-    getInviteLink.mockReturnValue('https://giftpool.app/groups/join/invite-code');
+    getInviteLink.mockReturnValue(
+      'https://giftpool.app/groups/join/invite-code',
+    );
     userHasGroupPermission.mockImplementation(
       async (_userId: string, _groupId: string, permission: string) =>
         ({
@@ -221,7 +236,9 @@ describe('groups detail route server module', () => {
     const membersById = new Map(
       result.giftGroup.groupMembers.map((member) => [member.user.id, member]),
     );
-    expect(membersById.get('viewer-1')?.friendRelationship.state).toBe('FRIENDS');
+    expect(membersById.get('viewer-1')?.friendRelationship.state).toBe(
+      'FRIENDS',
+    );
     expect(membersById.get('friend-1')?.friendRelationship).toEqual({
       friendshipId: 'friendship-1',
       incomingRequestId: null,

--- a/app/routes/groups+/$giftGroupId_+/__route.server.ts
+++ b/app/routes/groups+/$giftGroupId_+/__route.server.ts
@@ -7,6 +7,10 @@ import {
 } from 'react-router';
 import { type RelationshipState } from '#app/utils/friends.ts';
 import {
+  getNotificationTopicDefinition,
+  getNotificationTopicsForContext,
+} from '#app/utils/notification-catalog.ts';
+import {
   CreateInviteLinkFormSchema,
   DeleteFormSchema,
   DestroyInviteLinkFormSchema,
@@ -22,6 +26,8 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
   const { getInviteLink } =
     await import('#app/utils/group-invitations.server.ts');
   const userId = await requireUserIdInGroup(request, groupId);
+  const { getContextNotificationAwareness } =
+    await import('#app/utils/notification-preferences.server.ts');
   const giftGroup = await prisma.giftGroup.findUnique({
     where: {
       id: groupId,
@@ -245,6 +251,14 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
       ? getInviteLink(existingInvitation.code, request)
       : null,
     groupInvitationId: existingInvitation?.id,
+    notificationAwareness: await getContextNotificationAwareness({
+      userId,
+      context: { kind: 'GROUP', groupId },
+      requireAccess: false,
+    }),
+    notificationTopics: getNotificationTopicsForContext('GROUP').map(
+      (topic) => ({ topic, ...getNotificationTopicDefinition(topic) }),
+    ),
   };
 }
 export async function action({ request }: ActionFunctionArgs) {

--- a/app/routes/groups+/$giftGroupId_+/_layout.component.test.tsx
+++ b/app/routes/groups+/$giftGroupId_+/_layout.component.test.tsx
@@ -15,6 +15,17 @@ const layoutLoaderData = {
     ],
   },
   viewer: { userId: 'viewer-1', role: 'OWNER' as const },
+  notificationAwareness: {
+    notificationOff: false,
+    noticeVisible: false,
+    reason: null,
+    preference: {
+      activityLevel: 'IMPORTANT_ONLY',
+      source: 'application_default',
+      customTopics: [],
+    },
+  },
+  notificationTopics: [],
 };
 
 const location = { pathname: '/groups/group-1' };
@@ -66,6 +77,14 @@ vi.mock('#app/components/groups/RoleBadge.tsx', () => ({
   RoleBadge: ({ role }: { role: string }) => <span>{role}</span>,
 }));
 
+vi.mock(
+  '#app/components/notifications/context-notification-controls.tsx',
+  () => ({
+    ContextNotificationControl: () => <button>Important</button>,
+    ContextNotificationAwarenessNotice: () => null,
+  }),
+);
+
 import GroupLayout from './_layout.tsx';
 
 beforeEach(() => {
@@ -81,6 +100,9 @@ describe('group layout shell', () => {
     // Group header (not the settings header) with the group name.
     expect(screen.getByText('Family')).toBeInTheDocument();
     expect(screen.getByText('2 members')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Important' }),
+    ).toBeInTheDocument();
     // Two-tab bar, Activity removed.
     expect(screen.getByRole('link', { name: 'Overview' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Members' })).toBeInTheDocument();

--- a/app/routes/groups+/$giftGroupId_+/_layout.tsx
+++ b/app/routes/groups+/$giftGroupId_+/_layout.tsx
@@ -9,6 +9,10 @@ import {
 import { GroupAvatarCluster } from '#app/components/groups/group-avatar-cluster.tsx';
 import { GroupInviteButton } from '#app/components/groups/group-invite-button.tsx';
 import { RoleBadge } from '#app/components/groups/RoleBadge.tsx';
+import {
+  ContextNotificationAwarenessNotice,
+  ContextNotificationControl,
+} from '#app/components/notifications/context-notification-controls.tsx';
 import { PageHeader } from '#app/components/page-header.tsx';
 import { Stack } from '#app/components/ui-kit/stack.tsx';
 import { type GroupRole } from '#app/utils/group-role.ts';
@@ -19,8 +23,14 @@ import { type loader as routeLoader } from './__route.server';
 export { loader, action } from './__route.server';
 
 const GroupLayout = () => {
-  const { giftGroup, viewer, canInvite, inviteLink } =
-    useLoaderData<typeof routeLoader>();
+  const {
+    giftGroup,
+    viewer,
+    canInvite,
+    inviteLink,
+    notificationAwareness,
+    notificationTopics,
+  } = useLoaderData<typeof routeLoader>();
   const location = useLocation();
   // Settings is a distinct sub-page, not a tab: it gets its own header with a
   // back affordance to the group, and never shows the Overview/Members tab bar.
@@ -66,6 +76,12 @@ const GroupLayout = () => {
               viewerId={viewer.userId}
             />
             <RoleBadge role={viewer.role as GroupRole} />
+            <ContextNotificationControl
+              context={{ kind: 'GROUP', groupId: giftGroup.id }}
+              contextLabel={giftGroup.name}
+              awareness={notificationAwareness}
+              availableTopics={notificationTopics}
+            />
             {/* Invite — mobile only (desktop keeps it in the Group info rail
                 card). Rendered only for users who can invite; permission is also
                 enforced server-side in the create-invite-link action. */}
@@ -92,6 +108,13 @@ const GroupLayout = () => {
       <main className="min-h-0 flex-1 overflow-y-auto">
         <div className="mx-auto max-w-6xl p-3 sm:p-6">
           <Stack gap={6}>
+            {!isSettings ? (
+              <ContextNotificationAwarenessNotice
+                context={{ kind: 'GROUP', groupId: giftGroup.id }}
+                contextLabel={giftGroup.name}
+                awareness={notificationAwareness}
+              />
+            ) : null}
             {/* Tabs are retained on mobile/tablet; desktop collapses them
                 into the single dashboard rendered by the index route. The
                 settings sub-page never shows them. */}

--- a/app/routes/pools+/$poolId+/__route.server.test.ts
+++ b/app/routes/pools+/$poolId+/__route.server.test.ts
@@ -42,6 +42,7 @@ const wishlistItemFindFirst = vi.fn();
 const canViewWishlistOf = vi.fn();
 const queueLogEvent = vi.fn();
 const redirectWithToast = vi.fn();
+const getContextNotificationAwareness = vi.fn();
 
 vi.mock('#app/utils/auth.server.ts', () => ({
   requireUserId: (...args: Array<unknown>) => requireUserId(...args),
@@ -113,6 +114,11 @@ vi.mock('#app/utils/pool.server.ts', () => ({
 
 vi.mock('#app/utils/toast.server.ts', () => ({
   redirectWithToast: (...args: Array<unknown>) => redirectWithToast(...args),
+}));
+
+vi.mock('#app/utils/notification-preferences.server.ts', () => ({
+  getContextNotificationAwareness: (...args: Array<unknown>) =>
+    getContextNotificationAwareness(...args),
 }));
 
 import { action, loader } from './__route.server.ts';
@@ -199,6 +205,12 @@ beforeEach(() => {
       status: 302,
     }),
   );
+  getContextNotificationAwareness.mockReset().mockResolvedValue({
+    notificationOff: false,
+    noticeVisible: false,
+    reason: null,
+    preference: { activityLevel: 'IMPORTANT_ONLY' },
+  });
 });
 
 describe('pool detail route loader', () => {

--- a/app/routes/pools+/$poolId+/__route.server.ts
+++ b/app/routes/pools+/$poolId+/__route.server.ts
@@ -5,7 +5,11 @@ import { queueLogEvent } from '#app/utils/analytics.server.ts'
 import { requireUserId } from '#app/utils/auth.server.ts'
 import { prisma } from '#app/utils/db.server.ts'
 import { canViewWishlistOf } from '#app/utils/friends.server.ts'
-import { dollarsToCents } from '#app/utils/price.ts'
+import {
+	getNotificationTopicDefinition,
+	getNotificationTopicsForContext,
+} from '#app/utils/notification-catalog.ts'
+import { getContextNotificationAwareness } from '#app/utils/notification-preferences.server.ts'
 import {
 	OCCASION_TYPE,
 	POOL_STATUS,
@@ -41,6 +45,7 @@ import {
 	updatePool,
 	type UpdatePoolInput,
 } from '#app/utils/pool.server.ts'
+import { dollarsToCents } from '#app/utils/price.ts'
 import { getRequestContext } from '#app/utils/request-context.server.ts'
 import { redirectWithToast } from '#app/utils/toast.server.ts'
 
@@ -137,6 +142,15 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 		contributionBreakdown,
 		inviteUrl,
 		recipientWishlistItems,
+		notificationAwareness: await getContextNotificationAwareness({
+			userId,
+			context: { kind: 'POOL', poolId },
+			requireAccess: false,
+		}),
+		notificationTopics: getNotificationTopicsForContext('POOL').map(topic => ({
+			topic,
+			...getNotificationTopicDefinition(topic),
+		})),
 	}
 }
 

--- a/app/routes/pools+/$poolId+/_layout.test.tsx
+++ b/app/routes/pools+/$poolId+/_layout.test.tsx
@@ -7,6 +7,18 @@ import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const loaderDataSnapshot = {
+  canManage: true,
+  notificationAwareness: {
+    notificationOff: false,
+    noticeVisible: false,
+    reason: null,
+    preference: {
+      activityLevel: 'IMPORTANT_ONLY',
+      source: 'application_default',
+      customTopics: [],
+    },
+  },
+  notificationTopics: [],
   pool: {
     id: 'pool-1',
     occasionType: 'BIRTHDAY',
@@ -19,6 +31,11 @@ const loaderDataSnapshot = {
     title: 'Alex Birthday Pool',
   },
 };
+
+vi.mock('#app/components/notifications/context-notification-controls.tsx', () => ({
+  ContextNotificationControl: () => <button>Important</button>,
+  ContextNotificationAwarenessNotice: () => null,
+}));
 
 vi.mock('react-router', async () => {
   const actual = await vi.importActual<typeof import('react-router')>(
@@ -61,6 +78,9 @@ describe('app/routes/pools+/$poolId+/_layout.tsx', () => {
       screen.getByText((_, element) => element?.textContent === 'Birthday for Alex'),
     ).toBeInTheDocument();
     expect(screen.getByText('Voting')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Important' }),
+    ).toBeInTheDocument();
     expect(screen.getByText('Pool overview content')).toBeInTheDocument();
   });
 

--- a/app/routes/pools+/$poolId+/_layout.tsx
+++ b/app/routes/pools+/$poolId+/_layout.tsx
@@ -1,5 +1,9 @@
 import { LuGift, LuSettings, LuUsers } from 'react-icons/lu'
 import { Link, Outlet, useLoaderData } from 'react-router'
+import {
+	ContextNotificationAwarenessNotice,
+	ContextNotificationControl,
+} from '#app/components/notifications/context-notification-controls.tsx'
 import { PageHeader } from '#app/components/page-header.tsx'
 import { Stack, Text } from '#app/components/ui-kit'
 import {
@@ -22,7 +26,8 @@ const statusColors: Record<PoolStatus, string> = {
 }
 
 const PoolLayout = () => {
-	const { pool, canManage } = useLoaderData<typeof routeLoader>()
+	const { pool, canManage, notificationAwareness, notificationTopics } =
+		useLoaderData<typeof routeLoader>()
 
 	const status = pool.status as PoolStatus
 	const occasion = pool.occasionType as OccasionType
@@ -52,6 +57,13 @@ const PoolLayout = () => {
 					>
 						{POOL_STATUS_LABELS[status]}
 					</span>
+					<ContextNotificationControl
+						context={{ kind: 'POOL', poolId: pool.id }}
+						contextLabel={pool.title}
+						awareness={notificationAwareness}
+						availableTopics={notificationTopics}
+						inheritedFromLabel={pool.giftGroup?.name}
+					/>
 					{canManage && (
 						<Link
 							to="settings"
@@ -68,6 +80,12 @@ const PoolLayout = () => {
 			<main className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto">
 				<div className="mx-auto max-w-6xl p-3 sm:p-6">
 					<Stack gap={6}>
+						<ContextNotificationAwarenessNotice
+							context={{ kind: 'POOL', poolId: pool.id }}
+							contextLabel={pool.title}
+							awareness={notificationAwareness}
+							inheritedFromLabel={pool.giftGroup?.name}
+						/>
 						{pool.giftGroup && (
 							<Link
 								to={`/groups/${pool.giftGroup.id}`}

--- a/app/routes/settings+/profile.notifications.test.tsx
+++ b/app/routes/settings+/profile.notifications.test.tsx
@@ -1,13 +1,12 @@
 /**
  * @vitest-environment jsdom
  */
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
-  getRouteResultData,
   getRouteResultStatus,
   toActionArgs,
   toLoaderArgs,
@@ -16,78 +15,73 @@ import {
 const getUserId = vi.fn();
 const requireUserId = vi.fn();
 const verifyPreferenceToken = vi.fn();
-const getNotificationPreferences = vi.fn();
+const getCentralNotificationSettings = vi.fn();
+const setGlobalChannelPreference = vi.fn();
+const setCategoryChannelPreference = vi.fn();
+const setTopicChannelPreference = vi.fn();
 const setNotificationPreference = vi.fn();
 const disableEmailForAll = vi.fn();
+const submit = vi.fn();
 
 const loaderDataSnapshot = {
+  canEdit: true,
   isAuthenticated: true,
-  preferences: [
-    {
-      emailEnabled: true,
-      inAppEnabled: true,
-      pushEnabled: true,
-      type: 'FRIEND_REQUEST_RECEIVED',
-    },
-    {
-      emailEnabled: true,
-      inAppEnabled: true,
-      pushEnabled: false,
-      type: 'FRIEND_REQUEST_ACCEPTED',
-    },
-  ],
-  targetUserId: 'user-1' as string | null,
+  targetUserId: 'user-1',
   tokenValid: false,
-  viewerUserId: 'user-1' as string | null,
+  settings: {
+    channels: {
+      IN_APP: { enabled: true, source: 'application_default' },
+      EMAIL: { enabled: true, source: 'application_default' },
+      WEB_PUSH: { enabled: true, source: 'application_default' },
+    },
+    topics: [
+      {
+        topic: 'FRIEND_REQUESTS',
+        category: 'SOCIAL',
+        channels: {
+          IN_APP: { enabled: true },
+          EMAIL: { enabled: true },
+          WEB_PUSH: { enabled: false },
+        },
+      },
+      {
+        topic: 'BIRTHDAY_REMINDERS',
+        category: 'OCCASIONS',
+        channels: {
+          IN_APP: { enabled: true },
+          EMAIL: { enabled: false },
+          WEB_PUSH: { enabled: false },
+        },
+      },
+    ],
+  },
 };
-
-const toggleFetcherState = {
-  data: undefined as undefined | { ok?: boolean; requestId?: string | null },
-  state: 'idle' as 'idle' | 'submitting',
-  submit: vi.fn(),
-};
-
-const disableFetcherState = {
-  data: undefined as undefined | { ok?: boolean; requestId?: string | null },
-  state: 'idle' as 'idle' | 'submitting',
-  submit: vi.fn(),
-};
-
-let useFetcherCallCount = 0;
 
 vi.mock('react-router', async () => {
   const actual = await vi.importActual('react-router');
-
   return {
     ...actual,
-    useFetcher: () => {
-      useFetcherCallCount += 1;
-      const state =
-        useFetcherCallCount % 2 === 1
-          ? toggleFetcherState
-          : disableFetcherState;
-      return {
-        Form: (props: React.ComponentProps<'form'>) => <form {...props} />,
-        data: state.data,
-        state: state.state,
-        submit: state.submit,
-      };
-    },
+    useFetcher: () => ({
+      Form: ({ children }: React.ComponentProps<'form'>) => (
+        <form onSubmit={(event) => event.preventDefault()}>{children}</form>
+      ),
+      data: undefined,
+      formData: undefined,
+      state: 'idle',
+      submit,
+    }),
     useLoaderData: () => loaderDataSnapshot,
     useRevalidator: () => ({ revalidate: vi.fn(), state: 'idle' }),
   };
 });
 
-const webPushState = {
-  status: 'unsupported' as string,
-  isBusy: false,
-  subscribe: vi.fn().mockResolvedValue(true),
-  unsubscribe: vi.fn().mockResolvedValue(true),
-  refresh: vi.fn(),
-};
-
 vi.mock('#app/hooks/use-web-push.ts', () => ({
-  useWebPush: () => webPushState,
+  useWebPush: () => ({
+    status: 'unsupported',
+    isBusy: false,
+    subscribe: vi.fn(),
+    unsubscribe: vi.fn(),
+  }),
 }));
 
 vi.mock('#app/utils/auth.server.ts', () => ({
@@ -102,29 +96,16 @@ vi.mock('#app/utils/notification-preference-token.server.ts', () => ({
 
 vi.mock('#app/utils/notification-preferences.server.ts', () => ({
   disableEmailForAll: (...args: Array<unknown>) => disableEmailForAll(...args),
-  getNotificationPreferences: (...args: Array<unknown>) =>
-    getNotificationPreferences(...args),
+  getCentralNotificationSettings: (...args: Array<unknown>) =>
+    getCentralNotificationSettings(...args),
+  setCategoryChannelPreference: (...args: Array<unknown>) =>
+    setCategoryChannelPreference(...args),
+  setGlobalChannelPreference: (...args: Array<unknown>) =>
+    setGlobalChannelPreference(...args),
   setNotificationPreference: (...args: Array<unknown>) =>
     setNotificationPreference(...args),
-}));
-
-vi.mock('#app/components/ui/checkbox.tsx', () => ({
-  Checkbox: ({
-    checked,
-    disabled,
-    onCheckedChange,
-  }: {
-    checked: boolean;
-    disabled?: boolean;
-    onCheckedChange?: (next: boolean) => void;
-  }) => (
-    <input
-      checked={checked}
-      disabled={disabled}
-      onChange={() => onCheckedChange?.(!checked)}
-      type="checkbox"
-    />
-  ),
+  setTopicChannelPreference: (...args: Array<unknown>) =>
+    setTopicChannelPreference(...args),
 }));
 
 import NotificationsSettingsRoute, {
@@ -132,55 +113,18 @@ import NotificationsSettingsRoute, {
   loader,
 } from './profile.notifications.tsx';
 
-function renderRoute() {
-  return render(
-    <MemoryRouter>
-      <NotificationsSettingsRoute />
-    </MemoryRouter>,
-  );
-}
-
 beforeEach(() => {
-  getUserId.mockReset();
-  requireUserId.mockReset();
-  verifyPreferenceToken.mockReset();
-  getNotificationPreferences.mockReset();
-  setNotificationPreference.mockReset();
-  disableEmailForAll.mockReset();
-  toggleFetcherState.data = undefined;
-  toggleFetcherState.state = 'idle';
-  toggleFetcherState.submit.mockReset();
-  disableFetcherState.data = undefined;
-  disableFetcherState.state = 'idle';
-  disableFetcherState.submit.mockReset();
-  useFetcherCallCount = 0;
-  webPushState.status = 'unsupported';
-  webPushState.subscribe.mockClear();
-  webPushState.unsubscribe.mockClear();
-
+  vi.clearAllMocks();
+  loaderDataSnapshot.canEdit = true;
   loaderDataSnapshot.isAuthenticated = true;
-  loaderDataSnapshot.preferences = [
-    {
-      emailEnabled: true,
-      inAppEnabled: true,
-      pushEnabled: true,
-      type: 'FRIEND_REQUEST_RECEIVED',
-    },
-    {
-      emailEnabled: true,
-      inAppEnabled: true,
-      pushEnabled: false,
-      type: 'FRIEND_REQUEST_ACCEPTED',
-    },
-  ];
   loaderDataSnapshot.targetUserId = 'user-1';
   loaderDataSnapshot.tokenValid = false;
-  loaderDataSnapshot.viewerUserId = 'user-1';
+  getCentralNotificationSettings.mockResolvedValue(loaderDataSnapshot.settings);
 });
 
-describe('settings notifications route module', () => {
-  it('redirects anonymous users without a token and hydrates authenticated preferences', async () => {
-    getUserId.mockResolvedValueOnce(null);
+describe('notification settings route', () => {
+  it('redirects anonymous visitors without a valid preference token', async () => {
+    getUserId.mockResolvedValue(null);
     verifyPreferenceToken.mockReturnValue(null);
 
     await expect(
@@ -193,361 +137,159 @@ describe('settings notifications route module', () => {
           ),
         }),
       ),
-    ).rejects.toMatchObject({
-      status: 302,
-    });
-
-    const preferenceMap = new Map([
-      ['FRIEND_REQUEST_RECEIVED', { emailEnabled: false, inAppEnabled: true }],
-    ]);
-    getUserId.mockResolvedValueOnce('user-1');
-    verifyPreferenceToken.mockReturnValue(null);
-    getNotificationPreferences.mockResolvedValue(preferenceMap);
-
-    const result = await loader(
-      toLoaderArgs({
-        context: {},
-        params: {},
-        request: new Request(
-          'https://giftpool.app/settings/profile/notifications',
-        ),
-      }),
-    );
-
-    expect(result).toEqual({
-      isAuthenticated: true,
-      preferences: [
-        {
-          emailEnabled: false,
-          inAppEnabled: true,
-          type: 'FRIEND_REQUEST_RECEIVED',
-        },
-      ],
-      targetUserId: 'user-1',
-      tokenValid: false,
-      viewerUserId: 'user-1',
-    });
+    ).rejects.toMatchObject({ status: 302 });
   });
 
-  it('allows token-based preference viewing when the token is valid', async () => {
-    const preferenceMap = new Map([
-      ['FRIEND_REQUEST_ACCEPTED', { emailEnabled: true, inAppEnabled: false }],
-    ]);
+  it('loads a valid token view as read-only', async () => {
     getUserId.mockResolvedValue(null);
     verifyPreferenceToken.mockReturnValue({ uid: 'user-2' });
-    getNotificationPreferences.mockResolvedValue(preferenceMap);
-
-    const result = await loader(
-      toLoaderArgs({
-        context: {},
-        params: {},
-        request: new Request(
-          'https://giftpool.app/settings/profile/notifications?token=abc',
-        ),
-      }),
-    );
-
-    expect(result).toEqual({
-      isAuthenticated: false,
-      preferences: [
-        {
-          emailEnabled: true,
-          inAppEnabled: false,
-          type: 'FRIEND_REQUEST_ACCEPTED',
-        },
-      ],
-      targetUserId: 'user-2',
-      tokenValid: true,
-      viewerUserId: null,
-    });
-  });
-
-  it('handles toggle, disable-email, and invalid action payloads', async () => {
-    requireUserId.mockResolvedValue('user-1');
-
-    const toggleResult = await action(
-      toActionArgs({
-        context: {},
-        params: {},
-        request: new Request(
-          'https://giftpool.app/settings/profile/notifications',
-          {
-            body: new URLSearchParams({
-              channel: 'EMAIL',
-              enabled: 'false',
-              intent: 'toggle',
-              requestId: 'toggle-1',
-              type: 'FRIEND_REQUEST_RECEIVED',
-            }).toString(),
-            headers: {
-              'content-type': 'application/x-www-form-urlencoded',
-            },
-            method: 'POST',
-          },
-        ),
-      }),
-    );
-
-    expect(setNotificationPreference).toHaveBeenCalledWith(
-      'user-1',
-      'FRIEND_REQUEST_RECEIVED',
-      'EMAIL',
-      false,
-      'settings:notifications',
-    );
-    expect(toggleResult).toEqual({
-      ok: true,
-      requestId: 'toggle-1',
-    });
-
-    const disableResult = await action(
-      toActionArgs({
-        context: {},
-        params: {},
-        request: new Request(
-          'https://giftpool.app/settings/profile/notifications',
-          {
-            body: new URLSearchParams({
-              intent: 'disable-email',
-              requestId: 'disable-1',
-            }).toString(),
-            headers: {
-              'content-type': 'application/x-www-form-urlencoded',
-            },
-            method: 'POST',
-          },
-        ),
-      }),
-    );
-
-    expect(disableEmailForAll).toHaveBeenCalledWith(
-      'user-1',
-      'settings:notifications',
-    );
-    expect(disableResult).toEqual({
-      ok: true,
-      requestId: 'disable-1',
-    });
-
-    const invalidIntent = await action(
-      toActionArgs({
-        context: {},
-        params: {},
-        request: new Request(
-          'https://giftpool.app/settings/profile/notifications',
-          {
-            body: new URLSearchParams({
-              intent: 'unknown',
-              requestId: 'invalid-1',
-            }).toString(),
-            headers: {
-              'content-type': 'application/x-www-form-urlencoded',
-            },
-            method: 'POST',
-          },
-        ),
-      }),
-    );
-
-    expect(getRouteResultStatus(invalidIntent)).toBe(400);
-    await expect(getRouteResultData(invalidIntent)).resolves.toEqual({
-      ok: false,
-      requestId: 'invalid-1',
-    });
 
     await expect(
-      action(
+      loader(
+        toLoaderArgs({
+          context: {},
+          params: {},
+          request: new Request(
+            'https://giftpool.app/settings/profile/notifications?token=valid',
+          ),
+        }),
+      ),
+    ).resolves.toMatchObject({
+      canEdit: false,
+      isAuthenticated: false,
+      targetUserId: 'user-2',
+      tokenValid: true,
+    });
+    expect(getCentralNotificationSettings).toHaveBeenCalledWith('user-2');
+  });
+
+  it('handles global, category, and topic mutations', async () => {
+    requireUserId.mockResolvedValue('user-1');
+    const cases = [
+      {
+        fields: { intent: 'global-channel', channel: 'EMAIL' },
+        fn: setGlobalChannelPreference,
+        expected: { channel: 'EMAIL' },
+      },
+      {
+        fields: {
+          intent: 'category-channel',
+          category: 'SOCIAL',
+          channel: 'IN_APP',
+        },
+        fn: setCategoryChannelPreference,
+        expected: { category: 'SOCIAL', channel: 'IN_APP' },
+      },
+      {
+        fields: {
+          intent: 'topic-channel',
+          topic: 'BIRTHDAY_REMINDERS',
+          channel: 'WEB_PUSH',
+        },
+        fn: setTopicChannelPreference,
+        expected: { topic: 'BIRTHDAY_REMINDERS', channel: 'WEB_PUSH' },
+      },
+    ] as const;
+
+    for (const testCase of cases) {
+      await action(
         toActionArgs({
           context: {},
           params: {},
           request: new Request(
             'https://giftpool.app/settings/profile/notifications',
             {
-              body: new URLSearchParams({
-                channel: 'EMAIL',
-                enabled: 'true',
-                intent: 'toggle',
-                type: 'NOT_A_REAL_TYPE',
-              }).toString(),
+              method: 'POST',
               headers: {
                 'content-type': 'application/x-www-form-urlencoded',
               },
-              method: 'POST',
+              body: new URLSearchParams({
+                ...testCase.fields,
+                enabled: 'false',
+              }).toString(),
             },
           ),
         }),
-      ),
-    ).rejects.toMatchObject({
-      status: 400,
-    });
+      );
+      expect(testCase.fn).toHaveBeenCalledWith({
+        userId: 'user-1',
+        enabled: false,
+        source: 'settings:notifications',
+        ...testCase.expected,
+      });
+    }
+
+    const invalid = await action(
+      toActionArgs({
+        context: {},
+        params: {},
+        request: new Request(
+          'https://giftpool.app/settings/profile/notifications',
+          {
+            method: 'POST',
+            headers: {
+              'content-type': 'application/x-www-form-urlencoded',
+            },
+            body: new URLSearchParams({ intent: 'unknown' }).toString(),
+          },
+        ),
+      }),
+    );
+    expect(getRouteResultStatus(invalid)).toBe(400);
   });
 });
 
-describe('settings notifications route component', () => {
-  it('shows the one-time link prompt and disables updates when unauthenticated', () => {
-    loaderDataSnapshot.isAuthenticated = false;
-    loaderDataSnapshot.viewerUserId = null;
-    loaderDataSnapshot.tokenValid = true;
-
-    renderRoute();
-
-    expect(
-      screen.getByText(
-        'You are viewing notification preferences with a one-time link.',
-      ),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('link', { name: /sign in to update your preferences/i }),
-    ).toHaveAttribute(
-      'href',
-      '/login?redirectTo=/settings/profile/notifications',
-    );
-    expect(
-      screen.getAllByRole('checkbox', { name: /enable email/i })[0],
-    ).toBeDisabled();
-    expect(
-      screen.queryByRole('button', {
-        name: /turn off all email notifications/i,
-      }),
-    ).not.toBeInTheDocument();
-  });
-
-  it('optimistically toggles a preference and rolls it back when the request fails', async () => {
-    const { rerender } = renderRoute();
-
-    const emailToggle = screen.getAllByRole('checkbox', {
-      name: /enable email/i,
-    })[0];
-    if (!emailToggle) throw new Error('expected email toggle');
-
-    expect(emailToggle).toBeChecked();
-    await userEvent.click(emailToggle);
-
-    expect(emailToggle).not.toBeChecked();
-    const toggleFormData = toggleFetcherState.submit.mock.calls[0]?.[0] as
-      | FormData
-      | undefined;
-    const toggleRequestId = toggleFormData?.get('requestId');
-
-    toggleFetcherState.state = 'submitting';
-    toggleFetcherState.data = undefined;
-    useFetcherCallCount = 0;
-    rerender(
+describe('notification settings UI', () => {
+  it('shows one topic control for the shared friend-request topic', () => {
+    render(
       <MemoryRouter>
         <NotificationsSettingsRoute />
       </MemoryRouter>,
     );
 
-    toggleFetcherState.state = 'idle';
-    toggleFetcherState.data = {
-      ok: false,
-      requestId:
-        typeof toggleRequestId === 'string'
-          ? toggleRequestId
-          : 'toggle-request',
-    };
-    useFetcherCallCount = 0;
-    rerender(
+    expect(screen.getAllByText('Friend requests')).toHaveLength(1);
+    expect(screen.getByText('Delivery channels')).toBeInTheDocument();
+    expect(screen.getByText('Upcoming birthdays')).toBeInTheDocument();
+  });
+
+  it('submits account-level channel switches optimistically', async () => {
+    render(
       <MemoryRouter>
         <NotificationsSettingsRoute />
       </MemoryRouter>,
     );
-
-    await waitFor(() => {
-      expect(
-        screen.getAllByRole('checkbox', { name: /enable email/i })[0],
-      ).toBeChecked();
-    });
-    expect(toggleFetcherState.submit).toHaveBeenCalledTimes(1);
-  });
-
-  it('optimistically disables all email notifications and keeps the change on success', async () => {
-    const { rerender } = renderRoute();
 
     await userEvent.click(
-      screen.getByRole('button', { name: /turn off all email notifications/i }),
+      screen.getByRole('switch', { name: 'Email notifications' }),
+    );
+    const formData = submit.mock.calls[0]?.[0] as FormData;
+    expect(Object.fromEntries(formData)).toMatchObject({
+      intent: 'global-channel',
+      channel: 'EMAIL',
+      enabled: 'false',
+    });
+  });
+
+  it('disables every preference control in token view and offers sign-in', () => {
+    loaderDataSnapshot.canEdit = false;
+    loaderDataSnapshot.isAuthenticated = false;
+    loaderDataSnapshot.tokenValid = true;
+    render(
+      <MemoryRouter>
+        <NotificationsSettingsRoute />
+      </MemoryRouter>,
     );
 
     expect(
-      screen
-        .getAllByRole('checkbox', { name: /enable email/i })
-        .every((checkbox) => !(checkbox as HTMLInputElement).checked),
-    ).toBe(true);
-    const disableFormData = disableFetcherState.submit.mock.calls[0]?.[0] as
-      | FormData
-      | undefined;
-    const disableRequestId = disableFormData?.get('requestId');
-
-    disableFetcherState.state = 'submitting';
-    useFetcherCallCount = 0;
-    rerender(
-      <MemoryRouter>
-        <NotificationsSettingsRoute />
-      </MemoryRouter>,
-    );
-
-    disableFetcherState.state = 'idle';
-    disableFetcherState.data = {
-      ok: true,
-      requestId:
-        typeof disableRequestId === 'string'
-          ? disableRequestId
-          : 'disable-request',
-    };
-    useFetcherCallCount = 0;
-    rerender(
-      <MemoryRouter>
-        <NotificationsSettingsRoute />
-      </MemoryRouter>,
-    );
-
-    await waitFor(() => {
-      expect(
-        screen
-          .getAllByRole('checkbox', { name: /enable email/i })
-          .every((checkbox) => !(checkbox as HTMLInputElement).checked),
-      ).toBe(true);
-    });
-    expect(disableFetcherState.submit).toHaveBeenCalledTimes(1);
-  });
-
-  describe('push column', () => {
-    it('shows the Push column and "on" banner when subscribed', () => {
-      webPushState.status = 'subscribed';
-      renderRoute();
-      expect(
-        screen.getByRole('columnheader', { name: 'Push' }),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByText(/push notifications are on for this device/i),
-      ).toBeInTheDocument();
-    });
-
-    it('offers the enable button when push is available but off', () => {
-      webPushState.status = 'default';
-      renderRoute();
-      expect(
-        screen.getByRole('button', { name: /enable push notifications/i }),
-      ).toBeInTheDocument();
-    });
-
-    it('guides iOS users to install first', () => {
-      webPushState.status = 'ios-needs-install';
-      renderRoute();
-      expect(
-        screen.getByText(/add giftpool to your home screen/i),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByRole('link', { name: /how to install/i }),
-      ).toBeInTheDocument();
-    });
-
-    it('hides the Push column entirely when unsupported', () => {
-      webPushState.status = 'unsupported';
-      renderRoute();
-      expect(
-        screen.queryByRole('columnheader', { name: 'Push' }),
-      ).not.toBeInTheDocument();
-    });
+      screen.getByRole('link', {
+        name: /sign in to edit notification preferences/i,
+      }),
+    ).toBeInTheDocument();
+    for (const control of screen.getAllByRole('switch')) {
+      expect(control).toBeDisabled();
+    }
+    expect(
+      screen.queryByText(/enable on this device/i),
+    ).not.toBeInTheDocument();
   });
 });

--- a/app/routes/settings+/profile.notifications.tsx
+++ b/app/routes/settings+/profile.notifications.tsx
@@ -351,6 +351,9 @@ function CategoryBulkAction({
   const pending = fetcher.state !== 'idle';
   const nextEnabled = !enabled;
   const details = channelDetails[channel];
+  let stateLabel = 'All off';
+  if (enabled) stateLabel = 'All on';
+  else if (mixed) stateLabel = 'Mixed · turn on';
   return (
     <fetcher.Form method="post">
       <input type="hidden" name="intent" value="category-channel" />
@@ -366,9 +369,7 @@ function CategoryBulkAction({
         aria-label={`${enabled ? 'Turn off' : 'Turn on'} all ${getNotificationCategoryDefinition(category).label} ${details.label} notifications`}
       >
         <span>{details.label}</span>
-        <span className="text-xs text-muted-foreground">
-          {enabled ? 'All on' : mixed ? 'Mixed · turn on' : 'All off'}
-        </span>
+        <span className="text-xs text-muted-foreground">{stateLabel}</span>
       </Button>
     </fetcher.Form>
   );
@@ -450,9 +451,9 @@ function MutationSwitch({
         }}
       />
       {fetcher.data?.ok === false ? (
-        <span className="sr-only" role="status">
+        <output className="sr-only">
           Could not save {label}. Try again.
-        </span>
+        </output>
       ) : null}
     </>
   );
@@ -480,35 +481,44 @@ function PushCapabilityStatus({
     message = 'Push notifications are enabled on this device.';
   }
 
+  let action: React.ReactNode = null;
+  if (canEdit && push.status === 'ios-needs-install') {
+    action = (
+      <Button asChild variant="link" className="h-auto p-0">
+        <Link to="/pwa-install">How to install</Link>
+      </Button>
+    );
+  } else if (canEdit && push.status === 'subscribed') {
+    action = (
+      <Button
+        type="button"
+        variant="ghost"
+        disabled={push.isBusy}
+        onClick={() => {
+          void push.unsubscribe().then(() => revalidator.revalidate());
+        }}
+      >
+        Turn off on this device
+      </Button>
+    );
+  } else if (canEdit && push.status === 'default') {
+    action = (
+      <Button
+        type="button"
+        disabled={push.isBusy}
+        onClick={() => {
+          void push.subscribe().then(() => revalidator.revalidate());
+        }}
+      >
+        Enable on this device
+      </Button>
+    );
+  }
+
   return (
     <div className={className}>
       <span className="text-muted-foreground">{message}</span>
-      {!canEdit ? null : push.status === 'ios-needs-install' ? (
-        <Button asChild variant="link" className="h-auto p-0">
-          <Link to="/pwa-install">How to install</Link>
-        </Button>
-      ) : push.status === 'subscribed' ? (
-        <Button
-          type="button"
-          variant="ghost"
-          disabled={push.isBusy}
-          onClick={() => {
-            void push.unsubscribe().then(() => revalidator.revalidate());
-          }}
-        >
-          Turn off on this device
-        </Button>
-      ) : push.status === 'default' ? (
-        <Button
-          type="button"
-          disabled={push.isBusy}
-          onClick={() => {
-            void push.subscribe().then(() => revalidator.revalidate());
-          }}
-        >
-          Enable on this device
-        </Button>
-      ) : null}
+      {action}
     </div>
   );
 }

--- a/app/routes/settings+/profile.notifications.tsx
+++ b/app/routes/settings+/profile.notifications.tsx
@@ -1,6 +1,12 @@
 import { invariantResponse } from '@epic-web/invariant';
 import React from 'react';
 import {
+  LuBell,
+  LuChevronDown,
+  LuMail,
+  LuMonitorSmartphone,
+} from 'react-icons/lu';
+import {
   data,
   redirect,
   type ActionFunctionArgs,
@@ -10,675 +16,507 @@ import {
   useLoaderData,
   useRevalidator,
 } from 'react-router';
+import { PreferenceSwitch } from '#app/components/notifications/preference-switch.tsx';
 import { Button } from '#app/components/ui/button.tsx';
 import { Card } from '#app/components/ui/card.tsx';
-import { Checkbox } from '#app/components/ui/checkbox.tsx';
 import { Heading } from '#app/components/ui/heading.tsx';
 import { useWebPush } from '#app/hooks/use-web-push.ts';
 import { getUserId, requireUserId } from '#app/utils/auth.server.ts';
 import { cn } from '#app/utils/misc.tsx';
 import {
-  channelToColumn,
-  DEFAULT_NOTIFICATION_PREFERENCES,
+  getNotificationCategoryDefinition,
+  getNotificationTopicDefinition,
+  isNotificationCategory,
+  isNotificationChannel,
+  isNotificationTopic,
   isNotificationType,
+  NOTIFICATION_CATEGORY_VALUES,
   NOTIFICATION_CHANNELS,
-  NOTIFICATION_TYPES,
+  NOTIFICATION_CHANNEL_VALUES,
+  type NotificationCategory,
   type NotificationChannel,
-  type NotificationType,
+  type NotificationTopic,
 } from '#app/utils/notification-catalog.ts';
 import { verifyPreferenceToken } from '#app/utils/notification-preference-token.server.ts';
 import {
   disableEmailForAll,
-  getNotificationPreferences,
+  getCentralNotificationSettings,
+  setCategoryChannelPreference,
+  setGlobalChannelPreference,
   setNotificationPreference,
+  setTopicChannelPreference,
 } from '#app/utils/notification-preferences.server.ts';
-const preferenceGroups: Array<{
-  id: string;
-  title: string;
-  description?: string;
-  items: Array<{
-    type: NotificationType;
-    label: string;
-    description: string;
-    emailDefault: boolean;
-    disabled?: boolean;
-  }>;
-}> = [
-  {
-    id: 'friend-activity',
-    title: 'Friend activity',
-    items: [
-      {
-        type: NOTIFICATION_TYPES.FRIEND_REQUEST_RECEIVED,
-        label: 'Friend request received',
-        description: 'When someone sends you a friend request.',
-        emailDefault: true,
-      },
-      {
-        type: NOTIFICATION_TYPES.FRIEND_REQUEST_ACCEPTED,
-        label: 'Friend request accepted',
-        description: 'When someone accepts your friend request.',
-        emailDefault: true,
-      },
-    ],
-  },
-  {
-    id: 'reminders',
-    title: 'Reminders',
-    items: [
-      {
-        type: NOTIFICATION_TYPES.UPCOMING_BIRTHDAY,
-        label: 'Upcoming birthdays',
-        description:
-          "Sent once, about a week before a friend's or group member's birthday you can see.",
-        emailDefault: false,
-      },
-    ],
-  },
-];
+
+const SOURCE = 'settings:notifications';
+
 export async function loader({ request }: LoaderFunctionArgs) {
   const userId = await getUserId(request);
-  const url = new URL(request.url);
-  const tokenParam = url.searchParams.get('token');
-  const tokenPayload = tokenParam ? verifyPreferenceToken(tokenParam) : null;
+  const token = new URL(request.url).searchParams.get('token');
+  const tokenPayload = token ? verifyPreferenceToken(token) : null;
   const targetUserId = tokenPayload?.uid ?? userId ?? null;
   if (!targetUserId) {
     throw redirect('/login?redirectTo=/settings/profile/notifications');
   }
-  const canReadPreferences =
-    (userId && userId === targetUserId) || tokenPayload?.uid === targetUserId;
-  const preferencesMap = canReadPreferences
-    ? await getNotificationPreferences(targetUserId)
-    : null;
-  const preferences = new Map<
-    NotificationType,
-    {
-      inAppEnabled: boolean;
-      emailEnabled: boolean;
-      pushEnabled: boolean;
-    }
-  >();
-  if (preferencesMap) {
-    for (const [type, value] of preferencesMap.entries()) {
-      preferences.set(type, value);
-    }
-  }
+
+  const tokenValid = tokenPayload?.uid === targetUserId;
+  const canRead = userId === targetUserId || tokenValid;
+  invariantResponse(canRead, 'Invalid notification preference link', {
+    status: 403,
+  });
+
   return {
+    canEdit: userId === targetUserId,
     isAuthenticated: Boolean(userId),
-    viewerUserId: userId,
     targetUserId,
-    tokenValid: tokenPayload?.uid === targetUserId,
-    preferences: Array.from(preferences.entries()).map(([type, pref]) => ({
-      type,
-      inAppEnabled: pref.inAppEnabled,
-      emailEnabled: pref.emailEnabled,
-      pushEnabled: pref.pushEnabled,
-    })),
+    tokenValid,
+    settings: await getCentralNotificationSettings(targetUserId),
   };
 }
+
 export async function action({ request }: ActionFunctionArgs) {
   const formData = await request.formData();
   const intent = formData.get('intent');
-  const requestIdValue = formData.get('requestId');
-  const requestId = typeof requestIdValue === 'string' ? requestIdValue : null;
+  const requestId = stringValue(formData.get('requestId'));
   const userId = await requireUserId(request);
+  const enabledValue = formData.get('enabled');
+  const enabled = enabledValue === 'true';
+
+  if (intent === 'global-channel') {
+    const channel = formData.get('channel');
+    invariantResponse(isNotificationChannel(channel), 'Invalid channel');
+    invariantResponse(isBooleanString(enabledValue), 'Invalid enabled value');
+    await setGlobalChannelPreference({
+      userId,
+      channel,
+      enabled,
+      source: SOURCE,
+    });
+    return { ok: true, requestId };
+  }
+
+  if (intent === 'category-channel') {
+    const category = formData.get('category');
+    const channel = formData.get('channel');
+    invariantResponse(isNotificationCategory(category), 'Invalid category');
+    invariantResponse(isNotificationChannel(channel), 'Invalid channel');
+    invariantResponse(isBooleanString(enabledValue), 'Invalid enabled value');
+    await setCategoryChannelPreference({
+      userId,
+      category,
+      channel,
+      enabled,
+      source: SOURCE,
+    });
+    return { ok: true, requestId };
+  }
+
+  if (intent === 'topic-channel') {
+    const topic = formData.get('topic');
+    const channel = formData.get('channel');
+    invariantResponse(isNotificationTopic(topic), 'Invalid topic');
+    invariantResponse(isNotificationChannel(channel), 'Invalid channel');
+    invariantResponse(isBooleanString(enabledValue), 'Invalid enabled value');
+    await setTopicChannelPreference({
+      userId,
+      topic,
+      channel,
+      enabled,
+      source: SOURCE,
+    });
+    return { ok: true, requestId };
+  }
+
+  // Keep accepting the old payloads while links or an open tab can still be
+  // running the previous UI during a deploy.
   if (intent === 'toggle') {
     const type = formData.get('type');
     const channel = formData.get('channel');
-    const enabled = formData.get('enabled');
     invariantResponse(isNotificationType(type), 'Invalid notification type');
-    invariantResponse(
-      typeof channel === 'string' && channel in NOTIFICATION_CHANNELS,
-      'Invalid channel',
-    );
-    invariantResponse(typeof enabled === 'string', 'Invalid enabled value');
-    const normalizedEnabled = enabled === 'true';
-    await setNotificationPreference(
-      userId,
-      type as NotificationType,
-      channel as NotificationChannel,
-      normalizedEnabled,
-      'settings:notifications',
-    );
-    return {
-      ok: true,
-      requestId,
-    };
+    invariantResponse(isNotificationChannel(channel), 'Invalid channel');
+    invariantResponse(isBooleanString(enabledValue), 'Invalid enabled value');
+    await setNotificationPreference(userId, type, channel, enabled, SOURCE);
+    return { ok: true, requestId };
   }
+
   if (intent === 'disable-email') {
-    await disableEmailForAll(userId, 'settings:notifications');
-    return {
-      ok: true,
-      requestId,
-    };
+    await disableEmailForAll(userId, SOURCE);
+    return { ok: true, requestId };
   }
-  return data(
-    {
-      ok: false,
-      requestId,
-    },
-    {
-      status: 400,
-    },
-  );
+
+  return data({ ok: false, requestId }, { status: 400 });
 }
-type NotificationPreferenceState = Record<
-  NotificationType,
-  {
-    inAppEnabled: boolean;
-    emailEnabled: boolean;
-    pushEnabled: boolean;
-  }
->;
-type PreferenceKey = `${NotificationType}:${NotificationChannel}`;
-type PreferencesActionResult = {
-  ok: boolean;
-  requestId?: string | null;
-};
+
+const channelDetails = {
+  [NOTIFICATION_CHANNELS.IN_APP]: {
+    label: 'In-app',
+    description: 'Show updates in your Gift Pool notification center.',
+    icon: LuBell,
+  },
+  [NOTIFICATION_CHANNELS.EMAIL]: {
+    label: 'Email',
+    description: 'Send selected updates to your account email.',
+    icon: LuMail,
+  },
+  [NOTIFICATION_CHANNELS.WEB_PUSH]: {
+    label: 'Push',
+    description: 'Send selected updates to subscribed devices.',
+    icon: LuMonitorSmartphone,
+  },
+} as const;
+
+type ActionResult = { ok: boolean; requestId?: string | null };
+
 const NotificationsSettingsRoute = () => {
-  const data = useLoaderData<typeof loader>();
+  const loaderData = useLoaderData<typeof loader>();
   const push = useWebPush();
-  const pushColumnVisible =
-    data.isAuthenticated &&
-    push.status !== 'unsupported' &&
-    push.status !== 'loading';
-  const columnCount = pushColumnVisible ? 5 : 4;
-  const toggleFetcher = useFetcher<PreferencesActionResult>();
-  const disableEmailFetcher = useFetcher<PreferencesActionResult>();
-  const [preferences, setPreferences] =
-    React.useState<NotificationPreferenceState>(() =>
-      buildPreferenceState(data.preferences),
-    );
-  const [pendingKeys, setPendingKeys] = React.useState<Set<PreferenceKey>>(
-    () => new Set(),
-  );
-  const requestCounterRef = React.useRef(0);
-  const togglePendingRef = React.useRef<{
-    requestId: string;
-    key: PreferenceKey;
-    type: NotificationType;
-    channel: NotificationChannel;
-    previousValue: boolean;
-  } | null>(null);
-  const toggleFetcherWasPendingRef = React.useRef(false);
-  const disableEmailPendingRef = React.useRef<{
-    requestId: string;
-    previousValues: Record<NotificationType, boolean>;
-    keys: PreferenceKey[];
-  } | null>(null);
-  const disableEmailFetcherWasPendingRef = React.useRef(false);
-  React.useEffect(() => {
-    setPreferences(buildPreferenceState(data.preferences));
-  }, [data.preferences]);
-  const createRequestId = React.useCallback(() => {
-    requestCounterRef.current += 1;
-    return `notifications-${Date.now()}-${requestCounterRef.current}`;
-  }, []);
-  const submitTogglePreference = (formData: FormData) => {
-    Promise.resolve(
-      toggleFetcher.submit(formData, {
-        method: 'POST',
-      }),
-    ).catch(() => {});
-  };
-  const submitDisableAllEmail = (formData: FormData) => {
-    Promise.resolve(
-      disableEmailFetcher.submit(formData, {
-        method: 'POST',
-      }),
-    ).catch(() => {});
-  };
-  const handleToggle = (
-    type: NotificationType,
-    channel: NotificationChannel,
-    enabled: boolean,
-  ) => {
-    if (toggleFetcher.state !== 'idle') return;
-    const key = getPreferenceKey(type, channel);
-    if (pendingKeys.has(key)) return;
-    const nextEnabled = !enabled;
-    const requestId = createRequestId();
-    const channelField = getChannelField(channel);
-    togglePendingRef.current = {
-      requestId,
-      key,
-      type,
-      channel,
-      previousValue: enabled,
-    };
-    setPreferences((previous) => ({
-      ...previous,
-      [type]: {
-        ...previous[type],
-        [channelField]: nextEnabled,
-      },
-    }));
-    setPendingKeys((previous) => {
-      const next = new Set(previous);
-      next.add(key);
-      return next;
-    });
-    const formData = new FormData();
-    formData.set('intent', 'toggle');
-    formData.set('type', type);
-    formData.set('channel', channel);
-    formData.set('enabled', String(nextEnabled));
-    formData.set('requestId', requestId);
-    submitTogglePreference(formData);
-  };
-  const handleDisableAllEmail = React.useCallback(() => {
-    if (disableEmailFetcher.state !== 'idle') return;
-    const requestId = createRequestId();
-    const previousValues = {} as Record<NotificationType, boolean>;
-    const keys: PreferenceKey[] = [];
-    for (const type of PREFERENCE_TYPES) {
-      previousValues[type] = preferences[type].emailEnabled;
-      keys.push(getPreferenceKey(type, NOTIFICATION_CHANNELS.EMAIL));
-    }
-    disableEmailPendingRef.current = {
-      requestId,
-      previousValues,
-      keys,
-    };
-    setPreferences((previous) => {
-      const next = {
-        ...previous,
-      };
-      for (const type of PREFERENCE_TYPES) {
-        next[type] = {
-          ...next[type],
-          emailEnabled: false,
-        };
-      }
-      return next;
-    });
-    setPendingKeys((previous) => {
-      const next = new Set(previous);
-      for (const key of keys) next.add(key);
-      return next;
-    });
-    const formData = new FormData();
-    formData.set('intent', 'disable-email');
-    formData.set('requestId', requestId);
-    submitDisableAllEmail(formData);
-  }, [createRequestId, disableEmailFetcher, preferences]);
-  React.useEffect(() => {
-    if (toggleFetcher.state !== 'idle') {
-      toggleFetcherWasPendingRef.current = true;
-      return;
-    }
-    if (!toggleFetcherWasPendingRef.current) return;
-    toggleFetcherWasPendingRef.current = false;
-    const pending = togglePendingRef.current;
-    if (!pending) return;
-    const didSucceed =
-      toggleFetcher.data?.ok === true &&
-      toggleFetcher.data.requestId === pending.requestId;
-    if (!didSucceed) {
-      const channelField = getChannelField(pending.channel);
-      setPreferences((previous) => ({
-        ...previous,
-        [pending.type]: {
-          ...previous[pending.type],
-          [channelField]: pending.previousValue,
-        },
-      }));
-    }
-    setPendingKeys((previous) => {
-      const next = new Set(previous);
-      next.delete(pending.key);
-      return next;
-    });
-    togglePendingRef.current = null;
-  }, [toggleFetcher.data, toggleFetcher.state]);
-  React.useEffect(() => {
-    if (disableEmailFetcher.state !== 'idle') {
-      disableEmailFetcherWasPendingRef.current = true;
-      return;
-    }
-    if (!disableEmailFetcherWasPendingRef.current) return;
-    disableEmailFetcherWasPendingRef.current = false;
-    const pending = disableEmailPendingRef.current;
-    if (!pending) return;
-    const didSucceed =
-      disableEmailFetcher.data?.ok === true &&
-      disableEmailFetcher.data.requestId === pending.requestId;
-    if (!didSucceed) {
-      setPreferences((previous) => {
-        const next = {
-          ...previous,
-        };
-        for (const type of PREFERENCE_TYPES) {
-          next[type] = {
-            ...next[type],
-            emailEnabled: pending.previousValues[type],
-          };
-        }
-        return next;
-      });
-    }
-    setPendingKeys((previous) => {
-      const next = new Set(previous);
-      for (const key of pending.keys) next.delete(key);
-      return next;
-    });
-    disableEmailPendingRef.current = null;
-  }, [disableEmailFetcher.data, disableEmailFetcher.state]);
+
   return (
     <div className="space-y-6">
       <div className="space-y-2">
         <Heading>Notifications</Heading>
-        <p className="text-sm text-muted-foreground">
-          Choose how you want to hear from us. Transactional emails may still be
-          sent for critical account activity.
+        <p className="max-w-2xl text-sm text-muted-foreground">
+          Choose which updates matter and where they can reach you. Critical
+          account and security messages are managed separately.
         </p>
       </div>
 
-      <Card padding="lg" className="space-y-6">
-        {data.isAuthenticated ? null : (
-          <div className="rounded-md border border-dashed border-muted-foreground/50 bg-muted px-4 py-3 text-sm text-muted-foreground">
-            <p>
-              You are viewing notification preferences with a one-time link.
-            </p>
-            <p>
-              <Link
-                className="underline"
-                to={`/login?redirectTo=/settings/profile/notifications`}
-              >
-                Sign in to update your preferences.
-              </Link>
-            </p>
-          </div>
-        )}
+      {!loaderData.canEdit ? <ReadOnlyNotice /> : null}
 
-        {data.isAuthenticated && push.status !== 'unsupported' ? (
-          <PushStatusBanner push={push} />
-        ) : null}
-
-        <div className="overflow-x-auto rounded-lg border border-border">
-          <table className="w-full text-sm">
-            <thead className="bg-muted text-left text-xs uppercase tracking-wide text-muted-foreground">
-              <tr>
-                <th className="px-4 py-3">Notification</th>
-                <th className="px-4 py-3">Description</th>
-                <th className="px-4 py-3">In-app</th>
-                <th className="px-4 py-3">Email</th>
-                {pushColumnVisible ? <th className="px-4 py-3">Push</th> : null}
-              </tr>
-            </thead>
-            <tbody>
-              {preferenceGroups.map((group) => (
-                <React.Fragment key={group.id}>
-                  <tr className="bg-muted/60">
-                    <td
-                      className="px-4 py-3 font-semibold"
-                      colSpan={columnCount}
-                    >
-                      {group.title}
-                    </td>
-                  </tr>
-                  {group.description ? (
-                    <tr className="bg-muted/40 text-xs text-muted-foreground">
-                      <td className="px-4 pb-2" colSpan={columnCount}>
-                        {group.description}
-                      </td>
-                    </tr>
-                  ) : null}
-                  {group.items.map((item) => {
-                    const pref = preferences[item.type];
-                    const pendingInApp = pendingKeys.has(
-                      getPreferenceKey(item.type, NOTIFICATION_CHANNELS.IN_APP),
-                    );
-                    const pendingEmail = pendingKeys.has(
-                      getPreferenceKey(item.type, NOTIFICATION_CHANNELS.EMAIL),
-                    );
-                    const pendingPush = pendingKeys.has(
-                      getPreferenceKey(
-                        item.type,
-                        NOTIFICATION_CHANNELS.WEB_PUSH,
-                      ),
-                    );
-                    const disableToggles =
-                      item.disabled || !data.isAuthenticated;
-                    return (
-                      <tr key={item.type} className="even:bg-muted/10">
-                        <td className="px-4 py-3 font-medium">{item.label}</td>
-                        <td className="px-4 py-3 text-muted-foreground">
-                          {item.description}
-                        </td>
-                        <td className="px-4 py-3">
-                          <PreferenceCheckbox
-                            checked={pref.inAppEnabled}
-                            label="Enable in-app"
-                            disabled={disableToggles || pendingInApp}
-                            onChange={() =>
-                              handleToggle(
-                                item.type,
-                                NOTIFICATION_CHANNELS.IN_APP,
-                                pref.inAppEnabled,
-                              )
-                            }
-                          />
-                        </td>
-                        <td className="px-4 py-3">
-                          <PreferenceCheckbox
-                            checked={pref.emailEnabled}
-                            label="Enable email"
-                            disabled={
-                              disableToggles ||
-                              (!item.emailDefault && item.disabled) ||
-                              pendingEmail
-                            }
-                            onChange={() =>
-                              handleToggle(
-                                item.type,
-                                NOTIFICATION_CHANNELS.EMAIL,
-                                pref.emailEnabled,
-                              )
-                            }
-                          />
-                        </td>
-                        {pushColumnVisible ? (
-                          <td className="px-4 py-3">
-                            <PreferenceCheckbox
-                              checked={pref.pushEnabled}
-                              label="Enable push"
-                              // Push toggles only act once the device is
-                              // subscribed; otherwise use the banner above.
-                              disabled={
-                                disableToggles ||
-                                push.status !== 'subscribed' ||
-                                pendingPush
-                              }
-                              onChange={() =>
-                                handleToggle(
-                                  item.type,
-                                  NOTIFICATION_CHANNELS.WEB_PUSH,
-                                  pref.pushEnabled,
-                                )
-                              }
-                            />
-                          </td>
-                        ) : null}
-                      </tr>
-                    );
-                  })}
-                </React.Fragment>
-              ))}
-            </tbody>
-          </table>
+      <Card padding="none" className="overflow-hidden">
+        <div className="border-b border-border px-4 py-4 sm:px-6">
+          <h2 className="font-semibold">Delivery channels</h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            A channel must be on here and for a topic below before it can send.
+          </p>
         </div>
-
-        {data.isAuthenticated ? (
-          <Button
-            type="button"
-            variant="ghost"
-            className="text-sm"
-            disabled={disableEmailFetcher.state !== 'idle'}
-            onClick={handleDisableAllEmail}
-          >
-            Turn off all email notifications
-          </Button>
-        ) : null}
+        <div className="divide-y divide-border">
+          {NOTIFICATION_CHANNEL_VALUES.map((channel) => {
+            const details = channelDetails[channel];
+            const Icon = details.icon;
+            return (
+              <div
+                key={channel}
+                className="flex min-h-20 items-center gap-3 px-3 py-3 sm:px-5"
+              >
+                <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground">
+                  <Icon className="h-5 w-5" aria-hidden="true" />
+                </div>
+                <div className="min-w-0 flex-1">
+                  <p className="font-medium">{details.label}</p>
+                  <p className="text-sm text-muted-foreground">
+                    {details.description}
+                  </p>
+                </div>
+                <MutationSwitch
+                  intent="global-channel"
+                  channel={channel}
+                  checked={loaderData.settings.channels[channel].enabled}
+                  disabled={!loaderData.canEdit}
+                  label={`${details.label} notifications`}
+                />
+              </div>
+            );
+          })}
+        </div>
       </Card>
+
+      <PushCapabilityStatus push={push} canEdit={loaderData.canEdit} />
+
+      <section className="space-y-3" aria-labelledby="notification-topics">
+        <div>
+          <h2 id="notification-topics" className="font-semibold">
+            Notification topics
+          </h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Fine-tune each kind of update. Category actions change every topic
+            in that category at once.
+          </p>
+        </div>
+        {NOTIFICATION_CATEGORY_VALUES.map((category) => (
+          <CategoryCard
+            key={category}
+            category={category}
+            topics={loaderData.settings.topics.filter(
+              (topic) => topic.category === category,
+            )}
+            canEdit={loaderData.canEdit}
+          />
+        ))}
+      </section>
     </div>
   );
 };
+
 export default NotificationsSettingsRoute;
-const DEFAULT_CHANNEL_FALLBACK: Record<
-  NotificationType,
-  {
-    inAppEnabled: boolean;
-    emailEnabled: boolean;
-    pushEnabled: boolean;
-  }
-> = Object.fromEntries(
-  Object.entries(DEFAULT_NOTIFICATION_PREFERENCES).map(([key, value]) => [
-    key,
-    value,
-  ]),
-) as Record<
-  NotificationType,
-  {
-    inAppEnabled: boolean;
-    emailEnabled: boolean;
-    pushEnabled: boolean;
-  }
->;
-const PREFERENCE_TYPES = preferenceGroups.flatMap((group) =>
-  group.items.map((item) => item.type),
-);
-function buildPreferenceState(
-  preferences: Array<{
-    type: NotificationType;
-    inAppEnabled: boolean;
-    emailEnabled: boolean;
-    pushEnabled: boolean;
-  }>,
-): NotificationPreferenceState {
-  const next = {
-    ...DEFAULT_CHANNEL_FALLBACK,
-  } as NotificationPreferenceState;
-  for (const pref of preferences) {
-    next[pref.type] = {
-      inAppEnabled: pref.inAppEnabled,
-      emailEnabled: pref.emailEnabled,
-      pushEnabled: pref.pushEnabled,
-    };
-  }
-  return next;
-}
-function getChannelField(channel: NotificationChannel) {
-  return channelToColumn(channel);
-}
-function getPreferenceKey(
-  type: NotificationType,
-  channel: NotificationChannel,
-): PreferenceKey {
-  return `${type}:${channel}`;
-}
-function PushStatusBanner({
-  push,
-}: Readonly<{ push: ReturnType<typeof useWebPush> }>) {
-  const revalidator = useRevalidator();
-  // After enabling/disabling push the server flips pushEnabled on the prefs
-  // rows; revalidate so the per-type push checkboxes reflect the new state.
-  const revalidate = () => {
-    void revalidator.revalidate();
-  };
-  const className =
-    'flex flex-col gap-2 rounded-md border border-border bg-muted/40 px-4 py-3 text-sm sm:flex-row sm:items-center sm:justify-between';
 
-  if (push.status === 'ios-needs-install') {
-    return (
-      <div className={className}>
-        <span className="text-muted-foreground">
-          Add GiftPool to your home screen to turn on push notifications.
-        </span>
-        <Link className="font-medium underline" to="/pwa-install">
-          How to install
+function ReadOnlyNotice() {
+  return (
+    <div className="rounded-xl border border-dashed border-muted-foreground/50 bg-muted px-4 py-3 text-sm text-muted-foreground">
+      <p>You are viewing notification preferences with a one-time link.</p>
+      <Button asChild variant="link" className="h-auto justify-start p-0">
+        <Link to="/login?redirectTo=/settings/profile/notifications">
+          Sign in to edit notification preferences
         </Link>
+      </Button>
+    </div>
+  );
+}
+
+function CategoryCard({
+  category,
+  topics,
+  canEdit,
+}: Readonly<{
+  category: NotificationCategory;
+  topics: Array<{
+    topic: NotificationTopic;
+    category: NotificationCategory;
+    channels: Record<NotificationChannel, { enabled: boolean }>;
+  }>;
+  canEdit: boolean;
+}>) {
+  const [expanded, setExpanded] = React.useState(true);
+  const definition = getNotificationCategoryDefinition(category);
+
+  return (
+    <Card padding="none" className="overflow-hidden">
+      <button
+        type="button"
+        onClick={() => setExpanded((current) => !current)}
+        aria-expanded={expanded}
+        className="flex min-h-14 w-full items-center gap-3 px-4 py-3 text-left outline-none ring-inset ring-ring focus-visible:ring-2 sm:px-6"
+      >
+        <span className="min-w-0 flex-1">
+          <span className="block font-semibold">{definition.label}</span>
+          <span className="block text-sm text-muted-foreground">
+            {definition.description}
+          </span>
+        </span>
+        <LuChevronDown
+          aria-hidden="true"
+          className={cn(
+            'h-5 w-5 shrink-0 transition-transform',
+            expanded && 'rotate-180',
+          )}
+        />
+      </button>
+
+      {expanded ? (
+        <div className="border-t border-border">
+          <div className="grid gap-2 bg-muted/40 px-4 py-3 sm:grid-cols-3 sm:px-6">
+            {NOTIFICATION_CHANNEL_VALUES.map((channel) => {
+              const allOn = topics.every(
+                (topic) => topic.channels[channel].enabled,
+              );
+              const someOn = topics.some(
+                (topic) => topic.channels[channel].enabled,
+              );
+              return (
+                <CategoryBulkAction
+                  key={channel}
+                  category={category}
+                  channel={channel}
+                  enabled={allOn}
+                  mixed={someOn && !allOn}
+                  disabled={!canEdit}
+                />
+              );
+            })}
+          </div>
+          <div className="divide-y divide-border">
+            {topics.map((topic) => (
+              <TopicRow key={topic.topic} topic={topic} canEdit={canEdit} />
+            ))}
+          </div>
+        </div>
+      ) : null}
+    </Card>
+  );
+}
+
+function CategoryBulkAction({
+  category,
+  channel,
+  enabled,
+  mixed,
+  disabled,
+}: Readonly<{
+  category: NotificationCategory;
+  channel: NotificationChannel;
+  enabled: boolean;
+  mixed: boolean;
+  disabled: boolean;
+}>) {
+  const fetcher = useFetcher<ActionResult>();
+  const pending = fetcher.state !== 'idle';
+  const nextEnabled = !enabled;
+  const details = channelDetails[channel];
+  return (
+    <fetcher.Form method="post">
+      <input type="hidden" name="intent" value="category-channel" />
+      <input type="hidden" name="category" value={category} />
+      <input type="hidden" name="channel" value={channel} />
+      <input type="hidden" name="enabled" value={String(nextEnabled)} />
+      <Button
+        type="submit"
+        variant="outline"
+        size="sm"
+        className="w-full justify-between rounded-lg"
+        disabled={disabled || pending}
+        aria-label={`${enabled ? 'Turn off' : 'Turn on'} all ${getNotificationCategoryDefinition(category).label} ${details.label} notifications`}
+      >
+        <span>{details.label}</span>
+        <span className="text-xs text-muted-foreground">
+          {enabled ? 'All on' : mixed ? 'Mixed · turn on' : 'All off'}
+        </span>
+      </Button>
+    </fetcher.Form>
+  );
+}
+
+function TopicRow({
+  topic,
+  canEdit,
+}: Readonly<{
+  topic: {
+    topic: NotificationTopic;
+    channels: Record<NotificationChannel, { enabled: boolean }>;
+  };
+  canEdit: boolean;
+}>) {
+  const definition = getNotificationTopicDefinition(topic.topic);
+  return (
+    <div className="px-4 py-4 sm:px-6">
+      <p className="font-medium">{definition.label}</p>
+      <p className="mt-0.5 text-sm text-muted-foreground">
+        {definition.description}
+      </p>
+      <div className="mt-3 grid grid-cols-3 gap-2">
+        {NOTIFICATION_CHANNEL_VALUES.map((channel) => (
+          <div
+            key={channel}
+            className="flex min-w-0 flex-col items-center rounded-lg border border-border px-1 py-1 sm:flex-row sm:justify-between sm:px-2"
+          >
+            <span className="truncate text-xs text-muted-foreground">
+              {channelDetails[channel].label}
+            </span>
+            <MutationSwitch
+              intent="topic-channel"
+              topic={topic.topic}
+              channel={channel}
+              checked={topic.channels[channel].enabled}
+              disabled={!canEdit}
+              label={`${definition.label}: ${channelDetails[channel].label}`}
+            />
+          </div>
+        ))}
       </div>
-    );
+    </div>
+  );
+}
+
+function MutationSwitch({
+  intent,
+  channel,
+  topic,
+  checked,
+  disabled,
+  label,
+}: Readonly<{
+  intent: 'global-channel' | 'topic-channel';
+  channel: NotificationChannel;
+  topic?: NotificationTopic;
+  checked: boolean;
+  disabled: boolean;
+  label: string;
+}>) {
+  const fetcher = useFetcher<ActionResult>();
+  const pendingEnabled = fetcher.formData?.get('enabled');
+  const optimisticChecked =
+    typeof pendingEnabled === 'string' ? pendingEnabled === 'true' : checked;
+  return (
+    <>
+      <PreferenceSwitch
+        checked={optimisticChecked}
+        disabled={disabled || fetcher.state !== 'idle'}
+        label={label}
+        onCheckedChange={(enabled) => {
+          const formData = new FormData();
+          formData.set('intent', intent);
+          formData.set('channel', channel);
+          formData.set('enabled', String(enabled));
+          if (topic) formData.set('topic', topic);
+          void fetcher.submit(formData, { method: 'post' });
+        }}
+      />
+      {fetcher.data?.ok === false ? (
+        <span className="sr-only" role="status">
+          Could not save {label}. Try again.
+        </span>
+      ) : null}
+    </>
+  );
+}
+
+function PushCapabilityStatus({
+  push,
+  canEdit,
+}: Readonly<{
+  push: ReturnType<typeof useWebPush>;
+  canEdit: boolean;
+}>) {
+  const revalidator = useRevalidator();
+  if (push.status === 'unsupported' || push.status === 'loading') return null;
+
+  const className =
+    'flex flex-col gap-2 rounded-xl border border-border bg-muted/40 px-4 py-3 text-sm sm:flex-row sm:items-center sm:justify-between';
+  let message = 'Push notifications are available for this device.';
+  if (push.status === 'ios-needs-install') {
+    message =
+      'Add Gift Pool to your home screen to enable push on this device.';
+  } else if (push.status === 'denied') {
+    message = 'Push is blocked for this site in your browser settings.';
+  } else if (push.status === 'subscribed') {
+    message = 'Push notifications are enabled on this device.';
   }
 
-  if (push.status === 'denied') {
-    return (
-      <div className={className}>
-        <span className="text-muted-foreground">
-          Push notifications are blocked. Enable them for this site in your
-          browser settings, then reload.
-        </span>
-      </div>
-    );
-  }
-
-  if (push.status === 'subscribed') {
-    return (
-      <div className={className}>
-        <span className="text-muted-foreground">
-          Push notifications are on for this device.
-        </span>
+  return (
+    <div className={className}>
+      <span className="text-muted-foreground">{message}</span>
+      {!canEdit ? null : push.status === 'ios-needs-install' ? (
+        <Button asChild variant="link" className="h-auto p-0">
+          <Link to="/pwa-install">How to install</Link>
+        </Button>
+      ) : push.status === 'subscribed' ? (
         <Button
           type="button"
           variant="ghost"
           disabled={push.isBusy}
           onClick={() => {
-            void push.unsubscribe().then(revalidate);
+            void push.unsubscribe().then(() => revalidator.revalidate());
           }}
         >
           Turn off on this device
         </Button>
-      </div>
-    );
-  }
-
-  // status === 'default'
-  return (
-    <div className={className}>
-      <span className="text-muted-foreground">
-        Get notified on this device even when GiftPool isn&apos;t open.
-      </span>
-      <Button
-        type="button"
-        disabled={push.isBusy}
-        onClick={() => {
-          void push.subscribe().then(revalidate);
-        }}
-      >
-        Enable push notifications
-      </Button>
+      ) : push.status === 'default' ? (
+        <Button
+          type="button"
+          disabled={push.isBusy}
+          onClick={() => {
+            void push.subscribe().then(() => revalidator.revalidate());
+          }}
+        >
+          Enable on this device
+        </Button>
+      ) : null}
     </div>
   );
 }
-function PreferenceCheckbox({
-  checked,
-  onChange,
-  disabled,
-  label,
-}: Readonly<{
-  checked: boolean;
-  onChange: () => void;
-  disabled?: boolean;
-  label: string;
-}>) {
-  return (
-    <label
-      className={cn(
-        'flex items-center justify-center text-sm',
-        disabled && 'opacity-50',
-      )}
-    >
-      <Checkbox
-        checked={checked}
-        disabled={disabled}
-        onCheckedChange={(_value) => {
-          if (!disabled) onChange();
-        }}
-      />
-      {/* The column header already names the channel — keep the per-row label
-          for screen readers only so the table fits narrow viewports. */}
-      <span className="sr-only">{label}</span>
-    </label>
-  );
+
+function stringValue(value: FormDataEntryValue | null) {
+  return typeof value === 'string' ? value : null;
+}
+
+function isBooleanString(value: FormDataEntryValue | null) {
+  return value === 'true' || value === 'false';
 }

--- a/app/utils/notification-catalog.ts
+++ b/app/utils/notification-catalog.ts
@@ -30,6 +30,25 @@ export const NOTIFICATION_CATEGORY_VALUES = Object.values(
   NOTIFICATION_CATEGORIES,
 );
 
+type NotificationCategoryDefinition = {
+  label: string;
+  description: string;
+};
+
+export const NOTIFICATION_CATEGORY_CATALOG = {
+  [NOTIFICATION_CATEGORIES.SOCIAL]: {
+    label: 'Friend activity',
+    description: 'Requests and updates from people you connect with.',
+  },
+  [NOTIFICATION_CATEGORIES.OCCASIONS]: {
+    label: 'Reminders',
+    description: 'Timely reminders about occasions you can see.',
+  },
+} as const satisfies Record<
+  NotificationCategory,
+  NotificationCategoryDefinition
+>;
+
 export const NOTIFICATION_TOPICS = {
   FRIEND_REQUESTS: 'FRIEND_REQUESTS',
   BIRTHDAY_REMINDERS: 'BIRTHDAY_REMINDERS',
@@ -64,6 +83,8 @@ type NotificationEventDefinition = {
 
 type NotificationTopicDefinition = {
   category: NotificationCategory;
+  label: string;
+  description: string;
   defaults: NotificationPreferenceDefaults;
 };
 
@@ -73,6 +94,8 @@ const allChannels = NOTIFICATION_CHANNEL_VALUES;
 export const NOTIFICATION_TOPIC_CATALOG = {
   [NOTIFICATION_TOPICS.FRIEND_REQUESTS]: {
     category: NOTIFICATION_CATEGORIES.SOCIAL,
+    label: 'Friend requests',
+    description: 'When you receive a request or someone accepts yours.',
     defaults: {
       inAppEnabled: true,
       emailEnabled: true,
@@ -81,6 +104,8 @@ export const NOTIFICATION_TOPIC_CATALOG = {
   },
   [NOTIFICATION_TOPICS.BIRTHDAY_REMINDERS]: {
     category: NOTIFICATION_CATEGORIES.OCCASIONS,
+    label: 'Upcoming birthdays',
+    description: 'A heads-up before a visible friend or group birthday.',
     defaults: {
       inAppEnabled: true,
       emailEnabled: false,
@@ -90,9 +115,8 @@ export const NOTIFICATION_TOPIC_CATALOG = {
 } as const satisfies Record<NotificationTopic, NotificationTopicDefinition>;
 
 /**
- * Typed source of truth for event policy. User-facing topic/category copy will
- * be added with the scoped-preference UI; the stable identifiers live here now
- * so new events no longer have to become new preference concepts.
+ * Typed source of truth for event policy and user-facing preference copy. The
+ * stable identifiers let new events reuse existing preference concepts.
  */
 export const NOTIFICATION_EVENT_CATALOG = {
   [NOTIFICATION_TYPES.FRIEND_REQUEST_RECEIVED]: {
@@ -138,11 +162,29 @@ export function getNotificationTopicDefinition(topic: NotificationTopic) {
   return NOTIFICATION_TOPIC_CATALOG[topic];
 }
 
+export function getNotificationCategoryDefinition(
+  category: NotificationCategory,
+) {
+  return NOTIFICATION_CATEGORY_CATALOG[category];
+}
+
 export function getNotificationCategoryTopics(
   category: NotificationCategory,
 ): Array<NotificationTopic> {
   return NOTIFICATION_TOPIC_VALUES.filter(
     (topic) => NOTIFICATION_TOPIC_CATALOG[topic].category === category,
+  );
+}
+
+export function getNotificationTopicsForContext(
+  contextKind: Exclude<NotificationContextKind, 'NONE'>,
+): Array<NotificationTopic> {
+  const eligibleContexts =
+    contextKind === 'GROUP' ? new Set(['GROUP', 'POOL']) : new Set(['POOL']);
+  return NOTIFICATION_TOPIC_VALUES.filter((topic) =>
+    Object.values(NOTIFICATION_EVENT_CATALOG).some(
+      (event) => event.topic === topic && eligibleContexts.has(event.context),
+    ),
   );
 }
 
@@ -179,6 +221,15 @@ export function isNotificationCategory(
     Object.values(NOTIFICATION_CATEGORIES).includes(
       value as NotificationCategory,
     )
+  );
+}
+
+export function isNotificationChannel(
+  value: unknown,
+): value is NotificationChannel {
+  return (
+    typeof value === 'string' &&
+    NOTIFICATION_CHANNEL_VALUES.includes(value as NotificationChannel)
   );
 }
 

--- a/app/utils/notification-context.ts
+++ b/app/utils/notification-context.ts
@@ -1,0 +1,25 @@
+export const NOTIFICATION_ACTIVITY_LEVELS = {
+  ALL_ACTIVITY: 'ALL_ACTIVITY',
+  IMPORTANT_ONLY: 'IMPORTANT_ONLY',
+  MUTED: 'MUTED',
+  CUSTOM: 'CUSTOM',
+} as const;
+
+export type NotificationActivityLevel =
+  (typeof NOTIFICATION_ACTIVITY_LEVELS)[keyof typeof NOTIFICATION_ACTIVITY_LEVELS];
+
+export type ContextNotificationAwarenessReason =
+  | 'explicit_mute'
+  | 'inherited_mute'
+  | 'no_channels';
+
+export function isNotificationActivityLevel(
+  value: unknown,
+): value is NotificationActivityLevel {
+  return (
+    typeof value === 'string' &&
+    Object.values(NOTIFICATION_ACTIVITY_LEVELS).includes(
+      value as NotificationActivityLevel,
+    )
+  );
+}

--- a/app/utils/notification-preferences.server.test.ts
+++ b/app/utils/notification-preferences.server.test.ts
@@ -12,7 +12,10 @@ import {
   allowsContextActivity,
   clearContextActivityPreference,
   disableEmailForAll,
+  dismissContextNotificationNotice,
   dismissContextMutedNotice,
+  getCentralNotificationSettings,
+  getContextNotificationAwareness,
   getContextNotificationPreference,
   getNotificationPreferenceForChannels,
   getNotificationPreferences,
@@ -184,6 +187,12 @@ describe('notification preferences', () => {
       enabled: false,
       source: 'global_channel',
     });
+    const settings = await getCentralNotificationSettings(user.id);
+    expect(
+      settings.topics.find(
+        ({ topic }) => topic === NOTIFICATION_TOPICS.BIRTHDAY_REMINDERS,
+      )?.channels.EMAIL,
+    ).toEqual({ enabled: false, source: 'topic_override' });
 
     await setTopicChannelPreference({
       userId: user.id,
@@ -418,6 +427,119 @@ describe('notification preferences', () => {
     });
     expect(resolved.noticeVisible).toBe(true);
     expect(resolved.noticeDismissedAt).toBeNull();
+  });
+
+  it('starts a new inherited notice cycle when the controlling group is re-muted', async () => {
+    vi.useFakeTimers();
+    const user = await createUser();
+    const { group, pool } = await createGroupPool(user.id);
+    const groupContext = { kind: 'GROUP', groupId: group.id } as const;
+    const poolContext = { kind: 'POOL', poolId: pool.id } as const;
+
+    vi.setSystemTime(new Date('2026-07-13T12:00:00Z'));
+    await setContextActivityPreference({
+      userId: user.id,
+      context: groupContext,
+      activityLevel: NOTIFICATION_ACTIVITY_LEVELS.MUTED,
+      source: 'test-group-mute',
+    });
+    const first = await getContextNotificationAwareness({
+      userId: user.id,
+      context: poolContext,
+    });
+    expect(first).toMatchObject({
+      reason: 'inherited_mute',
+      noticeVisible: true,
+    });
+    await dismissContextNotificationNotice({
+      userId: user.id,
+      context: poolContext,
+      source: 'test-dismiss-inherited',
+    });
+    await expect(
+      getContextNotificationAwareness({
+        userId: user.id,
+        context: poolContext,
+      }),
+    ).resolves.toMatchObject({ noticeVisible: false });
+
+    vi.setSystemTime(new Date('2026-07-14T12:00:00Z'));
+    await setContextActivityPreference({
+      userId: user.id,
+      context: groupContext,
+      activityLevel: NOTIFICATION_ACTIVITY_LEVELS.ALL_ACTIVITY,
+      source: 'test-group-unmute',
+    });
+    vi.setSystemTime(new Date('2026-07-15T12:00:00Z'));
+    await setContextActivityPreference({
+      userId: user.id,
+      context: groupContext,
+      activityLevel: NOTIFICATION_ACTIVITY_LEVELS.MUTED,
+      source: 'test-group-remute',
+    });
+    const next = await getContextNotificationAwareness({
+      userId: user.id,
+      context: poolContext,
+    });
+    expect(next.noticeVisible).toBe(true);
+    expect(next.noticeKey).not.toBe(first.noticeKey);
+  });
+
+  it('shows and revisions a dismissible warning when every delivery channel is off', async () => {
+    vi.useFakeTimers();
+    const user = await createUser();
+    const { group } = await createGroupPool(user.id);
+    const context = { kind: 'GROUP', groupId: group.id } as const;
+    vi.setSystemTime(new Date('2026-07-13T12:00:00Z'));
+    for (const channel of Object.values(NOTIFICATION_CHANNELS)) {
+      await setGlobalChannelPreference({
+        userId: user.id,
+        channel,
+        enabled: false,
+        source: 'test-all-off',
+      });
+    }
+    const first = await getContextNotificationAwareness({
+      userId: user.id,
+      context,
+    });
+    expect(first).toMatchObject({
+      notificationOff: true,
+      reason: 'no_channels',
+      noticeVisible: true,
+    });
+    await dismissContextNotificationNotice({
+      userId: user.id,
+      context,
+      source: 'test-dismiss-all-off',
+    });
+    await expect(
+      getContextNotificationAwareness({ userId: user.id, context }),
+    ).resolves.toMatchObject({ noticeVisible: false });
+
+    vi.setSystemTime(new Date('2026-07-14T12:00:00Z'));
+    await setGlobalChannelPreference({
+      userId: user.id,
+      channel: NOTIFICATION_CHANNELS.IN_APP,
+      enabled: true,
+      source: 'test-one-on',
+    });
+    await expect(
+      getContextNotificationAwareness({ userId: user.id, context }),
+    ).resolves.toMatchObject({ notificationOff: false, reason: null });
+    vi.setSystemTime(new Date('2026-07-15T12:00:00Z'));
+    await setGlobalChannelPreference({
+      userId: user.id,
+      channel: NOTIFICATION_CHANNELS.IN_APP,
+      enabled: false,
+      source: 'test-all-off-again',
+    });
+    const next = await getContextNotificationAwareness({
+      userId: user.id,
+      context,
+    });
+    expect(next.noticeVisible).toBe(true);
+    expect(next.noticeKey).not.toBe(first.noticeKey);
   });
 
   it('rejects context writes for non-members without persisting state', async () => {

--- a/app/utils/notification-preferences.server.ts
+++ b/app/utils/notification-preferences.server.ts
@@ -1,4 +1,4 @@
-import { Prisma } from '@prisma/client';
+import { type Prisma } from '@prisma/client';
 import { data } from 'react-router';
 import { prisma } from '#app/utils/db.server.ts';
 import {
@@ -19,16 +19,18 @@ import {
   type NotificationTopic,
   type NotificationType,
 } from '#app/utils/notification-catalog.ts';
+import {
+  isNotificationActivityLevel,
+  NOTIFICATION_ACTIVITY_LEVELS,
+  type ContextNotificationAwarenessReason,
+  type NotificationActivityLevel,
+} from '#app/utils/notification-context.ts';
 
-export const NOTIFICATION_ACTIVITY_LEVELS = {
-  ALL_ACTIVITY: 'ALL_ACTIVITY',
-  IMPORTANT_ONLY: 'IMPORTANT_ONLY',
-  MUTED: 'MUTED',
-  CUSTOM: 'CUSTOM',
-} as const;
-
-export type NotificationActivityLevel =
-  (typeof NOTIFICATION_ACTIVITY_LEVELS)[keyof typeof NOTIFICATION_ACTIVITY_LEVELS];
+export {
+  isNotificationActivityLevel,
+  NOTIFICATION_ACTIVITY_LEVELS,
+  type NotificationActivityLevel,
+} from '#app/utils/notification-context.ts';
 
 export type CentralPreferenceSource =
   | 'catalog_default'
@@ -48,6 +50,22 @@ export type ResolvedCentralNotificationPreferences = {
   channels: Record<NotificationChannel, CentralChannelPreference>;
 };
 
+export type ResolvedGlobalChannelPreference = {
+  enabled: boolean;
+  source: 'application_default' | 'user_override';
+};
+
+export type ResolvedNotificationTopicPreferences = {
+  topic: NotificationTopic;
+  category: NotificationCategory;
+  channels: Record<NotificationChannel, CentralChannelPreference>;
+};
+
+export type CentralNotificationSettings = {
+  channels: Record<NotificationChannel, ResolvedGlobalChannelPreference>;
+  topics: Array<ResolvedNotificationTopicPreferences>;
+};
+
 export type ResolvedContextNotificationPreference = {
   context: NotificationContext;
   activityLevel: NotificationActivityLevel;
@@ -55,8 +73,18 @@ export type ResolvedContextNotificationPreference = {
   customTopics: Array<NotificationTopic>;
   mutedAt: Date | null;
   noticeDismissedAt: Date | null;
+  noticeDismissedKey: string | null;
+  noticeKey: string | null;
   noticeVisible: boolean;
   controllingContext: NotificationContext | null;
+};
+
+export type ContextNotificationAwareness = {
+  preference: ResolvedContextNotificationPreference;
+  notificationOff: boolean;
+  reason: ContextNotificationAwarenessReason | null;
+  noticeKey: string | null;
+  noticeVisible: boolean;
 };
 
 const DEFAULT_GLOBAL_CHANNEL_PREFERENCES: Record<NotificationChannel, boolean> =
@@ -83,6 +111,30 @@ export async function resolveCentralNotificationPreferences({
     type,
     await loadCentralPreferenceState(userId),
   );
+}
+
+export async function getCentralNotificationSettings(
+  userId: string,
+): Promise<CentralNotificationSettings> {
+  const state = await loadCentralPreferenceState(userId);
+  return {
+    channels: Object.fromEntries(
+      NOTIFICATION_CHANNEL_VALUES.map((channel) => [
+        channel,
+        {
+          enabled:
+            state.gates.get(channel) ??
+            DEFAULT_GLOBAL_CHANNEL_PREFERENCES[channel],
+          source: state.gates.has(channel)
+            ? ('user_override' as const)
+            : ('application_default' as const),
+        },
+      ]),
+    ) as Record<NotificationChannel, ResolvedGlobalChannelPreference>,
+    topics: NOTIFICATION_TOPIC_VALUES.map((topic) =>
+      resolveTopicFromState(topic, state, false),
+    ),
+  };
 }
 
 export async function getNotificationPreferences(userId: string) {
@@ -360,6 +412,8 @@ export async function setContextActivityPreference({
       mutedAt,
       noticeDismissedAt:
         isMuted && wasMuted ? existing?.noticeDismissedAt : null,
+      noticeDismissedKey:
+        isMuted && wasMuted ? existing?.noticeDismissedKey : null,
     });
     await auditPreferenceChange(tx, {
       userId,
@@ -391,6 +445,7 @@ export async function clearContextActivityPreference({
       customTopics: null,
       mutedAt: null,
       noticeDismissedAt: null,
+      noticeDismissedKey: null,
     });
     await auditPreferenceChange(tx, {
       userId,
@@ -413,10 +468,26 @@ export async function dismissContextMutedNotice({
   context: NotificationContext;
   source: string;
 }) {
+  return dismissContextNotificationNotice({ userId, context, source });
+}
+
+export async function dismissContextNotificationNotice({
+  userId,
+  context,
+  source,
+}: {
+  userId: string;
+  context: NotificationContext;
+  source: string;
+}) {
   await prisma.$transaction(async (tx) => {
     await requireContextAccess(tx, userId, context);
-    const resolved = await resolveContextInTransaction(tx, userId, context);
-    if (!resolved.mutedAt || !resolved.noticeVisible) return;
+    const awareness = await resolveContextAwarenessInTransaction(
+      tx,
+      userId,
+      context,
+    );
+    if (!awareness.noticeKey || !awareness.noticeVisible) return;
     const dismissedAt = new Date();
     const existing = await findContextPreference(tx, userId, context);
     await upsertContextPreference(tx, userId, context, {
@@ -424,14 +495,15 @@ export async function dismissContextMutedNotice({
       customTopics: existing?.customTopics ?? null,
       mutedAt: existing?.mutedAt ?? null,
       noticeDismissedAt: dismissedAt,
+      noticeDismissedKey: awareness.noticeKey,
     });
     await auditPreferenceChange(tx, {
       userId,
       kind: 'MUTED_NOTICE',
       contextKind: context.kind,
       contextId: contextId(context),
-      previousValue: resolved.noticeDismissedAt?.toISOString() ?? null,
-      newValue: dismissedAt.toISOString(),
+      previousValue: existing?.noticeDismissedKey ?? null,
+      newValue: awareness.noticeKey,
       source,
     });
   });
@@ -449,6 +521,21 @@ export async function getContextNotificationPreference({
   return prisma.$transaction(async (tx) => {
     if (requireAccess) await requireContextAccess(tx, userId, context);
     return resolveContextInTransaction(tx, userId, context);
+  });
+}
+
+export async function getContextNotificationAwareness({
+  userId,
+  context,
+  requireAccess = true,
+}: {
+  userId: string;
+  context: NotificationContext;
+  requireAccess?: boolean;
+}): Promise<ContextNotificationAwareness> {
+  return prisma.$transaction(async (tx) => {
+    if (requireAccess) await requireContextAccess(tx, userId, context);
+    return resolveContextAwarenessInTransaction(tx, userId, context);
   });
 }
 
@@ -523,17 +610,28 @@ function resolveCentralFromState(
   state: CentralPreferenceState,
 ): ResolvedCentralNotificationPreferences {
   const event = getNotificationEventDefinition(type);
-  const topicDefinition = getNotificationTopicDefinition(event.topic);
+  return {
+    type,
+    ...resolveTopicFromState(event.topic, state),
+  };
+}
+
+function resolveTopicFromState(
+  topic: NotificationTopic,
+  state: CentralPreferenceState,
+  applyGlobalGate = true,
+): ResolvedNotificationTopicPreferences {
+  const topicDefinition = getNotificationTopicDefinition(topic);
   const entries = NOTIFICATION_CHANNEL_VALUES.map((channel) => {
     const gate =
       state.gates.get(channel) ?? DEFAULT_GLOBAL_CHANNEL_PREFERENCES[channel];
-    if (!gate) {
+    if (applyGlobalGate && !gate) {
       return [
         channel,
         { enabled: false, source: 'global_channel' as const },
       ] as const;
     }
-    const topicValue = state.topics.get(preferenceKey(event.topic, channel));
+    const topicValue = state.topics.get(preferenceKey(topic, channel));
     if (topicValue !== undefined) {
       return [
         channel,
@@ -558,8 +656,7 @@ function resolveCentralFromState(
     ] as const;
   });
   return {
-    type,
-    topic: event.topic,
+    topic,
     category: topicDefinition.category,
     channels: Object.fromEntries(entries) as Record<
       NotificationChannel,
@@ -649,6 +746,7 @@ async function resolveContextInTransaction(
       source: row?.activityLevel ? 'group_override' : 'application_default',
       controllingContext: row?.activityLevel ? context : null,
       noticeDismissedAt: row?.noticeDismissedAt ?? null,
+      noticeDismissedKey: row?.noticeDismissedKey ?? null,
     });
   }
 
@@ -671,6 +769,7 @@ async function resolveContextInTransaction(
       source: 'pool_override',
       controllingContext: context,
       noticeDismissedAt: poolRow.noticeDismissedAt,
+      noticeDismissedKey: poolRow.noticeDismissedKey,
     });
   }
   const groupContext = pool.giftGroupId
@@ -692,7 +791,61 @@ async function resolveContextInTransaction(
     source: groupRow?.activityLevel ? 'group_override' : 'application_default',
     controllingContext: groupRow?.activityLevel ? groupContext : null,
     noticeDismissedAt: poolRow?.noticeDismissedAt ?? null,
+    noticeDismissedKey: poolRow?.noticeDismissedKey ?? null,
   });
+}
+
+async function resolveContextAwarenessInTransaction(
+  tx: Prisma.TransactionClient,
+  userId: string,
+  context: NotificationContext,
+): Promise<ContextNotificationAwareness> {
+  const preference = await resolveContextInTransaction(tx, userId, context);
+  if (preference.activityLevel === NOTIFICATION_ACTIVITY_LEVELS.MUTED) {
+    return {
+      preference,
+      notificationOff: true,
+      reason:
+        preference.source === 'group_override' && context.kind === 'POOL'
+          ? 'inherited_mute'
+          : 'explicit_mute',
+      noticeKey: preference.noticeKey,
+      noticeVisible: preference.noticeVisible,
+    };
+  }
+
+  const channelRows = await tx.notificationChannelPreference.findMany({
+    where: { userId },
+    select: { channel: true, enabled: true, updatedAt: true },
+  });
+  const disabledChannels = new Map(
+    channelRows.map((row) => [row.channel, row] as const),
+  );
+  const allChannelsDisabled = NOTIFICATION_CHANNEL_VALUES.every(
+    (channel) => disabledChannels.get(channel)?.enabled === false,
+  );
+  if (!allChannelsDisabled) {
+    return {
+      preference,
+      notificationOff: false,
+      reason: null,
+      noticeKey: null,
+      noticeVisible: false,
+    };
+  }
+
+  const revision = channelRows.reduce(
+    (latest, row) => (row.updatedAt > latest ? row.updatedAt : latest),
+    new Date(0),
+  );
+  const noticeKey = `no_channels:GLOBAL:${userId}:${revision.toISOString()}`;
+  return {
+    preference,
+    notificationOff: true,
+    reason: 'no_channels',
+    noticeKey,
+    noticeVisible: preference.noticeDismissedKey !== noticeKey,
+  };
 }
 
 function resolvedContext({
@@ -701,6 +854,7 @@ function resolvedContext({
   source,
   controllingContext,
   noticeDismissedAt,
+  noticeDismissedKey,
 }: {
   context: NotificationContext;
   row: {
@@ -711,14 +865,19 @@ function resolvedContext({
   source: ResolvedContextNotificationPreference['source'];
   controllingContext: NotificationContext | null;
   noticeDismissedAt: Date | null;
+  noticeDismissedKey: string | null;
 }): ResolvedContextNotificationPreference {
-  const activityLevel = isActivityLevel(row?.activityLevel)
+  const activityLevel = isNotificationActivityLevel(row?.activityLevel)
     ? row.activityLevel
     : NOTIFICATION_ACTIVITY_LEVELS.IMPORTANT_ONLY;
   const customTopics = deserializeTopics(row?.customTopics);
   const mutedAt =
     activityLevel === NOTIFICATION_ACTIVITY_LEVELS.MUTED
       ? (row?.mutedAt ?? null)
+      : null;
+  const noticeKey =
+    mutedAt && controllingContext
+      ? `mute:${controllingContext.kind}:${contextId(controllingContext)}:${mutedAt.toISOString()}`
       : null;
   return {
     context,
@@ -727,9 +886,9 @@ function resolvedContext({
     customTopics,
     mutedAt,
     noticeDismissedAt,
-    noticeVisible: Boolean(
-      mutedAt && (!noticeDismissedAt || mutedAt > noticeDismissedAt),
-    ),
+    noticeDismissedKey,
+    noticeKey,
+    noticeVisible: Boolean(noticeKey && noticeDismissedKey !== noticeKey),
     controllingContext,
   };
 }
@@ -759,6 +918,7 @@ async function upsertContextPreference(
     customTopics: string | null;
     mutedAt: Date | null;
     noticeDismissedAt: Date | null | undefined;
+    noticeDismissedKey: string | null | undefined;
   },
 ) {
   const data = {
@@ -766,6 +926,7 @@ async function upsertContextPreference(
     customTopics: values.customTopics,
     mutedAt: values.mutedAt,
     noticeDismissedAt: values.noticeDismissedAt ?? null,
+    noticeDismissedKey: values.noticeDismissedKey ?? null,
   };
   if (context.kind === 'GROUP') {
     return tx.groupNotificationPreference.upsert({
@@ -799,15 +960,6 @@ function deserializeTopics(value: string | null | undefined) {
   } catch {
     return [];
   }
-}
-
-function isActivityLevel(value: unknown): value is NotificationActivityLevel {
-  return (
-    typeof value === 'string' &&
-    Object.values(NOTIFICATION_ACTIVITY_LEVELS).includes(
-      value as NotificationActivityLevel,
-    )
-  );
 }
 
 function contextId(context: NotificationContext) {

--- a/prisma/migrations/20260714050000_notification_awareness_keys/migration.sql
+++ b/prisma/migrations/20260714050000_notification_awareness_keys/migration.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "GroupNotificationPreference"
+ADD COLUMN "noticeDismissedKey" TEXT;
+
+ALTER TABLE "PoolNotificationPreference"
+ADD COLUMN "noticeDismissedKey" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -419,6 +419,7 @@ model GroupNotificationPreference {
   customTopics      String?
   mutedAt           DateTime?
   noticeDismissedAt DateTime?
+  noticeDismissedKey String?
   createdAt         DateTime  @default(now())
   updatedAt         DateTime  @updatedAt
   user              User      @relation(fields: [userId], references: [id], onDelete: Cascade)
@@ -435,6 +436,7 @@ model PoolNotificationPreference {
   customTopics      String?
   mutedAt           DateTime?
   noticeDismissedAt DateTime?
+  noticeDismissedKey String?
   createdAt         DateTime  @default(now())
   updatedAt         DateTime  @updatedAt
   user              User      @relation(fields: [userId], references: [id], onDelete: Cascade)

--- a/tests/e2e/context-notifications.test.ts
+++ b/tests/e2e/context-notifications.test.ts
@@ -1,0 +1,74 @@
+import { randomUUID } from 'node:crypto';
+import { prisma } from '#app/utils/db.server.ts';
+import { expect, test } from '#tests/playwright-utils.ts';
+
+test('a member can mute a group and see inherited pool awareness', async ({
+  page,
+  login,
+}) => {
+  const user = await login();
+  const group = await prisma.giftGroup.create({
+    data: {
+      name: `Notification group ${randomUUID().slice(0, 8)}`,
+      groupMembers: { create: { userId: user.id } },
+    },
+    select: { id: true, name: true },
+  });
+  const pool = await prisma.pool.create({
+    data: {
+      title: 'Inherited notification pool',
+      organizerId: user.id,
+      giftGroupId: group.id,
+      contributors: { create: { userId: user.id } },
+    },
+    select: { id: true },
+  });
+
+  try {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto(`/groups/${group.id}`);
+    await page
+      .getByRole('button', {
+        name: `Notifications for ${group.name}: Important`,
+      })
+      .click();
+    await page.getByRole('radio', { name: /^Muted / }).click();
+    await page.getByRole('button', { name: 'Close' }).click();
+
+    await expect(page.getByText(`You muted ${group.name}`)).toBeVisible();
+    await expect(
+      page.getByRole('button', {
+        name: `Notifications for ${group.name}: Muted`,
+      }),
+    ).toBeVisible();
+
+    await page.goto(`/pools/${pool.id}`);
+    await expect(
+      page.getByText('Notifications are muted by the group setting'),
+    ).toBeVisible();
+    await expect(
+      page.getByText(
+        `${group.name} is muted, so Inherited notification pool inherits that choice.`,
+      ),
+    ).toBeVisible();
+
+    await page
+      .getByRole('button', { name: 'Dismiss notification settings notice' })
+      .click();
+    await expect(
+      page.getByText('Notifications are muted by the group setting'),
+    ).toBeHidden();
+    await page.reload();
+    await expect(
+      page.getByText('Notifications are muted by the group setting'),
+    ).toBeHidden();
+    await expect(
+      page.getByRole('button', {
+        name: 'Notifications for Inherited notification pool: Muted',
+      }),
+    ).toBeVisible();
+  } finally {
+    await prisma.pool.deleteMany({ where: { id: pool.id } });
+    await prisma.giftGroup.deleteMany({ where: { id: group.id } });
+  }
+});

--- a/tests/e2e/settings-notifications.test.ts
+++ b/tests/e2e/settings-notifications.test.ts
@@ -35,7 +35,7 @@ test('users can optimistically toggle notification channels while request is pen
       return;
     }
     const body = request.postData() ?? '';
-    if (!body.includes('intent=toggle')) {
+    if (!body.includes('intent=topic-channel')) {
       await route.continue();
       return;
     }
@@ -43,11 +43,8 @@ test('users can optimistically toggle notification channels while request is pen
     await route.continue();
   });
 
-  const receivedRow = page.getByRole('row', {
-    name: /friend request received/i,
-  });
-  const receivedEmailToggle = receivedRow.getByRole('checkbox', {
-    name: /enable email/i,
+  const receivedEmailToggle = page.getByRole('switch', {
+    name: 'Friend requests: Email',
   });
 
   await expect(receivedEmailToggle).toBeChecked();
@@ -78,11 +75,8 @@ test('users can optimistically toggle notification channels while request is pen
 
   await expect(receivedEmailToggle).not.toBeDisabled();
   await page.reload();
-  const finalRow = page.getByRole('row', {
-    name: /friend request received/i,
-  });
-  const finalToggle = finalRow.getByRole('checkbox', {
-    name: /enable email/i,
+  const finalToggle = page.getByRole('switch', {
+    name: 'Friend requests: Email',
   });
   await expect(finalToggle).not.toBeChecked({ timeout: 10000 });
 
@@ -104,7 +98,7 @@ test('failed toggle requests rollback optimistic notification channel updates', 
       return;
     }
     const params = new URLSearchParams(request.postData() ?? '');
-    if (params.get('intent') !== 'toggle') {
+    if (params.get('intent') !== 'topic-channel') {
       await route.continue();
       return;
     }
@@ -117,11 +111,8 @@ test('failed toggle requests rollback optimistic notification channel updates', 
     await route.fulfill({ status: 200, contentType, body });
   });
 
-  const receivedRow = page.getByRole('row', {
-    name: /friend request received/i,
-  });
-  const receivedEmailToggle = receivedRow.getByRole('checkbox', {
-    name: /enable email/i,
+  const receivedEmailToggle = page.getByRole('switch', {
+    name: 'Friend requests: Email',
   });
 
   const initiallyChecked =
@@ -164,7 +155,7 @@ test('failed toggle requests rollback optimistic notification channel updates', 
   await page.unroute('**/settings/profile/notifications*');
 });
 
-test('users can disable all email notifications at once', async ({
+test('users can disable the global email delivery channel', async ({
   page,
   login,
 }) => {
@@ -172,19 +163,12 @@ test('users can disable all email notifications at once', async ({
   await page.goto('/settings/profile/notifications');
   await dismissInstallPrompt(page);
 
-  const friendActivityEmailToggles = page
-    .getByRole('row', { name: /friend request (received|accepted)/i })
-    .getByRole('checkbox', { name: /enable email/i });
-
-  await expect(friendActivityEmailToggles.first()).toBeChecked();
-  await expect(friendActivityEmailToggles.nth(1)).toBeChecked();
-
-  await page
-    .getByRole('button', { name: /turn off all email notifications/i })
-    .click();
-
-  await expect(friendActivityEmailToggles.first()).not.toBeChecked();
-  await expect(friendActivityEmailToggles.nth(1)).not.toBeChecked();
+  const emailChannel = page.getByRole('switch', {
+    name: 'Email notifications',
+  });
+  await expect(emailChannel).toBeChecked();
+  await emailChannel.click();
+  await expect(emailChannel).not.toBeChecked();
 
   const updatedPreference = await waitFor(
     async () => {


### PR DESCRIPTION
## Summary

- replace the compatibility notification table with global delivery-channel gates and expandable category/topic controls
- add personal group and pool activity controls with responsive mobile bottom sheets and desktop dialogs
- show persistent muted/off indicators plus cause- and revision-specific dismissible awareness notices
- preserve group-to-pool inheritance, add pool reset behavior, and keep token-link views read-only
- add a migration for revision-aware awareness dismissal keys

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint` (0 errors)
- [x] 75 focused component, route, and preference tests
- [x] focused Chromium E2E suite: 4 passed
- [x] production build and from-scratch migration application (via E2E pretest)
- [x] mobile and desktop visual QA

## Visual QA

- Desktop central settings: delivery gates, category bulk state, expandable topic controls, and read-only behavior
- Mobile context controls: 390px viewport, no horizontal overflow, 44×44 switches, bottom-sheet behavior
- Desktop context controls: centered 512px dialog
- Group explicit mute and pool inherited-mute indicators/notices, including dismissal persistence

Local captures were recorded as `/tmp/notification-settings-desktop.png` and `/tmp/context-notifications-mobile.png`.

## Checklist

- [x] Dedicated branch and focused conventional commits
- [x] Responsive dialogs use `ResponsiveDialog`
- [x] Email remains off by default for newly introduced topics
- [x] No automatic pool events or organizer nudges included
- [x] Schema migration included
- [ ] CI and Sonar green
