### PR TITLE
feat(notifications): send important pool updates

### DIFF
--- a/app/emails/pool-activity.tsx
+++ b/app/emails/pool-activity.tsx
@@ -1,0 +1,53 @@
+import * as E from '@react-email/components';
+
+type PoolActivityEmailProps = {
+  appName: string;
+  heading: string;
+  message: string;
+  poolUrl: string;
+  managePreferencesUrl: string;
+};
+
+export function PoolActivityEmail({
+  appName,
+  heading,
+  message,
+  poolUrl,
+  managePreferencesUrl,
+}: Readonly<PoolActivityEmailProps>) {
+  return (
+    <E.Html lang="en" dir="ltr">
+      <E.Container>
+        <E.Heading as="h1">{heading}</E.Heading>
+        <E.Text>{message}</E.Text>
+        <E.Button
+          href={poolUrl}
+          style={{
+            backgroundColor: '#0f172a',
+            color: '#ffffff',
+            padding: '12px 24px',
+            borderRadius: '9999px',
+            display: 'inline-block',
+            textDecoration: 'none',
+            fontWeight: 600,
+          }}
+        >
+          Open pool
+        </E.Button>
+        <E.Text
+          style={{ marginTop: '32px', fontSize: '12px', color: '#64748b' }}
+        >
+          You are receiving this email because you enabled pool coordination
+          email notifications on {appName}. You can update your preferences at
+          any time.
+        </E.Text>
+        <E.Link
+          href={managePreferencesUrl}
+          style={{ fontSize: '12px', color: '#0f172a' }}
+        >
+          Manage notification preferences
+        </E.Link>
+      </E.Container>
+    </E.Html>
+  );
+}

--- a/app/i18n/dictionaries/en.ts
+++ b/app/i18n/dictionaries/en.ts
@@ -41,6 +41,26 @@ export const en = {
       message: "{{name}}'s birthday is {{when}}",
       pushTitle: 'Upcoming birthday',
     },
+    poolVoteStarted: {
+      message: 'Voting has started in {{pool}}',
+      pushTitle: 'Voting started',
+    },
+    poolGiftChosen: {
+      message: '{{idea}} was chosen for {{pool}}',
+      pushTitle: 'Gift chosen',
+    },
+    poolCancelled: {
+      message: '{{pool}} was cancelled',
+      pushTitle: 'Pool cancelled',
+    },
+    poolPurchaserAssigned: {
+      message: "You're the purchaser for {{pool}}",
+      pushTitle: 'Purchase assignment',
+    },
+    poolDelivererAssigned: {
+      message: "You're delivering the gift for {{pool}}",
+      pushTitle: 'Delivery assignment',
+    },
     markAllReadSuccess: 'All notifications marked as read.',
   },
   friends: {

--- a/app/utils/analytics.ts
+++ b/app/utils/analytics.ts
@@ -24,6 +24,11 @@ export const ANALYTIC_EVENT_NAMES = [
   'pool_purchased',
   'pool_delivered',
   'pool_cancelled',
+  'pool_purchaser_assigned',
+  'pool_deliverer_assigned',
+  // Automatic pool activity fanout. Fires per recipient only when at least one
+  // channel newly delivers; properties contain type, pool id, and channels.
+  'pool_activity_notification_sent',
   'friend_request_sent',
   'friend_request_accepted',
   'friend_request_rejected',
@@ -185,6 +190,9 @@ export const USER_REQUIRED_EVENTS: Set<AnalyticEventName> = new Set([
   'pool_purchased',
   'pool_delivered',
   'pool_cancelled',
+  'pool_purchaser_assigned',
+  'pool_deliverer_assigned',
+  'pool_activity_notification_sent',
   'friend_request_sent',
   'friend_request_accepted',
   'friend_request_rejected',

--- a/app/utils/notification-catalog.test.ts
+++ b/app/utils/notification-catalog.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   getNotificationEventDefinition,
+  getNotificationTopicsForContext,
   isNotificationType,
   matchesNotificationContext,
   NOTIFICATION_CHANNELS,
@@ -8,6 +9,7 @@ import {
   NOTIFICATION_TOPIC_CATALOG,
   NOTIFICATION_TOPICS,
   NOTIFICATION_TYPES,
+  POOL_ACTIVITY_NOTIFICATION_TYPES,
 } from '#app/utils/notification-catalog.ts';
 
 describe('notification catalog', () => {
@@ -40,6 +42,42 @@ describe('notification catalog', () => {
         NOTIFICATION_CHANNELS.IN_APP,
       );
     }
+  });
+
+  it('classifies important pool activity into scoped, ledger-backed topics', () => {
+    for (const type of POOL_ACTIVITY_NOTIFICATION_TYPES) {
+      expect(getNotificationEventDefinition(type)).toMatchObject({
+        context: 'POOL',
+        importance: 'IMPORTANT',
+        deliveryStrategy: 'PER_CHANNEL_LEDGER',
+      });
+    }
+
+    expect(
+      getNotificationEventDefinition(NOTIFICATION_TYPES.POOL_VOTE_STARTED)
+        .topic,
+    ).toBe(NOTIFICATION_TOPICS.IDEAS_AND_VOTING);
+    expect(
+      getNotificationEventDefinition(NOTIFICATION_TYPES.POOL_GIFT_CHOSEN).topic,
+    ).toBe(NOTIFICATION_TOPICS.IDEAS_AND_VOTING);
+    expect(
+      getNotificationEventDefinition(NOTIFICATION_TYPES.POOL_CANCELLED).topic,
+    ).toBe(NOTIFICATION_TOPICS.POOL_PROGRESS);
+    expect(
+      getNotificationEventDefinition(NOTIFICATION_TYPES.POOL_PURCHASER_ASSIGNED)
+        .topic,
+    ).toBe(NOTIFICATION_TOPICS.ASSIGNMENTS);
+  });
+
+  it('exposes pool topics for pool and group context controls', () => {
+    const poolTopics = [
+      NOTIFICATION_TOPICS.IDEAS_AND_VOTING,
+      NOTIFICATION_TOPICS.POOL_PROGRESS,
+      NOTIFICATION_TOPICS.ASSIGNMENTS,
+    ];
+
+    expect(getNotificationTopicsForContext('POOL')).toEqual(poolTopics);
+    expect(getNotificationTopicsForContext('GROUP')).toEqual(poolTopics);
   });
 
   it('validates persisted type strings through the catalog', () => {

--- a/app/utils/notification-catalog.ts
+++ b/app/utils/notification-catalog.ts
@@ -2,10 +2,34 @@ export const NOTIFICATION_TYPES = {
   FRIEND_REQUEST_RECEIVED: 'FRIEND_REQUEST_RECEIVED',
   FRIEND_REQUEST_ACCEPTED: 'FRIEND_REQUEST_ACCEPTED',
   UPCOMING_BIRTHDAY: 'UPCOMING_BIRTHDAY',
+  POOL_VOTE_STARTED: 'POOL_VOTE_STARTED',
+  POOL_GIFT_CHOSEN: 'POOL_GIFT_CHOSEN',
+  POOL_CANCELLED: 'POOL_CANCELLED',
+  POOL_PURCHASER_ASSIGNED: 'POOL_PURCHASER_ASSIGNED',
+  POOL_DELIVERER_ASSIGNED: 'POOL_DELIVERER_ASSIGNED',
 } as const;
 
 export type NotificationType =
   (typeof NOTIFICATION_TYPES)[keyof typeof NOTIFICATION_TYPES];
+
+export const POOL_ACTIVITY_NOTIFICATION_TYPES = [
+  NOTIFICATION_TYPES.POOL_VOTE_STARTED,
+  NOTIFICATION_TYPES.POOL_GIFT_CHOSEN,
+  NOTIFICATION_TYPES.POOL_CANCELLED,
+  NOTIFICATION_TYPES.POOL_PURCHASER_ASSIGNED,
+  NOTIFICATION_TYPES.POOL_DELIVERER_ASSIGNED,
+] as const;
+
+export type PoolActivityNotificationType =
+  (typeof POOL_ACTIVITY_NOTIFICATION_TYPES)[number];
+
+export function isPoolActivityNotificationType(
+  type: NotificationType,
+): type is PoolActivityNotificationType {
+  return POOL_ACTIVITY_NOTIFICATION_TYPES.includes(
+    type as PoolActivityNotificationType,
+  );
+}
 
 export const NOTIFICATION_CHANNELS = {
   IN_APP: 'IN_APP',
@@ -21,6 +45,7 @@ export const NOTIFICATION_CHANNEL_VALUES = Object.values(NOTIFICATION_CHANNELS);
 export const NOTIFICATION_CATEGORIES = {
   SOCIAL: 'SOCIAL',
   OCCASIONS: 'OCCASIONS',
+  POOL_COORDINATION: 'POOL_COORDINATION',
 } as const;
 
 export type NotificationCategory =
@@ -44,6 +69,10 @@ export const NOTIFICATION_CATEGORY_CATALOG = {
     label: 'Reminders',
     description: 'Timely reminders about occasions you can see.',
   },
+  [NOTIFICATION_CATEGORIES.POOL_COORDINATION]: {
+    label: 'Pool coordination',
+    description: 'Important decisions and assignments in your gift pools.',
+  },
 } as const satisfies Record<
   NotificationCategory,
   NotificationCategoryDefinition
@@ -52,6 +81,9 @@ export const NOTIFICATION_CATEGORY_CATALOG = {
 export const NOTIFICATION_TOPICS = {
   FRIEND_REQUESTS: 'FRIEND_REQUESTS',
   BIRTHDAY_REMINDERS: 'BIRTHDAY_REMINDERS',
+  IDEAS_AND_VOTING: 'IDEAS_AND_VOTING',
+  POOL_PROGRESS: 'POOL_PROGRESS',
+  ASSIGNMENTS: 'ASSIGNMENTS',
 } as const;
 
 export type NotificationTopic =
@@ -112,6 +144,36 @@ export const NOTIFICATION_TOPIC_CATALOG = {
       pushEnabled: false,
     },
   },
+  [NOTIFICATION_TOPICS.IDEAS_AND_VOTING]: {
+    category: NOTIFICATION_CATEGORIES.POOL_COORDINATION,
+    label: 'Ideas and voting',
+    description: 'When voting starts or a gift is chosen.',
+    defaults: {
+      inAppEnabled: true,
+      emailEnabled: false,
+      pushEnabled: false,
+    },
+  },
+  [NOTIFICATION_TOPICS.POOL_PROGRESS]: {
+    category: NOTIFICATION_CATEGORIES.POOL_COORDINATION,
+    label: 'Pool progress',
+    description: "Important changes to a pool's lifecycle.",
+    defaults: {
+      inAppEnabled: true,
+      emailEnabled: false,
+      pushEnabled: false,
+    },
+  },
+  [NOTIFICATION_TOPICS.ASSIGNMENTS]: {
+    category: NOTIFICATION_CATEGORIES.POOL_COORDINATION,
+    label: 'Assignments',
+    description: 'When you are assigned to purchase or deliver a gift.',
+    defaults: {
+      inAppEnabled: true,
+      emailEnabled: false,
+      pushEnabled: false,
+    },
+  },
 } as const satisfies Record<NotificationTopic, NotificationTopicDefinition>;
 
 /**
@@ -137,6 +199,41 @@ export const NOTIFICATION_EVENT_CATALOG = {
     topic: NOTIFICATION_TOPICS.BIRTHDAY_REMINDERS,
     importance: 'IMPORTANT',
     context: 'NONE',
+    supportedChannels: allChannels,
+    deliveryStrategy: 'PER_CHANNEL_LEDGER',
+  },
+  [NOTIFICATION_TYPES.POOL_VOTE_STARTED]: {
+    topic: NOTIFICATION_TOPICS.IDEAS_AND_VOTING,
+    importance: 'IMPORTANT',
+    context: 'POOL',
+    supportedChannels: allChannels,
+    deliveryStrategy: 'PER_CHANNEL_LEDGER',
+  },
+  [NOTIFICATION_TYPES.POOL_GIFT_CHOSEN]: {
+    topic: NOTIFICATION_TOPICS.IDEAS_AND_VOTING,
+    importance: 'IMPORTANT',
+    context: 'POOL',
+    supportedChannels: allChannels,
+    deliveryStrategy: 'PER_CHANNEL_LEDGER',
+  },
+  [NOTIFICATION_TYPES.POOL_CANCELLED]: {
+    topic: NOTIFICATION_TOPICS.POOL_PROGRESS,
+    importance: 'IMPORTANT',
+    context: 'POOL',
+    supportedChannels: allChannels,
+    deliveryStrategy: 'PER_CHANNEL_LEDGER',
+  },
+  [NOTIFICATION_TYPES.POOL_PURCHASER_ASSIGNED]: {
+    topic: NOTIFICATION_TOPICS.ASSIGNMENTS,
+    importance: 'IMPORTANT',
+    context: 'POOL',
+    supportedChannels: allChannels,
+    deliveryStrategy: 'PER_CHANNEL_LEDGER',
+  },
+  [NOTIFICATION_TYPES.POOL_DELIVERER_ASSIGNED]: {
+    topic: NOTIFICATION_TOPICS.ASSIGNMENTS,
+    importance: 'IMPORTANT',
+    context: 'POOL',
     supportedChannels: allChannels,
     deliveryStrategy: 'PER_CHANNEL_LEDGER',
   },
@@ -260,6 +357,12 @@ type FriendRequestPayload = {
   recipientUserId: string;
 };
 
+type PoolActivityPayload = {
+  poolId: string;
+  poolTitle: string;
+  actorUserId: string;
+};
+
 type PayloadByType = {
   [NOTIFICATION_TYPES.FRIEND_REQUEST_RECEIVED]: FriendRequestPayload;
   [NOTIFICATION_TYPES.FRIEND_REQUEST_ACCEPTED]: FriendRequestPayload;
@@ -273,6 +376,13 @@ type PayloadByType = {
     // spans local midnight.
     birthdayDate: Date;
   };
+  [NOTIFICATION_TYPES.POOL_VOTE_STARTED]: PoolActivityPayload;
+  [NOTIFICATION_TYPES.POOL_GIFT_CHOSEN]: PoolActivityPayload & {
+    chosenIdeaName: string;
+  };
+  [NOTIFICATION_TYPES.POOL_CANCELLED]: PoolActivityPayload;
+  [NOTIFICATION_TYPES.POOL_PURCHASER_ASSIGNED]: PoolActivityPayload;
+  [NOTIFICATION_TYPES.POOL_DELIVERER_ASSIGNED]: PoolActivityPayload;
 };
 
 export type NotificationPayload<T extends NotificationType> = PayloadByType[T];

--- a/app/utils/notification-dispatcher.server.test.tsx
+++ b/app/utils/notification-dispatcher.server.test.tsx
@@ -109,6 +109,7 @@ describe('notification dispatcher', () => {
     await prisma.notification.deleteMany();
     await prisma.friendRequest.deleteMany();
     await prisma.friendship.deleteMany();
+    await prisma.pool.deleteMany();
     await prisma.user.deleteMany({
       where: { email: { contains: '@example.com' } },
     });
@@ -271,6 +272,63 @@ describe('notification dispatcher', () => {
       `/users/${birthdayOwner.username}`,
     );
     expect(emailMock).not.toHaveBeenCalled();
+  });
+
+  it('delivers pool activity once per occurrence with email off by default', async () => {
+    const organizer = await createUser();
+    const recipient = await createUser();
+    const member = await createUser();
+    const pool = await prisma.pool.create({
+      data: {
+        title: 'Taylor birthday',
+        organizerId: organizer.id,
+        recipientUserId: recipient.id,
+        contributors: {
+          create: [{ userId: organizer.id }, { userId: member.id }],
+        },
+      },
+      select: { id: true, title: true },
+    });
+    const notify = () =>
+      dispatchNotification({
+        userId: member.id,
+        type: NOTIFICATION_TYPES.POOL_VOTE_STARTED,
+        context: { kind: 'POOL', poolId: pool.id },
+        sourceIdentifier: 'test-pool-vote-started',
+        payload: {
+          poolId: pool.id,
+          poolTitle: pool.title,
+          actorUserId: organizer.id,
+        },
+      });
+
+    await notify();
+    await notify();
+
+    const notifications = await prisma.notification.findMany({
+      where: {
+        userId: member.id,
+        type: NOTIFICATION_TYPES.POOL_VOTE_STARTED,
+      },
+    });
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0]).toMatchObject({
+      messageKey: 'notifications.poolVoteStarted.message',
+      targetUrl: `/pools/${pool.id}`,
+      sourceIdentifier: 'test-pool-vote-started:IN_APP',
+    });
+    expect(emailMock).not.toHaveBeenCalled();
+    expect(queueLogEvent).toHaveBeenCalledTimes(1);
+    expect(queueLogEvent).toHaveBeenCalledWith({
+      name: 'pool_activity_notification_sent',
+      source: 'server',
+      userId: member.id,
+      properties: {
+        notificationType: NOTIFICATION_TYPES.POOL_VOTE_STARTED,
+        poolId: pool.id,
+        channels: [NOTIFICATION_CHANNELS.IN_APP],
+      },
+    });
   });
 
   it('is idempotent per sourceIdentifier for UPCOMING_BIRTHDAY', async () => {

--- a/app/utils/notification-events.server.test.tsx
+++ b/app/utils/notification-events.server.test.tsx
@@ -1,0 +1,169 @@
+/**
+ * @vitest-environment node
+ */
+import { renderToStaticMarkup } from 'react-dom/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  NOTIFICATION_CHANNELS,
+  NOTIFICATION_TYPES,
+  type NotificationIntent,
+} from '#app/utils/notification-catalog.ts';
+
+vi.mock('#app/utils/app-url.server.ts', () => ({
+  buildAppUrl: (path: string) => `https://giftpool.example${path}`,
+}));
+
+const createPreferenceToken = vi.fn();
+
+vi.mock('#app/utils/notification-preference-token.server.ts', () => ({
+  createPreferenceToken: (...args: Array<unknown>) =>
+    createPreferenceToken(...args),
+  getPreferenceManagementUrl: (token: string) =>
+    `https://giftpool.example/settings/profile/notifications?token=${token}`,
+}));
+
+import {
+  getNotificationOccurrenceKey,
+  renderNotificationChannel,
+} from './notification-events.server.tsx';
+
+const base = {
+  userId: 'member-1',
+  context: { kind: 'POOL' as const, poolId: 'pool-1' },
+  sourceIdentifier: 'pool-event-1',
+};
+
+const poolCases = [
+  {
+    intent: {
+      ...base,
+      type: NOTIFICATION_TYPES.POOL_VOTE_STARTED,
+      payload: {
+        poolId: 'pool-1',
+        poolTitle: 'Taylor birthday',
+        actorUserId: 'actor-1',
+      },
+    },
+    messageKey: 'notifications.poolVoteStarted.message',
+    message: 'Voting has started in Taylor birthday',
+    pushTitle: 'Voting started',
+  },
+  {
+    intent: {
+      ...base,
+      type: NOTIFICATION_TYPES.POOL_GIFT_CHOSEN,
+      payload: {
+        poolId: 'pool-1',
+        poolTitle: 'Taylor birthday',
+        actorUserId: 'actor-1',
+        chosenIdeaName: 'Record player',
+      },
+    },
+    messageKey: 'notifications.poolGiftChosen.message',
+    message: 'Record player was chosen for Taylor birthday',
+    pushTitle: 'Gift chosen',
+  },
+  {
+    intent: {
+      ...base,
+      type: NOTIFICATION_TYPES.POOL_CANCELLED,
+      payload: {
+        poolId: 'pool-1',
+        poolTitle: 'Taylor birthday',
+        actorUserId: 'actor-1',
+      },
+    },
+    messageKey: 'notifications.poolCancelled.message',
+    message: 'Taylor birthday was cancelled',
+    pushTitle: 'Pool cancelled',
+  },
+  {
+    intent: {
+      ...base,
+      type: NOTIFICATION_TYPES.POOL_PURCHASER_ASSIGNED,
+      payload: {
+        poolId: 'pool-1',
+        poolTitle: 'Taylor birthday',
+        actorUserId: 'actor-1',
+      },
+    },
+    messageKey: 'notifications.poolPurchaserAssigned.message',
+    message: "You're the purchaser for Taylor birthday",
+    pushTitle: 'Purchase assignment',
+  },
+  {
+    intent: {
+      ...base,
+      type: NOTIFICATION_TYPES.POOL_DELIVERER_ASSIGNED,
+      payload: {
+        poolId: 'pool-1',
+        poolTitle: 'Taylor birthday',
+        actorUserId: 'actor-1',
+      },
+    },
+    messageKey: 'notifications.poolDelivererAssigned.message',
+    message: "You're delivering the gift for Taylor birthday",
+    pushTitle: 'Delivery assignment',
+  },
+] as const satisfies ReadonlyArray<{
+  intent: NotificationIntent;
+  messageKey: string;
+  message: string;
+  pushTitle: string;
+}>;
+
+describe('pool activity notification rendering', () => {
+  beforeEach(() => {
+    createPreferenceToken.mockResolvedValue('preference-token');
+  });
+
+  it('renders every pool event for the bell and web push', async () => {
+    for (const { intent, messageKey, message, pushTitle } of poolCases) {
+      const inApp = await renderNotificationChannel(
+        intent,
+        NOTIFICATION_CHANNELS.IN_APP,
+      );
+      expect(inApp).toMatchObject({
+        messageKey,
+        targetUrl: '/pools/pool-1',
+        metadata: JSON.stringify({ poolId: 'pool-1' }),
+      });
+
+      const push = await renderNotificationChannel(
+        intent,
+        NOTIFICATION_CHANNELS.WEB_PUSH,
+      );
+      expect(push).toEqual({
+        title: pushTitle,
+        body: message,
+        url: '/pools/pool-1',
+        tag: 'pool-event-1',
+      });
+    }
+  });
+
+  it('renders the opt-in email with its pool and preference links', async () => {
+    const message = await renderNotificationChannel(
+      poolCases[1].intent,
+      NOTIFICATION_CHANNELS.EMAIL,
+    );
+    const markup = renderToStaticMarkup(message.react);
+
+    expect(message.subject).toBe(
+      'Record player was chosen for Taylor birthday on GiftPool',
+    );
+    expect(markup).toContain('Open pool');
+    expect(markup).toContain('https://giftpool.example/pools/pool-1');
+    expect(markup).toContain('Manage notification preferences');
+    expect(markup).toContain('preference-token');
+  });
+
+  it('requires callers to provide a stable pool occurrence identifier', () => {
+    const { sourceIdentifier: _sourceIdentifier, ...withoutSource } =
+      poolCases[0].intent;
+
+    expect(() => getNotificationOccurrenceKey(withoutSource)).toThrow(
+      'POOL_VOTE_STARTED requires a sourceIdentifier',
+    );
+  });
+});

--- a/app/utils/notification-events.server.tsx
+++ b/app/utils/notification-events.server.tsx
@@ -1,6 +1,7 @@
 import { type ReactElement } from 'react';
 import { FriendRequestAcceptedEmail } from '#app/emails/friend-request-accepted.tsx';
 import { FriendRequestReceivedEmail } from '#app/emails/friend-request-received.tsx';
+import { PoolActivityEmail } from '#app/emails/pool-activity.tsx';
 import { UpcomingBirthdayEmail } from '#app/emails/upcoming-birthday.tsx';
 import { queueLogEvent } from '#app/utils/analytics.server.ts';
 import { OCCASION_REMINDER_EMAIL_SRC } from '#app/utils/analytics.ts';
@@ -10,8 +11,10 @@ import { translate } from '#app/utils/i18n.tsx';
 import {
   NOTIFICATION_CHANNELS,
   NOTIFICATION_TYPES,
+  isPoolActivityNotificationType,
   type NotificationChannel,
   type NotificationIntent,
+  type PoolActivityNotificationType,
 } from '#app/utils/notification-catalog.ts';
 import {
   createPreferenceToken,
@@ -60,6 +63,14 @@ export function getNotificationOccurrenceKey(
       return `friend-request:${intent.payload.friendRequestId}:accepted`;
     case NOTIFICATION_TYPES.UPCOMING_BIRTHDAY:
       return `birthday:${intent.payload.birthdayUserId}:${formatLocalDateKey(intent.payload.birthdayDate)}`;
+    case NOTIFICATION_TYPES.POOL_VOTE_STARTED:
+    case NOTIFICATION_TYPES.POOL_GIFT_CHOSEN:
+    case NOTIFICATION_TYPES.POOL_CANCELLED:
+    case NOTIFICATION_TYPES.POOL_PURCHASER_ASSIGNED:
+    case NOTIFICATION_TYPES.POOL_DELIVERER_ASSIGNED:
+      throw new Error(
+        `Pool notification ${intent.type} requires a sourceIdentifier.`,
+      );
   }
 }
 
@@ -74,6 +85,12 @@ export async function renderNotificationChannel<C extends NotificationChannel>(
       return renderFriendRequestAccepted(intent, channel);
     case NOTIFICATION_TYPES.UPCOMING_BIRTHDAY:
       return renderUpcomingBirthday(intent, channel);
+    case NOTIFICATION_TYPES.POOL_VOTE_STARTED:
+    case NOTIFICATION_TYPES.POOL_GIFT_CHOSEN:
+    case NOTIFICATION_TYPES.POOL_CANCELLED:
+    case NOTIFICATION_TYPES.POOL_PURCHASER_ASSIGNED:
+    case NOTIFICATION_TYPES.POOL_DELIVERER_ASSIGNED:
+      return renderPoolActivity(intent, channel);
   }
 }
 
@@ -233,6 +250,112 @@ async function renderUpcomingBirthday<C extends NotificationChannel>(
   }
 }
 
+type PoolActivityIntent = NotificationIntent<PoolActivityNotificationType>;
+
+type PoolActivityCopy = {
+  messageKey:
+    | 'notifications.poolVoteStarted.message'
+    | 'notifications.poolGiftChosen.message'
+    | 'notifications.poolCancelled.message'
+    | 'notifications.poolPurchaserAssigned.message'
+    | 'notifications.poolDelivererAssigned.message';
+  pushTitleKey:
+    | 'notifications.poolVoteStarted.pushTitle'
+    | 'notifications.poolGiftChosen.pushTitle'
+    | 'notifications.poolCancelled.pushTitle'
+    | 'notifications.poolPurchaserAssigned.pushTitle'
+    | 'notifications.poolDelivererAssigned.pushTitle';
+  messageParams: Record<string, string>;
+  emailBody: string;
+};
+
+async function renderPoolActivity<C extends NotificationChannel>(
+  intent: PoolActivityIntent,
+  channel: C,
+): Promise<NotificationChannelMessageMap[C]> {
+  const copy = getPoolActivityCopy(intent);
+  const message = translate('en', copy.messageKey, copy.messageParams);
+  const poolUrl = `/pools/${intent.payload.poolId}`;
+
+  switch (channel) {
+    case NOTIFICATION_CHANNELS.IN_APP:
+      return {
+        status: 'UNREAD',
+        messageKey: copy.messageKey,
+        messageParams: JSON.stringify(copy.messageParams),
+        targetUrl: poolUrl,
+        metadata: JSON.stringify({ poolId: intent.payload.poolId }),
+        friendRequestId: null,
+      } as NotificationChannelMessageMap[C];
+    case NOTIFICATION_CHANNELS.EMAIL: {
+      const managePreferencesUrl = await buildManagePreferencesUrl(intent);
+      return {
+        subject: `${message} on ${appName}`,
+        react: (
+          <PoolActivityEmail
+            appName={appName}
+            heading={message}
+            message={copy.emailBody}
+            poolUrl={buildAppUrl(poolUrl)}
+            managePreferencesUrl={managePreferencesUrl}
+          />
+        ),
+      } as NotificationChannelMessageMap[C];
+    }
+    case NOTIFICATION_CHANNELS.WEB_PUSH:
+      return {
+        title: translate('en', copy.pushTitleKey),
+        body: message,
+        url: poolUrl,
+        tag: getNotificationOccurrenceKey(intent),
+      } as NotificationChannelMessageMap[C];
+  }
+}
+
+function getPoolActivityCopy(intent: PoolActivityIntent): PoolActivityCopy {
+  const pool = intent.payload.poolTitle;
+  switch (intent.type) {
+    case NOTIFICATION_TYPES.POOL_VOTE_STARTED:
+      return {
+        messageKey: 'notifications.poolVoteStarted.message',
+        pushTitleKey: 'notifications.poolVoteStarted.pushTitle',
+        messageParams: { pool },
+        emailBody: 'Open the pool to review the ideas and cast your vote.',
+      };
+    case NOTIFICATION_TYPES.POOL_GIFT_CHOSEN:
+      return {
+        messageKey: 'notifications.poolGiftChosen.message',
+        pushTitleKey: 'notifications.poolGiftChosen.pushTitle',
+        messageParams: {
+          pool,
+          idea: intent.payload.chosenIdeaName,
+        },
+        emailBody: 'Open the pool to see the chosen gift and next steps.',
+      };
+    case NOTIFICATION_TYPES.POOL_CANCELLED:
+      return {
+        messageKey: 'notifications.poolCancelled.message',
+        pushTitleKey: 'notifications.poolCancelled.pushTitle',
+        messageParams: { pool },
+        emailBody: 'Open the pool to review its final status.',
+      };
+    case NOTIFICATION_TYPES.POOL_PURCHASER_ASSIGNED:
+      return {
+        messageKey: 'notifications.poolPurchaserAssigned.message',
+        pushTitleKey: 'notifications.poolPurchaserAssigned.pushTitle',
+        messageParams: { pool },
+        emailBody: 'Open the pool to review the gift and purchase details.',
+      };
+    case NOTIFICATION_TYPES.POOL_DELIVERER_ASSIGNED:
+      return {
+        messageKey: 'notifications.poolDelivererAssigned.message',
+        pushTitleKey: 'notifications.poolDelivererAssigned.pushTitle',
+        messageParams: { pool },
+        emailBody: 'Open the pool to review the delivery details.',
+      };
+  }
+}
+
 async function buildManagePreferencesUrl(intent: NotificationIntent) {
   const token = await createPreferenceToken({
     userId: intent.userId,
@@ -245,21 +368,38 @@ export function recordNotificationDelivery(
   intent: NotificationIntent,
   deliveredChannels: Array<NotificationChannel>,
 ) {
-  if (
-    intent.type !== NOTIFICATION_TYPES.UPCOMING_BIRTHDAY ||
-    deliveredChannels.length === 0
-  ) {
+  if (deliveredChannels.length === 0) return;
+
+  if (intent.type === NOTIFICATION_TYPES.UPCOMING_BIRTHDAY) {
+    queueLogEvent({
+      name: 'occasion_reminder_sent',
+      source: 'server',
+      userId: intent.userId,
+      properties: {
+        birthdayUserId: intent.payload.birthdayUserId,
+        daysUntil: intent.payload.daysUntil,
+        channels: deliveredChannels,
+      },
+    });
     return;
   }
 
-  queueLogEvent({
-    name: 'occasion_reminder_sent',
-    source: 'server',
-    userId: intent.userId,
-    properties: {
-      birthdayUserId: intent.payload.birthdayUserId,
-      daysUntil: intent.payload.daysUntil,
-      channels: deliveredChannels,
-    },
-  });
+  if (isPoolActivityIntent(intent)) {
+    queueLogEvent({
+      name: 'pool_activity_notification_sent',
+      source: 'server',
+      userId: intent.userId,
+      properties: {
+        notificationType: intent.type,
+        poolId: intent.payload.poolId,
+        channels: deliveredChannels,
+      },
+    });
+  }
+}
+
+function isPoolActivityIntent(
+  intent: NotificationIntent,
+): intent is NotificationIntent<PoolActivityNotificationType> {
+  return isPoolActivityNotificationType(intent.type);
 }

--- a/app/utils/pool-notifications.server.test.ts
+++ b/app/utils/pool-notifications.server.test.ts
@@ -1,0 +1,207 @@
+/**
+ * @vitest-environment node
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NOTIFICATION_TYPES } from '#app/utils/notification-catalog.ts';
+
+const captureException = vi.fn();
+const poolFindUnique = vi.fn();
+const queueNotification = vi.fn();
+
+vi.mock('@sentry/react-router', () => ({
+  captureException: (...args: Array<unknown>) => captureException(...args),
+}));
+
+vi.mock('#app/utils/db.server.ts', () => ({
+  prisma: {
+    pool: {
+      findUnique: (...args: Array<unknown>) => poolFindUnique(...args),
+    },
+  },
+}));
+
+vi.mock('#app/utils/notification-dispatcher.server.ts', () => ({
+  queueNotification: (...args: Array<unknown>) => queueNotification(...args),
+}));
+
+import { queuePoolActivityNotifications } from './pool-notifications.server.ts';
+
+const pool = {
+  id: 'pool-1',
+  title: 'Taylor birthday',
+  recipientUserId: 'recipient-1',
+  purchaserId: 'purchaser-1',
+  delivererId: 'deliverer-1',
+  chosenIdea: { name: 'Record player' },
+  contributors: [
+    { userId: 'actor-1' },
+    { userId: 'recipient-1' },
+    { userId: 'member-1' },
+    { userId: 'purchaser-1' },
+    { userId: 'deliverer-1' },
+  ],
+};
+
+beforeEach(() => {
+  captureException.mockReset();
+  poolFindUnique.mockReset().mockResolvedValue(pool);
+  queueNotification.mockReset();
+});
+
+describe('pool activity notification fanout', () => {
+  it('broadcasts to current contributors except the actor and concealed recipient', async () => {
+    queuePoolActivityNotifications({
+      type: NOTIFICATION_TYPES.POOL_GIFT_CHOSEN,
+      poolId: pool.id,
+      actorUserId: 'actor-1',
+      occurrenceId: 'event-1',
+    });
+
+    await vi.waitFor(() => expect(queueNotification).toHaveBeenCalledTimes(3));
+    expect(
+      queueNotification.mock.calls.map(([intent]) => intent.userId),
+    ).toEqual(['member-1', 'purchaser-1', 'deliverer-1']);
+    expect(queueNotification).toHaveBeenCalledWith({
+      userId: 'member-1',
+      type: NOTIFICATION_TYPES.POOL_GIFT_CHOSEN,
+      context: { kind: 'POOL', poolId: pool.id },
+      sourceIdentifier: `pool-activity:${NOTIFICATION_TYPES.POOL_GIFT_CHOSEN}:event-1`,
+      payload: {
+        poolId: pool.id,
+        poolTitle: pool.title,
+        actorUserId: 'actor-1',
+        chosenIdeaName: 'Record player',
+      },
+    });
+  });
+
+  it('targets a current assignment only when the assignee is still a contributor', async () => {
+    queuePoolActivityNotifications({
+      type: NOTIFICATION_TYPES.POOL_PURCHASER_ASSIGNED,
+      poolId: pool.id,
+      actorUserId: 'actor-1',
+      assigneeUserId: 'purchaser-1',
+      occurrenceId: 'event-2',
+    });
+
+    await vi.waitFor(() => expect(queueNotification).toHaveBeenCalledTimes(1));
+    expect(queueNotification).toHaveBeenCalledWith({
+      userId: 'purchaser-1',
+      type: NOTIFICATION_TYPES.POOL_PURCHASER_ASSIGNED,
+      context: { kind: 'POOL', poolId: pool.id },
+      sourceIdentifier: `pool-activity:${NOTIFICATION_TYPES.POOL_PURCHASER_ASSIGNED}:event-2`,
+      payload: {
+        poolId: pool.id,
+        poolTitle: pool.title,
+        actorUserId: 'actor-1',
+      },
+    });
+  });
+
+  it('targets the current deliverer through the same assignment boundary', async () => {
+    queuePoolActivityNotifications({
+      type: NOTIFICATION_TYPES.POOL_DELIVERER_ASSIGNED,
+      poolId: pool.id,
+      actorUserId: 'actor-1',
+      assigneeUserId: 'deliverer-1',
+      occurrenceId: 'event-deliverer',
+    });
+
+    await vi.waitFor(() => expect(queueNotification).toHaveBeenCalledTimes(1));
+    expect(queueNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'deliverer-1',
+        type: NOTIFICATION_TYPES.POOL_DELIVERER_ASSIGNED,
+      }),
+    );
+  });
+
+  it('drops stale, self, recipient, and non-contributor assignments', async () => {
+    const events = [
+      {
+        assigneeUserId: 'former-purchaser',
+        actorUserId: 'actor-1',
+        currentAssigneeUserId: 'purchaser-1',
+      },
+      {
+        assigneeUserId: 'purchaser-1',
+        actorUserId: 'purchaser-1',
+        currentAssigneeUserId: 'purchaser-1',
+      },
+      {
+        assigneeUserId: 'recipient-1',
+        actorUserId: 'actor-1',
+        currentAssigneeUserId: 'recipient-1',
+      },
+      {
+        assigneeUserId: 'outsider-1',
+        actorUserId: 'actor-1',
+        currentAssigneeUserId: 'outsider-1',
+      },
+    ];
+
+    for (const [index, event] of events.entries()) {
+      poolFindUnique.mockResolvedValueOnce({
+        ...pool,
+        purchaserId: event.currentAssigneeUserId,
+      });
+      queuePoolActivityNotifications({
+        type: NOTIFICATION_TYPES.POOL_PURCHASER_ASSIGNED,
+        poolId: pool.id,
+        occurrenceId: `event-${index + 3}`,
+        actorUserId: event.actorUserId,
+        assigneeUserId: event.assigneeUserId,
+      });
+    }
+
+    await vi.waitFor(() => expect(poolFindUnique).toHaveBeenCalledTimes(4));
+    expect(queueNotification).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the pool disappeared before fanout', async () => {
+    poolFindUnique.mockResolvedValue(null);
+
+    queuePoolActivityNotifications({
+      type: NOTIFICATION_TYPES.POOL_CANCELLED,
+      poolId: pool.id,
+      actorUserId: 'actor-1',
+      occurrenceId: 'event-7',
+    });
+
+    await vi.waitFor(() => expect(poolFindUnique).toHaveBeenCalledTimes(1));
+    expect(queueNotification).not.toHaveBeenCalled();
+    expect(captureException).not.toHaveBeenCalled();
+  });
+
+  it('reports an inconsistent chosen-gift snapshot instead of sending partial copy', async () => {
+    poolFindUnique.mockResolvedValue({ ...pool, chosenIdea: null });
+
+    queuePoolActivityNotifications({
+      type: NOTIFICATION_TYPES.POOL_GIFT_CHOSEN,
+      poolId: pool.id,
+      actorUserId: 'actor-1',
+      occurrenceId: 'event-missing-idea',
+    });
+
+    await vi.waitFor(() => expect(captureException).toHaveBeenCalledTimes(1));
+    expect(queueNotification).not.toHaveBeenCalled();
+  });
+
+  it('reports background setup failures without rejecting the mutation path', async () => {
+    const error = new Error('database unavailable');
+    poolFindUnique.mockRejectedValue(error);
+
+    expect(() =>
+      queuePoolActivityNotifications({
+        type: NOTIFICATION_TYPES.POOL_VOTE_STARTED,
+        poolId: pool.id,
+        actorUserId: 'actor-1',
+        occurrenceId: 'event-8',
+      }),
+    ).not.toThrow();
+
+    await vi.waitFor(() =>
+      expect(captureException).toHaveBeenCalledWith(error),
+    );
+  });
+});

--- a/app/utils/pool-notifications.server.ts
+++ b/app/utils/pool-notifications.server.ts
@@ -1,0 +1,164 @@
+import * as Sentry from '@sentry/react-router';
+import { prisma } from '#app/utils/db.server.ts';
+import {
+  NOTIFICATION_TYPES,
+  type PoolActivityNotificationType,
+} from '#app/utils/notification-catalog.ts';
+import { queueNotification } from '#app/utils/notification-dispatcher.server.ts';
+
+type BroadcastPoolActivityEvent = {
+  type:
+    | typeof NOTIFICATION_TYPES.POOL_VOTE_STARTED
+    | typeof NOTIFICATION_TYPES.POOL_GIFT_CHOSEN
+    | typeof NOTIFICATION_TYPES.POOL_CANCELLED;
+  poolId: string;
+  actorUserId: string;
+  occurrenceId: string;
+};
+
+type AssignmentPoolActivityEvent = {
+  type:
+    | typeof NOTIFICATION_TYPES.POOL_PURCHASER_ASSIGNED
+    | typeof NOTIFICATION_TYPES.POOL_DELIVERER_ASSIGNED;
+  poolId: string;
+  actorUserId: string;
+  assigneeUserId: string;
+  occurrenceId: string;
+};
+
+export type PoolActivityNotificationEvent =
+  | BroadcastPoolActivityEvent
+  | AssignmentPoolActivityEvent;
+
+type PoolAudienceSnapshot = {
+  id: string;
+  title: string;
+  recipientUserId: string | null;
+  purchaserId: string | null;
+  delivererId: string | null;
+  chosenIdea: { name: string } | null;
+  contributors: Array<{ userId: string }>;
+};
+
+/**
+ * Deep pool fanout module. Callers provide only the committed domain event;
+ * audience lookup, privacy exclusions, stale-assignment checks, payloads, and
+ * preference-aware delivery remain local to this implementation.
+ */
+export function queuePoolActivityNotifications(
+  event: PoolActivityNotificationEvent,
+): void {
+  void fanoutPoolActivityNotifications(event).catch((error: unknown) => {
+    Sentry.captureException(error);
+  });
+}
+
+async function fanoutPoolActivityNotifications(
+  event: PoolActivityNotificationEvent,
+) {
+  const pool = await prisma.pool.findUnique({
+    where: { id: event.poolId },
+    select: {
+      id: true,
+      title: true,
+      recipientUserId: true,
+      purchaserId: true,
+      delivererId: true,
+      chosenIdea: { select: { name: true } },
+      contributors: { select: { userId: true } },
+    },
+  });
+  if (!pool) return;
+
+  const recipientIds = getEligibleRecipientIds(event, pool);
+  const sourceIdentifier = occurrenceKey(event.type, event.occurrenceId);
+  for (const userId of recipientIds) {
+    queuePoolNotification({ event, pool, userId, sourceIdentifier });
+  }
+}
+
+function getEligibleRecipientIds(
+  event: PoolActivityNotificationEvent,
+  pool: PoolAudienceSnapshot,
+) {
+  const contributors = new Set(
+    pool.contributors.map((contributor) => contributor.userId),
+  );
+  let candidates = [...contributors];
+  if (isAssignmentEvent(event)) {
+    candidates = assignmentIsCurrent(event, pool) ? [event.assigneeUserId] : [];
+  }
+
+  return candidates.filter(
+    (userId) =>
+      contributors.has(userId) &&
+      userId !== event.actorUserId &&
+      userId !== pool.recipientUserId,
+  );
+}
+
+function assignmentIsCurrent(
+  event: AssignmentPoolActivityEvent,
+  pool: PoolAudienceSnapshot,
+) {
+  return event.type === NOTIFICATION_TYPES.POOL_PURCHASER_ASSIGNED
+    ? pool.purchaserId === event.assigneeUserId
+    : pool.delivererId === event.assigneeUserId;
+}
+
+function isAssignmentEvent(
+  event: PoolActivityNotificationEvent,
+): event is AssignmentPoolActivityEvent {
+  return (
+    event.type === NOTIFICATION_TYPES.POOL_PURCHASER_ASSIGNED ||
+    event.type === NOTIFICATION_TYPES.POOL_DELIVERER_ASSIGNED
+  );
+}
+
+function queuePoolNotification({
+  event,
+  pool,
+  userId,
+  sourceIdentifier,
+}: {
+  event: PoolActivityNotificationEvent;
+  pool: PoolAudienceSnapshot;
+  userId: string;
+  sourceIdentifier: string;
+}) {
+  const base = {
+    userId,
+    context: { kind: 'POOL' as const, poolId: pool.id },
+    sourceIdentifier,
+  };
+  const payload = {
+    poolId: pool.id,
+    poolTitle: pool.title,
+    actorUserId: event.actorUserId,
+  };
+
+  switch (event.type) {
+    case NOTIFICATION_TYPES.POOL_VOTE_STARTED:
+    case NOTIFICATION_TYPES.POOL_CANCELLED:
+    case NOTIFICATION_TYPES.POOL_PURCHASER_ASSIGNED:
+    case NOTIFICATION_TYPES.POOL_DELIVERER_ASSIGNED:
+      queueNotification({ ...base, type: event.type, payload });
+      return;
+    case NOTIFICATION_TYPES.POOL_GIFT_CHOSEN:
+      if (!pool.chosenIdea) {
+        throw new Error(`Pool ${pool.id} has no chosen idea after decision.`);
+      }
+      queueNotification({
+        ...base,
+        type: event.type,
+        payload: { ...payload, chosenIdeaName: pool.chosenIdea.name },
+      });
+  }
+}
+
+function occurrenceKey(
+  type: PoolActivityNotificationType,
+  occurrenceId: string,
+) {
+  return `pool-activity:${type}:${occurrenceId}`;
+}

--- a/app/utils/pool.server.test.ts
+++ b/app/utils/pool.server.test.ts
@@ -2,6 +2,7 @@
  * @vitest-environment node
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NOTIFICATION_TYPES } from '#app/utils/notification-catalog.ts';
 
 const nanoid = vi.fn(() => 'invite-123');
 
@@ -20,6 +21,8 @@ const poolCreate = vi.fn();
 const poolDelete = vi.fn();
 const poolFindUnique = vi.fn();
 const poolUpdate = vi.fn();
+const queueLogEvent = vi.fn();
+const queuePoolActivityNotifications = vi.fn();
 
 vi.mock('nanoid', () => ({
   nanoid: () => nanoid(),
@@ -57,6 +60,15 @@ vi.mock('#app/utils/db.server.ts', () => ({
 
 vi.mock('#app/utils/pool-activity.server.ts', () => ({
   logPoolActivity: (...args: Array<unknown>) => logPoolActivity(...args),
+}));
+
+vi.mock('#app/utils/analytics.server.ts', () => ({
+  queueLogEvent: (...args: Array<unknown>) => queueLogEvent(...args),
+}));
+
+vi.mock('#app/utils/pool-notifications.server.ts', () => ({
+  queuePoolActivityNotifications: (...args: Array<unknown>) =>
+    queuePoolActivityNotifications(...args),
 }));
 
 import {
@@ -106,6 +118,8 @@ beforeEach(() => {
   poolDelete.mockReset().mockResolvedValue(undefined);
   poolFindUnique.mockReset();
   poolUpdate.mockReset().mockResolvedValue(undefined);
+  queueLogEvent.mockReset().mockReturnValue({ eventId: 'event-123' });
+  queuePoolActivityNotifications.mockReset();
 });
 
 describe('pool server utilities', () => {
@@ -420,6 +434,12 @@ describe('pool server utilities', () => {
     expect(logPoolActivity).toHaveBeenCalledWith('pool-1', 'vote.called', {
       actorId: 'user-1',
     });
+    expect(queuePoolActivityNotifications).toHaveBeenCalledWith({
+      type: NOTIFICATION_TYPES.POOL_VOTE_STARTED,
+      poolId: 'pool-1',
+      actorUserId: 'user-1',
+      occurrenceId: 'event-123',
+    });
   });
 
   it('castVote rejects ideas from another pool before writing', async () => {
@@ -504,6 +524,12 @@ describe('pool server utilities', () => {
       actorId: 'user-1',
       payload: { finalPriceCents: 8000, ideaId: 'idea-1', name: 'Speaker' },
     });
+    expect(queuePoolActivityNotifications).toHaveBeenCalledWith({
+      type: NOTIFICATION_TYPES.POOL_GIFT_CHOSEN,
+      poolId: 'pool-1',
+      actorUserId: 'user-1',
+      occurrenceId: 'event-123',
+    });
   });
 
   it('updates final price and logs the new amount', async () => {
@@ -520,6 +546,9 @@ describe('pool server utilities', () => {
   });
 
   it('assigns purchaser and deliverer roles with activity logs', async () => {
+    queueLogEvent
+      .mockReturnValueOnce({ eventId: 'purchaser-event' })
+      .mockReturnValueOnce({ eventId: 'deliverer-event' });
     await assignPurchaser('pool-1', 'user-2', 'manager-1');
     await assignDeliverer('pool-1', 'user-3', 'manager-1');
 
@@ -538,6 +567,20 @@ describe('pool server utilities', () => {
     expect(logPoolActivity).toHaveBeenNthCalledWith(2, 'pool-1', 'deliverer.assigned', {
       actorId: 'manager-1',
       payload: { userId: 'user-3' },
+    });
+    expect(queuePoolActivityNotifications).toHaveBeenNthCalledWith(1, {
+      type: NOTIFICATION_TYPES.POOL_PURCHASER_ASSIGNED,
+      poolId: 'pool-1',
+      actorUserId: 'manager-1',
+      assigneeUserId: 'user-2',
+      occurrenceId: 'purchaser-event',
+    });
+    expect(queuePoolActivityNotifications).toHaveBeenNthCalledWith(2, {
+      type: NOTIFICATION_TYPES.POOL_DELIVERER_ASSIGNED,
+      poolId: 'pool-1',
+      actorUserId: 'manager-1',
+      assigneeUserId: 'user-3',
+      occurrenceId: 'deliverer-event',
     });
   });
 
@@ -579,6 +622,12 @@ describe('pool server utilities', () => {
     });
     expect(logPoolActivity).toHaveBeenNthCalledWith(4, 'pool-1', 'pool.deleted', {
       actorId: 'user-1',
+    });
+    expect(queuePoolActivityNotifications).toHaveBeenCalledWith({
+      type: NOTIFICATION_TYPES.POOL_CANCELLED,
+      poolId: 'pool-1',
+      actorUserId: 'user-1',
+      occurrenceId: 'event-123',
     });
   });
 

--- a/app/utils/pool.server.test.ts
+++ b/app/utils/pool.server.test.ts
@@ -21,6 +21,7 @@ const poolCreate = vi.fn();
 const poolDelete = vi.fn();
 const poolFindUnique = vi.fn();
 const poolUpdate = vi.fn();
+const poolUpdateMany = vi.fn();
 const queueLogEvent = vi.fn();
 const queuePoolActivityNotifications = vi.fn();
 
@@ -48,6 +49,7 @@ vi.mock('#app/utils/db.server.ts', () => ({
       delete: (...args: Array<unknown>) => poolDelete(...args),
       findUnique: (...args: Array<unknown>) => poolFindUnique(...args),
       update: (...args: Array<unknown>) => poolUpdate(...args),
+      updateMany: (...args: Array<unknown>) => poolUpdateMany(...args),
     },
     poolContributor: {
       create: (...args: Array<unknown>) => poolContributorCreate(...args),
@@ -118,6 +120,7 @@ beforeEach(() => {
   poolDelete.mockReset().mockResolvedValue(undefined);
   poolFindUnique.mockReset();
   poolUpdate.mockReset().mockResolvedValue(undefined);
+  poolUpdateMany.mockReset().mockResolvedValue({ count: 1 });
   queueLogEvent.mockReset().mockReturnValue({ eventId: 'event-123' });
   queuePoolActivityNotifications.mockReset();
 });
@@ -415,21 +418,22 @@ describe('pool server utilities', () => {
   });
 
   it('callVote rejects pools that are not open', async () => {
-    poolFindUnique.mockResolvedValue({ status: 'DECIDED' });
+    poolUpdateMany.mockResolvedValue({ count: 0 });
 
     await expect(callVote('pool-1', 'user-1')).rejects.toMatchObject({
       init: { status: 400 },
     });
+    expect(logPoolActivity).not.toHaveBeenCalled();
+    expect(queueLogEvent).not.toHaveBeenCalled();
+    expect(queuePoolActivityNotifications).not.toHaveBeenCalled();
   });
 
   it('callVote transitions open pools to voting', async () => {
-    poolFindUnique.mockResolvedValue({ status: 'OPEN' });
-
     await callVote('pool-1', 'user-1');
 
-    expect(poolUpdate).toHaveBeenCalledWith({
+    expect(poolUpdateMany).toHaveBeenCalledWith({
       data: { status: 'VOTING' },
-      where: { id: 'pool-1' },
+      where: { id: 'pool-1', status: 'OPEN' },
     });
     expect(logPoolActivity).toHaveBeenCalledWith('pool-1', 'vote.called', {
       actorId: 'user-1',
@@ -501,7 +505,7 @@ describe('pool server utilities', () => {
       init: { status: 404 },
     });
 
-    expect(poolUpdate).not.toHaveBeenCalled();
+    expect(poolUpdateMany).not.toHaveBeenCalled();
   });
 
   it('chooseIdea falls back to the estimated idea price when none is provided', async () => {
@@ -512,13 +516,20 @@ describe('pool server utilities', () => {
 
     await chooseIdea('pool-1', 'idea-1', 'user-1');
 
-    expect(poolUpdate).toHaveBeenCalledWith({
+    expect(poolUpdateMany).toHaveBeenCalledWith({
       data: {
         chosenIdeaId: 'idea-1',
         finalPriceCents: 8000,
         status: 'DECIDED',
       },
-      where: { id: 'pool-1' },
+      where: {
+        id: 'pool-1',
+        OR: [
+          { status: { not: 'DECIDED' } },
+          { chosenIdeaId: null },
+          { chosenIdeaId: { not: 'idea-1' } },
+        ],
+      },
     });
     expect(logPoolActivity).toHaveBeenCalledWith('pool-1', 'idea.chosen', {
       actorId: 'user-1',
@@ -530,6 +541,20 @@ describe('pool server utilities', () => {
       actorUserId: 'user-1',
       occurrenceId: 'event-123',
     });
+  });
+
+  it('does not repeat decision side effects when the gift is already chosen', async () => {
+    giftIdeaFindFirst.mockResolvedValue({
+      estimatedPriceCents: 8000,
+      name: 'Speaker',
+    });
+    poolUpdateMany.mockResolvedValue({ count: 0 });
+
+    await chooseIdea('pool-1', 'idea-1', 'user-1');
+
+    expect(logPoolActivity).not.toHaveBeenCalled();
+    expect(queueLogEvent).not.toHaveBeenCalled();
+    expect(queuePoolActivityNotifications).not.toHaveBeenCalled();
   });
 
   it('updates final price and logs the new amount', async () => {
@@ -552,13 +577,19 @@ describe('pool server utilities', () => {
     await assignPurchaser('pool-1', 'user-2', 'manager-1');
     await assignDeliverer('pool-1', 'user-3', 'manager-1');
 
-    expect(poolUpdate).toHaveBeenNthCalledWith(1, {
+    expect(poolUpdateMany).toHaveBeenNthCalledWith(1, {
       data: { purchaserId: 'user-2' },
-      where: { id: 'pool-1' },
+      where: {
+        id: 'pool-1',
+        OR: [{ purchaserId: null }, { purchaserId: { not: 'user-2' } }],
+      },
     });
-    expect(poolUpdate).toHaveBeenNthCalledWith(2, {
+    expect(poolUpdateMany).toHaveBeenNthCalledWith(2, {
       data: { delivererId: 'user-3' },
-      where: { id: 'pool-1' },
+      where: {
+        id: 'pool-1',
+        OR: [{ delivererId: null }, { delivererId: { not: 'user-3' } }],
+      },
     });
     expect(logPoolActivity).toHaveBeenNthCalledWith(1, 'pool-1', 'purchaser.assigned', {
       actorId: 'manager-1',
@@ -584,6 +615,19 @@ describe('pool server utilities', () => {
     });
   });
 
+  it('does not repeat assignment or cancellation side effects for unchanged state', async () => {
+    poolUpdateMany.mockResolvedValue({ count: 0 });
+
+    await assignPurchaser('pool-1', 'user-2', 'manager-1');
+    await assignDeliverer('pool-1', 'user-3', 'manager-1');
+    await cancelPool('pool-1', 'manager-1');
+
+    expect(poolUpdateMany).toHaveBeenCalledTimes(3);
+    expect(logPoolActivity).not.toHaveBeenCalled();
+    expect(queueLogEvent).not.toHaveBeenCalled();
+    expect(queuePoolActivityNotifications).not.toHaveBeenCalled();
+  });
+
   it('marks purchased, delivered, cancelled, and deleted pools', async () => {
     // deletePool now guards on an empty "mistake" pool — seed the empty state so
     // the guard passes and the hard delete proceeds.
@@ -606,9 +650,9 @@ describe('pool server utilities', () => {
       data: { status: 'DELIVERED' },
       where: { id: 'pool-1' },
     });
-    expect(poolUpdate).toHaveBeenNthCalledWith(3, {
+    expect(poolUpdateMany).toHaveBeenCalledWith({
       data: { status: 'CANCELLED' },
-      where: { id: 'pool-1' },
+      where: { id: 'pool-1', status: { not: 'CANCELLED' } },
     });
     expect(poolDelete).toHaveBeenCalledWith({ where: { id: 'pool-1' } });
     expect(logPoolActivity).toHaveBeenNthCalledWith(1, 'pool-1', 'pool.purchased', {
@@ -689,9 +733,9 @@ describe('pool server utilities', () => {
     // pools, so a cancelled pool's ideas are preserved, not shown).
     await cancelPool('pool-1', 'user-1');
 
-    expect(poolUpdate).toHaveBeenCalledWith({
+    expect(poolUpdateMany).toHaveBeenCalledWith({
       data: { status: 'CANCELLED' },
-      where: { id: 'pool-1' },
+      where: { id: 'pool-1', status: { not: 'CANCELLED' } },
     });
     expect(poolDelete).not.toHaveBeenCalled();
     expect(giftIdeaDelete).not.toHaveBeenCalled();

--- a/app/utils/pool.server.ts
+++ b/app/utils/pool.server.ts
@@ -3,6 +3,7 @@ import { data } from 'react-router'
 import { nanoid } from 'nanoid'
 import { queueLogEvent } from '#app/utils/analytics.server.ts'
 import { prisma } from '#app/utils/db.server.ts'
+import { NOTIFICATION_TYPES } from '#app/utils/notification-catalog.ts'
 import { logPoolActivity } from '#app/utils/pool-activity.server.ts'
 import {
 	POOL_ACTIVITY_TYPE,
@@ -10,6 +11,7 @@ import {
 	DECISION_MODE,
 } from '#app/utils/pool-constants.ts'
 import { calculateContributions } from '#app/utils/pool-contributions.ts'
+import { queuePoolActivityNotifications } from '#app/utils/pool-notifications.server.ts'
 import type { DecisionMode, OccasionType } from '#app/utils/pool-constants.ts'
 
 // ─── Selects ──────────────────────────────────────────────────────────────────
@@ -414,11 +416,17 @@ export async function callVote(poolId: string, actorId: string) {
 
 	await logPoolActivity(poolId, POOL_ACTIVITY_TYPE.VOTE_CALLED, { actorId })
 
-	queueLogEvent({
+	const { eventId } = queueLogEvent({
 		name: 'pool_vote_called',
 		userId: actorId,
 		source: 'server',
 		properties: { poolId },
+	})
+	queuePoolActivityNotifications({
+		type: NOTIFICATION_TYPES.POOL_VOTE_STARTED,
+		poolId,
+		actorUserId: actorId,
+		occurrenceId: eventId,
 	})
 }
 
@@ -514,11 +522,17 @@ export async function chooseIdea(
 		payload: { ideaId, name: idea.name, finalPriceCents: resolvedPrice },
 	})
 
-	queueLogEvent({
+	const { eventId } = queueLogEvent({
 		name: 'pool_decided',
 		userId: actorId,
 		source: 'server',
 		properties: { poolId, ideaId, finalPriceCents: resolvedPrice },
+	})
+	queuePoolActivityNotifications({
+		type: NOTIFICATION_TYPES.POOL_GIFT_CHOSEN,
+		poolId,
+		actorUserId: actorId,
+		occurrenceId: eventId,
 	})
 }
 
@@ -555,6 +569,20 @@ export async function assignPurchaser(
 		actorId,
 		payload: { userId },
 	})
+
+	const { eventId } = queueLogEvent({
+		name: 'pool_purchaser_assigned',
+		userId: actorId,
+		source: 'server',
+		properties: { poolId, assigneeUserId: userId },
+	})
+	queuePoolActivityNotifications({
+		type: NOTIFICATION_TYPES.POOL_PURCHASER_ASSIGNED,
+		poolId,
+		actorUserId: actorId,
+		assigneeUserId: userId,
+		occurrenceId: eventId,
+	})
 }
 
 export async function assignDeliverer(
@@ -570,6 +598,20 @@ export async function assignDeliverer(
 	await logPoolActivity(poolId, POOL_ACTIVITY_TYPE.DELIVERER_ASSIGNED, {
 		actorId,
 		payload: { userId },
+	})
+
+	const { eventId } = queueLogEvent({
+		name: 'pool_deliverer_assigned',
+		userId: actorId,
+		source: 'server',
+		properties: { poolId, assigneeUserId: userId },
+	})
+	queuePoolActivityNotifications({
+		type: NOTIFICATION_TYPES.POOL_DELIVERER_ASSIGNED,
+		poolId,
+		actorUserId: actorId,
+		assigneeUserId: userId,
+		occurrenceId: eventId,
 	})
 }
 
@@ -615,11 +657,17 @@ export async function cancelPool(poolId: string, actorId: string) {
 
 	await logPoolActivity(poolId, POOL_ACTIVITY_TYPE.POOL_CANCELLED, { actorId })
 
-	queueLogEvent({
+	const { eventId } = queueLogEvent({
 		name: 'pool_cancelled',
 		userId: actorId,
 		source: 'server',
 		properties: { poolId },
+	})
+	queuePoolActivityNotifications({
+		type: NOTIFICATION_TYPES.POOL_CANCELLED,
+		poolId,
+		actorUserId: actorId,
+		occurrenceId: eventId,
 	})
 }
 

--- a/app/utils/pool.server.ts
+++ b/app/utils/pool.server.ts
@@ -397,22 +397,17 @@ export async function deleteIdea(
 
 // Transition pool to VOTING status. Only valid from OPEN.
 export async function callVote(poolId: string, actorId: string) {
-	const pool = await prisma.pool.findUnique({
-		where: { id: poolId },
-		select: { status: true },
+	const transition = await prisma.pool.updateMany({
+		where: { id: poolId, status: POOL_STATUS.OPEN },
+		data: { status: POOL_STATUS.VOTING },
 	})
 
-	if (pool?.status !== POOL_STATUS.OPEN) {
+	if (transition.count !== 1) {
 		throw data(
 			{ error: 'A vote can only be called when the pool is open.' },
 			{ status: 400 },
 		)
 	}
-
-	await prisma.pool.update({
-		where: { id: poolId },
-		data: { status: POOL_STATUS.VOTING },
-	})
 
 	await logPoolActivity(poolId, POOL_ACTIVITY_TYPE.VOTE_CALLED, { actorId })
 
@@ -508,14 +503,22 @@ export async function chooseIdea(
 
 	const resolvedPrice = finalPriceCents ?? idea.estimatedPriceCents ?? null
 
-	await prisma.pool.update({
-		where: { id: poolId },
+	const decision = await prisma.pool.updateMany({
+		where: {
+			id: poolId,
+			OR: [
+				{ status: { not: POOL_STATUS.DECIDED } },
+				{ chosenIdeaId: null },
+				{ chosenIdeaId: { not: ideaId } },
+			],
+		},
 		data: {
 			status: POOL_STATUS.DECIDED,
 			chosenIdeaId: ideaId,
 			finalPriceCents: resolvedPrice,
 		},
 	})
+	if (decision.count === 0) return
 
 	await logPoolActivity(poolId, POOL_ACTIVITY_TYPE.IDEA_CHOSEN, {
 		actorId,
@@ -560,10 +563,14 @@ export async function assignPurchaser(
 	userId: string,
 	actorId: string,
 ) {
-	await prisma.pool.update({
-		where: { id: poolId },
+	const assignment = await prisma.pool.updateMany({
+		where: {
+			id: poolId,
+			OR: [{ purchaserId: null }, { purchaserId: { not: userId } }],
+		},
 		data: { purchaserId: userId },
 	})
+	if (assignment.count === 0) return
 
 	await logPoolActivity(poolId, POOL_ACTIVITY_TYPE.PURCHASER_ASSIGNED, {
 		actorId,
@@ -590,10 +597,14 @@ export async function assignDeliverer(
 	userId: string,
 	actorId: string,
 ) {
-	await prisma.pool.update({
-		where: { id: poolId },
+	const assignment = await prisma.pool.updateMany({
+		where: {
+			id: poolId,
+			OR: [{ delivererId: null }, { delivererId: { not: userId } }],
+		},
 		data: { delivererId: userId },
 	})
+	if (assignment.count === 0) return
 
 	await logPoolActivity(poolId, POOL_ACTIVITY_TYPE.DELIVERER_ASSIGNED, {
 		actorId,
@@ -650,10 +661,11 @@ export async function markDelivered(poolId: string, actorId: string) {
 }
 
 export async function cancelPool(poolId: string, actorId: string) {
-	await prisma.pool.update({
-		where: { id: poolId },
+	const cancellation = await prisma.pool.updateMany({
+		where: { id: poolId, status: { not: POOL_STATUS.CANCELLED } },
 		data: { status: POOL_STATUS.CANCELLED },
 	})
+	if (cancellation.count === 0) return
 
 	await logPoolActivity(poolId, POOL_ACTIVITY_TYPE.POOL_CANCELLED, { actorId })
 


### PR DESCRIPTION
## Summary
- register five important pool lifecycle and assignment notifications under reusable preference topics
- fan out committed pool events through the shared scoped-preference dispatcher while excluding actors and concealed recipients
- keep email and push off by default, use per-channel delivery ledgers, and record newly delivered pool activity

## Test plan
- [x] npm run typecheck
- [x] npm run lint (0 errors; pre-existing warnings remain)
- [x] npm test -- --run (201 files, 1,256 tests)
- [x] npm run test:e2e:run (106 passed, 6 skipped)
- [x] npm run build
- [x] focused fanout, pool mutation, catalog, and dispatcher tests (69 passed)

## Checklist
- [x] actor and concealed recipient are excluded from broadcast audiences
- [x] stale, self, recipient, and non-contributor assignments do not deliver
- [x] fanout remains off the action response and reports setup failures to Sentry
- [x] scoped pool/group preferences and per-channel dedupe are reused
- [x] no migration or environment change
- [x] no new UI pattern; existing catalog-driven settings, bell, and email surfaces are reused

## Product scope
This completes milestone 7 of the local notification-coordination plan. Routine activity and organizer nudges remain out of scope for this PR.