### PR TITLE
fix(notifications): contain preference switch thumb

### DIFF
--- a/app/components/notifications/preference-switch.tsx
+++ b/app/components/notifications/preference-switch.tsx
@@ -32,8 +32,8 @@ export function PreferenceSwitch({
       >
         <span
           className={cn(
-            'absolute top-0.5 h-[18px] w-[18px] rounded-full bg-background shadow-sm transition-transform',
-            checked ? 'translate-x-[18px]' : 'translate-x-0.5',
+            'absolute left-0.5 top-0.5 h-[18px] w-[18px] rounded-full bg-background shadow-sm transition-transform',
+            checked ? 'translate-x-4' : 'translate-x-0',
           )}
         />
       </span>

--- a/tests/e2e/settings-notifications.test.ts
+++ b/tests/e2e/settings-notifications.test.ts
@@ -1,4 +1,4 @@
-import { type Page } from '@playwright/test';
+import { type Locator, type Page } from '@playwright/test';
 import { prisma } from '#app/utils/db.server.ts';
 import {
   NOTIFICATION_CHANNELS,
@@ -19,6 +19,59 @@ const dismissInstallPrompt = async (page: Page) => {
 };
 
 const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const getSwitchGeometry = async (toggle: Locator) => {
+  return toggle.evaluate((element) => {
+    const track = element.querySelector(':scope > span');
+    const thumb = track?.querySelector(':scope > span');
+
+    if (!(track instanceof HTMLElement) || !(thumb instanceof HTMLElement)) {
+      throw new Error('Expected switch track and thumb elements');
+    }
+
+    const trackRect = track.getBoundingClientRect();
+    const thumbRect = thumb.getBoundingClientRect();
+
+    return {
+      leftGap: thumbRect.left - trackRect.left,
+      rightGap: trackRect.right - thumbRect.right,
+    };
+  });
+};
+
+test('notification switch thumb stays contained and reflects both states', async ({
+  page,
+  login,
+}) => {
+  await login();
+  await page.goto('/settings/profile/notifications');
+  await dismissInstallPrompt(page);
+
+  const emailChannel = page.getByRole('switch', {
+    name: 'Email notifications',
+  });
+  await expect(emailChannel).toBeChecked();
+
+  const checkedGeometry = await getSwitchGeometry(emailChannel);
+  expect(checkedGeometry.leftGap).toBeGreaterThan(0);
+  expect(checkedGeometry.rightGap).toBeGreaterThan(0);
+  expect(checkedGeometry.leftGap).toBeGreaterThan(checkedGeometry.rightGap);
+
+  await emailChannel.click();
+  await expect(emailChannel).not.toBeChecked();
+
+  await expect
+    .poll(async () => {
+      const geometry = await getSwitchGeometry(emailChannel);
+      return geometry.leftGap < geometry.rightGap;
+    })
+    .toBe(true);
+
+  const uncheckedGeometry = await getSwitchGeometry(emailChannel);
+  expect(uncheckedGeometry.leftGap).toBeGreaterThan(0);
+  expect(uncheckedGeometry.rightGap).toBeGreaterThan(0);
+  expect(uncheckedGeometry.leftGap).toBeLessThan(uncheckedGeometry.rightGap);
+});
 
 test('users can optimistically toggle notification channels while request is pending', async ({
   page,


### PR DESCRIPTION
## Summary

- anchor the notification preference switch thumb explicitly
- use symmetric off/on translation distances so the thumb remains inside its track
- add a browser geometry regression covering containment and state direction

## Test plan

- [x] `npm run typecheck`
- [x] focused ESLint with zero warnings
- [x] Prettier and `git diff --check`
- [x] `npm run test:e2e:run -- settings-notifications.test.ts --project chromium --reporter=line` (4 passed)
- [x] visual QA at 1440px with checked and unchecked states

## Checklist

- [x] Dedicated branch and focused conventional commit
- [x] No schema, migration, or environment changes
- [x] Regression test added for the reported UI defect

## Visual verification

A 1440px screenshot showing corrected checked and unchecked states was captured and is included in the accompanying Codex task handoff.