### PR TITLE
feat(notifications): add organizer reminders

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -258,6 +258,18 @@ never create rows, including signup and the settings loader.
 - Category bulk writes are transactional and clear more-specific topic rows for that channel so the selected category value actually applies to every child topic.
 - Admin notification reporting resolves effective choices for the full user denominator; it must not count sparse rows as if they were the user population.
 
+### Organizer nudges
+
+Preset, task-bound Pool Manager reminders live behind the deep module in `app/utils/organizer-nudges.server.ts`. Routes and UI call only `previewOrganizerNudge` or `sendOrganizerNudge`; audience selection, manager authorization, current-task validation, preference suppression, limits, idempotency, audit persistence, and fanout stay inside the module.
+
+- Domain kinds are contribution, vote, purchase, and delivery. Customer-facing copy says “reminder,” never message/broadcast/nudge.
+- `OrganizerNudge` is the durable send-action audit. `OrganizerNudgeRecipient` is private operational state for the recipient/pool cooldown and must never be returned to senders.
+- An audit row is created only after at least one recipient remains eligible. Zero-recipient attempts consume no limit.
+- Limits are pool-wide across managers: one pool+kind action per 24 hours, at most three pool actions in a rolling seven days, and one recipient+pool nudge per 24 hours.
+- The sender, concealed pool recipient, former contributors, completed actors, muted contexts, and opted-out recipients are excluded. Permission, membership, task state, and limits are rechecked in the write transaction.
+- Each committed nudge queues typed, per-channel-ledger notifications after the transaction. The action reports “queued”; delivery failures go to Sentry and never turn a committed request into a 500.
+- Resource route: `/api/pools/:poolId/reminders` (`GET ?kind=` previews the aggregate count; `POST` requires `kind` plus an idempotency key).
+
 ### Occasion reminders (the scheduler)
 
 Beat 2 of the retention loop ("surface occasions proactively, before the user would otherwise remember") — see `docs/product/giftpool-vision-spine.md`. Previously the one entirely-unbuilt piece of the four-beat loop; `UPCOMING_BIRTHDAY` was a registered-but-stubbed notification type with no caller.

--- a/app/i18n/dictionaries/en.ts
+++ b/app/i18n/dictionaries/en.ts
@@ -61,6 +61,22 @@ export const en = {
       message: "You're delivering the gift for {{pool}}",
       pushTitle: 'Delivery assignment',
     },
+    poolContributionReminder: {
+      message: '{{sender}} reminded you to set your contribution in {{pool}}',
+      pushTitle: 'Contribution reminder',
+    },
+    poolVoteReminder: {
+      message: '{{sender}} reminded you to vote in {{pool}}',
+      pushTitle: 'Voting reminder',
+    },
+    poolPurchaseReminder: {
+      message: '{{sender}} reminded you to buy the gift for {{pool}}',
+      pushTitle: 'Purchase reminder',
+    },
+    poolDeliveryReminder: {
+      message: '{{sender}} reminded you to deliver the gift for {{pool}}',
+      pushTitle: 'Delivery reminder',
+    },
     markAllReadSuccess: 'All notifications marked as read.',
   },
   friends: {

--- a/app/routes/api.pools.$poolId.reminders.test.ts
+++ b/app/routes/api.pools.$poolId.reminders.test.ts
@@ -1,0 +1,150 @@
+/**
+ * @vitest-environment node
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  getRouteResultData,
+  getRouteResultStatus,
+  toActionArgs,
+  toLoaderArgs,
+} from '#tests/route-module-test-utils.ts';
+
+const requireUserId = vi.fn();
+const previewOrganizerNudge = vi.fn();
+const sendOrganizerNudge = vi.fn();
+
+vi.mock('#app/utils/auth.server.ts', () => ({
+  requireUserId: (...args: Array<unknown>) => requireUserId(...args),
+}));
+
+vi.mock('#app/utils/organizer-nudges.server.ts', () => ({
+  OrganizerNudgeError: class OrganizerNudgeError extends Error {
+    constructor(
+      public readonly code: string,
+      message: string,
+    ) {
+      super(message);
+      this.name = 'OrganizerNudgeError';
+    }
+  },
+  isOrganizerNudgeKind: (value: unknown) =>
+    ['CONTRIBUTION', 'VOTE', 'PURCHASE', 'DELIVERY'].includes(String(value)),
+  previewOrganizerNudge: (...args: Array<unknown>) =>
+    previewOrganizerNudge(...args),
+  sendOrganizerNudge: (...args: Array<unknown>) => sendOrganizerNudge(...args),
+}));
+
+import { OrganizerNudgeError } from '#app/utils/organizer-nudges.server.ts';
+import { action, loader } from './api.pools.$poolId.reminders.ts';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  requireUserId.mockResolvedValue('manager-1');
+  previewOrganizerNudge.mockResolvedValue({
+    status: 'AVAILABLE',
+    kind: 'VOTE',
+    eligibleCount: 3,
+    latestNudge: null,
+  });
+  sendOrganizerNudge.mockResolvedValue({
+    status: 'QUEUED',
+    kind: 'VOTE',
+    nudgeId: 'nudge-1',
+    queuedCount: 3,
+  });
+});
+
+describe('organizer reminder resource route', () => {
+  it('loads an aggregate preview through the nudge module', async () => {
+    const result = await loader(
+      toLoaderArgs({
+        context: {},
+        params: { poolId: 'pool-1' },
+        request: new Request(
+          'https://giftpool.app/api/pools/pool-1/reminders?kind=VOTE',
+        ),
+      }),
+    );
+
+    expect(getRouteResultStatus(result)).toBe(200);
+    expect(await getRouteResultData(result)).toMatchObject({
+      status: 'AVAILABLE',
+      eligibleCount: 3,
+    });
+    expect(previewOrganizerNudge).toHaveBeenCalledWith({
+      poolId: 'pool-1',
+      senderId: 'manager-1',
+      kind: 'VOTE',
+    });
+  });
+
+  it('sends a validated idempotent request through the same module', async () => {
+    const result = await action(
+      toActionArgs({
+        context: {},
+        params: { poolId: 'pool-1' },
+        request: formRequest({
+          kind: 'VOTE',
+          idempotencyKey: 'client-mutation-1',
+        }),
+      }),
+    );
+
+    expect(getRouteResultStatus(result)).toBe(200);
+    expect(sendOrganizerNudge).toHaveBeenCalledWith({
+      poolId: 'pool-1',
+      senderId: 'manager-1',
+      kind: 'VOTE',
+      idempotencyKey: 'client-mutation-1',
+    });
+  });
+
+  it('rejects invalid kinds and idempotency keys before the module', async () => {
+    for (const values of [
+      { kind: 'MESSAGE', idempotencyKey: 'client-mutation-1' },
+      { kind: 'VOTE', idempotencyKey: '' },
+    ]) {
+      const result = await action(
+        toLoaderArgs({
+          context: {},
+          params: { poolId: 'pool-1' },
+          request: formRequest(values),
+        }),
+      );
+      expect(getRouteResultStatus(result)).toBe(400);
+    }
+    expect(sendOrganizerNudge).not.toHaveBeenCalled();
+  });
+
+  it('maps privacy, permission, and stale-task errors without flattening them', async () => {
+    for (const [code, status] of [
+      ['POOL_NOT_FOUND', 404],
+      ['FORBIDDEN', 403],
+      ['TASK_UNAVAILABLE', 409],
+      ['IDEMPOTENCY_CONFLICT', 409],
+    ] as const) {
+      previewOrganizerNudge.mockRejectedValueOnce(
+        new OrganizerNudgeError(code, `error:${code}`),
+      );
+      const result = await loader(
+        toActionArgs({
+          context: {},
+          params: { poolId: 'pool-1' },
+          request: new Request(
+            'https://giftpool.app/api/pools/pool-1/reminders?kind=VOTE',
+          ),
+        }),
+      );
+      expect(getRouteResultStatus(result)).toBe(status);
+      expect(await getRouteResultData(result)).toMatchObject({ code });
+    }
+  });
+});
+
+function formRequest(values: Record<string, string>) {
+  return new Request('https://giftpool.app/api/pools/pool-1/reminders', {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams(values).toString(),
+  });
+}

--- a/app/routes/api.pools.$poolId.reminders.ts
+++ b/app/routes/api.pools.$poolId.reminders.ts
@@ -1,0 +1,75 @@
+import {
+  data,
+  type ActionFunctionArgs,
+  type LoaderFunctionArgs,
+} from 'react-router';
+import { z } from 'zod';
+import { requireUserId } from '#app/utils/auth.server.ts';
+import {
+  OrganizerNudgeError,
+  isOrganizerNudgeKind,
+  previewOrganizerNudge,
+  sendOrganizerNudge,
+} from '#app/utils/organizer-nudges.server.ts';
+
+const SendOrganizerNudgeSchema = z.object({
+  kind: z.string().refine(isOrganizerNudgeKind),
+  idempotencyKey: z.string().trim().min(1).max(200),
+});
+
+export async function loader({ request, params }: LoaderFunctionArgs) {
+  const senderId = await requireUserId(request);
+  const poolId = params.poolId;
+  const kind = new URL(request.url).searchParams.get('kind');
+  if (!poolId || !isOrganizerNudgeKind(kind)) {
+    return data({ error: 'Invalid reminder request.' }, { status: 400 });
+  }
+
+  try {
+    return data(await previewOrganizerNudge({ poolId, senderId, kind }));
+  } catch (error) {
+    return organizerNudgeErrorResponse(error);
+  }
+}
+
+export async function action({ request, params }: ActionFunctionArgs) {
+  const senderId = await requireUserId(request);
+  const poolId = params.poolId;
+  if (!poolId) {
+    return data({ error: 'Invalid reminder request.' }, { status: 400 });
+  }
+
+  const parsed = SendOrganizerNudgeSchema.safeParse(
+    Object.fromEntries(await request.formData()),
+  );
+  if (!parsed.success || !isOrganizerNudgeKind(parsed.data.kind)) {
+    return data({ error: 'Invalid reminder request.' }, { status: 400 });
+  }
+
+  try {
+    return data(
+      await sendOrganizerNudge({
+        poolId,
+        senderId,
+        kind: parsed.data.kind,
+        idempotencyKey: parsed.data.idempotencyKey,
+      }),
+    );
+  } catch (error) {
+    return organizerNudgeErrorResponse(error);
+  }
+}
+
+function organizerNudgeErrorResponse(error: unknown) {
+  if (!(error instanceof OrganizerNudgeError)) throw error;
+  const status =
+    error.code === 'POOL_NOT_FOUND'
+      ? 404
+      : error.code === 'FORBIDDEN'
+        ? 403
+        : error.code === 'TASK_UNAVAILABLE' ||
+            error.code === 'IDEMPOTENCY_CONFLICT'
+          ? 409
+          : 400;
+  return data({ error: error.message, code: error.code }, { status });
+}

--- a/app/routes/api.pools.$poolId.reminders.ts
+++ b/app/routes/api.pools.$poolId.reminders.ts
@@ -62,14 +62,20 @@ export async function action({ request, params }: ActionFunctionArgs) {
 
 function organizerNudgeErrorResponse(error: unknown) {
   if (!(error instanceof OrganizerNudgeError)) throw error;
-  const status =
-    error.code === 'POOL_NOT_FOUND'
-      ? 404
-      : error.code === 'FORBIDDEN'
-        ? 403
-        : error.code === 'TASK_UNAVAILABLE' ||
-            error.code === 'IDEMPOTENCY_CONFLICT'
-          ? 409
-          : 400;
+  const status = organizerNudgeErrorStatus(error.code);
   return data({ error: error.message, code: error.code }, { status });
+}
+
+function organizerNudgeErrorStatus(code: OrganizerNudgeError['code']) {
+  switch (code) {
+    case 'POOL_NOT_FOUND':
+      return 404;
+    case 'FORBIDDEN':
+      return 403;
+    case 'TASK_UNAVAILABLE':
+    case 'IDEMPOTENCY_CONFLICT':
+      return 409;
+    case 'INVALID_IDEMPOTENCY_KEY':
+      return 400;
+  }
 }

--- a/app/utils/analytics.ts
+++ b/app/utils/analytics.ts
@@ -29,6 +29,10 @@ export const ANALYTIC_EVENT_NAMES = [
   // Automatic pool activity fanout. Fires per recipient only when at least one
   // channel newly delivers; properties contain type, pool id, and channels.
   'pool_activity_notification_sent',
+  // Preset task-bound organizer reminders. Fires per recipient only after at
+  // least one channel delivers; repeated requests remain queryable from the
+  // OrganizerNudge audit rows without putting recipient lists in analytics.
+  'organizer_reminder_sent',
   'friend_request_sent',
   'friend_request_accepted',
   'friend_request_rejected',
@@ -193,6 +197,7 @@ export const USER_REQUIRED_EVENTS: Set<AnalyticEventName> = new Set([
   'pool_purchaser_assigned',
   'pool_deliverer_assigned',
   'pool_activity_notification_sent',
+  'organizer_reminder_sent',
   'friend_request_sent',
   'friend_request_accepted',
   'friend_request_rejected',

--- a/app/utils/notification-catalog.test.ts
+++ b/app/utils/notification-catalog.test.ts
@@ -9,6 +9,7 @@ import {
   NOTIFICATION_TOPIC_CATALOG,
   NOTIFICATION_TOPICS,
   NOTIFICATION_TYPES,
+  ORGANIZER_NUDGE_NOTIFICATION_TYPES,
   POOL_ACTIVITY_NOTIFICATION_TYPES,
 } from '#app/utils/notification-catalog.ts';
 
@@ -69,11 +70,30 @@ describe('notification catalog', () => {
     ).toBe(NOTIFICATION_TOPICS.ASSIGNMENTS);
   });
 
+  it('maps every organizer nudge to one in-app-first pool topic', () => {
+    for (const type of ORGANIZER_NUDGE_NOTIFICATION_TYPES) {
+      expect(getNotificationEventDefinition(type)).toMatchObject({
+        topic: NOTIFICATION_TOPICS.ORGANIZER_NUDGES,
+        context: 'POOL',
+        importance: 'IMPORTANT',
+        deliveryStrategy: 'PER_CHANNEL_LEDGER',
+      });
+    }
+    expect(
+      NOTIFICATION_TOPIC_CATALOG[NOTIFICATION_TOPICS.ORGANIZER_NUDGES].defaults,
+    ).toEqual({
+      inAppEnabled: true,
+      emailEnabled: false,
+      pushEnabled: false,
+    });
+  });
+
   it('exposes pool topics for pool and group context controls', () => {
     const poolTopics = [
       NOTIFICATION_TOPICS.IDEAS_AND_VOTING,
       NOTIFICATION_TOPICS.POOL_PROGRESS,
       NOTIFICATION_TOPICS.ASSIGNMENTS,
+      NOTIFICATION_TOPICS.ORGANIZER_NUDGES,
     ];
 
     expect(getNotificationTopicsForContext('POOL')).toEqual(poolTopics);

--- a/app/utils/notification-catalog.ts
+++ b/app/utils/notification-catalog.ts
@@ -7,6 +7,10 @@ export const NOTIFICATION_TYPES = {
   POOL_CANCELLED: 'POOL_CANCELLED',
   POOL_PURCHASER_ASSIGNED: 'POOL_PURCHASER_ASSIGNED',
   POOL_DELIVERER_ASSIGNED: 'POOL_DELIVERER_ASSIGNED',
+  POOL_CONTRIBUTION_REMINDER: 'POOL_CONTRIBUTION_REMINDER',
+  POOL_VOTE_REMINDER: 'POOL_VOTE_REMINDER',
+  POOL_PURCHASE_REMINDER: 'POOL_PURCHASE_REMINDER',
+  POOL_DELIVERY_REMINDER: 'POOL_DELIVERY_REMINDER',
 } as const;
 
 export type NotificationType =
@@ -28,6 +32,24 @@ export function isPoolActivityNotificationType(
 ): type is PoolActivityNotificationType {
   return POOL_ACTIVITY_NOTIFICATION_TYPES.includes(
     type as PoolActivityNotificationType,
+  );
+}
+
+export const ORGANIZER_NUDGE_NOTIFICATION_TYPES = [
+  NOTIFICATION_TYPES.POOL_CONTRIBUTION_REMINDER,
+  NOTIFICATION_TYPES.POOL_VOTE_REMINDER,
+  NOTIFICATION_TYPES.POOL_PURCHASE_REMINDER,
+  NOTIFICATION_TYPES.POOL_DELIVERY_REMINDER,
+] as const;
+
+export type OrganizerNudgeNotificationType =
+  (typeof ORGANIZER_NUDGE_NOTIFICATION_TYPES)[number];
+
+export function isOrganizerNudgeNotificationType(
+  type: NotificationType,
+): type is OrganizerNudgeNotificationType {
+  return ORGANIZER_NUDGE_NOTIFICATION_TYPES.includes(
+    type as OrganizerNudgeNotificationType,
   );
 }
 
@@ -84,6 +106,7 @@ export const NOTIFICATION_TOPICS = {
   IDEAS_AND_VOTING: 'IDEAS_AND_VOTING',
   POOL_PROGRESS: 'POOL_PROGRESS',
   ASSIGNMENTS: 'ASSIGNMENTS',
+  ORGANIZER_NUDGES: 'ORGANIZER_NUDGES',
 } as const;
 
 export type NotificationTopic =
@@ -174,6 +197,16 @@ export const NOTIFICATION_TOPIC_CATALOG = {
       pushEnabled: false,
     },
   },
+  [NOTIFICATION_TOPICS.ORGANIZER_NUDGES]: {
+    category: NOTIFICATION_CATEGORIES.POOL_COORDINATION,
+    label: 'Organizer reminders',
+    description: 'Preset reminders from pool managers about unfinished tasks.',
+    defaults: {
+      inAppEnabled: true,
+      emailEnabled: false,
+      pushEnabled: false,
+    },
+  },
 } as const satisfies Record<NotificationTopic, NotificationTopicDefinition>;
 
 /**
@@ -232,6 +265,34 @@ export const NOTIFICATION_EVENT_CATALOG = {
   },
   [NOTIFICATION_TYPES.POOL_DELIVERER_ASSIGNED]: {
     topic: NOTIFICATION_TOPICS.ASSIGNMENTS,
+    importance: 'IMPORTANT',
+    context: 'POOL',
+    supportedChannels: allChannels,
+    deliveryStrategy: 'PER_CHANNEL_LEDGER',
+  },
+  [NOTIFICATION_TYPES.POOL_CONTRIBUTION_REMINDER]: {
+    topic: NOTIFICATION_TOPICS.ORGANIZER_NUDGES,
+    importance: 'IMPORTANT',
+    context: 'POOL',
+    supportedChannels: allChannels,
+    deliveryStrategy: 'PER_CHANNEL_LEDGER',
+  },
+  [NOTIFICATION_TYPES.POOL_VOTE_REMINDER]: {
+    topic: NOTIFICATION_TOPICS.ORGANIZER_NUDGES,
+    importance: 'IMPORTANT',
+    context: 'POOL',
+    supportedChannels: allChannels,
+    deliveryStrategy: 'PER_CHANNEL_LEDGER',
+  },
+  [NOTIFICATION_TYPES.POOL_PURCHASE_REMINDER]: {
+    topic: NOTIFICATION_TOPICS.ORGANIZER_NUDGES,
+    importance: 'IMPORTANT',
+    context: 'POOL',
+    supportedChannels: allChannels,
+    deliveryStrategy: 'PER_CHANNEL_LEDGER',
+  },
+  [NOTIFICATION_TYPES.POOL_DELIVERY_REMINDER]: {
+    topic: NOTIFICATION_TOPICS.ORGANIZER_NUDGES,
     importance: 'IMPORTANT',
     context: 'POOL',
     supportedChannels: allChannels,
@@ -363,6 +424,14 @@ type PoolActivityPayload = {
   actorUserId: string;
 };
 
+type OrganizerNudgePayload = {
+  nudgeId: string;
+  poolId: string;
+  poolTitle: string;
+  senderUserId: string;
+  senderDisplayName: string;
+};
+
 type PayloadByType = {
   [NOTIFICATION_TYPES.FRIEND_REQUEST_RECEIVED]: FriendRequestPayload;
   [NOTIFICATION_TYPES.FRIEND_REQUEST_ACCEPTED]: FriendRequestPayload;
@@ -383,6 +452,10 @@ type PayloadByType = {
   [NOTIFICATION_TYPES.POOL_CANCELLED]: PoolActivityPayload;
   [NOTIFICATION_TYPES.POOL_PURCHASER_ASSIGNED]: PoolActivityPayload;
   [NOTIFICATION_TYPES.POOL_DELIVERER_ASSIGNED]: PoolActivityPayload;
+  [NOTIFICATION_TYPES.POOL_CONTRIBUTION_REMINDER]: OrganizerNudgePayload;
+  [NOTIFICATION_TYPES.POOL_VOTE_REMINDER]: OrganizerNudgePayload;
+  [NOTIFICATION_TYPES.POOL_PURCHASE_REMINDER]: OrganizerNudgePayload;
+  [NOTIFICATION_TYPES.POOL_DELIVERY_REMINDER]: OrganizerNudgePayload;
 };
 
 export type NotificationPayload<T extends NotificationType> = PayloadByType[T];

--- a/app/utils/notification-dispatcher.server.test.tsx
+++ b/app/utils/notification-dispatcher.server.test.tsx
@@ -331,6 +331,64 @@ describe('notification dispatcher', () => {
     });
   });
 
+  it('delivers an organizer reminder once with email off by default', async () => {
+    const organizer = await createUser({ name: 'Wade Wilson' });
+    const member = await createUser();
+    const pool = await prisma.pool.create({
+      data: {
+        title: 'Taylor birthday',
+        organizerId: organizer.id,
+        contributors: {
+          create: [{ userId: organizer.id }, { userId: member.id }],
+        },
+      },
+      select: { id: true, title: true },
+    });
+    const notify = () =>
+      dispatchNotification({
+        userId: member.id,
+        type: NOTIFICATION_TYPES.POOL_VOTE_REMINDER,
+        context: { kind: 'POOL', poolId: pool.id },
+        sourceIdentifier: 'organizer-nudge:nudge-1',
+        payload: {
+          nudgeId: 'nudge-1',
+          poolId: pool.id,
+          poolTitle: pool.title,
+          senderUserId: organizer.id,
+          senderDisplayName: organizer.name ?? organizer.username,
+        },
+      });
+
+    await notify();
+    await notify();
+
+    const notifications = await prisma.notification.findMany({
+      where: {
+        userId: member.id,
+        type: NOTIFICATION_TYPES.POOL_VOTE_REMINDER,
+      },
+    });
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0]).toMatchObject({
+      messageKey: 'notifications.poolVoteReminder.message',
+      targetUrl: `/pools/${pool.id}`,
+      sourceIdentifier: 'organizer-nudge:nudge-1:IN_APP',
+    });
+    expect(emailMock).not.toHaveBeenCalled();
+    expect(queueLogEvent).toHaveBeenCalledTimes(1);
+    expect(queueLogEvent).toHaveBeenCalledWith({
+      name: 'organizer_reminder_sent',
+      source: 'server',
+      userId: member.id,
+      properties: {
+        notificationType: NOTIFICATION_TYPES.POOL_VOTE_REMINDER,
+        poolId: pool.id,
+        organizerNudgeId: 'nudge-1',
+        channels: [NOTIFICATION_CHANNELS.IN_APP],
+      },
+    });
+  });
+
   it('is idempotent per sourceIdentifier for UPCOMING_BIRTHDAY', async () => {
     const viewer = await createUser();
     const birthdayOwner = await createUser();

--- a/app/utils/notification-events.server.test.tsx
+++ b/app/utils/notification-events.server.test.tsx
@@ -14,6 +14,11 @@ vi.mock('#app/utils/app-url.server.ts', () => ({
 }));
 
 const createPreferenceToken = vi.fn();
+const queueLogEvent = vi.fn();
+
+vi.mock('#app/utils/analytics.server.ts', () => ({
+  queueLogEvent: (...args: Array<unknown>) => queueLogEvent(...args),
+}));
 
 vi.mock('#app/utils/notification-preference-token.server.ts', () => ({
   createPreferenceToken: (...args: Array<unknown>) =>
@@ -24,6 +29,7 @@ vi.mock('#app/utils/notification-preference-token.server.ts', () => ({
 
 import {
   getNotificationOccurrenceKey,
+  recordNotificationDelivery,
   renderNotificationChannel,
 } from './notification-events.server.tsx';
 
@@ -105,6 +111,71 @@ const poolCases = [
     message: "You're delivering the gift for Taylor birthday",
     pushTitle: 'Delivery assignment',
   },
+  {
+    intent: {
+      ...base,
+      type: NOTIFICATION_TYPES.POOL_CONTRIBUTION_REMINDER,
+      payload: {
+        nudgeId: 'nudge-1',
+        poolId: 'pool-1',
+        poolTitle: 'Taylor birthday',
+        senderUserId: 'manager-1',
+        senderDisplayName: 'Wade Wilson',
+      },
+    },
+    messageKey: 'notifications.poolContributionReminder.message',
+    message:
+      'Wade Wilson reminded you to set your contribution in Taylor birthday',
+    pushTitle: 'Contribution reminder',
+  },
+  {
+    intent: {
+      ...base,
+      type: NOTIFICATION_TYPES.POOL_VOTE_REMINDER,
+      payload: {
+        nudgeId: 'nudge-1',
+        poolId: 'pool-1',
+        poolTitle: 'Taylor birthday',
+        senderUserId: 'manager-1',
+        senderDisplayName: 'Wade Wilson',
+      },
+    },
+    messageKey: 'notifications.poolVoteReminder.message',
+    message: 'Wade Wilson reminded you to vote in Taylor birthday',
+    pushTitle: 'Voting reminder',
+  },
+  {
+    intent: {
+      ...base,
+      type: NOTIFICATION_TYPES.POOL_PURCHASE_REMINDER,
+      payload: {
+        nudgeId: 'nudge-1',
+        poolId: 'pool-1',
+        poolTitle: 'Taylor birthday',
+        senderUserId: 'manager-1',
+        senderDisplayName: 'Wade Wilson',
+      },
+    },
+    messageKey: 'notifications.poolPurchaseReminder.message',
+    message: 'Wade Wilson reminded you to buy the gift for Taylor birthday',
+    pushTitle: 'Purchase reminder',
+  },
+  {
+    intent: {
+      ...base,
+      type: NOTIFICATION_TYPES.POOL_DELIVERY_REMINDER,
+      payload: {
+        nudgeId: 'nudge-1',
+        poolId: 'pool-1',
+        poolTitle: 'Taylor birthday',
+        senderUserId: 'manager-1',
+        senderDisplayName: 'Wade Wilson',
+      },
+    },
+    messageKey: 'notifications.poolDeliveryReminder.message',
+    message: 'Wade Wilson reminded you to deliver the gift for Taylor birthday',
+    pushTitle: 'Delivery reminder',
+  },
 ] as const satisfies ReadonlyArray<{
   intent: NotificationIntent;
   messageKey: string;
@@ -115,6 +186,7 @@ const poolCases = [
 describe('pool activity notification rendering', () => {
   beforeEach(() => {
     createPreferenceToken.mockResolvedValue('preference-token');
+    queueLogEvent.mockReset();
   });
 
   it('renders every pool event for the bell and web push', async () => {
@@ -126,7 +198,12 @@ describe('pool activity notification rendering', () => {
       expect(inApp).toMatchObject({
         messageKey,
         targetUrl: '/pools/pool-1',
-        metadata: JSON.stringify({ poolId: 'pool-1' }),
+        metadata: JSON.stringify({
+          poolId: 'pool-1',
+          ...('nudgeId' in intent.payload
+            ? { organizerNudgeId: intent.payload.nudgeId }
+            : {}),
+        }),
       });
 
       const push = await renderNotificationChannel(
@@ -165,5 +242,22 @@ describe('pool activity notification rendering', () => {
     expect(() => getNotificationOccurrenceKey(withoutSource)).toThrow(
       'POOL_VOTE_STARTED requires a sourceIdentifier',
     );
+  });
+
+  it('records actual organizer-reminder delivery without recipient-list analytics', () => {
+    const intent = poolCases[6].intent;
+    recordNotificationDelivery(intent, [NOTIFICATION_CHANNELS.IN_APP]);
+
+    expect(queueLogEvent).toHaveBeenCalledWith({
+      name: 'organizer_reminder_sent',
+      source: 'server',
+      userId: intent.userId,
+      properties: {
+        notificationType: NOTIFICATION_TYPES.POOL_VOTE_REMINDER,
+        poolId: 'pool-1',
+        organizerNudgeId: 'nudge-1',
+        channels: [NOTIFICATION_CHANNELS.IN_APP],
+      },
+    });
   });
 });

--- a/app/utils/notification-events.server.tsx
+++ b/app/utils/notification-events.server.tsx
@@ -11,9 +11,11 @@ import { translate } from '#app/utils/i18n.tsx';
 import {
   NOTIFICATION_CHANNELS,
   NOTIFICATION_TYPES,
+  isOrganizerNudgeNotificationType,
   isPoolActivityNotificationType,
   type NotificationChannel,
   type NotificationIntent,
+  type OrganizerNudgeNotificationType,
   type PoolActivityNotificationType,
 } from '#app/utils/notification-catalog.ts';
 import {
@@ -68,6 +70,10 @@ export function getNotificationOccurrenceKey(
     case NOTIFICATION_TYPES.POOL_CANCELLED:
     case NOTIFICATION_TYPES.POOL_PURCHASER_ASSIGNED:
     case NOTIFICATION_TYPES.POOL_DELIVERER_ASSIGNED:
+    case NOTIFICATION_TYPES.POOL_CONTRIBUTION_REMINDER:
+    case NOTIFICATION_TYPES.POOL_VOTE_REMINDER:
+    case NOTIFICATION_TYPES.POOL_PURCHASE_REMINDER:
+    case NOTIFICATION_TYPES.POOL_DELIVERY_REMINDER:
       throw new Error(
         `Pool notification ${intent.type} requires a sourceIdentifier.`,
       );
@@ -90,6 +96,10 @@ export async function renderNotificationChannel<C extends NotificationChannel>(
     case NOTIFICATION_TYPES.POOL_CANCELLED:
     case NOTIFICATION_TYPES.POOL_PURCHASER_ASSIGNED:
     case NOTIFICATION_TYPES.POOL_DELIVERER_ASSIGNED:
+    case NOTIFICATION_TYPES.POOL_CONTRIBUTION_REMINDER:
+    case NOTIFICATION_TYPES.POOL_VOTE_REMINDER:
+    case NOTIFICATION_TYPES.POOL_PURCHASE_REMINDER:
+    case NOTIFICATION_TYPES.POOL_DELIVERY_REMINDER:
       return renderPoolActivity(intent, channel);
   }
 }
@@ -250,7 +260,10 @@ async function renderUpcomingBirthday<C extends NotificationChannel>(
   }
 }
 
-type PoolActivityIntent = NotificationIntent<PoolActivityNotificationType>;
+type PoolContextIntent = NotificationIntent<
+  PoolActivityNotificationType | OrganizerNudgeNotificationType
+>;
+type OrganizerNudgeIntent = NotificationIntent<OrganizerNudgeNotificationType>;
 
 type PoolActivityCopy = {
   messageKey:
@@ -258,19 +271,27 @@ type PoolActivityCopy = {
     | 'notifications.poolGiftChosen.message'
     | 'notifications.poolCancelled.message'
     | 'notifications.poolPurchaserAssigned.message'
-    | 'notifications.poolDelivererAssigned.message';
+    | 'notifications.poolDelivererAssigned.message'
+    | 'notifications.poolContributionReminder.message'
+    | 'notifications.poolVoteReminder.message'
+    | 'notifications.poolPurchaseReminder.message'
+    | 'notifications.poolDeliveryReminder.message';
   pushTitleKey:
     | 'notifications.poolVoteStarted.pushTitle'
     | 'notifications.poolGiftChosen.pushTitle'
     | 'notifications.poolCancelled.pushTitle'
     | 'notifications.poolPurchaserAssigned.pushTitle'
-    | 'notifications.poolDelivererAssigned.pushTitle';
+    | 'notifications.poolDelivererAssigned.pushTitle'
+    | 'notifications.poolContributionReminder.pushTitle'
+    | 'notifications.poolVoteReminder.pushTitle'
+    | 'notifications.poolPurchaseReminder.pushTitle'
+    | 'notifications.poolDeliveryReminder.pushTitle';
   messageParams: Record<string, string>;
   emailBody: string;
 };
 
 async function renderPoolActivity<C extends NotificationChannel>(
-  intent: PoolActivityIntent,
+  intent: PoolContextIntent,
   channel: C,
 ): Promise<NotificationChannelMessageMap[C]> {
   const copy = getPoolActivityCopy(intent);
@@ -284,7 +305,12 @@ async function renderPoolActivity<C extends NotificationChannel>(
         messageKey: copy.messageKey,
         messageParams: JSON.stringify(copy.messageParams),
         targetUrl: poolUrl,
-        metadata: JSON.stringify({ poolId: intent.payload.poolId }),
+        metadata: JSON.stringify({
+          poolId: intent.payload.poolId,
+          ...(isOrganizerNudgeIntent(intent)
+            ? { organizerNudgeId: intent.payload.nudgeId }
+            : {}),
+        }),
         friendRequestId: null,
       } as NotificationChannelMessageMap[C];
     case NOTIFICATION_CHANNELS.EMAIL: {
@@ -312,7 +338,7 @@ async function renderPoolActivity<C extends NotificationChannel>(
   }
 }
 
-function getPoolActivityCopy(intent: PoolActivityIntent): PoolActivityCopy {
+function getPoolActivityCopy(intent: PoolContextIntent): PoolActivityCopy {
   const pool = intent.payload.poolTitle;
   switch (intent.type) {
     case NOTIFICATION_TYPES.POOL_VOTE_STARTED:
@@ -353,6 +379,46 @@ function getPoolActivityCopy(intent: PoolActivityIntent): PoolActivityCopy {
         messageParams: { pool },
         emailBody: 'Open the pool to review the delivery details.',
       };
+    case NOTIFICATION_TYPES.POOL_CONTRIBUTION_REMINDER:
+      return {
+        messageKey: 'notifications.poolContributionReminder.message',
+        pushTitleKey: 'notifications.poolContributionReminder.pushTitle',
+        messageParams: {
+          pool,
+          sender: intent.payload.senderDisplayName,
+        },
+        emailBody: 'Open the pool to set your contribution.',
+      };
+    case NOTIFICATION_TYPES.POOL_VOTE_REMINDER:
+      return {
+        messageKey: 'notifications.poolVoteReminder.message',
+        pushTitleKey: 'notifications.poolVoteReminder.pushTitle',
+        messageParams: {
+          pool,
+          sender: intent.payload.senderDisplayName,
+        },
+        emailBody: 'Open the pool to review the ideas and cast your vote.',
+      };
+    case NOTIFICATION_TYPES.POOL_PURCHASE_REMINDER:
+      return {
+        messageKey: 'notifications.poolPurchaseReminder.message',
+        pushTitleKey: 'notifications.poolPurchaseReminder.pushTitle',
+        messageParams: {
+          pool,
+          sender: intent.payload.senderDisplayName,
+        },
+        emailBody: 'Open the pool to review the gift and purchase details.',
+      };
+    case NOTIFICATION_TYPES.POOL_DELIVERY_REMINDER:
+      return {
+        messageKey: 'notifications.poolDeliveryReminder.message',
+        pushTitleKey: 'notifications.poolDeliveryReminder.pushTitle',
+        messageParams: {
+          pool,
+          sender: intent.payload.senderDisplayName,
+        },
+        emailBody: 'Open the pool to review the delivery details.',
+      };
   }
 }
 
@@ -384,6 +450,21 @@ export function recordNotificationDelivery(
     return;
   }
 
+  if (isOrganizerNudgeIntent(intent)) {
+    queueLogEvent({
+      name: 'organizer_reminder_sent',
+      source: 'server',
+      userId: intent.userId,
+      properties: {
+        notificationType: intent.type,
+        poolId: intent.payload.poolId,
+        organizerNudgeId: intent.payload.nudgeId,
+        channels: deliveredChannels,
+      },
+    });
+    return;
+  }
+
   if (isPoolActivityIntent(intent)) {
     queueLogEvent({
       name: 'pool_activity_notification_sent',
@@ -396,6 +477,12 @@ export function recordNotificationDelivery(
       },
     });
   }
+}
+
+function isOrganizerNudgeIntent(
+  intent: NotificationIntent,
+): intent is OrganizerNudgeIntent {
+  return isOrganizerNudgeNotificationType(intent.type);
 }
 
 function isPoolActivityIntent(

--- a/app/utils/organizer-nudges.server.test.ts
+++ b/app/utils/organizer-nudges.server.test.ts
@@ -1,0 +1,469 @@
+/**
+ * @vitest-environment node
+ */
+import { randomUUID } from 'node:crypto';
+import { type User } from '@prisma/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { prisma } from '#app/utils/db.server.ts';
+
+const queueNotification = vi.fn();
+const captureException = vi.fn();
+
+vi.mock('#app/utils/notification-dispatcher.server.ts', () => ({
+  queueNotification: (...args: Array<unknown>) => queueNotification(...args),
+}));
+
+vi.mock('@sentry/react-router', () => ({
+  captureException: (...args: Array<unknown>) => captureException(...args),
+}));
+
+import {
+  ORGANIZER_NUDGE_KIND_COOLDOWN_MS,
+  ORGANIZER_NUDGE_KINDS,
+  ORGANIZER_NUDGE_POOL_WINDOW_MS,
+  OrganizerNudgeError,
+  previewOrganizerNudge,
+  sendOrganizerNudge,
+} from './organizer-nudges.server.ts';
+
+const createdUserIds: string[] = [];
+const createdPoolIds: string[] = [];
+const createdGroupIds: string[] = [];
+
+afterEach(async () => {
+  queueNotification.mockReset();
+  captureException.mockReset();
+  if (createdPoolIds.length > 0) {
+    await prisma.pool.deleteMany({ where: { id: { in: createdPoolIds } } });
+  }
+  if (createdGroupIds.length > 0) {
+    await prisma.giftGroup.deleteMany({
+      where: { id: { in: createdGroupIds } },
+    });
+  }
+  if (createdUserIds.length > 0) {
+    await prisma.user.deleteMany({ where: { id: { in: createdUserIds } } });
+  }
+  createdPoolIds.length = 0;
+  createdGroupIds.length = 0;
+  createdUserIds.length = 0;
+});
+
+describe('organizer nudge module', () => {
+  it('returns only an aggregate count after privacy and preference suppression', async () => {
+    const [organizer, eligible, muted, recipient] = await createUsers(
+      'preview',
+      4,
+    );
+    const pool = await createPool({
+      organizerId: organizer.id,
+      recipientUserId: recipient.id,
+      status: 'OPEN',
+      contributors: [
+        { userId: organizer.id, contributionCents: 2500 },
+        { userId: eligible.id, contributionCents: null },
+        { userId: muted.id, contributionCents: null },
+        { userId: recipient.id, contributionCents: null },
+      ],
+    });
+    await prisma.poolNotificationPreference.create({
+      data: { userId: muted.id, poolId: pool.id, activityLevel: 'MUTED' },
+    });
+
+    await expect(
+      previewOrganizerNudge({
+        poolId: pool.id,
+        senderId: organizer.id,
+        kind: ORGANIZER_NUDGE_KINDS.CONTRIBUTION,
+      }),
+    ).resolves.toMatchObject({ status: 'AVAILABLE', eligibleCount: 1 });
+    await expect(
+      prisma.organizerNudge.count({ where: { poolId: pool.id } }),
+    ).resolves.toBe(0);
+  });
+
+  it('claims an audit and private recipients once, then replays idempotently', async () => {
+    const [organizer, contributor] = await createUsers('send', 2);
+    const pool = await createPool({
+      organizerId: organizer.id,
+      status: 'OPEN',
+      contributors: [
+        { userId: organizer.id, contributionCents: 1000 },
+        { userId: contributor.id, contributionCents: null },
+      ],
+    });
+
+    const input = {
+      poolId: pool.id,
+      senderId: organizer.id,
+      kind: ORGANIZER_NUDGE_KINDS.CONTRIBUTION,
+      idempotencyKey: `test:${randomUUID()}`,
+    };
+    const first = await sendOrganizerNudge(input);
+    expect(first).toMatchObject({ status: 'QUEUED', queuedCount: 1 });
+    await vi.waitFor(() => expect(queueNotification).toHaveBeenCalledTimes(1));
+    expect(queueNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: contributor.id,
+        sourceIdentifier: expect.stringMatching(/^organizer-nudge:/),
+        payload: expect.objectContaining({
+          poolId: pool.id,
+          senderDisplayName: organizer.name,
+        }),
+      }),
+    );
+
+    const replay = await sendOrganizerNudge(input);
+    expect(replay).toMatchObject({
+      status: 'QUEUED',
+      nudgeId: first.status === 'QUEUED' ? first.nudgeId : '',
+      queuedCount: 1,
+    });
+    await expect(
+      prisma.organizerNudge.count({ where: { poolId: pool.id } }),
+    ).resolves.toBe(1);
+    await expect(
+      prisma.organizerNudgeRecipient.findMany({
+        where: { nudge: { poolId: pool.id } },
+        select: { userId: true },
+      }),
+    ).resolves.toEqual([{ userId: contributor.id }]);
+    expect(queueNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it('collapses concurrent submissions with the same idempotency key', async () => {
+    const [organizer, contributor] = await createUsers('concurrent', 2);
+    const pool = await createPool({
+      organizerId: organizer.id,
+      status: 'OPEN',
+      contributors: [
+        { userId: organizer.id, contributionCents: 1000 },
+        { userId: contributor.id, contributionCents: null },
+      ],
+    });
+    const input = {
+      poolId: pool.id,
+      senderId: organizer.id,
+      kind: ORGANIZER_NUDGE_KINDS.CONTRIBUTION,
+      idempotencyKey: `test:${randomUUID()}`,
+    };
+
+    const [first, second] = await Promise.all([
+      sendOrganizerNudge(input),
+      sendOrganizerNudge(input),
+    ]);
+    expect(first).toMatchObject({ status: 'QUEUED' });
+    expect(second).toMatchObject({
+      status: 'QUEUED',
+      nudgeId: first.status === 'QUEUED' ? first.nudgeId : '',
+    });
+    await expect(
+      prisma.organizerNudge.count({ where: { poolId: pool.id } }),
+    ).resolves.toBe(1);
+  });
+
+  it('serializes distinct concurrent requests against the kind cooldown', async () => {
+    const [organizer, contributor] = await createUsers('concurrent-limit', 2);
+    const pool = await createPool({
+      organizerId: organizer.id,
+      status: 'OPEN',
+      contributors: [
+        { userId: organizer.id, contributionCents: 1000 },
+        { userId: contributor.id, contributionCents: null },
+      ],
+    });
+    const input = {
+      poolId: pool.id,
+      senderId: organizer.id,
+      kind: ORGANIZER_NUDGE_KINDS.CONTRIBUTION,
+    };
+
+    const results = await Promise.all([
+      sendOrganizerNudge({
+        ...input,
+        idempotencyKey: `test:${randomUUID()}`,
+      }),
+      sendOrganizerNudge({
+        ...input,
+        idempotencyKey: `test:${randomUUID()}`,
+      }),
+    ]);
+    expect(results.map((result) => result.status).sort()).toEqual([
+      'COOLDOWN',
+      'QUEUED',
+    ]);
+    await expect(
+      prisma.organizerNudge.count({ where: { poolId: pool.id } }),
+    ).resolves.toBe(1);
+  });
+
+  it('keeps a zero-recipient attempt as a no-op that consumes no limit', async () => {
+    const [organizer, contributor] = await createUsers('noop', 2);
+    const pool = await createPool({
+      organizerId: organizer.id,
+      status: 'OPEN',
+      contributors: [
+        { userId: organizer.id, contributionCents: 1000 },
+        { userId: contributor.id, contributionCents: 2000 },
+      ],
+    });
+
+    await expect(
+      sendOrganizerNudge({
+        poolId: pool.id,
+        senderId: organizer.id,
+        kind: ORGANIZER_NUDGE_KINDS.CONTRIBUTION,
+        idempotencyKey: `test:${randomUUID()}`,
+      }),
+    ).resolves.toMatchObject({ status: 'NO_ELIGIBLE' });
+    await expect(
+      prisma.organizerNudge.count({ where: { poolId: pool.id } }),
+    ).resolves.toBe(0);
+    expect(queueNotification).not.toHaveBeenCalled();
+  });
+
+  it('enforces manager permission and current assignment state', async () => {
+    const [organizer, member] = await createUsers('permission', 2);
+    const pool = await createPool({
+      organizerId: organizer.id,
+      purchaserId: organizer.id,
+      status: 'DECIDED',
+      contributors: [
+        { userId: organizer.id, contributionCents: 1000 },
+        { userId: member.id, contributionCents: 1000 },
+      ],
+    });
+
+    await expect(
+      previewOrganizerNudge({
+        poolId: pool.id,
+        senderId: member.id,
+        kind: ORGANIZER_NUDGE_KINDS.PURCHASE,
+      }),
+    ).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+    } satisfies Partial<OrganizerNudgeError>);
+    await expect(
+      previewOrganizerNudge({
+        poolId: pool.id,
+        senderId: organizer.id,
+        kind: ORGANIZER_NUDGE_KINDS.PURCHASE,
+      }),
+    ).rejects.toMatchObject({
+      code: 'TASK_UNAVAILABLE',
+    } satisfies Partial<OrganizerNudgeError>);
+  });
+
+  it('allows a current group admin who is also a pool contributor', async () => {
+    const [organizer, admin, contributor] = await createUsers('admin', 3);
+    const group = await prisma.giftGroup.create({
+      data: {
+        name: `Admin group ${randomUUID()}`,
+        groupMembers: {
+          create: { userId: admin.id, role: 'ADMIN' },
+        },
+      },
+    });
+    createdGroupIds.push(group.id);
+    const pool = await createPool({
+      organizerId: organizer.id,
+      giftGroupId: group.id,
+      status: 'OPEN',
+      contributors: [
+        { userId: organizer.id, contributionCents: 1000 },
+        { userId: admin.id, contributionCents: 1000 },
+        { userId: contributor.id, contributionCents: null },
+      ],
+    });
+
+    await expect(
+      previewOrganizerNudge({
+        poolId: pool.id,
+        senderId: admin.id,
+        kind: ORGANIZER_NUDGE_KINDS.CONTRIBUTION,
+      }),
+    ).resolves.toMatchObject({ status: 'AVAILABLE', eligibleCount: 1 });
+
+    await prisma.usersInGiftGroups.update({
+      where: {
+        userId_giftGroupId: { userId: admin.id, giftGroupId: group.id },
+      },
+      data: { removedAt: new Date() },
+    });
+    await expect(
+      previewOrganizerNudge({
+        poolId: pool.id,
+        senderId: admin.id,
+        kind: ORGANIZER_NUDGE_KINDS.CONTRIBUTION,
+      }),
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+  });
+
+  it('uses exact 24-hour and rolling-seven-day unlock timestamps', async () => {
+    const now = new Date();
+    const [organizer, contributor] = await createUsers('limits', 2);
+    const pool = await createPool({
+      organizerId: organizer.id,
+      status: 'VOTING',
+      contributors: [
+        { userId: organizer.id, contributionCents: 1000 },
+        { userId: contributor.id, contributionCents: null },
+      ],
+    });
+    const sentAt = new Date(now.getTime() - 60 * 60 * 1000);
+    await createAudit({
+      poolId: pool.id,
+      senderId: organizer.id,
+      kind: ORGANIZER_NUDGE_KINDS.VOTE,
+      createdAt: sentAt,
+      recipientId: contributor.id,
+    });
+
+    const cooldown = await previewOrganizerNudge({
+      poolId: pool.id,
+      senderId: organizer.id,
+      kind: ORGANIZER_NUDGE_KINDS.VOTE,
+    });
+    expect(cooldown).toMatchObject({
+      status: 'COOLDOWN',
+      availableAt: new Date(
+        sentAt.getTime() + ORGANIZER_NUDGE_KIND_COOLDOWN_MS,
+      ),
+    });
+
+    await prisma.organizerNudge.deleteMany({ where: { poolId: pool.id } });
+    const oldest = new Date(now.getTime() - 6 * 24 * 60 * 60 * 1000);
+    for (const [index, kind] of [
+      ORGANIZER_NUDGE_KINDS.CONTRIBUTION,
+      ORGANIZER_NUDGE_KINDS.PURCHASE,
+      ORGANIZER_NUDGE_KINDS.DELIVERY,
+    ].entries()) {
+      await createAudit({
+        poolId: pool.id,
+        senderId: organizer.id,
+        kind,
+        createdAt: new Date(oldest.getTime() + index * 24 * 60 * 60 * 1000),
+      });
+    }
+
+    const weekly = await previewOrganizerNudge({
+      poolId: pool.id,
+      senderId: organizer.id,
+      kind: ORGANIZER_NUDGE_KINDS.VOTE,
+    });
+    expect(weekly).toMatchObject({
+      status: 'WEEKLY_LIMIT',
+      availableAt: new Date(oldest.getTime() + ORGANIZER_NUDGE_POOL_WINDOW_MS),
+    });
+  });
+
+  it('applies the recipient/pool cooldown across different reminder kinds', async () => {
+    const now = new Date();
+    const [organizer, contributor] = await createUsers('recipient-limit', 2);
+    const pool = await createPool({
+      organizerId: organizer.id,
+      status: 'VOTING',
+      contributors: [
+        { userId: organizer.id, contributionCents: 1000 },
+        { userId: contributor.id, contributionCents: null },
+      ],
+    });
+    await createAudit({
+      poolId: pool.id,
+      senderId: organizer.id,
+      kind: ORGANIZER_NUDGE_KINDS.CONTRIBUTION,
+      createdAt: new Date(now.getTime() - 60 * 60 * 1000),
+      recipientId: contributor.id,
+    });
+
+    await expect(
+      previewOrganizerNudge({
+        poolId: pool.id,
+        senderId: organizer.id,
+        kind: ORGANIZER_NUDGE_KINDS.VOTE,
+      }),
+    ).resolves.toMatchObject({ status: 'NO_ELIGIBLE' });
+  });
+});
+
+function createUsers(prefix: string, count: 2): Promise<[User, User]>;
+function createUsers(prefix: string, count: 3): Promise<[User, User, User]>;
+function createUsers(
+  prefix: string,
+  count: 4,
+): Promise<[User, User, User, User]>;
+async function createUsers(prefix: string, count: number): Promise<User[]> {
+  const users: User[] = [];
+  for (let index = 0; index < count; index += 1) {
+    const token = randomUUID();
+    const user = await prisma.user.create({
+      data: {
+        email: `${prefix}-${index}-${token}@organizer-nudge.test`,
+        username: `${prefix}_${index}_${token.slice(0, 8)}`.slice(0, 20),
+        name: `${prefix} user ${index}`,
+      },
+    });
+    createdUserIds.push(user.id);
+    users.push(user);
+  }
+  return users;
+}
+
+async function createPool({
+  organizerId,
+  recipientUserId = null,
+  giftGroupId = null,
+  purchaserId = null,
+  delivererId = null,
+  status,
+  contributors,
+}: {
+  organizerId: string;
+  recipientUserId?: string | null;
+  giftGroupId?: string | null;
+  purchaserId?: string | null;
+  delivererId?: string | null;
+  status: string;
+  contributors: Array<{ userId: string; contributionCents: number | null }>;
+}) {
+  const pool = await prisma.pool.create({
+    data: {
+      title: `Nudge pool ${randomUUID()}`,
+      organizerId,
+      recipientUserId,
+      giftGroupId,
+      purchaserId,
+      delivererId,
+      status,
+      contributors: { create: contributors },
+    },
+  });
+  createdPoolIds.push(pool.id);
+  return pool;
+}
+
+async function createAudit({
+  poolId,
+  senderId,
+  kind,
+  createdAt,
+  recipientId,
+}: {
+  poolId: string;
+  senderId: string;
+  kind: string;
+  createdAt: Date;
+  recipientId?: string;
+}) {
+  return prisma.organizerNudge.create({
+    data: {
+      poolId,
+      senderId,
+      kind,
+      idempotencyKey: `test:${randomUUID()}`,
+      targetCount: recipientId ? 1 : 0,
+      createdAt,
+      recipients: recipientId ? { create: { userId: recipientId } } : undefined,
+    },
+  });
+}

--- a/app/utils/organizer-nudges.server.ts
+++ b/app/utils/organizer-nudges.server.ts
@@ -1,0 +1,612 @@
+import { Prisma } from '@prisma/client';
+import * as Sentry from '@sentry/react-router';
+import { prisma } from '#app/utils/db.server.ts';
+import {
+  NOTIFICATION_CHANNEL_VALUES,
+  NOTIFICATION_TYPES,
+  type OrganizerNudgeNotificationType,
+} from '#app/utils/notification-catalog.ts';
+import { queueNotification } from '#app/utils/notification-dispatcher.server.ts';
+import { resolveNotificationPolicy } from '#app/utils/notification-policy.server.ts';
+import { POOL_STATUS } from '#app/utils/pool-constants.ts';
+
+export const ORGANIZER_NUDGE_KINDS = {
+  CONTRIBUTION: 'CONTRIBUTION',
+  VOTE: 'VOTE',
+  PURCHASE: 'PURCHASE',
+  DELIVERY: 'DELIVERY',
+} as const;
+
+export type OrganizerNudgeKind =
+  (typeof ORGANIZER_NUDGE_KINDS)[keyof typeof ORGANIZER_NUDGE_KINDS];
+
+export const ORGANIZER_NUDGE_KIND_VALUES = Object.values(ORGANIZER_NUDGE_KINDS);
+
+export const ORGANIZER_NUDGE_KIND_COOLDOWN_MS = 24 * 60 * 60 * 1000;
+export const ORGANIZER_NUDGE_POOL_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+export const ORGANIZER_NUDGE_POOL_LIMIT = 3;
+
+type LatestNudge = {
+  createdAt: Date;
+  targetCount: number;
+  status: string;
+};
+
+type OrganizerNudgeResultBase = {
+  kind: OrganizerNudgeKind;
+  latestNudge: LatestNudge | null;
+};
+
+export type OrganizerNudgePreview = OrganizerNudgeResultBase &
+  (
+    | { status: 'AVAILABLE'; eligibleCount: number }
+    | { status: 'NO_ELIGIBLE' }
+    | { status: 'COOLDOWN'; availableAt: Date }
+    | { status: 'WEEKLY_LIMIT'; availableAt: Date }
+  );
+
+export type OrganizerNudgeSendResult =
+  | OrganizerNudgePreview
+  | (OrganizerNudgeResultBase & {
+      status: 'QUEUED';
+      nudgeId: string;
+      queuedCount: number;
+      createdAt: Date;
+      availableAt: Date;
+    });
+
+export type OrganizerNudgeErrorCode =
+  | 'POOL_NOT_FOUND'
+  | 'FORBIDDEN'
+  | 'TASK_UNAVAILABLE'
+  | 'INVALID_IDEMPOTENCY_KEY'
+  | 'IDEMPOTENCY_CONFLICT';
+
+export class OrganizerNudgeError extends Error {
+  constructor(
+    public readonly code: OrganizerNudgeErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'OrganizerNudgeError';
+  }
+}
+
+type NudgeEvaluation = OrganizerNudgeResultBase &
+  (
+    | { status: 'READY'; candidateUserIds: string[] }
+    | { status: 'NO_ELIGIBLE' }
+    | { status: 'COOLDOWN'; availableAt: Date }
+    | { status: 'WEEKLY_LIMIT'; availableAt: Date }
+  );
+
+type ExistingNudge = {
+  id: string;
+  poolId: string;
+  senderId: string;
+  kind: string;
+  targetCount: number;
+  status: string;
+  createdAt: Date;
+};
+
+/**
+ * Read interface for the task-local confirmation surface. Audience details
+ * remain inside the module; callers receive only the aggregate eligible count.
+ */
+export async function previewOrganizerNudge({
+  poolId,
+  senderId,
+  kind,
+}: {
+  poolId: string;
+  senderId: string;
+  kind: OrganizerNudgeKind;
+}): Promise<OrganizerNudgePreview> {
+  const now = new Date();
+  const evaluation = await prisma.$transaction((tx) =>
+    evaluateNudge(tx, { poolId, senderId, kind, now }),
+  );
+  if (evaluation.status !== 'READY') return evaluation;
+
+  const eligibleUserIds = await filterPreferenceEligibleRecipients({
+    poolId,
+    kind,
+    candidateUserIds: evaluation.candidateUserIds,
+  });
+  return eligibleUserIds.length === 0
+    ? {
+        status: 'NO_ELIGIBLE',
+        kind,
+        latestNudge: evaluation.latestNudge,
+      }
+    : {
+        status: 'AVAILABLE',
+        kind,
+        latestNudge: evaluation.latestNudge,
+        eligibleCount: eligibleUserIds.length,
+      };
+}
+
+/**
+ * Command interface for one preset nudge. Authorization, current task state,
+ * target selection, preference suppression, rolling limits, audit creation,
+ * idempotency, and background fanout all stay behind this seam.
+ */
+export async function sendOrganizerNudge({
+  poolId,
+  senderId,
+  kind,
+  idempotencyKey,
+}: {
+  poolId: string;
+  senderId: string;
+  kind: OrganizerNudgeKind;
+  idempotencyKey: string;
+}): Promise<OrganizerNudgeSendResult> {
+  assertIdempotencyKey(idempotencyKey);
+
+  const existing = await prisma.organizerNudge.findUnique({
+    where: { senderId_idempotencyKey: { senderId, idempotencyKey } },
+  });
+  if (existing) return replayExistingNudge(existing, { poolId, kind });
+
+  const now = new Date();
+  const initial = await prisma.$transaction((tx) =>
+    evaluateNudge(tx, { poolId, senderId, kind, now }),
+  );
+  if (initial.status !== 'READY') {
+    const raced = await prisma.organizerNudge.findUnique({
+      where: { senderId_idempotencyKey: { senderId, idempotencyKey } },
+    });
+    return raced ? replayExistingNudge(raced, { poolId, kind }) : initial;
+  }
+
+  const preferenceEligibleUserIds = await filterPreferenceEligibleRecipients({
+    poolId,
+    kind,
+    candidateUserIds: initial.candidateUserIds,
+  });
+
+  let result: OrganizerNudgeSendResult;
+  try {
+    result = await prisma.$transaction(async (tx) => {
+      const concurrentExisting = await tx.organizerNudge.findUnique({
+        where: { senderId_idempotencyKey: { senderId, idempotencyKey } },
+      });
+      if (concurrentExisting) {
+        return replayExistingNudge(concurrentExisting, { poolId, kind });
+      }
+
+      // Re-evaluate every mutable domain and rate-limit input immediately before
+      // the audit row is claimed. Preference policy is rechecked by the delivery
+      // dispatcher as well, so a concurrent opt-out still suppresses delivery.
+      const current = await evaluateNudge(tx, {
+        poolId,
+        senderId,
+        kind,
+        now: new Date(),
+      });
+      if (current.status !== 'READY') {
+        const raced = await tx.organizerNudge.findUnique({
+          where: { senderId_idempotencyKey: { senderId, idempotencyKey } },
+        });
+        return raced ? replayExistingNudge(raced, { poolId, kind }) : current;
+      }
+
+      const allowed = new Set(preferenceEligibleUserIds);
+      const recipientIds = current.candidateUserIds.filter((userId) =>
+        allowed.has(userId),
+      );
+      if (recipientIds.length === 0) {
+        return {
+          status: 'NO_ELIGIBLE' as const,
+          kind,
+          latestNudge: current.latestNudge,
+        };
+      }
+
+      const nudge = await tx.organizerNudge.create({
+        data: {
+          poolId,
+          senderId,
+          kind,
+          idempotencyKey,
+          targetCount: recipientIds.length,
+          recipients: {
+            create: recipientIds.map((userId) => ({ userId })),
+          },
+        },
+      });
+
+      return {
+        status: 'QUEUED' as const,
+        kind,
+        nudgeId: nudge.id,
+        queuedCount: recipientIds.length,
+        createdAt: nudge.createdAt,
+        availableAt: addMilliseconds(
+          nudge.createdAt,
+          ORGANIZER_NUDGE_KIND_COOLDOWN_MS,
+        ),
+        latestNudge: {
+          createdAt: nudge.createdAt,
+          targetCount: nudge.targetCount,
+          status: nudge.status,
+        },
+      };
+    });
+  } catch (error) {
+    if (!isUniqueConstraintError(error)) throw error;
+    const raced = await prisma.organizerNudge.findUnique({
+      where: { senderId_idempotencyKey: { senderId, idempotencyKey } },
+    });
+    if (!raced) throw error;
+    result = replayExistingNudge(raced, { poolId, kind });
+  }
+
+  if (result.status === 'QUEUED') {
+    queueOrganizerNudgeNotifications(result.nudgeId);
+  }
+  return result;
+}
+
+async function evaluateNudge(
+  tx: Prisma.TransactionClient,
+  {
+    poolId,
+    senderId,
+    kind,
+    now,
+  }: {
+    poolId: string;
+    senderId: string;
+    kind: OrganizerNudgeKind;
+    now: Date;
+  },
+): Promise<NudgeEvaluation> {
+  const pool = await tx.pool.findUnique({
+    where: { id: poolId },
+    select: {
+      id: true,
+      status: true,
+      organizerId: true,
+      giftGroupId: true,
+      recipientUserId: true,
+      purchaserId: true,
+      delivererId: true,
+      contributors: {
+        select: { userId: true, contributionCents: true },
+      },
+      votes: { select: { voterId: true } },
+    },
+  });
+  if (!pool || pool.recipientUserId === senderId) {
+    throw new OrganizerNudgeError('POOL_NOT_FOUND', 'Pool not found.');
+  }
+
+  const senderIsContributor = pool.contributors.some(
+    (contributor) => contributor.userId === senderId,
+  );
+  if (!senderIsContributor) {
+    throw new OrganizerNudgeError('POOL_NOT_FOUND', 'Pool not found.');
+  }
+
+  if (!(await senderCanManagePool(tx, senderId, pool))) {
+    throw new OrganizerNudgeError(
+      'FORBIDDEN',
+      'Only a Pool Manager can send this reminder.',
+    );
+  }
+
+  const taskCandidateUserIds = getTaskCandidateUserIds(pool, senderId, kind);
+  const [latest, recentPoolNudges] = await Promise.all([
+    tx.organizerNudge.findFirst({
+      where: { poolId, kind },
+      orderBy: { createdAt: 'desc' },
+      select: { createdAt: true, targetCount: true, status: true },
+    }),
+    tx.organizerNudge.findMany({
+      where: {
+        poolId,
+        createdAt: {
+          gt: addMilliseconds(now, -ORGANIZER_NUDGE_POOL_WINDOW_MS),
+        },
+      },
+      orderBy: { createdAt: 'asc' },
+      take: ORGANIZER_NUDGE_POOL_LIMIT,
+      select: { createdAt: true },
+    }),
+  ]);
+
+  const limit = getBlockingLimit({ latest, recentPoolNudges, now });
+  if (limit) return { ...limit, kind, latestNudge: latest };
+
+  if (taskCandidateUserIds.length === 0) {
+    return { status: 'NO_ELIGIBLE', kind, latestNudge: latest };
+  }
+
+  const recentRecipients = await tx.organizerNudgeRecipient.findMany({
+    where: {
+      userId: { in: taskCandidateUserIds },
+      nudge: {
+        poolId,
+        createdAt: {
+          gt: addMilliseconds(now, -ORGANIZER_NUDGE_KIND_COOLDOWN_MS),
+        },
+      },
+    },
+    select: { userId: true },
+  });
+  const recentlyNudged = new Set(
+    recentRecipients.map((recipient) => recipient.userId),
+  );
+  const candidateUserIds = taskCandidateUserIds.filter(
+    (userId) => !recentlyNudged.has(userId),
+  );
+
+  return candidateUserIds.length === 0
+    ? { status: 'NO_ELIGIBLE', kind, latestNudge: latest }
+    : {
+        status: 'READY',
+        kind,
+        latestNudge: latest,
+        candidateUserIds,
+      };
+}
+
+async function senderCanManagePool(
+  tx: Prisma.TransactionClient,
+  senderId: string,
+  pool: { organizerId: string; giftGroupId: string | null },
+) {
+  if (pool.organizerId === senderId) return true;
+  if (!pool.giftGroupId) return false;
+  const membership = await tx.usersInGiftGroups.findUnique({
+    where: {
+      userId_giftGroupId: { userId: senderId, giftGroupId: pool.giftGroupId },
+    },
+    select: { role: true, removedAt: true },
+  });
+  return (
+    membership?.removedAt === null &&
+    (membership.role === 'OWNER' || membership.role === 'ADMIN')
+  );
+}
+
+function getTaskCandidateUserIds(
+  pool: {
+    status: string;
+    recipientUserId: string | null;
+    purchaserId: string | null;
+    delivererId: string | null;
+    contributors: Array<{ userId: string; contributionCents: number | null }>;
+    votes: Array<{ voterId: string }>;
+  },
+  senderId: string,
+  kind: OrganizerNudgeKind,
+) {
+  const currentContributors = new Set(
+    pool.contributors.map((contributor) => contributor.userId),
+  );
+  const excludePrivateActors = (userId: string) =>
+    userId !== senderId &&
+    userId !== pool.recipientUserId &&
+    currentContributors.has(userId);
+
+  switch (kind) {
+    case ORGANIZER_NUDGE_KINDS.CONTRIBUTION:
+      if (
+        pool.status !== POOL_STATUS.OPEN &&
+        pool.status !== POOL_STATUS.VOTING
+      ) {
+        throw taskUnavailable(kind);
+      }
+      return pool.contributors
+        .filter(
+          (contributor) =>
+            contributor.contributionCents === null &&
+            excludePrivateActors(contributor.userId),
+        )
+        .map((contributor) => contributor.userId);
+    case ORGANIZER_NUDGE_KINDS.VOTE: {
+      if (pool.status !== POOL_STATUS.VOTING) throw taskUnavailable(kind);
+      const voters = new Set(pool.votes.map((vote) => vote.voterId));
+      return pool.contributors
+        .map((contributor) => contributor.userId)
+        .filter(
+          (userId) => excludePrivateActors(userId) && !voters.has(userId),
+        );
+    }
+    case ORGANIZER_NUDGE_KINDS.PURCHASE:
+      if (
+        pool.status !== POOL_STATUS.DECIDED ||
+        !pool.purchaserId ||
+        pool.purchaserId === senderId
+      ) {
+        throw taskUnavailable(kind);
+      }
+      return excludePrivateActors(pool.purchaserId) ? [pool.purchaserId] : [];
+    case ORGANIZER_NUDGE_KINDS.DELIVERY:
+      if (
+        pool.status !== POOL_STATUS.PURCHASED ||
+        !pool.delivererId ||
+        pool.delivererId === senderId
+      ) {
+        throw taskUnavailable(kind);
+      }
+      return excludePrivateActors(pool.delivererId) ? [pool.delivererId] : [];
+  }
+}
+
+function getBlockingLimit({
+  latest,
+  recentPoolNudges,
+  now,
+}: {
+  latest: LatestNudge | null;
+  recentPoolNudges: Array<{ createdAt: Date }>;
+  now: Date;
+}) {
+  const kindAvailableAt = latest
+    ? addMilliseconds(latest.createdAt, ORGANIZER_NUDGE_KIND_COOLDOWN_MS)
+    : null;
+  const weeklyAvailableAt =
+    recentPoolNudges.length >= ORGANIZER_NUDGE_POOL_LIMIT
+      ? addMilliseconds(
+          recentPoolNudges[0]!.createdAt,
+          ORGANIZER_NUDGE_POOL_WINDOW_MS,
+        )
+      : null;
+  const kindBlocked = kindAvailableAt && kindAvailableAt > now;
+  const weeklyBlocked = weeklyAvailableAt && weeklyAvailableAt > now;
+  if (!kindBlocked && !weeklyBlocked) return null;
+  if (weeklyBlocked && (!kindBlocked || weeklyAvailableAt >= kindAvailableAt)) {
+    return { status: 'WEEKLY_LIMIT' as const, availableAt: weeklyAvailableAt };
+  }
+  return { status: 'COOLDOWN' as const, availableAt: kindAvailableAt! };
+}
+
+async function filterPreferenceEligibleRecipients({
+  poolId,
+  kind,
+  candidateUserIds,
+}: {
+  poolId: string;
+  kind: OrganizerNudgeKind;
+  candidateUserIds: string[];
+}) {
+  const type = notificationTypeForKind(kind);
+  const policies = await Promise.all(
+    candidateUserIds.map(async (userId) => ({
+      userId,
+      policy: await resolveNotificationPolicy({
+        userId,
+        type,
+        context: { kind: 'POOL', poolId },
+      }),
+    })),
+  );
+  return policies
+    .filter(({ policy }) =>
+      NOTIFICATION_CHANNEL_VALUES.some(
+        (channel) => policy.channels[channel].allowed,
+      ),
+    )
+    .map(({ userId }) => userId);
+}
+
+function queueOrganizerNudgeNotifications(nudgeId: string): void {
+  void fanoutOrganizerNudgeNotifications(nudgeId).catch((error: unknown) => {
+    Sentry.captureException(error);
+  });
+}
+
+async function fanoutOrganizerNudgeNotifications(nudgeId: string) {
+  const nudge = await prisma.organizerNudge.findUnique({
+    where: { id: nudgeId },
+    select: {
+      id: true,
+      kind: true,
+      pool: { select: { id: true, title: true } },
+      sender: { select: { id: true, name: true, username: true } },
+      recipients: { select: { userId: true } },
+    },
+  });
+  if (!nudge) return;
+
+  const type = notificationTypeForKind(nudge.kind as OrganizerNudgeKind);
+  const senderDisplayName = nudge.sender.name ?? nudge.sender.username;
+  for (const recipient of nudge.recipients) {
+    queueNotification({
+      userId: recipient.userId,
+      type,
+      context: { kind: 'POOL', poolId: nudge.pool.id },
+      sourceIdentifier: `organizer-nudge:${nudge.id}`,
+      payload: {
+        nudgeId: nudge.id,
+        poolId: nudge.pool.id,
+        poolTitle: nudge.pool.title,
+        senderUserId: nudge.sender.id,
+        senderDisplayName,
+      },
+    });
+  }
+}
+
+function notificationTypeForKind(
+  kind: OrganizerNudgeKind,
+): OrganizerNudgeNotificationType {
+  const byKind: Record<OrganizerNudgeKind, OrganizerNudgeNotificationType> = {
+    [ORGANIZER_NUDGE_KINDS.CONTRIBUTION]:
+      NOTIFICATION_TYPES.POOL_CONTRIBUTION_REMINDER,
+    [ORGANIZER_NUDGE_KINDS.VOTE]: NOTIFICATION_TYPES.POOL_VOTE_REMINDER,
+    [ORGANIZER_NUDGE_KINDS.PURCHASE]: NOTIFICATION_TYPES.POOL_PURCHASE_REMINDER,
+    [ORGANIZER_NUDGE_KINDS.DELIVERY]: NOTIFICATION_TYPES.POOL_DELIVERY_REMINDER,
+  };
+  return byKind[kind];
+}
+
+function replayExistingNudge(
+  existing: ExistingNudge,
+  expected: { poolId: string; kind: OrganizerNudgeKind },
+): OrganizerNudgeSendResult {
+  if (existing.poolId !== expected.poolId || existing.kind !== expected.kind) {
+    throw new OrganizerNudgeError(
+      'IDEMPOTENCY_CONFLICT',
+      'This idempotency key was already used for another reminder.',
+    );
+  }
+  return {
+    status: 'QUEUED',
+    kind: expected.kind,
+    nudgeId: existing.id,
+    queuedCount: existing.targetCount,
+    createdAt: existing.createdAt,
+    availableAt: addMilliseconds(
+      existing.createdAt,
+      ORGANIZER_NUDGE_KIND_COOLDOWN_MS,
+    ),
+    latestNudge: {
+      createdAt: existing.createdAt,
+      targetCount: existing.targetCount,
+      status: existing.status,
+    },
+  };
+}
+
+function assertIdempotencyKey(value: string) {
+  if (value.trim().length === 0 || value.length > 200) {
+    throw new OrganizerNudgeError(
+      'INVALID_IDEMPOTENCY_KEY',
+      'A valid idempotency key is required.',
+    );
+  }
+}
+
+function taskUnavailable(kind: OrganizerNudgeKind) {
+  return new OrganizerNudgeError(
+    'TASK_UNAVAILABLE',
+    `The ${kind.toLowerCase()} reminder is no longer available.`,
+  );
+}
+
+function addMilliseconds(date: Date, milliseconds: number) {
+  return new Date(date.getTime() + milliseconds);
+}
+
+function isUniqueConstraintError(error: unknown) {
+  return (
+    error instanceof Prisma.PrismaClientKnownRequestError &&
+    error.code === 'P2002'
+  );
+}
+
+export function isOrganizerNudgeKind(
+  value: unknown,
+): value is OrganizerNudgeKind {
+  return (
+    typeof value === 'string' &&
+    ORGANIZER_NUDGE_KIND_VALUES.includes(value as OrganizerNudgeKind)
+  );
+}

--- a/docs/product/notification-coordination-architecture.md
+++ b/docs/product/notification-coordination-architecture.md
@@ -363,11 +363,14 @@ New pool topics default to in-app on where useful, email off, and push off.
 
 ## Organizer nudges
 
-V1 nudges are pool-scoped, preset, and task-bound. A group owner/admin may send
-them only through their pool-manager capability; there is no group-wide
-broadcast and no free-form text.
+V1 nudges are pool-scoped, preset, and task-bound. A pool organizer or active
+group owner/admin may send them only through their pool-manager capability;
+there is no group-wide broadcast and no free-form text. The implementation seam
+is `organizer-nudges.server.ts`: callers may preview an aggregate eligible count
+or request a send, while authorization, audience selection, limits,
+idempotency, audit persistence, and fanout remain private to that module.
 
-Candidate presets:
+Presets:
 
 - set a contribution preference, targeting contributors who have not set one;
 - cast a vote, targeting eligible contributors who have not voted;
@@ -375,8 +378,10 @@ Candidate presets:
 
 Before creating a nudge, re-check pool state, sender permission, recipient
 membership, unresolved task state, actor exclusion, and concealed-recipient
-exclusion. Persist one nudge audit record before fanout so rate checks do not
-depend on notification rows.
+exclusion. `OrganizerNudge` is the durable send-action audit and
+`OrganizerNudgeRecipient` is private cooldown state; neither rate checks nor
+idempotency depend on visible notification rows. Audit and recipient claims are
+committed atomically before fanout.
 
 Recommended initial limits:
 

--- a/prisma/migrations/20260714130000_add_organizer_nudges/migration.sql
+++ b/prisma/migrations/20260714130000_add_organizer_nudges/migration.sql
@@ -1,0 +1,25 @@
+CREATE TABLE "OrganizerNudge" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "poolId" TEXT NOT NULL,
+    "senderId" TEXT NOT NULL,
+    "kind" TEXT NOT NULL,
+    "idempotencyKey" TEXT NOT NULL,
+    "targetCount" INTEGER NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'QUEUED',
+    CONSTRAINT "OrganizerNudge_poolId_fkey" FOREIGN KEY ("poolId") REFERENCES "Pool" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "OrganizerNudge_senderId_fkey" FOREIGN KEY ("senderId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE TABLE "OrganizerNudgeRecipient" (
+    "nudgeId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    PRIMARY KEY ("nudgeId", "userId"),
+    CONSTRAINT "OrganizerNudgeRecipient_nudgeId_fkey" FOREIGN KEY ("nudgeId") REFERENCES "OrganizerNudge" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "OrganizerNudgeRecipient_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE UNIQUE INDEX "OrganizerNudge_senderId_idempotencyKey_key" ON "OrganizerNudge"("senderId", "idempotencyKey");
+CREATE INDEX "OrganizerNudge_poolId_kind_createdAt_idx" ON "OrganizerNudge"("poolId", "kind", "createdAt");
+CREATE INDEX "OrganizerNudge_poolId_createdAt_idx" ON "OrganizerNudge"("poolId", "createdAt");
+CREATE INDEX "OrganizerNudgeRecipient_userId_idx" ON "OrganizerNudgeRecipient"("userId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -67,6 +67,8 @@ model User {
   ideaVotesCast                IdeaVote[]
   poolActivities               PoolActivity[]                @relation("PoolActivity_Actor")
   poolMessages                 PoolMessage[]
+  organizerNudgesSent          OrganizerNudge[]               @relation("OrganizerNudge_Sender")
+  organizerNudgeRecipients     OrganizerNudgeRecipient[]
   feedback                     Feedback[]
   consents                     Consent[]
   // Person-surface memory relations
@@ -401,6 +403,7 @@ model Pool {
   votes         IdeaVote[]
   activities    PoolActivity[]
   messages      PoolMessage[]
+  organizerNudges OrganizerNudge[]
   notificationPreferences PoolNotificationPreference[]
 
   @@index([giftGroupId])
@@ -537,6 +540,40 @@ model PoolActivity {
   actor     User?    @relation("PoolActivity_Actor", fields: [actorId], references: [id])
 
   @@index([poolId, createdAt])
+}
+
+// Durable audit and rate-limit source for preset, task-bound organizer nudges.
+// Customer-facing UI calls these reminders; Organizer Nudge is the domain term.
+// A row exists only when at least one eligible recipient is claimed, so no-op
+// attempts never consume the pool/kind or rolling-pool limits.
+model OrganizerNudge {
+  id             String   @id @default(cuid())
+  createdAt      DateTime @default(now())
+  poolId         String
+  senderId       String
+  kind           String
+  idempotencyKey String
+  targetCount    Int
+  status         String   @default("QUEUED")
+  pool           Pool     @relation(fields: [poolId], references: [id], onDelete: Cascade)
+  sender         User     @relation("OrganizerNudge_Sender", fields: [senderId], references: [id], onDelete: Cascade)
+  recipients     OrganizerNudgeRecipient[]
+
+  @@unique([senderId, idempotencyKey])
+  @@index([poolId, kind, createdAt])
+  @@index([poolId, createdAt])
+}
+
+// Access-controlled operational targets. These identifiers are required for
+// the per-recipient/per-pool 24-hour limit and are never exposed to senders.
+model OrganizerNudgeRecipient {
+  nudgeId String
+  userId  String
+  nudge   OrganizerNudge @relation(fields: [nudgeId], references: [id], onDelete: Cascade)
+  user    User           @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@id([nudgeId, userId])
+  @@index([userId])
 }
 
 // Stub for future in-pool chat/discussion thread.


### PR DESCRIPTION
## Summary

- add a deep organizer-reminder module with aggregate previews and idempotent send commands
- authorize pool managers and derive task-bound contribution, vote, purchase, and delivery audiences without exposing recipient identities
- enforce pool/kind, rolling pool, and per-recipient cooldowns from durable audit records
- register preference-aware in-app/email/push reminder events with email and push off by default
- queue fanout only after the audit transaction commits and record delivery analytics

## Test plan

- [x] Prisma schema validation, client generation, and from-scratch migration reset
- [x] focused catalog, rendering, dispatcher, module, route, privacy, boundary, and concurrency tests (45 tests)
- [x] `npm run lint` (0 errors)
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] full Node 20 unit/component suite (204 files, 1,279 tests)
- [x] Prettier and `git diff --check`

## Migration and environment

- Adds `OrganizerNudge` and `OrganizerNudgeRecipient` tables.
- No new environment variables.

## Checklist

- [x] Free-form messages and group-wide broadcasts remain out of scope.
- [x] Zero-recipient requests create no audit and consume no rate limit.
- [x] Sender, concealed recipient, former contributors, completed actors, muted contexts, and opted-out recipients are excluded.
- [x] API outcomes say queued rather than claiming delivery.
- [x] Durable architecture and agent guidance are updated.

## Screenshots

Not applicable: this PR is backend-only. The accepted task-local UI is a follow-up PR.
