### PR TITLE
feat(pools): add task-local organizer reminders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ node_modules
 /test-results/
 /playwright-report/
 /playwright/.cache/
+/.playwright-cli/
+/output/playwright/
 /tests/fixtures/email/
 /coverage
 

--- a/app/components/pools/organizer-reminder-action.test.tsx
+++ b/app/components/pools/organizer-reminder-action.test.tsx
@@ -1,0 +1,205 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router';
+import type * as ReactRouter from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  OrganizerReminderAction,
+  type OrganizerReminderAvailability,
+} from './organizer-reminder-action.tsx';
+
+const previewFetcher = {
+  data: undefined as unknown,
+  load: vi.fn(),
+  state: 'idle',
+};
+const sendFetcher = {
+  data: undefined as unknown,
+  state: 'idle',
+  submit: vi.fn(),
+};
+let previewResult: unknown;
+let sendResult: unknown;
+
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual<typeof ReactRouter>('react-router');
+  return {
+    ...actual,
+    useFetcher: ({ key }: { key: string }) =>
+      key.includes('-preview-') ? previewFetcher : sendFetcher,
+  };
+});
+
+vi.mock('#app/utils/client-mutation-id.ts', () => ({
+  createClientMutationId: () => 'ui-reminder-request-1',
+}));
+
+beforeEach(() => {
+  previewResult = {
+    eligibleCount: 1,
+    kind: 'VOTE',
+    latestNudge: null,
+    status: 'AVAILABLE',
+  };
+  sendResult = {
+    availableAt: '2026-07-15T15:00:00.000Z',
+    createdAt: '2026-07-14T15:00:00.000Z',
+    kind: 'VOTE',
+    latestNudge: {
+      createdAt: '2026-07-14T15:00:00.000Z',
+      status: 'QUEUED',
+      targetCount: 1,
+    },
+    nudgeId: 'nudge-1',
+    queuedCount: 1,
+    status: 'QUEUED',
+  };
+  previewFetcher.data = undefined;
+  previewFetcher.state = 'idle';
+  previewFetcher.load.mockReset().mockImplementation(() => {
+    previewFetcher.data = previewResult;
+  });
+  sendFetcher.data = undefined;
+  sendFetcher.state = 'idle';
+  sendFetcher.submit.mockReset().mockImplementation(() => {
+    sendFetcher.data = sendResult;
+  });
+});
+
+describe('OrganizerReminderAction', () => {
+  it('resolves the aggregate count only after opening and queues the preset reminder', async () => {
+    renderReminder();
+    expect(previewFetcher.load).not.toHaveBeenCalled();
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Remind voters' }),
+    );
+
+    expect(
+      await screen.findByText('1 person can currently be notified.'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Taylor reminded you to vote in Alex Birthday Pool'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /notification preferences and delivery channels stay private/i,
+      ),
+    ).toBeInTheDocument();
+    expect(previewFetcher.load).toHaveBeenCalledTimes(1);
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Send reminder' }),
+    );
+    expect(
+      await screen.findByText('Reminder queued for 1 person.'),
+    ).toBeInTheDocument();
+
+    expect(sendFetcher.submit).toHaveBeenCalledWith(
+      { idempotencyKey: 'ui-reminder-request-1', kind: 'VOTE' },
+      { action: '/api/pools/pool-1/reminders', method: 'post' },
+    );
+    for (const unlockCopy of screen.getAllByText(/Available again at/)) {
+      expect(unlockCopy).not.toHaveTextContent(/tomorrow/i);
+    }
+  });
+
+  it('keeps a rate-limited reminder visible and disabled with an exact unlock time', () => {
+    renderReminder({
+      availability: {
+        availableAt: '2026-07-16T18:30:00.000Z',
+        kind: 'VOTE',
+        latestNudge: {
+          createdAt: '2026-07-14T15:00:00.000Z',
+          status: 'QUEUED',
+          targetCount: 2,
+        },
+        status: 'WEEKLY_LIMIT',
+      },
+    });
+
+    expect(
+      screen.getByRole('button', { name: 'Remind voters' }),
+    ).toBeDisabled();
+    expect(
+      screen.getByText(/Rolling seven-day reminder limit reached/),
+    ).toHaveTextContent(/Available again at/);
+    expect(previewFetcher.load).not.toHaveBeenCalled();
+  });
+
+  it('shows a privacy-safe no-op when preferences leave no eligible recipients', async () => {
+    previewResult = {
+      kind: 'VOTE',
+      latestNudge: null,
+      status: 'NO_ELIGIBLE',
+    };
+    renderReminder();
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Remind voters' }),
+    );
+
+    expect(
+      await screen.findByRole('heading', {
+        name: 'No one can be notified right now',
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/didn't count toward your limits/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Send reminder' }),
+    ).not.toBeInTheDocument();
+    expect(sendFetcher.submit).not.toHaveBeenCalled();
+  });
+
+  it('replaces confirmation with a neutral stale-task state', async () => {
+    sendResult = {
+      code: 'TASK_UNAVAILABLE',
+      error: 'The vote reminder is no longer available.',
+    };
+    renderReminder();
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Remind voters' }),
+    );
+    await screen.findByText('1 person can currently be notified.');
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Send reminder' }),
+    );
+
+    expect(
+      await screen.findByRole('heading', {
+        name: 'This reminder is no longer available',
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Retry' }),
+    ).not.toBeInTheDocument();
+  });
+});
+
+function renderReminder({
+  availability = {
+    kind: 'VOTE',
+    latestNudge: null,
+    status: 'AVAILABLE',
+  },
+}: {
+  availability?: OrganizerReminderAvailability;
+} = {}) {
+  render(
+    <MemoryRouter>
+      <OrganizerReminderAction
+        availability={availability}
+        kind="VOTE"
+        poolId="pool-1"
+        poolTitle="Alex Birthday Pool"
+        senderDisplayName="Taylor"
+      />
+    </MemoryRouter>,
+  );
+}

--- a/app/components/pools/organizer-reminder-action.tsx
+++ b/app/components/pools/organizer-reminder-action.tsx
@@ -118,14 +118,14 @@ export function OrganizerReminderAction({
   poolId,
   poolTitle,
   senderDisplayName,
-}: {
+}: Readonly<{
   availability: OrganizerReminderAvailability;
   className?: string;
   kind: OrganizerReminderKind;
   poolId: string;
   poolTitle: string;
   senderDisplayName: string;
-}) {
+}>) {
   const { locale } = useTranslation();
   const previewFetcher = useFetcher<OrganizerReminderPreviewResponse>({
     key: `organizer-reminder-preview-${poolId}-${kind}`,
@@ -177,12 +177,10 @@ export function OrganizerReminderAction({
   const statusId = `organizer-reminder-${poolId}-${kind}-status`;
   const endpoint = `/api/pools/${encodeURIComponent(poolId)}/reminders`;
 
-  const loadPreview = () => {
+  const loadPreview = async () => {
     setPreviewError(false);
     try {
-      void Promise.resolve(
-        previewFetcher.load(`${endpoint}?kind=${encodeURIComponent(kind)}`),
-      ).catch(() => setPreviewError(true));
+      await previewFetcher.load(`${endpoint}?kind=${encodeURIComponent(kind)}`);
     } catch {
       setPreviewError(true);
     }
@@ -198,21 +196,19 @@ export function OrganizerReminderAction({
     setSendAttempt(0);
     setSendStarted(false);
     setSendTimedOut(false);
-    loadPreview();
+    void loadPreview();
   };
 
-  const sendReminder = () => {
+  const sendReminder = async () => {
     setSendStarted(true);
     setSendAttempt((attempt) => attempt + 1);
     setSendError(false);
     setSendTimedOut(false);
     try {
-      void Promise.resolve(
-        sendFetcher.submit(
-          { kind, idempotencyKey: idempotencyKeyRef.current },
-          { action: endpoint, method: 'post' },
-        ),
-      ).catch(() => setSendError(true));
+      await sendFetcher.submit(
+        { kind, idempotencyKey: idempotencyKeyRef.current },
+        { action: endpoint, method: 'post' },
+      );
     } catch {
       setSendError(true);
     }
@@ -280,7 +276,7 @@ function OrganizerReminderDialogBody({
   sendPending,
   sendReminder,
   sendTimedOut,
-}: {
+}: Readonly<{
   config: ReminderConfig;
   locale: Parameters<typeof formatRelativeTime>[1];
   poolTitle: string;
@@ -292,9 +288,9 @@ function OrganizerReminderDialogBody({
   sendData: OrganizerReminderSendResponse | undefined;
   sendError: boolean;
   sendPending: boolean;
-  sendReminder: () => void;
+  sendReminder: () => Promise<void>;
   sendTimedOut: boolean;
-}) {
+}>) {
   const liveProps = { 'aria-live': 'polite' as const, role: 'status' as const };
 
   if (sendTimedOut && sendPending) {
@@ -334,40 +330,13 @@ function OrganizerReminderDialogBody({
   }
 
   if (sendData) {
-    if (isErrorResponse(sendData)) {
-      return isStaleResponse(sendData) ? (
-        <TerminalState
-          title="This reminder is no longer available"
-          description="The pool task or your access changed. Close this window to refresh the pool."
-        />
-      ) : (
-        <RecoverableError onRetry={sendReminder} message={sendData.error} />
-      );
-    }
-    if (sendData.status === 'QUEUED') {
-      return (
-        <>
-          <ResponsiveDialogHeader>
-            <div className="mb-2 flex h-10 w-10 items-center justify-center rounded-full bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300">
-              <LuCheck className="h-5 w-5" aria-hidden />
-            </div>
-            <ResponsiveDialogTitle>Reminder queued</ResponsiveDialogTitle>
-            <ResponsiveDialogDescription {...liveProps}>
-              Reminder queued for {formatPeople(sendData.queuedCount)}.
-            </ResponsiveDialogDescription>
-          </ResponsiveDialogHeader>
-          <div className="space-y-1 rounded-xl border bg-muted/30 p-4 text-sm">
-            <p>Queued {formatRelativeTime(sendData.createdAt, locale)}</p>
-            <p className="text-muted-foreground">
-              Available again at {formatExactTime(sendData.availableAt, locale)}
-              .
-            </p>
-          </div>
-          <CloseFooter label="Done" />
-        </>
-      );
-    }
-    return <UnavailableState availability={sendData} locale={locale} />;
+    return (
+      <OrganizerReminderSendOutcome
+        locale={locale}
+        sendData={sendData}
+        sendReminder={sendReminder}
+      />
+    );
   }
 
   if (previewError) {
@@ -457,13 +426,57 @@ function OrganizerReminderDialogBody({
   );
 }
 
+function OrganizerReminderSendOutcome({
+  locale,
+  sendData,
+  sendReminder,
+}: Readonly<{
+  locale: Parameters<typeof formatRelativeTime>[1];
+  sendData: OrganizerReminderSendResponse;
+  sendReminder: () => Promise<void>;
+}>) {
+  if (isErrorResponse(sendData)) {
+    return isStaleResponse(sendData) ? (
+      <TerminalState
+        title="This reminder is no longer available"
+        description="The pool task or your access changed. Close this window to refresh the pool."
+      />
+    ) : (
+      <RecoverableError onRetry={sendReminder} message={sendData.error} />
+    );
+  }
+  if (sendData.status !== 'QUEUED') {
+    return <UnavailableState availability={sendData} locale={locale} />;
+  }
+  return (
+    <>
+      <ResponsiveDialogHeader>
+        <div className="mb-2 flex h-10 w-10 items-center justify-center rounded-full bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300">
+          <LuCheck className="h-5 w-5" aria-hidden />
+        </div>
+        <ResponsiveDialogTitle>Reminder queued</ResponsiveDialogTitle>
+        <ResponsiveDialogDescription aria-live="polite" role="status">
+          Reminder queued for {formatPeople(sendData.queuedCount)}.
+        </ResponsiveDialogDescription>
+      </ResponsiveDialogHeader>
+      <div className="space-y-1 rounded-xl border bg-muted/30 p-4 text-sm">
+        <p>Queued {formatRelativeTime(sendData.createdAt, locale)}</p>
+        <p className="text-muted-foreground">
+          Available again at {formatExactTime(sendData.availableAt, locale)}.
+        </p>
+      </div>
+      <CloseFooter label="Done" />
+    </>
+  );
+}
+
 function UnavailableState({
   availability,
   locale,
-}: {
+}: Readonly<{
   availability: OrganizerReminderUnavailable;
   locale: Parameters<typeof formatRelativeTime>[1];
-}) {
+}>) {
   if (availability.status === 'NO_ELIGIBLE') {
     return (
       <TerminalState
@@ -491,10 +504,10 @@ function UnavailableState({
 function RecoverableError({
   message = 'We could not confirm the reminder. You can safely retry with the same request.',
   onRetry,
-}: {
+}: Readonly<{
   message?: string;
-  onRetry: () => void;
-}) {
+  onRetry: () => void | Promise<void>;
+}>) {
   return (
     <>
       <ResponsiveDialogHeader>
@@ -520,10 +533,10 @@ function RecoverableError({
 function TerminalState({
   description,
   title,
-}: {
+}: Readonly<{
   description: string;
   title: string;
-}) {
+}>) {
   return (
     <>
       <ResponsiveDialogHeader>
@@ -537,7 +550,7 @@ function TerminalState({
   );
 }
 
-function CloseFooter({ label }: { label: string }) {
+function CloseFooter({ label }: Readonly<{ label: string }>) {
   return (
     <ResponsiveDialogFooter>
       <ResponsiveDialogClose asChild>

--- a/app/components/pools/organizer-reminder-action.tsx
+++ b/app/components/pools/organizer-reminder-action.tsx
@@ -1,0 +1,605 @@
+import { useEffect, useRef, useState } from 'react';
+import { LuBell, LuCheck, LuLoader } from 'react-icons/lu';
+import { useFetcher } from 'react-router';
+import { Button } from '#app/components/ui/button.tsx';
+import {
+  ResponsiveDialog,
+  ResponsiveDialogClose,
+  ResponsiveDialogContent,
+  ResponsiveDialogDescription,
+  ResponsiveDialogFooter,
+  ResponsiveDialogHeader,
+  ResponsiveDialogTitle,
+  ResponsiveDialogTrigger,
+} from '#app/components/ui/responsive-dialog.tsx';
+import { createClientMutationId } from '#app/utils/client-mutation-id.ts';
+import { formatRelativeTime, useTranslation } from '#app/utils/i18n.tsx';
+import { cn } from '#app/utils/misc.tsx';
+
+export type OrganizerReminderKind =
+  | 'CONTRIBUTION'
+  | 'VOTE'
+  | 'PURCHASE'
+  | 'DELIVERY';
+
+type LatestReminder = {
+  createdAt: Date | string;
+  targetCount: number;
+  status: string;
+};
+
+type OrganizerReminderBase = {
+  kind: OrganizerReminderKind;
+  latestNudge: LatestReminder | null;
+};
+
+type OrganizerReminderUnavailable = OrganizerReminderBase &
+  (
+    | { status: 'NO_ELIGIBLE' }
+    | { status: 'COOLDOWN'; availableAt: Date | string }
+    | { status: 'WEEKLY_LIMIT'; availableAt: Date | string }
+  );
+
+export type OrganizerReminderAvailability = OrganizerReminderBase &
+  (
+    | { status: 'AVAILABLE' }
+    | { status: 'NO_ELIGIBLE' }
+    | { status: 'COOLDOWN'; availableAt: Date | string }
+    | { status: 'WEEKLY_LIMIT'; availableAt: Date | string }
+  );
+
+type OrganizerReminderPreviewResponse =
+  | OrganizerReminderUnavailable
+  | (OrganizerReminderBase & {
+      status: 'AVAILABLE';
+      eligibleCount: number;
+    })
+  | OrganizerReminderErrorResponse;
+
+type OrganizerReminderQueuedResponse = OrganizerReminderBase & {
+  status: 'QUEUED';
+  nudgeId: string;
+  queuedCount: number;
+  createdAt: Date | string;
+  availableAt: Date | string;
+};
+
+type OrganizerReminderSendResponse =
+  | OrganizerReminderUnavailable
+  | OrganizerReminderQueuedResponse
+  | OrganizerReminderErrorResponse;
+
+type OrganizerReminderErrorResponse = { error: string; code?: string };
+
+type ReminderConfig = {
+  actionLabel: string;
+  title: string;
+  qualification: string;
+  preview: (sender: string, pool: string) => string;
+};
+
+const REMINDER_CONFIG: Record<OrganizerReminderKind, ReminderConfig> = {
+  CONTRIBUTION: {
+    actionLabel: 'Remind contributors',
+    title: 'Remind contributors',
+    qualification:
+      'People in this pool who have not set a contribution preference yet.',
+    preview: (sender, pool) =>
+      `${sender} reminded you to set your contribution in ${pool}`,
+  },
+  VOTE: {
+    actionLabel: 'Remind voters',
+    title: 'Remind voters',
+    qualification: 'People in this pool who have not voted yet.',
+    preview: (sender, pool) => `${sender} reminded you to vote in ${pool}`,
+  },
+  PURCHASE: {
+    actionLabel: 'Remind buyer',
+    title: 'Remind the buyer',
+    qualification: 'The assigned buyer while the purchase is still incomplete.',
+    preview: (sender, pool) =>
+      `${sender} reminded you to buy the gift for ${pool}`,
+  },
+  DELIVERY: {
+    actionLabel: 'Remind deliverer',
+    title: 'Remind the deliverer',
+    qualification: 'The assigned deliverer while delivery is still incomplete.',
+    preview: (sender, pool) =>
+      `${sender} reminded you to deliver the gift for ${pool}`,
+  },
+};
+
+const SEND_TIMEOUT_MS = 15_000;
+
+export function OrganizerReminderAction({
+  availability,
+  className,
+  kind,
+  poolId,
+  poolTitle,
+  senderDisplayName,
+}: {
+  availability: OrganizerReminderAvailability;
+  className?: string;
+  kind: OrganizerReminderKind;
+  poolId: string;
+  poolTitle: string;
+  senderDisplayName: string;
+}) {
+  const { locale } = useTranslation();
+  const previewFetcher = useFetcher<OrganizerReminderPreviewResponse>({
+    key: `organizer-reminder-preview-${poolId}-${kind}`,
+  });
+  const sendFetcher = useFetcher<OrganizerReminderSendResponse>({
+    key: `organizer-reminder-send-${poolId}-${kind}`,
+  });
+  const idempotencyKeyRef = useRef('');
+  const [open, setOpen] = useState(false);
+  const [previewError, setPreviewError] = useState(false);
+  const [sendError, setSendError] = useState(false);
+  const [sendAttempt, setSendAttempt] = useState(0);
+  const [sendStarted, setSendStarted] = useState(false);
+  const [sendTimedOut, setSendTimedOut] = useState(false);
+  const [queuedResult, setQueuedResult] = useState<
+    OrganizerReminderQueuedResponse | undefined
+  >();
+  const config = REMINDER_CONFIG[kind];
+  const sendPending = sendStarted && sendFetcher.state === 'submitting';
+
+  useEffect(() => {
+    if (sendAttempt === 0 || !sendPending) return;
+    const timeout = window.setTimeout(
+      () => setSendTimedOut(true),
+      SEND_TIMEOUT_MS,
+    );
+    return () => window.clearTimeout(timeout);
+  }, [sendAttempt, sendPending]);
+
+  useEffect(() => {
+    if (!sendStarted || !isQueuedResponse(sendFetcher.data)) return;
+    setQueuedResult(sendFetcher.data);
+  }, [sendFetcher.data, sendStarted]);
+
+  const effectiveAvailability: OrganizerReminderAvailability = queuedResult
+    ? {
+        status: 'COOLDOWN',
+        kind,
+        latestNudge: {
+          createdAt: queuedResult.createdAt,
+          targetCount: queuedResult.queuedCount,
+          status: queuedResult.status,
+        },
+        availableAt: queuedResult.availableAt,
+      }
+    : availability;
+  const disabled = effectiveAvailability.status !== 'AVAILABLE';
+  const statusText = getTriggerStatus(effectiveAvailability, locale);
+  const statusId = `organizer-reminder-${poolId}-${kind}-status`;
+  const endpoint = `/api/pools/${encodeURIComponent(poolId)}/reminders`;
+
+  const loadPreview = () => {
+    setPreviewError(false);
+    try {
+      void Promise.resolve(
+        previewFetcher.load(`${endpoint}?kind=${encodeURIComponent(kind)}`),
+      ).catch(() => setPreviewError(true));
+    } catch {
+      setPreviewError(true);
+    }
+  };
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    setOpen(nextOpen);
+    if (!nextOpen) return;
+
+    idempotencyKeyRef.current = createClientMutationId();
+    setPreviewError(false);
+    setSendError(false);
+    setSendAttempt(0);
+    setSendStarted(false);
+    setSendTimedOut(false);
+    loadPreview();
+  };
+
+  const sendReminder = () => {
+    setSendStarted(true);
+    setSendAttempt((attempt) => attempt + 1);
+    setSendError(false);
+    setSendTimedOut(false);
+    try {
+      void Promise.resolve(
+        sendFetcher.submit(
+          { kind, idempotencyKey: idempotencyKeyRef.current },
+          { action: endpoint, method: 'post' },
+        ),
+      ).catch(() => setSendError(true));
+    } catch {
+      setSendError(true);
+    }
+  };
+
+  return (
+    <div className={cn('flex min-w-0 flex-col items-start gap-1.5', className)}>
+      <ResponsiveDialog open={open} onOpenChange={handleOpenChange}>
+        <ResponsiveDialogTrigger asChild>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            className="min-h-11 gap-1.5 sm:min-h-9"
+            disabled={disabled}
+            aria-describedby={statusText ? statusId : undefined}
+            data-testid={`organizer-reminder-trigger-${kind.toLowerCase()}`}
+          >
+            <LuBell className="h-3.5 w-3.5" aria-hidden />
+            {config.actionLabel}
+          </Button>
+        </ResponsiveDialogTrigger>
+        <ResponsiveDialogContent className="sm:max-w-md">
+          <OrganizerReminderDialogBody
+            config={config}
+            locale={locale}
+            poolTitle={poolTitle}
+            previewData={previewFetcher.data}
+            previewError={previewError}
+            previewPending={previewFetcher.state !== 'idle'}
+            retryPreview={loadPreview}
+            senderDisplayName={senderDisplayName}
+            sendData={sendStarted ? sendFetcher.data : undefined}
+            sendError={sendError}
+            sendPending={sendPending}
+            sendReminder={sendReminder}
+            sendTimedOut={sendTimedOut}
+          />
+        </ResponsiveDialogContent>
+      </ResponsiveDialog>
+      {statusText ? (
+        <p
+          id={statusId}
+          className="max-w-xs text-xs leading-snug text-muted-foreground"
+          data-testid={`organizer-reminder-status-${kind.toLowerCase()}`}
+        >
+          {statusText}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+function OrganizerReminderDialogBody({
+  config,
+  locale,
+  poolTitle,
+  previewData,
+  previewError,
+  previewPending,
+  retryPreview,
+  senderDisplayName,
+  sendData,
+  sendError,
+  sendPending,
+  sendReminder,
+  sendTimedOut,
+}: {
+  config: ReminderConfig;
+  locale: Parameters<typeof formatRelativeTime>[1];
+  poolTitle: string;
+  previewData: OrganizerReminderPreviewResponse | undefined;
+  previewError: boolean;
+  previewPending: boolean;
+  retryPreview: () => void;
+  senderDisplayName: string;
+  sendData: OrganizerReminderSendResponse | undefined;
+  sendError: boolean;
+  sendPending: boolean;
+  sendReminder: () => void;
+  sendTimedOut: boolean;
+}) {
+  const liveProps = { 'aria-live': 'polite' as const, role: 'status' as const };
+
+  if (sendTimedOut && sendPending) {
+    return (
+      <TerminalState
+        title="We couldn't confirm the outcome"
+        description="Close and refresh the pool before trying again. This request cannot queue the same reminder twice."
+      />
+    );
+  }
+
+  if (sendPending) {
+    return (
+      <>
+        <ResponsiveDialogHeader>
+          <ResponsiveDialogTitle>Queueing reminder…</ResponsiveDialogTitle>
+          <ResponsiveDialogDescription>
+            You can close this window; the request will continue safely.
+          </ResponsiveDialogDescription>
+        </ResponsiveDialogHeader>
+        <div
+          className="flex items-center gap-3 rounded-xl bg-muted/50 p-4"
+          {...liveProps}
+        >
+          <LuLoader className="h-5 w-5 animate-spin text-primary" aria-hidden />
+          <p className="text-sm">
+            Checking the task and queueing the reminder.
+          </p>
+        </div>
+        <CloseFooter label="Close" />
+      </>
+    );
+  }
+
+  if (sendError) {
+    return <RecoverableError onRetry={sendReminder} />;
+  }
+
+  if (sendData) {
+    if (isErrorResponse(sendData)) {
+      return isStaleResponse(sendData) ? (
+        <TerminalState
+          title="This reminder is no longer available"
+          description="The pool task or your access changed. Close this window to refresh the pool."
+        />
+      ) : (
+        <RecoverableError onRetry={sendReminder} message={sendData.error} />
+      );
+    }
+    if (sendData.status === 'QUEUED') {
+      return (
+        <>
+          <ResponsiveDialogHeader>
+            <div className="mb-2 flex h-10 w-10 items-center justify-center rounded-full bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300">
+              <LuCheck className="h-5 w-5" aria-hidden />
+            </div>
+            <ResponsiveDialogTitle>Reminder queued</ResponsiveDialogTitle>
+            <ResponsiveDialogDescription {...liveProps}>
+              Reminder queued for {formatPeople(sendData.queuedCount)}.
+            </ResponsiveDialogDescription>
+          </ResponsiveDialogHeader>
+          <div className="space-y-1 rounded-xl border bg-muted/30 p-4 text-sm">
+            <p>Queued {formatRelativeTime(sendData.createdAt, locale)}</p>
+            <p className="text-muted-foreground">
+              Available again at {formatExactTime(sendData.availableAt, locale)}
+              .
+            </p>
+          </div>
+          <CloseFooter label="Done" />
+        </>
+      );
+    }
+    return <UnavailableState availability={sendData} locale={locale} />;
+  }
+
+  if (previewError) {
+    return <RecoverableError onRetry={retryPreview} />;
+  }
+
+  if (previewPending || !previewData) {
+    return (
+      <>
+        <ResponsiveDialogHeader>
+          <ResponsiveDialogTitle>{config.title}</ResponsiveDialogTitle>
+          <ResponsiveDialogDescription>
+            Checking who can be notified right now.
+          </ResponsiveDialogDescription>
+        </ResponsiveDialogHeader>
+        <div
+          className="flex items-center gap-3 rounded-xl bg-muted/50 p-4"
+          {...liveProps}
+        >
+          <LuLoader className="h-5 w-5 animate-spin text-primary" aria-hidden />
+          <p className="text-sm">Resolving the eligible count…</p>
+        </div>
+        <CloseFooter label="Cancel" />
+      </>
+    );
+  }
+
+  if (isErrorResponse(previewData)) {
+    return isStaleResponse(previewData) ? (
+      <TerminalState
+        title="This reminder is no longer available"
+        description="The pool task or your access changed. Close this window to refresh the pool."
+      />
+    ) : (
+      <RecoverableError onRetry={retryPreview} message={previewData.error} />
+    );
+  }
+
+  if (previewData.status !== 'AVAILABLE') {
+    return <UnavailableState availability={previewData} locale={locale} />;
+  }
+
+  return (
+    <>
+      <ResponsiveDialogHeader>
+        <ResponsiveDialogTitle>{config.title}</ResponsiveDialogTitle>
+        <ResponsiveDialogDescription>
+          Review this preset reminder before queueing it.
+        </ResponsiveDialogDescription>
+      </ResponsiveDialogHeader>
+      <div className="space-y-4">
+        <div className="rounded-xl border bg-muted/30 p-4">
+          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Notification preview
+          </p>
+          <p className="mt-2 text-sm font-medium">
+            {config.preview(senderDisplayName, poolTitle)}
+          </p>
+        </div>
+        <div className="rounded-xl border p-4">
+          <p className="text-2xl font-semibold tabular-nums">
+            {previewData.eligibleCount}
+          </p>
+          <p className="text-sm text-muted-foreground">
+            {formatPeople(previewData.eligibleCount)} can currently be notified.
+          </p>
+          <p className="mt-2 text-xs text-muted-foreground">
+            {config.qualification}
+          </p>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Individual notification preferences and delivery channels stay
+          private.
+        </p>
+      </div>
+      <ResponsiveDialogFooter className="gap-2">
+        <ResponsiveDialogClose asChild>
+          <Button type="button" variant="outline">
+            Cancel
+          </Button>
+        </ResponsiveDialogClose>
+        <Button type="button" onClick={sendReminder}>
+          Send reminder
+        </Button>
+      </ResponsiveDialogFooter>
+    </>
+  );
+}
+
+function UnavailableState({
+  availability,
+  locale,
+}: {
+  availability: OrganizerReminderUnavailable;
+  locale: Parameters<typeof formatRelativeTime>[1];
+}) {
+  if (availability.status === 'NO_ELIGIBLE') {
+    return (
+      <TerminalState
+        title="No one can be notified right now"
+        description="No reminder was sent, so this didn't count toward your limits."
+      />
+    );
+  }
+  if (availability.status === 'COOLDOWN') {
+    return (
+      <TerminalState
+        title="A reminder was queued recently"
+        description={`This reminder becomes available again at ${formatExactTime(availability.availableAt, locale)}.`}
+      />
+    );
+  }
+  return (
+    <TerminalState
+      title="Rolling seven-day limit reached"
+      description={`Pool reminders become available again at ${formatExactTime(availability.availableAt, locale)}.`}
+    />
+  );
+}
+
+function RecoverableError({
+  message = 'We could not confirm the reminder. You can safely retry with the same request.',
+  onRetry,
+}: {
+  message?: string;
+  onRetry: () => void;
+}) {
+  return (
+    <>
+      <ResponsiveDialogHeader>
+        <ResponsiveDialogTitle>Reminder not queued</ResponsiveDialogTitle>
+        <ResponsiveDialogDescription role="alert">
+          {message}
+        </ResponsiveDialogDescription>
+      </ResponsiveDialogHeader>
+      <ResponsiveDialogFooter className="gap-2">
+        <ResponsiveDialogClose asChild>
+          <Button type="button" variant="outline">
+            Close
+          </Button>
+        </ResponsiveDialogClose>
+        <Button type="button" onClick={onRetry}>
+          Retry
+        </Button>
+      </ResponsiveDialogFooter>
+    </>
+  );
+}
+
+function TerminalState({
+  description,
+  title,
+}: {
+  description: string;
+  title: string;
+}) {
+  return (
+    <>
+      <ResponsiveDialogHeader>
+        <ResponsiveDialogTitle>{title}</ResponsiveDialogTitle>
+        <ResponsiveDialogDescription aria-live="polite" role="status">
+          {description}
+        </ResponsiveDialogDescription>
+      </ResponsiveDialogHeader>
+      <CloseFooter label="Done" />
+    </>
+  );
+}
+
+function CloseFooter({ label }: { label: string }) {
+  return (
+    <ResponsiveDialogFooter>
+      <ResponsiveDialogClose asChild>
+        <Button type="button">{label}</Button>
+      </ResponsiveDialogClose>
+    </ResponsiveDialogFooter>
+  );
+}
+
+function getTriggerStatus(
+  availability: OrganizerReminderAvailability,
+  locale: Parameters<typeof formatRelativeTime>[1],
+) {
+  switch (availability.status) {
+    case 'AVAILABLE':
+      return null;
+    case 'NO_ELIGIBLE':
+      return 'No one can be notified right now.';
+    case 'COOLDOWN': {
+      const latest = availability.latestNudge
+        ? `Queued ${formatRelativeTime(availability.latestNudge.createdAt, locale)}. `
+        : '';
+      return `${latest}Available again at ${formatExactTime(availability.availableAt, locale)}.`;
+    }
+    case 'WEEKLY_LIMIT':
+      return `Rolling seven-day reminder limit reached. Available again at ${formatExactTime(availability.availableAt, locale)}.`;
+  }
+}
+
+function formatExactTime(
+  value: Date | string,
+  locale: Parameters<typeof formatRelativeTime>[1],
+) {
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return 'the time shown after refresh';
+  return new Intl.DateTimeFormat(locale, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(date);
+}
+
+function formatPeople(count: number) {
+  return `${count} ${count === 1 ? 'person' : 'people'}`;
+}
+
+function isErrorResponse(
+  value: OrganizerReminderPreviewResponse | OrganizerReminderSendResponse,
+): value is OrganizerReminderErrorResponse {
+  return 'error' in value;
+}
+
+function isQueuedResponse(
+  value: OrganizerReminderSendResponse | undefined,
+): value is OrganizerReminderQueuedResponse {
+  return Boolean(value && !isErrorResponse(value) && value.status === 'QUEUED');
+}
+
+function isStaleResponse(value: OrganizerReminderErrorResponse) {
+  return (
+    value.code === 'POOL_NOT_FOUND' ||
+    value.code === 'FORBIDDEN' ||
+    value.code === 'TASK_UNAVAILABLE' ||
+    value.code === 'IDEMPOTENCY_CONFLICT'
+  );
+}

--- a/app/routes/pools+/$poolId+/__route.server.test.ts
+++ b/app/routes/pools+/$poolId+/__route.server.test.ts
@@ -43,6 +43,7 @@ const canViewWishlistOf = vi.fn();
 const queueLogEvent = vi.fn();
 const redirectWithToast = vi.fn();
 const getContextNotificationAwareness = vi.fn();
+const getOrganizerNudgeAvailability = vi.fn();
 
 vi.mock('#app/utils/auth.server.ts', () => ({
   requireUserId: (...args: Array<unknown>) => requireUserId(...args),
@@ -119,6 +120,17 @@ vi.mock('#app/utils/toast.server.ts', () => ({
 vi.mock('#app/utils/notification-preferences.server.ts', () => ({
   getContextNotificationAwareness: (...args: Array<unknown>) =>
     getContextNotificationAwareness(...args),
+}));
+
+vi.mock('#app/utils/organizer-nudges.server.ts', () => ({
+  ORGANIZER_NUDGE_KINDS: {
+    CONTRIBUTION: 'CONTRIBUTION',
+    DELIVERY: 'DELIVERY',
+    PURCHASE: 'PURCHASE',
+    VOTE: 'VOTE',
+  },
+  getOrganizerNudgeAvailability: (...args: Array<unknown>) =>
+    getOrganizerNudgeAvailability(...args),
 }));
 
 import { action, loader } from './__route.server.ts';
@@ -211,6 +223,13 @@ beforeEach(() => {
     reason: null,
     preference: { activityLevel: 'IMPORTANT_ONLY' },
   });
+  getOrganizerNudgeAvailability.mockImplementation(
+    async ({ kind }: { kind: string }) => ({
+      kind,
+      latestNudge: null,
+      status: 'AVAILABLE',
+    }),
+  );
 });
 
 describe('pool detail route loader', () => {
@@ -323,6 +342,7 @@ describe('pool detail route loader', () => {
       inviteUrl: 'https://giftpool.app/pools/join/invite-123',
       isOrganizer: false,
       myVoteIdeaId: 'idea-1',
+      organizerReminderStates: {},
       viewer: { userId: 'viewer-1' },
     });
     expect(getContributionBreakdown).toHaveBeenCalledWith('pool-1');
@@ -342,8 +362,35 @@ describe('pool detail route loader', () => {
     await expect(getRouteResultData(result)).resolves.toMatchObject({
       contributionBreakdown: null,
       myVoteIdeaId: null,
+      organizerReminderStates: {
+        CONTRIBUTION: { status: 'AVAILABLE' },
+      },
+    });
+    expect(getOrganizerNudgeAvailability).toHaveBeenCalledTimes(1);
+    expect(getOrganizerNudgeAvailability).toHaveBeenCalledWith({
+      kind: 'CONTRIBUTION',
+      poolId: 'pool-1',
+      senderId: 'viewer-1',
     });
     expect(getContributionBreakdown).not.toHaveBeenCalled();
+  });
+
+  it('loads voting reminder availability without resolving recipient counts', async () => {
+    const result = await loader(
+      toLoaderArgs({
+        context: {} as never,
+        params: { poolId: 'pool-1' },
+        request: new Request('https://giftpool.app/pools/pool-1'),
+      }),
+    );
+
+    await expect(getRouteResultData(result)).resolves.toMatchObject({
+      organizerReminderStates: {
+        CONTRIBUTION: { status: 'AVAILABLE' },
+        VOTE: { status: 'AVAILABLE' },
+      },
+    });
+    expect(getOrganizerNudgeAvailability).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/app/routes/pools+/$poolId+/__route.server.test.ts
+++ b/app/routes/pools+/$poolId+/__route.server.test.ts
@@ -3,6 +3,7 @@
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { OrganizerNudgeError as MockOrganizerNudgeError } from '#app/utils/organizer-nudges.server.ts';
 import {
   getRouteResultData,
   getRouteResultStatus,
@@ -128,6 +129,15 @@ vi.mock('#app/utils/organizer-nudges.server.ts', () => ({
     DELIVERY: 'DELIVERY',
     PURCHASE: 'PURCHASE',
     VOTE: 'VOTE',
+  },
+  OrganizerNudgeError: class OrganizerNudgeError extends Error {
+    constructor(
+      public readonly code: string,
+      message: string,
+    ) {
+      super(message);
+      this.name = 'OrganizerNudgeError';
+    }
   },
   getOrganizerNudgeAvailability: (...args: Array<unknown>) =>
     getOrganizerNudgeAvailability(...args),
@@ -391,6 +401,54 @@ describe('pool detail route loader', () => {
       },
     });
     expect(getOrganizerNudgeAvailability).toHaveBeenCalledTimes(2);
+  });
+
+  it.each(['POOL_NOT_FOUND', 'FORBIDDEN', 'TASK_UNAVAILABLE'] as const)(
+    'omits stale reminder availability after a %s race',
+    async (code) => {
+      getOrganizerNudgeAvailability.mockImplementation(
+        async ({ kind }: { kind: string }) => {
+          if (kind === 'VOTE') throw new MockOrganizerNudgeError(code, code);
+          return { kind, latestNudge: null, status: 'AVAILABLE' };
+        },
+      );
+
+      const result = await loader(
+        toLoaderArgs({
+          context: {} as never,
+          params: { poolId: 'pool-1' },
+          request: new Request('https://giftpool.app/pools/pool-1'),
+        }),
+      );
+      const resultData = await getRouteResultData(result);
+
+      expect(
+        (resultData as { organizerReminderStates: unknown })
+          .organizerReminderStates,
+      ).toEqual({
+        CONTRIBUTION: {
+          kind: 'CONTRIBUTION',
+          latestNudge: null,
+          status: 'AVAILABLE',
+        },
+      });
+    },
+  );
+
+  it('keeps unexpected reminder availability failures visible', async () => {
+    getOrganizerNudgeAvailability.mockRejectedValueOnce(
+      new Error('database unavailable'),
+    );
+
+    await expect(
+      loader(
+        toLoaderArgs({
+          context: {} as never,
+          params: { poolId: 'pool-1' },
+          request: new Request('https://giftpool.app/pools/pool-1'),
+        }),
+      ),
+    ).rejects.toThrow('database unavailable');
   });
 });
 

--- a/app/routes/pools+/$poolId+/__route.server.ts
+++ b/app/routes/pools+/$poolId+/__route.server.ts
@@ -11,6 +11,12 @@ import {
 } from '#app/utils/notification-catalog.ts'
 import { getContextNotificationAwareness } from '#app/utils/notification-preferences.server.ts'
 import {
+	getOrganizerNudgeAvailability,
+	ORGANIZER_NUDGE_KINDS,
+	type OrganizerNudgeAvailability,
+	type OrganizerNudgeKind,
+} from '#app/utils/organizer-nudges.server.ts'
+import {
 	OCCASION_TYPE,
 	POOL_STATUS,
 	type OccasionType,
@@ -133,6 +139,46 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 				})
 			: []
 
+	const organizerReminderKinds: OrganizerNudgeKind[] = []
+	if (canManage && ideasOpen) {
+		organizerReminderKinds.push(ORGANIZER_NUDGE_KINDS.CONTRIBUTION)
+	}
+	if (canManage && pool.status === POOL_STATUS.VOTING) {
+		organizerReminderKinds.push(ORGANIZER_NUDGE_KINDS.VOTE)
+	}
+	if (
+		canManage &&
+		pool.status === POOL_STATUS.DECIDED &&
+		pool.purchaserId &&
+		pool.purchaserId !== userId
+	) {
+		organizerReminderKinds.push(ORGANIZER_NUDGE_KINDS.PURCHASE)
+	}
+	if (
+		canManage &&
+		pool.status === POOL_STATUS.PURCHASED &&
+		pool.delivererId &&
+		pool.delivererId !== userId
+	) {
+		organizerReminderKinds.push(ORGANIZER_NUDGE_KINDS.DELIVERY)
+	}
+	const organizerReminderEntries = await Promise.all(
+		organizerReminderKinds.map(
+			async kind =>
+				[
+					kind,
+					await getOrganizerNudgeAvailability({
+						poolId,
+						senderId: userId,
+						kind,
+					}),
+				] as const,
+		),
+	)
+	const organizerReminderStates = Object.fromEntries(
+		organizerReminderEntries,
+	) as Partial<Record<OrganizerNudgeKind, OrganizerNudgeAvailability>>
+
 	return {
 		pool,
 		viewer,
@@ -142,6 +188,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 		contributionBreakdown,
 		inviteUrl,
 		recipientWishlistItems,
+		organizerReminderStates,
 		notificationAwareness: await getContextNotificationAwareness({
 			userId,
 			context: { kind: 'POOL', poolId },

--- a/app/routes/pools+/$poolId+/__route.server.ts
+++ b/app/routes/pools+/$poolId+/__route.server.ts
@@ -13,6 +13,7 @@ import { getContextNotificationAwareness } from '#app/utils/notification-prefere
 import {
 	getOrganizerNudgeAvailability,
 	ORGANIZER_NUDGE_KINDS,
+	OrganizerNudgeError,
 	type OrganizerNudgeAvailability,
 	type OrganizerNudgeKind,
 } from '#app/utils/organizer-nudges.server.ts'
@@ -162,19 +163,13 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 	) {
 		organizerReminderKinds.push(ORGANIZER_NUDGE_KINDS.DELIVERY)
 	}
-	const organizerReminderEntries = await Promise.all(
-		organizerReminderKinds.map(
-			async kind =>
-				[
-					kind,
-					await getOrganizerNudgeAvailability({
-						poolId,
-						senderId: userId,
-						kind,
-					}),
-				] as const,
-		),
-	)
+	const organizerReminderEntries = (
+		await Promise.all(
+			organizerReminderKinds.map(kind =>
+				getOrganizerReminderEntry({ poolId, senderId: userId, kind }),
+			),
+		)
+	).filter(entry => entry !== null)
 	const organizerReminderStates = Object.fromEntries(
 		organizerReminderEntries,
 	) as Partial<Record<OrganizerNudgeKind, OrganizerNudgeAvailability>>
@@ -199,6 +194,40 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 			...getNotificationTopicDefinition(topic),
 		})),
 	}
+}
+
+type OrganizerReminderEntry = readonly [
+	OrganizerNudgeKind,
+	OrganizerNudgeAvailability,
+]
+
+async function getOrganizerReminderEntry({
+	poolId,
+	senderId,
+	kind,
+}: {
+	poolId: string
+	senderId: string
+	kind: OrganizerNudgeKind
+}): Promise<OrganizerReminderEntry | null> {
+	try {
+		return [
+			kind,
+			await getOrganizerNudgeAvailability({ poolId, senderId, kind }),
+		]
+	} catch (error) {
+		if (isStaleOrganizerReminderError(error)) return null
+		throw error
+	}
+}
+
+function isStaleOrganizerReminderError(error: unknown) {
+	return (
+		error instanceof OrganizerNudgeError &&
+		(error.code === 'POOL_NOT_FOUND' ||
+			error.code === 'FORBIDDEN' ||
+			error.code === 'TASK_UNAVAILABLE')
+	)
 }
 
 // ─── Intents ──────────────────────────────────────────────────────────────────

--- a/app/routes/pools+/$poolId+/index.test.tsx
+++ b/app/routes/pools+/$poolId+/index.test.tsx
@@ -30,6 +30,14 @@ const loaderDataSnapshot = {
   inviteUrl: 'https://giftpool.app/pools/join/invite-1' as string | null,
   isOrganizer: true,
   myVoteIdeaId: 'idea-1' as string | null,
+  organizerReminderStates: {
+    CONTRIBUTION: {
+      kind: 'CONTRIBUTION',
+      latestNudge: null,
+      status: 'AVAILABLE',
+    },
+    VOTE: { kind: 'VOTE', latestNudge: null, status: 'AVAILABLE' },
+  } as Record<string, unknown>,
   pool: {
     chosenIdeaId: null as string | null,
     contributors: [
@@ -57,6 +65,12 @@ const loaderDataSnapshot = {
     ],
     decisionMode: 'VOTE',
     delivererId: 'deliverer-1' as string | null,
+    deliverer: {
+      id: 'deliverer-1',
+      image: null,
+      name: null,
+      username: 'casey',
+    },
     finalPriceCents: null as number | null,
     id: 'pool-1',
     ideas: [
@@ -90,6 +104,12 @@ const loaderDataSnapshot = {
     occasionType: 'BIRTHDAY',
     organizerId: 'viewer-1',
     purchaserId: 'buyer-1' as string | null,
+    purchaser: {
+      id: 'buyer-1',
+      image: null,
+      name: 'Jordan',
+      username: 'jordan',
+    },
     recipientName: 'Alex',
     status: 'VOTING',
     title: 'Alex Birthday Pool',
@@ -144,6 +164,14 @@ describe('app/routes/pools+/$poolId+/index.tsx', () => {
     loaderDataSnapshot.inviteUrl = 'https://giftpool.app/pools/join/invite-1';
     loaderDataSnapshot.isOrganizer = true;
     loaderDataSnapshot.myVoteIdeaId = 'idea-1';
+    loaderDataSnapshot.organizerReminderStates = {
+      CONTRIBUTION: {
+        kind: 'CONTRIBUTION',
+        latestNudge: null,
+        status: 'AVAILABLE',
+      },
+      VOTE: { kind: 'VOTE', latestNudge: null, status: 'AVAILABLE' },
+    };
     loaderDataSnapshot.pool.chosenIdeaId = null;
     loaderDataSnapshot.pool.decisionMode = 'VOTE';
     loaderDataSnapshot.pool.delivererId = 'deliverer-1';
@@ -174,6 +202,12 @@ describe('app/routes/pools+/$poolId+/index.tsx', () => {
 
     expect(screen.getByText('Organizer controls')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Close vote' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Remind voters' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Remind contributors' }),
+    ).toBeInTheDocument();
     expect(screen.getByText('Voting open')).toBeInTheDocument();
     expect(screen.getAllByTestId('idea-card')).toHaveLength(2);
     expect(screen.getByText('≈ $15.99')).toBeInTheDocument();
@@ -301,5 +335,40 @@ describe('app/routes/pools+/$poolId+/index.tsx', () => {
     expect(
       screen.getByRole('button', { name: 'Mark as delivered' }),
     ).toBeInTheDocument();
+  });
+
+  it('renders task-local buyer and delivery reminders only for managers who are not the assignee', () => {
+    loaderDataSnapshot.pool.status = 'DECIDED';
+    loaderDataSnapshot.pool.chosenIdeaId = 'idea-1';
+    loaderDataSnapshot.pool.purchaserId = 'buyer-1';
+    loaderDataSnapshot.viewer.userId = 'viewer-1';
+    loaderDataSnapshot.organizerReminderStates = {
+      PURCHASE: { kind: 'PURCHASE', latestNudge: null, status: 'AVAILABLE' },
+    };
+
+    const { unmount } = renderRoute();
+    expect(screen.getByText('Waiting for the buyer')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Remind buyer' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'I bought it' }),
+    ).not.toBeInTheDocument();
+    unmount();
+
+    loaderDataSnapshot.pool.status = 'PURCHASED';
+    loaderDataSnapshot.pool.delivererId = 'deliverer-1';
+    loaderDataSnapshot.organizerReminderStates = {
+      DELIVERY: { kind: 'DELIVERY', latestNudge: null, status: 'AVAILABLE' },
+    };
+    renderRoute();
+
+    expect(screen.getByText('Waiting for delivery')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Remind deliverer' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Mark as delivered' }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/app/routes/pools+/$poolId+/index.tsx
+++ b/app/routes/pools+/$poolId+/index.tsx
@@ -21,6 +21,7 @@ import {
 	useRouteLoaderData,
 } from 'react-router'
 import { z } from 'zod'
+import { OrganizerReminderAction } from '#app/components/pools/organizer-reminder-action.tsx'
 import { Badge } from '#app/components/ui/badge.tsx'
 import { Button } from '#app/components/ui/button.tsx'
 import { Card } from '#app/components/ui/card.tsx'
@@ -591,6 +592,7 @@ const ContributorsList = ({
 	delivererId,
 	canManage,
 	isDecided,
+	reminderAction,
 }: {
 	contributors: Contributor[]
 	poolId: string
@@ -600,11 +602,15 @@ const ContributorsList = ({
 	delivererId: string | null
 	canManage: boolean
 	isDecided: boolean
+	reminderAction?: React.ReactNode
 }) => {
 	return (
 		<Card className="p-4">
 			<Stack gap={3}>
-				<SectionHeading>Contributors ({contributors.length})</SectionHeading>
+				<div className="flex items-center justify-between gap-3">
+					<SectionHeading>Contributors ({contributors.length})</SectionHeading>
+					{reminderAction}
+				</div>
 				<p className="text-xs text-muted-foreground">
 					How much each person is chipping in for this one gift.
 				</p>
@@ -786,6 +792,7 @@ const PoolIndex = () => {
 		myVoteIdeaId,
 		contributionBreakdown,
 		recipientWishlistItems,
+		organizerReminderStates,
 	} = useRouteLoaderData<typeof routeLoader>(
 		'routes/pools+/$poolId+/_layout',
 	)!
@@ -801,6 +808,8 @@ const PoolIndex = () => {
 	const chosenIdea = pool.ideas.find(i => i.id === pool.chosenIdeaId) ?? null
 	const isPurchaser = viewer?.userId === pool.purchaserId
 	const isDeliverer = viewer?.userId === pool.delivererId
+	const senderDisplayName =
+		viewer?.user.name ?? viewer?.user.username ?? 'A pool manager'
 
 	const navigation = useNavigation()
 
@@ -824,13 +833,24 @@ const PoolIndex = () => {
 									</Form>
 								)}
 								{isVoting && (
-									<Form method="post">
-										<input type="hidden" name="intent" value="close-vote" />
-										<input type="hidden" name="poolId" value={pool.id} />
-										<Button type="submit" size="sm" variant="outline">
-											Close vote
-										</Button>
-									</Form>
+									<>
+										<Form method="post">
+											<input type="hidden" name="intent" value="close-vote" />
+											<input type="hidden" name="poolId" value={pool.id} />
+											<Button type="submit" size="sm" variant="outline">
+												Close vote
+											</Button>
+										</Form>
+										{organizerReminderStates.VOTE && (
+											<OrganizerReminderAction
+												availability={organizerReminderStates.VOTE}
+												kind="VOTE"
+												poolId={pool.id}
+												poolTitle={pool.title}
+												senderDisplayName={senderDisplayName}
+											/>
+										)}
+									</>
 								)}
 							</Flex>
 						</Stack>
@@ -859,6 +879,35 @@ const PoolIndex = () => {
 				</Form>
 			)}
 
+			{isDecided &&
+				canManage &&
+				!isPurchaser &&
+				pool.purchaser &&
+				organizerReminderStates.PURCHASE && (
+					<Card className="border-dashed bg-muted/20 p-4">
+						<div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+							<div className="flex min-w-0 items-start gap-3">
+								<LuPackage className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" />
+								<div>
+									<p className="text-sm font-medium">Waiting for the buyer</p>
+									<p className="text-xs text-muted-foreground">
+										{getUserDisplayName(pool.purchaser)} is assigned to buy the
+										gift.
+									</p>
+								</div>
+							</div>
+							<OrganizerReminderAction
+								availability={organizerReminderStates.PURCHASE}
+								kind="PURCHASE"
+								poolId={pool.id}
+								poolTitle={pool.title}
+								senderDisplayName={senderDisplayName}
+								className="sm:items-end"
+							/>
+						</div>
+					</Card>
+				)}
+
 			{/* ── Contribution breakdown (DECIDED+) ── */}
 			{contributionBreakdown && (
 				<ContributionBreakdown
@@ -879,6 +928,35 @@ const PoolIndex = () => {
 					</Button>
 				</Form>
 			)}
+
+			{isPurchased &&
+				canManage &&
+				!isDeliverer &&
+				pool.deliverer &&
+				organizerReminderStates.DELIVERY && (
+					<Card className="border-dashed bg-muted/20 p-4">
+						<div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+							<div className="flex min-w-0 items-start gap-3">
+								<LuTruck className="mt-0.5 h-4 w-4 shrink-0 text-blue-600" />
+								<div>
+									<p className="text-sm font-medium">Waiting for delivery</p>
+									<p className="text-xs text-muted-foreground">
+										{getUserDisplayName(pool.deliverer)} is assigned to deliver
+										the gift.
+									</p>
+								</div>
+							</div>
+							<OrganizerReminderAction
+								availability={organizerReminderStates.DELIVERY}
+								kind="DELIVERY"
+								poolId={pool.id}
+								poolTitle={pool.title}
+								senderDisplayName={senderDisplayName}
+								className="sm:items-end"
+							/>
+						</div>
+					</Card>
+				)}
 
 			{/* ── Ideas section (OPEN + VOTING) ── */}
 			{isActive && (
@@ -971,6 +1049,18 @@ const PoolIndex = () => {
 				delivererId={pool.delivererId}
 				canManage={canManage}
 				isDecided={isDecided || isPurchased || isDelivered}
+				reminderAction={
+					canManage && isActive && organizerReminderStates.CONTRIBUTION ? (
+						<OrganizerReminderAction
+							availability={organizerReminderStates.CONTRIBUTION}
+							kind="CONTRIBUTION"
+							poolId={pool.id}
+							poolTitle={pool.title}
+							senderDisplayName={senderDisplayName}
+							className="items-end"
+						/>
+					) : undefined
+				}
 			/>
 
 			{/* ── Assign roles (organizer, DECIDED+, while roles still need setting) ── */}

--- a/app/utils/organizer-nudges.server.test.ts
+++ b/app/utils/organizer-nudges.server.test.ts
@@ -21,9 +21,10 @@ import {
   ORGANIZER_NUDGE_KIND_COOLDOWN_MS,
   ORGANIZER_NUDGE_KINDS,
   ORGANIZER_NUDGE_POOL_WINDOW_MS,
-  OrganizerNudgeError,
+  getOrganizerNudgeAvailability,
   previewOrganizerNudge,
   sendOrganizerNudge,
+  type OrganizerNudgeError,
 } from './organizer-nudges.server.ts';
 
 const createdUserIds: string[] = [];
@@ -50,6 +51,36 @@ afterEach(async () => {
 });
 
 describe('organizer nudge module', () => {
+  it('keeps page availability independent from preference-resolved counts', async () => {
+    const [organizer, muted] = await createUsers('availability', 2);
+    const pool = await createPool({
+      organizerId: organizer.id,
+      status: 'OPEN',
+      contributors: [
+        { userId: organizer.id, contributionCents: 2500 },
+        { userId: muted.id, contributionCents: null },
+      ],
+    });
+    await prisma.poolNotificationPreference.create({
+      data: { userId: muted.id, poolId: pool.id, activityLevel: 'MUTED' },
+    });
+
+    await expect(
+      getOrganizerNudgeAvailability({
+        poolId: pool.id,
+        senderId: organizer.id,
+        kind: ORGANIZER_NUDGE_KINDS.CONTRIBUTION,
+      }),
+    ).resolves.toMatchObject({ status: 'AVAILABLE' });
+    await expect(
+      previewOrganizerNudge({
+        poolId: pool.id,
+        senderId: organizer.id,
+        kind: ORGANIZER_NUDGE_KINDS.CONTRIBUTION,
+      }),
+    ).resolves.toMatchObject({ status: 'NO_ELIGIBLE' });
+  });
+
   it('returns only an aggregate count after privacy and preference suppression', async () => {
     const [organizer, eligible, muted, recipient] = await createUsers(
       'preview',

--- a/app/utils/organizer-nudges.server.ts
+++ b/app/utils/organizer-nudges.server.ts
@@ -45,6 +45,14 @@ export type OrganizerNudgePreview = OrganizerNudgeResultBase &
     | { status: 'WEEKLY_LIMIT'; availableAt: Date }
   );
 
+export type OrganizerNudgeAvailability = OrganizerNudgeResultBase &
+  (
+    | { status: 'AVAILABLE' }
+    | { status: 'NO_ELIGIBLE' }
+    | { status: 'COOLDOWN'; availableAt: Date }
+    | { status: 'WEEKLY_LIMIT'; availableAt: Date }
+  );
+
 export type OrganizerNudgeSendResult =
   | OrganizerNudgePreview
   | (OrganizerNudgeResultBase & {
@@ -89,6 +97,32 @@ type ExistingNudge = {
   status: string;
   createdAt: Date;
 };
+
+/**
+ * Lightweight page-state interface. It deliberately stops before preference
+ * resolution so pool pages can render task and rate-limit availability without
+ * calculating or exposing a recipient count. The dialog calls
+ * previewOrganizerNudge only after the manager opens it.
+ */
+export async function getOrganizerNudgeAvailability({
+  poolId,
+  senderId,
+  kind,
+}: {
+  poolId: string;
+  senderId: string;
+  kind: OrganizerNudgeKind;
+}): Promise<OrganizerNudgeAvailability> {
+  const evaluation = await prisma.$transaction((tx) =>
+    evaluateNudge(tx, { poolId, senderId, kind, now: new Date() }),
+  );
+  if (evaluation.status !== 'READY') return evaluation;
+  return {
+    status: 'AVAILABLE',
+    kind,
+    latestNudge: evaluation.latestNudge,
+  };
+}
 
 /**
  * Read interface for the task-local confirmation surface. Audience details

--- a/tests/e2e/organizer-reminders.test.ts
+++ b/tests/e2e/organizer-reminders.test.ts
@@ -1,0 +1,150 @@
+import { prisma } from '#app/utils/db.server.ts';
+import { NOTIFICATION_TYPES } from '#app/utils/notification-catalog.ts';
+import { DECISION_MODE, POOL_STATUS } from '#app/utils/pool-constants.ts';
+import { createPool } from '#app/utils/pool.server.ts';
+import { createPassword, createUser } from '#tests/db-utils.ts';
+import {
+  expect,
+  loginWithPassword,
+  test,
+  waitFor,
+} from '#tests/playwright-utils.ts';
+
+const connectUserRole = { connect: { name: 'user' } };
+
+async function createAppUser(name: string) {
+  const userData = createUser();
+  const user = await prisma.user.create({
+    select: { id: true, username: true },
+    data: {
+      ...userData,
+      name,
+      roles: connectUserRole,
+      password: { create: createPassword(userData.username) },
+    },
+  });
+
+  return { ...user, password: userData.username };
+}
+
+async function setupVotingPool() {
+  const organizer = await createAppUser('Morgan Manager');
+  const voter = await createAppUser('Private Recipient');
+  const pool = await createPool({
+    decisionMode: DECISION_MODE.VOTE,
+    organizerId: organizer.id,
+    recipientName: 'Riley',
+    title: 'Riley Birthday Pool',
+  });
+  await prisma.pool.update({
+    where: { id: pool.id },
+    data: {
+      status: POOL_STATUS.VOTING,
+      contributors: { create: { userId: voter.id } },
+    },
+  });
+
+  return { organizer, pool, voter };
+}
+
+test.describe('organizer reminders', () => {
+  test('loads the eligible count on demand and queues a preset reminder', async ({
+    page,
+  }) => {
+    const { organizer, pool, voter } = await setupVotingPool();
+    let previewRequests = 0;
+    page.on('request', (request) => {
+      if (
+        request.method() === 'GET' &&
+        request.url().includes(`/api/pools/${pool.id}/reminders`)
+      ) {
+        previewRequests += 1;
+      }
+    });
+
+    try {
+      await loginWithPassword(page, {
+        username: organizer.username,
+        password: organizer.password,
+      });
+      await page.goto(`/pools/${pool.id}`);
+
+      const trigger = page.getByRole('button', { name: 'Remind voters' });
+      await expect(trigger).toBeVisible();
+      expect(previewRequests).toBe(0);
+
+      await trigger.click();
+      const dialog = page.getByRole('dialog');
+      await expect(
+        dialog.getByText('1 person can currently be notified.'),
+      ).toBeVisible();
+      expect(previewRequests).toBe(1);
+      await expect(dialog).not.toContainText('Private Recipient');
+      await expect(dialog).not.toContainText(voter.username);
+      await expect(dialog).toContainText(
+        'Individual notification preferences and delivery channels stay private.',
+      );
+
+      await dialog.getByRole('button', { name: 'Send reminder' }).click();
+      await expect(
+        dialog.getByRole('heading', { name: 'Reminder queued' }),
+      ).toBeVisible();
+      await expect(dialog).toContainText('Reminder queued for 1 person.');
+      await dialog.getByRole('button', { name: 'Done' }).click();
+
+      await expect(trigger).toBeDisabled();
+      await expect(
+        page.getByTestId('organizer-reminder-status-vote'),
+      ).toContainText('Available again at');
+
+      await waitFor(async () => {
+        const notification = await prisma.notification.findFirst({
+          where: {
+            type: NOTIFICATION_TYPES.POOL_VOTE_REMINDER,
+            userId: voter.id,
+          },
+          select: { id: true },
+        });
+        if (notification) return notification;
+        throw new Error('Reminder notification has not been queued yet');
+      });
+    } finally {
+      await prisma.pool.deleteMany({ where: { id: pool.id } });
+      await prisma.user.deleteMany({
+        where: { id: { in: [organizer.id, voter.id] } },
+      });
+    }
+  });
+
+  test('uses a bottom sheet on a mobile viewport', async ({ page }) => {
+    const { organizer, pool, voter } = await setupVotingPool();
+
+    try {
+      await page.setViewportSize({ width: 390, height: 844 });
+      await loginWithPassword(page, {
+        username: organizer.username,
+        password: organizer.password,
+      });
+      await page.goto(`/pools/${pool.id}`);
+      await page.getByRole('button', { name: 'Remind voters' }).click();
+
+      const dialog = page.getByRole('dialog');
+      await expect(
+        dialog.getByText('1 person can currently be notified.'),
+      ).toBeVisible();
+      await expect
+        .poll(async () => {
+          const box = await dialog.boundingBox();
+          return Math.abs((box?.y ?? 0) + (box?.height ?? 0) - 844);
+        })
+        .toBeLessThan(3);
+      const settledBox = await dialog.boundingBox();
+      expect(settledBox?.width).toBeLessThanOrEqual(390);
+    } finally {
+      await prisma.pool.deleteMany({ where: { id: pool.id } });
+      await prisma.user.deleteMany({
+        where: { id: { in: [organizer.id, voter.id] } },
+      });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add task-local reminder actions for contribution, voting, purchase, and delivery work
- resolve preference-aware recipient counts only after the confirmation surface opens and keep individual recipients and channels private
- preserve exact cooldown and rolling-limit times, idempotent queueing, bounded pending/error states, and responsive mobile bottom sheets

Follows the organizer-reminder backend in #480 and the accepted Claude Design handoff/audit.

## Test plan
- [x] npm run lint (0 errors; existing warnings remain)
- [x] npm run typecheck
- [x] npm test -- --run (205 files, 1,286 tests)
- [x] npm run build
- [x] focused Playwright organizer-reminder suite on desktop and 390x844 mobile (2 tests)
- [x] desktop dialog and mobile bottom-sheet visual inspection with no console errors

## Checklist
- [x] focused conventional commits
- [x] no schema migration
- [x] no environment changes
- [x] screenshots captured locally in the ignored output/playwright handoff directory