### PR TITLE
feat(admin): add organizer reminder observability

### DIFF
--- a/app/routes/admin+/analytics.dom.test.tsx
+++ b/app/routes/admin+/analytics.dom.test.tsx
@@ -2,9 +2,9 @@
  * @vitest-environment jsdom
  */
 import { render, screen } from '@testing-library/react';
-import * as ReactRouter from 'react-router';
+import type * as ReactRouter from 'react-router';
 import { MemoryRouter } from 'react-router';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 const loaderDataSnapshot = {
   analytics: {
@@ -70,6 +70,56 @@ const loaderDataSnapshot = {
       total: 10,
     },
   ],
+  organizerReminders: {
+    days: 30,
+    queuedReminders: 4,
+    targetedRecipients: 10,
+    deliveredRecipients: 8,
+    deliveryRate: 80,
+    notificationClicks: 3,
+    clickEventRate: 38,
+    repeatSends: 1,
+    skippedAttempts: { noEligible: 2, cooldown: 1, weeklyLimit: 1 },
+    settingsReducedWithin7Days: 1,
+    byKind: [
+      {
+        kind: 'CONTRIBUTION',
+        label: 'Contribution',
+        notificationType: 'POOL_CONTRIBUTION_REMINDER',
+        queued: 2,
+        targeted: 5,
+        delivered: 4,
+        clicks: 2,
+      },
+      {
+        kind: 'VOTE',
+        label: 'Vote',
+        notificationType: 'POOL_VOTE_REMINDER',
+        queued: 1,
+        targeted: 3,
+        delivered: 2,
+        clicks: 1,
+      },
+      {
+        kind: 'PURCHASE',
+        label: 'Purchase',
+        notificationType: 'POOL_PURCHASE_REMINDER',
+        queued: 1,
+        targeted: 2,
+        delivered: 2,
+        clicks: 0,
+      },
+      {
+        kind: 'DELIVERY',
+        label: 'Delivery',
+        notificationType: 'POOL_DELIVERY_REMINDER',
+        queued: 0,
+        targeted: 0,
+        delivered: 0,
+        clicks: 0,
+      },
+    ],
+  },
   enrichment: {
     attempts: 20,
     successes: 15,
@@ -163,6 +213,10 @@ vi.mock('#app/utils/admin.server.ts', () => ({
   getSmartLinkAdoption: vi.fn(),
 }));
 
+vi.mock('#app/utils/admin-organizer-reminders.server.ts', () => ({
+  getOrganizerReminderMetrics: vi.fn(),
+}));
+
 import AnalyticsRoute from './analytics.tsx';
 
 const renderAnalytics = () =>
@@ -254,6 +308,23 @@ describe('admin analytics page', () => {
     ).toBeInTheDocument();
     expect(screen.getByText('friend request received')).toBeInTheDocument();
     expect(screen.getByText('upcoming birthday')).toBeInTheDocument();
+  });
+
+  it('renders aggregate organizer reminder outcomes and caveats', () => {
+    renderAnalytics();
+    expect(
+      screen.getByRole('heading', { name: 'Organizer reminders' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Reminders queued')).toBeInTheDocument();
+    expect(screen.getByText('Recipients delivered')).toBeInTheDocument();
+    expect(screen.getByText('Rate-limited attempts')).toBeInTheDocument();
+    expect(screen.getByText('1 cooldown · 1 weekly limit')).toBeInTheDocument();
+    expect(screen.getByText('Contribution')).toBeInTheDocument();
+    expect(screen.getByText('Delivery')).toBeInTheDocument();
+    expect(screen.getByText(/not per-nudge attribution/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/not proof the reminder caused/i),
+    ).toBeInTheDocument();
   });
 
   it('renders the environment analytics section', () => {

--- a/app/routes/admin+/analytics.test.ts
+++ b/app/routes/admin+/analytics.test.ts
@@ -112,6 +112,7 @@ describe('/admin/analytics loader', () => {
     const data = await getRouteResultData<{
       analytics: any;
       environment: any;
+      organizerReminders: any;
     }>(response);
     expect(data.analytics.totalUsers).toBe(2);
     expect(data.analytics.dau).toBe(1);
@@ -140,6 +141,13 @@ describe('/admin/analytics loader', () => {
       label: 'Chrome 120',
       count: 1,
       percent: 100,
+    });
+    expect(data.organizerReminders).toMatchObject({
+      days: 30,
+      queuedReminders: 0,
+      targetedRecipients: 0,
+      deliveredRecipients: 0,
+      notificationClicks: 0,
     });
   });
 });

--- a/app/routes/admin+/analytics.tsx
+++ b/app/routes/admin+/analytics.tsx
@@ -7,11 +7,9 @@ import {
 import { GeneralErrorBoundary } from '#app/components/error-boundary.tsx';
 import { Card } from '#app/components/ui/card.tsx';
 import {
-  type AnalyticsCounts,
-  type EnvironmentAnalytics,
-  getAnalyticsCounts,
-  getEnvironmentAnalytics,
-} from '#app/utils/analytics.server.ts';
+  type OrganizerReminderMetrics,
+  getOrganizerReminderMetrics,
+} from '#app/utils/admin-organizer-reminders.server.ts';
 import {
   type DropOffFunnels,
   type EnrichmentFailures,
@@ -30,6 +28,12 @@ import {
   getSmartLinkAdoption,
   getWeeklyRetention,
 } from '#app/utils/admin.server.ts';
+import {
+  type AnalyticsCounts,
+  type EnvironmentAnalytics,
+  getAnalyticsCounts,
+  getEnvironmentAnalytics,
+} from '#app/utils/analytics.server.ts';
 import { cn } from '#app/utils/misc.tsx';
 import { requireUserWithRole } from '#app/utils/permissions.server.ts';
 
@@ -45,6 +49,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
     dropOff,
     retention,
     optOutMatrix,
+    organizerReminders,
     enrichment,
     enrichmentFailures,
     linkClicks,
@@ -56,6 +61,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
     getDropOffFunnels({ days: 30 }),
     getWeeklyRetention(8),
     getNotificationOptOutMatrix(),
+    getOrganizerReminderMetrics({ days: 30, now }),
     getEnrichmentFunnel({ days: 30 }),
     getEnrichmentFailures({ days: 30 }),
     getLinkClickStats({ days: 30 }),
@@ -69,6 +75,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
     dropOff,
     retention,
     optOutMatrix,
+    organizerReminders,
     enrichment,
     enrichmentFailures,
     linkClicks,
@@ -191,6 +198,7 @@ const AnalyticsRoute = () => {
     dropOff,
     retention,
     optOutMatrix,
+    organizerReminders,
     enrichment,
     enrichmentFailures,
     linkClicks,
@@ -278,6 +286,13 @@ const AnalyticsRoute = () => {
       </SectionCard>
 
       <SectionCard
+        title="Organizer reminders"
+        description="Last 30 days. Aggregate outcomes for preset, task-bound reminders; no pool, sender, or recipient identities are shown."
+      >
+        <OrganizerReminderSection metrics={organizerReminders} />
+      </SectionCard>
+
+      <SectionCard
         title="Environment"
         description="Last 30 days. Daily visitor snapshots by browser, device, OS, and PWA launch mode."
       >
@@ -318,6 +333,109 @@ const AnalyticsRoute = () => {
 
 const pctOf = (count: number, total: number) =>
   total > 0 ? Math.round((count / total) * 100) : 0;
+
+const OrganizerReminderSection = ({
+  metrics,
+}: {
+  metrics: OrganizerReminderMetrics;
+}) => {
+  const rateLimitedAttempts =
+    metrics.skippedAttempts.cooldown + metrics.skippedAttempts.weeklyLimit;
+  return (
+    <div className="space-y-5">
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <SummaryCard label="Reminders queued" value={metrics.queuedReminders} />
+        <SummaryCard
+          label="Recipients targeted"
+          value={metrics.targetedRecipients}
+        />
+        <SummaryCard
+          label="Recipients delivered"
+          value={metrics.deliveredRecipients}
+          delta={`${metrics.deliveryRate}% of targeted recipients`}
+        />
+        <SummaryCard
+          label="Reminder click events"
+          value={metrics.notificationClicks}
+          delta={`${metrics.clickEventRate}% of delivered recipients`}
+        />
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <SummaryCard
+          label="Repeat sends"
+          value={metrics.repeatSends}
+          delta="Additional sends to the same pool and task in this window"
+        />
+        <SummaryCard
+          label="No eligible recipients"
+          value={metrics.skippedAttempts.noEligible}
+          delta="Send actions suppressed before a nudge was queued"
+        />
+        <SummaryCard
+          label="Rate-limited attempts"
+          value={rateLimitedAttempts}
+          delta={`${metrics.skippedAttempts.cooldown} cooldown · ${metrics.skippedAttempts.weeklyLimit} weekly limit`}
+        />
+        <SummaryCard
+          label="Settings reduced"
+          value={metrics.settingsReducedWithin7Days}
+          delta="Distinct recipients within 7 days of delivery"
+        />
+      </div>
+
+      <div className="overflow-x-auto rounded-md border border-border/50">
+        <table className="min-w-[34rem] divide-y divide-border/60 text-sm">
+          <thead className="bg-muted/40">
+            <tr>
+              <th className="px-4 py-2 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                Reminder
+              </th>
+              <th className="px-4 py-2 text-right text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                Queued
+              </th>
+              <th className="px-4 py-2 text-right text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                Targeted
+              </th>
+              <th className="px-4 py-2 text-right text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                Delivered
+              </th>
+              <th className="px-4 py-2 text-right text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                Clicks
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border/60">
+            {metrics.byKind.map((row) => (
+              <tr key={row.kind}>
+                <td className="px-4 py-2 font-medium">{row.label}</td>
+                <td className="px-4 py-2 text-right tabular-nums">
+                  {row.queued.toLocaleString()}
+                </td>
+                <td className="px-4 py-2 text-right tabular-nums">
+                  {row.targeted.toLocaleString()}
+                </td>
+                <td className="px-4 py-2 text-right tabular-nums">
+                  {row.delivered.toLocaleString()}
+                </td>
+                <td className="px-4 py-2 text-right tabular-nums">
+                  {row.clicks.toLocaleString()}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <p className="text-xs text-muted-foreground">
+        Clicks are aggregate notification-type events, not per-nudge
+        attribution. “Settings reduced” is a directional signal, not proof the
+        reminder caused the change. Treat rates as preliminary until at least 50
+        reminders have been queued.
+      </p>
+    </div>
+  );
+};
 
 // ---------------------------------------------------------------------------
 // Browser/device/PWA environment

--- a/app/utils/admin-organizer-reminders.server.test.ts
+++ b/app/utils/admin-organizer-reminders.server.test.ts
@@ -1,0 +1,293 @@
+/**
+ * @vitest-environment node
+ */
+import { randomUUID } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import { prisma } from '#app/utils/db.server.ts';
+import { createUser } from '#tests/db-utils.ts';
+import { getOrganizerReminderMetrics } from './admin-organizer-reminders.server.ts';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+describe('organizer reminder admin metrics', () => {
+  it('aggregates outcomes and de-identifies post-delivery preference reductions', async () => {
+    const now = new Date('2026-07-14T12:00:00.000Z');
+    const [organizer, recipientOne, recipientTwo, recipientThree] =
+      await Promise.all([
+        prisma.user.create({ data: createUser() }),
+        prisma.user.create({ data: createUser() }),
+        prisma.user.create({ data: createUser() }),
+        prisma.user.create({ data: createUser() }),
+      ]);
+    const pool = await prisma.pool.create({
+      data: { title: 'Observable pool', organizerId: organizer.id },
+    });
+
+    const contributionOne = await createNudge({
+      poolId: pool.id,
+      senderId: organizer.id,
+      kind: 'CONTRIBUTION',
+      targetCount: 2,
+      createdAt: daysBefore(now, 10),
+    });
+    const contributionTwo = await createNudge({
+      poolId: pool.id,
+      senderId: organizer.id,
+      kind: 'CONTRIBUTION',
+      targetCount: 1,
+      createdAt: daysBefore(now, 8),
+    });
+    const vote = await createNudge({
+      poolId: pool.id,
+      senderId: organizer.id,
+      kind: 'VOTE',
+      targetCount: 1,
+      createdAt: daysBefore(now, 6),
+    });
+    await createNudge({
+      poolId: pool.id,
+      senderId: organizer.id,
+      kind: 'DELIVERY',
+      targetCount: 20,
+      createdAt: daysBefore(now, 40),
+    });
+
+    const firstDeliveryAt = daysBefore(now, 10);
+    const secondDeliveryAt = daysBefore(now, 6);
+    await Promise.all([
+      createEvent({
+        name: 'organizer_reminder_sent',
+        userId: recipientOne.id,
+        createdAt: firstDeliveryAt,
+        properties: deliveryProperties(
+          contributionOne.id,
+          pool.id,
+          'POOL_CONTRIBUTION_REMINDER',
+          ['IN_APP'],
+        ),
+      }),
+      createEvent({
+        name: 'organizer_reminder_sent',
+        userId: recipientTwo.id,
+        createdAt: firstDeliveryAt,
+        properties: deliveryProperties(
+          contributionOne.id,
+          pool.id,
+          'POOL_CONTRIBUTION_REMINDER',
+          ['IN_APP', 'EMAIL'],
+        ),
+      }),
+      createEvent({
+        name: 'organizer_reminder_sent',
+        userId: recipientThree.id,
+        createdAt: secondDeliveryAt,
+        properties: deliveryProperties(vote.id, pool.id, 'POOL_VOTE_REMINDER', [
+          'IN_APP',
+        ]),
+      }),
+      createEvent({
+        name: 'notification_clicked',
+        userId: recipientOne.id,
+        createdAt: daysBefore(now, 9),
+        properties: { type: 'POOL_CONTRIBUTION_REMINDER' },
+      }),
+      createEvent({
+        name: 'notification_clicked',
+        userId: recipientThree.id,
+        createdAt: daysBefore(now, 5),
+        properties: { type: 'POOL_VOTE_REMINDER' },
+      }),
+      createEvent({
+        name: 'organizer_reminder_skipped',
+        userId: organizer.id,
+        createdAt: daysBefore(now, 4),
+        properties: { kind: 'VOTE', reason: 'NO_ELIGIBLE' },
+      }),
+      createEvent({
+        name: 'organizer_reminder_skipped',
+        userId: organizer.id,
+        createdAt: daysBefore(now, 3),
+        properties: { kind: 'VOTE', reason: 'COOLDOWN' },
+      }),
+      createEvent({
+        name: 'organizer_reminder_skipped',
+        userId: organizer.id,
+        createdAt: daysBefore(now, 2),
+        properties: { kind: 'VOTE', reason: 'WEEKLY_LIMIT' },
+      }),
+    ]);
+
+    await Promise.all([
+      prisma.notificationPreferenceAudit.create({
+        data: {
+          userId: recipientOne.id,
+          kind: 'TOPIC',
+          preferenceKey: 'ORGANIZER_NUDGES',
+          channel: 'IN_APP',
+          previousValue: 'true',
+          newValue: 'false',
+          source: 'test',
+          createdAt: daysAfter(firstDeliveryAt, 1),
+        },
+      }),
+      prisma.notificationPreferenceAudit.create({
+        data: {
+          userId: recipientTwo.id,
+          kind: 'CONTEXT_ACTIVITY',
+          contextKind: 'POOL',
+          contextId: pool.id,
+          previousValue: null,
+          newValue: JSON.stringify({
+            activityLevel: 'CUSTOM',
+            customTopics: ['IDEAS_AND_VOTING'],
+          }),
+          source: 'test',
+          createdAt: daysAfter(firstDeliveryAt, 2),
+        },
+      }),
+      prisma.notificationPreferenceAudit.create({
+        data: {
+          userId: recipientThree.id,
+          kind: 'TOPIC',
+          preferenceKey: 'BIRTHDAY_REMINDERS',
+          channel: 'IN_APP',
+          previousValue: 'true',
+          newValue: 'false',
+          source: 'test',
+          createdAt: daysAfter(secondDeliveryAt, 1),
+        },
+      }),
+    ]);
+
+    const metrics = await getOrganizerReminderMetrics({ days: 30, now });
+
+    expect(metrics).toMatchObject({
+      days: 30,
+      queuedReminders: 3,
+      targetedRecipients: 4,
+      deliveredRecipients: 3,
+      deliveryRate: 75,
+      notificationClicks: 2,
+      clickEventRate: 67,
+      repeatSends: 1,
+      skippedAttempts: { noEligible: 1, cooldown: 1, weeklyLimit: 1 },
+      settingsReducedWithin7Days: 2,
+    });
+    expect(metrics.byKind).toEqual([
+      expect.objectContaining({
+        kind: 'CONTRIBUTION',
+        queued: 2,
+        targeted: 3,
+        delivered: 2,
+        clicks: 1,
+      }),
+      expect.objectContaining({
+        kind: 'VOTE',
+        queued: 1,
+        targeted: 1,
+        delivered: 1,
+        clicks: 1,
+      }),
+      expect.objectContaining({
+        kind: 'PURCHASE',
+        queued: 0,
+        targeted: 0,
+        delivered: 0,
+        clicks: 0,
+      }),
+      expect.objectContaining({
+        kind: 'DELIVERY',
+        queued: 0,
+        targeted: 0,
+        delivered: 0,
+        clicks: 0,
+      }),
+    ]);
+
+    // A nudge can be queued but deliver to nobody after a concurrent opt-out.
+    expect(contributionTwo.targetCount).toBe(1);
+  });
+
+  it('returns stable zero rates when there is no reminder data', async () => {
+    await expect(
+      getOrganizerReminderMetrics({
+        days: 27,
+        now: new Date('2040-01-01T00:00:00.000Z'),
+      }),
+    ).resolves.toMatchObject({
+      queuedReminders: 0,
+      targetedRecipients: 0,
+      deliveredRecipients: 0,
+      deliveryRate: 0,
+      notificationClicks: 0,
+      clickEventRate: 0,
+      repeatSends: 0,
+      settingsReducedWithin7Days: 0,
+    });
+  });
+});
+
+function createNudge({
+  poolId,
+  senderId,
+  kind,
+  targetCount,
+  createdAt,
+}: {
+  poolId: string;
+  senderId: string;
+  kind: string;
+  targetCount: number;
+  createdAt: Date;
+}) {
+  return prisma.organizerNudge.create({
+    data: {
+      poolId,
+      senderId,
+      kind,
+      targetCount,
+      idempotencyKey: randomUUID(),
+      createdAt,
+    },
+  });
+}
+
+function createEvent({
+  name,
+  userId,
+  properties,
+  createdAt,
+}: {
+  name: string;
+  userId: string;
+  properties: Record<string, unknown>;
+  createdAt: Date;
+}) {
+  return prisma.analyticsEvent.create({
+    data: {
+      eventId: randomUUID(),
+      name,
+      userId,
+      source: 'server',
+      properties: JSON.stringify(properties),
+      createdAt,
+    },
+  });
+}
+
+function deliveryProperties(
+  organizerNudgeId: string,
+  poolId: string,
+  notificationType: string,
+  channels: string[],
+) {
+  return { organizerNudgeId, poolId, notificationType, channels };
+}
+
+function daysBefore(date: Date, days: number) {
+  return new Date(date.getTime() - days * DAY_MS);
+}
+
+function daysAfter(date: Date, days: number) {
+  return new Date(date.getTime() + days * DAY_MS);
+}

--- a/app/utils/admin-organizer-reminders.server.test.ts
+++ b/app/utils/admin-organizer-reminders.server.test.ts
@@ -225,6 +225,59 @@ describe('organizer reminder admin metrics', () => {
       settingsReducedWithin7Days: 0,
     });
   });
+
+  it('counts a parent-group preference reduction inherited by a pool', async () => {
+    const now = new Date('2030-07-14T12:00:00.000Z');
+    const [organizer, recipient] = await Promise.all([
+      prisma.user.create({ data: createUser() }),
+      prisma.user.create({ data: createUser() }),
+    ]);
+    const group = await prisma.giftGroup.create({
+      data: { name: 'Reminder group' },
+    });
+    const pool = await prisma.pool.create({
+      data: {
+        title: 'Group reminder pool',
+        organizerId: organizer.id,
+        giftGroupId: group.id,
+      },
+    });
+    const deliveredAt = daysBefore(now, 2);
+    const nudge = await createNudge({
+      poolId: pool.id,
+      senderId: organizer.id,
+      kind: 'CONTRIBUTION',
+      targetCount: 1,
+      createdAt: deliveredAt,
+    });
+    await createEvent({
+      name: 'organizer_reminder_sent',
+      userId: recipient.id,
+      createdAt: deliveredAt,
+      properties: deliveryProperties(
+        nudge.id,
+        pool.id,
+        'POOL_CONTRIBUTION_REMINDER',
+        ['IN_APP'],
+      ),
+    });
+    await prisma.notificationPreferenceAudit.create({
+      data: {
+        userId: recipient.id,
+        kind: 'CONTEXT_ACTIVITY',
+        contextKind: 'GROUP',
+        contextId: group.id,
+        previousValue: null,
+        newValue: JSON.stringify({ activityLevel: 'MUTED' }),
+        source: 'test',
+        createdAt: daysAfter(deliveredAt, 1),
+      },
+    });
+
+    await expect(
+      getOrganizerReminderMetrics({ days: 30, now }),
+    ).resolves.toMatchObject({ settingsReducedWithin7Days: 1 });
+  });
 });
 
 function createNudge({

--- a/app/utils/admin-organizer-reminders.server.ts
+++ b/app/utils/admin-organizer-reminders.server.ts
@@ -1,0 +1,347 @@
+import { prisma } from '#app/utils/db.server.ts';
+import {
+  NOTIFICATION_CATEGORIES,
+  NOTIFICATION_TOPICS,
+  NOTIFICATION_TYPES,
+  type OrganizerNudgeNotificationType,
+} from '#app/utils/notification-catalog.ts';
+import { NOTIFICATION_ACTIVITY_LEVELS } from '#app/utils/notification-context.ts';
+import { type OrganizerNudgeKind } from '#app/utils/organizer-nudges.server.ts';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const PREFERENCE_REDUCTION_WINDOW_MS = 7 * DAY_MS;
+
+const KIND_DEFINITIONS = [
+  {
+    kind: 'CONTRIBUTION',
+    label: 'Contribution',
+    notificationType: NOTIFICATION_TYPES.POOL_CONTRIBUTION_REMINDER,
+  },
+  {
+    kind: 'VOTE',
+    label: 'Vote',
+    notificationType: NOTIFICATION_TYPES.POOL_VOTE_REMINDER,
+  },
+  {
+    kind: 'PURCHASE',
+    label: 'Purchase',
+    notificationType: NOTIFICATION_TYPES.POOL_PURCHASE_REMINDER,
+  },
+  {
+    kind: 'DELIVERY',
+    label: 'Delivery',
+    notificationType: NOTIFICATION_TYPES.POOL_DELIVERY_REMINDER,
+  },
+] as const satisfies ReadonlyArray<{
+  kind: OrganizerNudgeKind;
+  label: string;
+  notificationType: OrganizerNudgeNotificationType;
+}>;
+
+type ReminderEventProperties = {
+  notificationType?: unknown;
+  organizerNudgeId?: unknown;
+  poolId?: unknown;
+  channels?: unknown;
+  kind?: unknown;
+  reason?: unknown;
+  type?: unknown;
+};
+
+type PreferenceAudit = {
+  userId: string;
+  kind: string;
+  preferenceKey: string | null;
+  channel: string | null;
+  contextKind: string | null;
+  contextId: string | null;
+  newValue: string | null;
+  createdAt: Date;
+};
+
+type Delivery = {
+  userId: string;
+  poolId: string;
+  channels: string[];
+  createdAt: Date;
+};
+
+export type OrganizerReminderKindMetrics = {
+  kind: OrganizerNudgeKind;
+  label: string;
+  notificationType: OrganizerNudgeNotificationType;
+  queued: number;
+  targeted: number;
+  delivered: number;
+  clicks: number;
+};
+
+export type OrganizerReminderMetrics = {
+  days: number;
+  queuedReminders: number;
+  targetedRecipients: number;
+  deliveredRecipients: number;
+  deliveryRate: number;
+  notificationClicks: number;
+  clickEventRate: number;
+  repeatSends: number;
+  skippedAttempts: {
+    noEligible: number;
+    cooldown: number;
+    weeklyLimit: number;
+  };
+  settingsReducedWithin7Days: number;
+  byKind: OrganizerReminderKindMetrics[];
+};
+
+/**
+ * Aggregates the organizer-reminder experiment without returning pool, sender,
+ * or recipient identifiers. Clicks are type-level notification events, so the
+ * click ratio is directional rather than a per-nudge attribution funnel.
+ */
+export async function getOrganizerReminderMetrics({
+  days = 30,
+  now = new Date(),
+}: {
+  days?: number;
+  now?: Date;
+} = {}): Promise<OrganizerReminderMetrics> {
+  const since = new Date(now.getTime() - days * DAY_MS);
+  const [nudges, events, audits] = await Promise.all([
+    prisma.organizerNudge.findMany({
+      where: { createdAt: { gte: since, lte: now } },
+      orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
+      select: {
+        id: true,
+        poolId: true,
+        kind: true,
+        targetCount: true,
+      },
+    }),
+    prisma.analyticsEvent.findMany({
+      where: {
+        name: {
+          in: [
+            'organizer_reminder_sent',
+            'organizer_reminder_skipped',
+            'notification_clicked',
+          ],
+        },
+        createdAt: { gte: since, lte: now },
+      },
+      select: {
+        name: true,
+        userId: true,
+        properties: true,
+        createdAt: true,
+      },
+    }),
+    prisma.notificationPreferenceAudit.findMany({
+      where: {
+        createdAt: { gte: since, lte: now },
+        kind: {
+          in: ['GLOBAL_CHANNEL', 'TOPIC', 'CATEGORY', 'CONTEXT_ACTIVITY'],
+        },
+      },
+      select: {
+        userId: true,
+        kind: true,
+        preferenceKey: true,
+        channel: true,
+        contextKind: true,
+        contextId: true,
+        newValue: true,
+        createdAt: true,
+      },
+    }),
+  ]);
+
+  const nudgeIds = new Set(nudges.map((nudge) => nudge.id));
+  const kindByNotificationType = new Map(
+    KIND_DEFINITIONS.map((definition) => [
+      definition.notificationType,
+      definition.kind,
+    ]),
+  );
+  const countsByKind = new Map(
+    KIND_DEFINITIONS.map((definition) => [
+      definition.kind,
+      { queued: 0, targeted: 0, delivered: 0, clicks: 0 },
+    ]),
+  );
+
+  const seenPoolKinds = new Set<string>();
+  let repeatSends = 0;
+  for (const nudge of nudges) {
+    const counts = countsByKind.get(nudge.kind as OrganizerNudgeKind);
+    if (counts) {
+      counts.queued += 1;
+      counts.targeted += nudge.targetCount;
+    }
+    const repeatKey = `${nudge.poolId}:${nudge.kind}`;
+    if (seenPoolKinds.has(repeatKey)) repeatSends += 1;
+    seenPoolKinds.add(repeatKey);
+  }
+
+  const deliveries: Delivery[] = [];
+  let notificationClicks = 0;
+  const skippedAttempts = { noEligible: 0, cooldown: 0, weeklyLimit: 0 };
+
+  for (const event of events) {
+    const properties = parseProperties(event.properties);
+    if (!properties) continue;
+
+    if (event.name === 'organizer_reminder_sent') {
+      if (
+        !event.userId ||
+        typeof properties.organizerNudgeId !== 'string' ||
+        !nudgeIds.has(properties.organizerNudgeId) ||
+        typeof properties.poolId !== 'string' ||
+        !Array.isArray(properties.channels)
+      ) {
+        continue;
+      }
+      const kind = kindByNotificationType.get(
+        properties.notificationType as OrganizerNudgeNotificationType,
+      );
+      const counts = kind ? countsByKind.get(kind) : undefined;
+      if (!counts) continue;
+      counts.delivered += 1;
+      deliveries.push({
+        userId: event.userId,
+        poolId: properties.poolId,
+        channels: properties.channels.filter(
+          (channel): channel is string => typeof channel === 'string',
+        ),
+        createdAt: event.createdAt,
+      });
+      continue;
+    }
+
+    if (event.name === 'notification_clicked') {
+      const kind = kindByNotificationType.get(
+        properties.type as OrganizerNudgeNotificationType,
+      );
+      const counts = kind ? countsByKind.get(kind) : undefined;
+      if (!counts) continue;
+      counts.clicks += 1;
+      notificationClicks += 1;
+      continue;
+    }
+
+    if (event.name === 'organizer_reminder_skipped') {
+      if (!countsByKind.has(properties.kind as OrganizerNudgeKind)) continue;
+      if (properties.reason === 'NO_ELIGIBLE') skippedAttempts.noEligible += 1;
+      if (properties.reason === 'COOLDOWN') skippedAttempts.cooldown += 1;
+      if (properties.reason === 'WEEKLY_LIMIT')
+        skippedAttempts.weeklyLimit += 1;
+    }
+  }
+
+  const targetedRecipients = nudges.reduce(
+    (total, nudge) => total + nudge.targetCount,
+    0,
+  );
+  const deliveredRecipients = deliveries.length;
+
+  return {
+    days,
+    queuedReminders: nudges.length,
+    targetedRecipients,
+    deliveredRecipients,
+    deliveryRate: percentOf(deliveredRecipients, targetedRecipients),
+    notificationClicks,
+    clickEventRate: percentOf(notificationClicks, deliveredRecipients),
+    repeatSends,
+    skippedAttempts,
+    settingsReducedWithin7Days: countPreferenceReductions(deliveries, audits),
+    byKind: KIND_DEFINITIONS.map((definition) => ({
+      ...definition,
+      ...countsByKind.get(definition.kind)!,
+    })),
+  };
+}
+
+function countPreferenceReductions(
+  deliveries: Delivery[],
+  audits: PreferenceAudit[],
+) {
+  const auditsByUser = new Map<string, PreferenceAudit[]>();
+  for (const audit of audits) {
+    const userAudits = auditsByUser.get(audit.userId) ?? [];
+    userAudits.push(audit);
+    auditsByUser.set(audit.userId, userAudits);
+  }
+
+  const usersWhoReducedSettings = new Set<string>();
+  for (const delivery of deliveries) {
+    const deadline =
+      delivery.createdAt.getTime() + PREFERENCE_REDUCTION_WINDOW_MS;
+    const reducedSettings = (auditsByUser.get(delivery.userId) ?? []).some(
+      (audit) =>
+        audit.createdAt >= delivery.createdAt &&
+        audit.createdAt.getTime() <= deadline &&
+        auditReducesReminderDelivery(audit, delivery),
+    );
+    if (reducedSettings) usersWhoReducedSettings.add(delivery.userId);
+  }
+  return usersWhoReducedSettings.size;
+}
+
+function auditReducesReminderDelivery(
+  audit: PreferenceAudit,
+  delivery: Delivery,
+) {
+  if (audit.kind === 'CONTEXT_ACTIVITY') {
+    return (
+      audit.contextKind === 'POOL' &&
+      audit.contextId === delivery.poolId &&
+      contextValueDisablesOrganizerReminders(audit.newValue)
+    );
+  }
+
+  if (audit.newValue !== 'false' || !audit.channel) return false;
+  if (!delivery.channels.includes(audit.channel)) return false;
+  return (
+    audit.kind === 'GLOBAL_CHANNEL' ||
+    (audit.kind === 'TOPIC' &&
+      audit.preferenceKey === NOTIFICATION_TOPICS.ORGANIZER_NUDGES) ||
+    (audit.kind === 'CATEGORY' &&
+      audit.preferenceKey === NOTIFICATION_CATEGORIES.POOL_COORDINATION)
+  );
+}
+
+function contextValueDisablesOrganizerReminders(value: string | null) {
+  if (!value) return false;
+  try {
+    const parsed: unknown = JSON.parse(value);
+    if (!isRecord(parsed)) return false;
+    if (parsed.activityLevel === NOTIFICATION_ACTIVITY_LEVELS.MUTED)
+      return true;
+    return (
+      parsed.activityLevel === NOTIFICATION_ACTIVITY_LEVELS.CUSTOM &&
+      Array.isArray(parsed.customTopics) &&
+      !parsed.customTopics.includes(NOTIFICATION_TOPICS.ORGANIZER_NUDGES)
+    );
+  } catch {
+    return false;
+  }
+}
+
+function parseProperties(value: string | null): ReminderEventProperties | null {
+  if (!value) return null;
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return isRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function percentOf(count: number, total: number) {
+  return total > 0 ? Math.round((count / total) * 100) : 0;
+}

--- a/app/utils/admin-organizer-reminders.server.ts
+++ b/app/utils/admin-organizer-reminders.server.ts
@@ -62,6 +62,7 @@ type PreferenceAudit = {
 type Delivery = {
   userId: string;
   poolId: string;
+  groupId: string | null;
   channels: string[];
   createdAt: Date;
 };
@@ -114,6 +115,7 @@ export async function getOrganizerReminderMetrics({
       select: {
         id: true,
         poolId: true,
+        pool: { select: { giftGroupId: true } },
         kind: true,
         targetCount: true,
       },
@@ -156,7 +158,7 @@ export async function getOrganizerReminderMetrics({
     }),
   ]);
 
-  const nudgeIds = new Set(nudges.map((nudge) => nudge.id));
+  const nudgesById = new Map(nudges.map((nudge) => [nudge.id, nudge]));
   const kindByNotificationType = new Map(
     KIND_DEFINITIONS.map((definition) => [
       definition.notificationType,
@@ -192,11 +194,14 @@ export async function getOrganizerReminderMetrics({
     if (!properties) continue;
 
     if (event.name === 'organizer_reminder_sent') {
+      const nudge =
+        typeof properties.organizerNudgeId === 'string'
+          ? nudgesById.get(properties.organizerNudgeId)
+          : undefined;
       if (
         !event.userId ||
-        typeof properties.organizerNudgeId !== 'string' ||
-        !nudgeIds.has(properties.organizerNudgeId) ||
-        typeof properties.poolId !== 'string' ||
+        !nudge ||
+        properties.poolId !== nudge.poolId ||
         !Array.isArray(properties.channels)
       ) {
         continue;
@@ -209,7 +214,8 @@ export async function getOrganizerReminderMetrics({
       counts.delivered += 1;
       deliveries.push({
         userId: event.userId,
-        poolId: properties.poolId,
+        poolId: nudge.poolId,
+        groupId: nudge.pool.giftGroupId,
         channels: properties.channels.filter(
           (channel): channel is string => typeof channel === 'string',
         ),
@@ -293,9 +299,13 @@ function auditReducesReminderDelivery(
   delivery: Delivery,
 ) {
   if (audit.kind === 'CONTEXT_ACTIVITY') {
+    const matchesDeliveryContext =
+      (audit.contextKind === 'POOL' && audit.contextId === delivery.poolId) ||
+      (delivery.groupId !== null &&
+        audit.contextKind === 'GROUP' &&
+        audit.contextId === delivery.groupId);
     return (
-      audit.contextKind === 'POOL' &&
-      audit.contextId === delivery.poolId &&
+      matchesDeliveryContext &&
       contextValueDisablesOrganizerReminders(audit.newValue)
     );
   }

--- a/app/utils/analytics.ts
+++ b/app/utils/analytics.ts
@@ -33,6 +33,11 @@ export const ANALYTIC_EVENT_NAMES = [
   // least one channel delivers; repeated requests remain queryable from the
   // OrganizerNudge audit rows without putting recipient lists in analytics.
   'organizer_reminder_sent',
+  // A send action that did not create an OrganizerNudge audit row. `reason`
+  // distinguishes preference/task suppression from cooldown and weekly-limit
+  // enforcement, so admin observability does not infer blocked attempts from
+  // page views or availability checks.
+  'organizer_reminder_skipped',
   'friend_request_sent',
   'friend_request_accepted',
   'friend_request_rejected',
@@ -198,6 +203,7 @@ export const USER_REQUIRED_EVENTS: Set<AnalyticEventName> = new Set([
   'pool_deliverer_assigned',
   'pool_activity_notification_sent',
   'organizer_reminder_sent',
+  'organizer_reminder_skipped',
   'friend_request_sent',
   'friend_request_accepted',
   'friend_request_rejected',

--- a/app/utils/organizer-nudges.server.test.ts
+++ b/app/utils/organizer-nudges.server.test.ts
@@ -7,7 +7,12 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { prisma } from '#app/utils/db.server.ts';
 
 const queueNotification = vi.fn();
+const queueLogEvent = vi.fn().mockReturnValue({ eventId: 'test-event' });
 const captureException = vi.fn();
+
+vi.mock('#app/utils/analytics.server.ts', () => ({
+  queueLogEvent: (...args: Array<unknown>) => queueLogEvent(...args),
+}));
 
 vi.mock('#app/utils/notification-dispatcher.server.ts', () => ({
   queueNotification: (...args: Array<unknown>) => queueNotification(...args),
@@ -33,6 +38,7 @@ const createdGroupIds: string[] = [];
 
 afterEach(async () => {
   queueNotification.mockReset();
+  queueLogEvent.mockReset().mockReturnValue({ eventId: 'test-event' });
   captureException.mockReset();
   if (createdPoolIds.length > 0) {
     await prisma.pool.deleteMany({ where: { id: { in: createdPoolIds } } });
@@ -226,6 +232,16 @@ describe('organizer nudge module', () => {
     await expect(
       prisma.organizerNudge.count({ where: { poolId: pool.id } }),
     ).resolves.toBe(1);
+    expect(queueLogEvent).toHaveBeenCalledWith({
+      name: 'organizer_reminder_skipped',
+      source: 'server',
+      userId: organizer.id,
+      properties: {
+        poolId: pool.id,
+        kind: ORGANIZER_NUDGE_KINDS.CONTRIBUTION,
+        reason: 'COOLDOWN',
+      },
+    });
   });
 
   it('keeps a zero-recipient attempt as a no-op that consumes no limit', async () => {
@@ -251,6 +267,16 @@ describe('organizer nudge module', () => {
       prisma.organizerNudge.count({ where: { poolId: pool.id } }),
     ).resolves.toBe(0);
     expect(queueNotification).not.toHaveBeenCalled();
+    expect(queueLogEvent).toHaveBeenCalledWith({
+      name: 'organizer_reminder_skipped',
+      source: 'server',
+      userId: organizer.id,
+      properties: {
+        poolId: pool.id,
+        kind: ORGANIZER_NUDGE_KINDS.CONTRIBUTION,
+        reason: 'NO_ELIGIBLE',
+      },
+    });
   });
 
   it('enforces manager permission and current assignment state', async () => {

--- a/app/utils/organizer-nudges.server.ts
+++ b/app/utils/organizer-nudges.server.ts
@@ -1,5 +1,6 @@
 import { Prisma } from '@prisma/client';
 import * as Sentry from '@sentry/react-router';
+import { queueLogEvent } from '#app/utils/analytics.server.ts';
 import { prisma } from '#app/utils/db.server.ts';
 import {
   NOTIFICATION_CHANNEL_VALUES,
@@ -193,7 +194,9 @@ export async function sendOrganizerNudge({
     const raced = await prisma.organizerNudge.findUnique({
       where: { senderId_idempotencyKey: { senderId, idempotencyKey } },
     });
-    return raced ? replayExistingNudge(raced, { poolId, kind }) : initial;
+    if (raced) return replayExistingNudge(raced, { poolId, kind });
+    recordSkippedOrganizerNudge({ poolId, senderId, result: initial });
+    return initial;
   }
 
   const preferenceEligibleUserIds = await filterPreferenceEligibleRecipients({
@@ -281,8 +284,31 @@ export async function sendOrganizerNudge({
 
   if (result.status === 'QUEUED') {
     queueOrganizerNudgeNotifications(result.nudgeId);
+  } else {
+    recordSkippedOrganizerNudge({ poolId, senderId, result });
   }
   return result;
+}
+
+function recordSkippedOrganizerNudge({
+  poolId,
+  senderId,
+  result,
+}: {
+  poolId: string;
+  senderId: string;
+  result: Exclude<OrganizerNudgeSendResult, { status: 'QUEUED' }>;
+}) {
+  queueLogEvent({
+    name: 'organizer_reminder_skipped',
+    source: 'server',
+    userId: senderId,
+    properties: {
+      poolId,
+      kind: result.kind,
+      reason: result.status,
+    },
+  });
 }
 
 async function evaluateNudge(


### PR DESCRIPTION
## Summary

- record actual organizer-reminder send actions that queue no nudge, with `NO_ELIGIBLE`, cooldown, or weekly-limit reasons
- aggregate 30-day queued, targeted, delivered, click, repeat-send, skipped-attempt, and post-delivery preference-reduction signals without returning pool, sender, or recipient identities
- add an established-pattern Organizer reminders section to admin analytics with per-kind outcomes and explicit attribution/sample-size caveats

## Measurement notes

- notification clicks are aggregate type-level events, so the click ratio is directional rather than per-nudge attribution
- “Settings reduced” counts distinct delivered recipients who reduced a relevant delivered channel or pool context within seven days; it is not presented as causal
- skipped-attempt counts begin prospectively with this PR and exclude availability reads, previews, and idempotent replays
- no migration or environment changes

## Test plan

- [x] Node 20 focused suite: 37 analytics, organizer-nudge, loader, and DOM tests
- [x] `npm run typecheck`
- [x] repository `npm run lint` (0 errors; pre-existing warnings remain)
- [x] `npm run build`
- [x] focused ESLint, Prettier, and diff checks
- [x] desktop visual QA at 1440×1000
- [x] narrow visual QA at 390×844, including scrollable breakdown table and zero document-level horizontal overflow

## Visual evidence

Verified against the seeded Wade admin account. Screenshots remain in the ignored local `output/playwright` / `.playwright-cli` verification artifacts rather than adding generated binaries to the repository.