### PR TITLE
docs(agents): stabilize layout test guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -307,3 +307,5 @@ On mobile surfaces, use bottom-sheet patterns (not centered modals), and ensure 
 ## Debugging & Testing
 
 When a test or CI check fails, run the specific test type the user requested (jest/unit vs. e2e). If a fix isn't working after two attempts, stop and step back to re-diagnose the root cause rather than iterating on throwaway diagnostics.
+
+For Playwright layout comparisons, measure related element geometry in a single `evaluate` or `evaluateAll` call. Separate awaited `boundingBox()` calls can be invalidated by hydration-driven layout shifts such as the PWA install banner. Inspect trace screenshots before treating geometry failures as product regressions.


### PR DESCRIPTION
## Summary
- document atomic Playwright geometry measurement for layout assertions
- call out hydration-driven layout shifts and trace screenshot inspection

## Test plan
- npm run validate:agent-config
- npx prettier --check AGENTS.md

## Checklist
- [x] Focused documentation-only change
- [x] No screenshot required