### PR TITLE
feat(pools): add direct invitations

### DIFF
--- a/app/components/notifications/notification-bell.test.tsx
+++ b/app/components/notifications/notification-bell.test.tsx
@@ -3,8 +3,9 @@
  */
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import React from 'react';
+import type * as ReactModule from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NotificationBell } from './notification-bell.tsx';
 import { NotificationsProvider } from './notifications-context.tsx';
 
 const {
@@ -67,6 +68,8 @@ vi.mock('#app/utils/i18n.tsx', () => ({
         'notifications.loading': 'Loading notifications',
         'notifications.markAllRead': 'Mark all as read',
         'notifications.markAllReadSuccess': 'All notifications marked as read.',
+        'notifications.poolInvitation.acceptSuccess': 'Pool joined',
+        'notifications.poolInvitation.declineSuccess': 'Invitation declined',
         'notifications.title': 'Notifications',
         'notifications.viewMore': 'View more',
         'toasts.genericError': 'Something went wrong',
@@ -75,7 +78,7 @@ vi.mock('#app/utils/i18n.tsx', () => ({
 }));
 
 vi.mock('#app/components/ui/popover.tsx', async () => {
-  const React = await vi.importActual<typeof import('react')>('react');
+  const React = await vi.importActual<typeof ReactModule>('react');
 
   const PopoverContext = React.createContext<{
     onOpenChange?: (open: boolean) => void;
@@ -90,7 +93,7 @@ vi.mock('#app/components/ui/popover.tsx', async () => {
       onOpenChange,
       open = false,
     }: {
-      children: React.ReactNode;
+      children: ReactModule.ReactNode;
       onOpenChange?: (open: boolean) => void;
       open?: boolean;
     }) => (
@@ -98,7 +101,7 @@ vi.mock('#app/components/ui/popover.tsx', async () => {
         {children}
       </PopoverContext.Provider>
     ),
-    PopoverContent: ({ children }: { children: React.ReactNode }) => {
+    PopoverContent: ({ children }: { children: ReactModule.ReactNode }) => {
       const context = React.useContext(PopoverContext);
       return context.open ? <div role="dialog">{children}</div> : null;
     },
@@ -107,12 +110,12 @@ vi.mock('#app/components/ui/popover.tsx', async () => {
       children,
     }: {
       asChild?: boolean;
-      children: React.ReactElement;
+      children: ReactModule.ReactElement;
     }) => {
       const context = React.useContext(PopoverContext);
       if (asChild) {
         return React.cloneElement(children, {
-          onClick: (event: React.MouseEvent) => {
+          onClick: (event: ReactModule.MouseEvent) => {
             children.props.onClick?.(event);
             context.onOpenChange?.(!context.open);
           },
@@ -132,19 +135,19 @@ vi.mock('#app/components/ui/popover.tsx', async () => {
 });
 
 vi.mock('#app/components/ui/tooltip.tsx', () => ({
-  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  TooltipContent: ({ children }: { children: React.ReactNode }) => (
+  Tooltip: ({ children }: { children: ReactModule.ReactNode }) => (
     <>{children}</>
   ),
-  TooltipProvider: ({ children }: { children: React.ReactNode }) => (
+  TooltipContent: ({ children }: { children: ReactModule.ReactNode }) => (
     <>{children}</>
   ),
-  TooltipTrigger: ({ children }: { children: React.ReactNode }) => (
+  TooltipProvider: ({ children }: { children: ReactModule.ReactNode }) => (
+    <>{children}</>
+  ),
+  TooltipTrigger: ({ children }: { children: ReactModule.ReactNode }) => (
     <>{children}</>
   ),
 }));
-
-import { NotificationBell } from './notification-bell.tsx';
 
 function jsonResponse(payload: unknown, init?: ResponseInit) {
   return new Response(JSON.stringify(payload), {
@@ -339,5 +342,64 @@ describe('NotificationBell', () => {
       success: true,
     });
     expect(toastSuccess).toHaveBeenCalledWith('Friend accepted');
+  });
+
+  it('keeps a pool invitation visible until the server accepts it', async () => {
+    let resolveAction: ((response: Response) => void) | undefined;
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({
+          hasMore: false,
+          nextCursor: null,
+          notifications: [
+            {
+              actions: [
+                { kind: 'POOL_INVITATION_ACCEPT', label: 'Accept' },
+                { kind: 'POOL_INVITATION_DECLINE', label: 'Decline' },
+              ],
+              createdAt: '2026-03-31T12:00:00.000Z',
+              friendRequestId: null,
+              poolInvitationId: 'invitation-1',
+              id: 'notification-1',
+              messageKey: 'pool.invitation.received',
+              messageParams: null,
+              metadata: null,
+              status: 'UNREAD',
+              targetUrl: '/pools/invitations/invitation-1',
+              type: 'POOL_INVITATION_RECEIVED',
+            },
+          ],
+          unreadCount: 1,
+        }),
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise<Response>((resolve) => {
+            resolveAction = resolve;
+          }),
+      );
+
+    renderBell(1);
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Notifications' }),
+    );
+    await screen.findByText('pool.invitation.received');
+    await userEvent.click(screen.getByRole('button', { name: 'Accept' }));
+
+    expect(screen.getByText('pool.invitation.received')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Decline' })).toBeDisabled();
+    resolveAction?.(jsonResponse({ unreadCount: 0, poolId: 'pool-1' }));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText('pool.invitation.received'),
+      ).not.toBeInTheDocument();
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/pool-invitations/invitation-1/accept',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(navigate).toHaveBeenCalledWith('/pools/pool-1');
+    expect(toastSuccess).toHaveBeenCalledWith('Pool joined');
   });
 });

--- a/app/components/notifications/notification-bell.tsx
+++ b/app/components/notifications/notification-bell.tsx
@@ -43,6 +43,7 @@ interface ApiNotification {
   metadata?: Record<string, unknown> | null;
   actions: NotificationActionPayload[];
   friendRequestId?: string | null;
+  poolInvitationId?: string | null;
 }
 
 interface NotificationsResponse {
@@ -80,6 +81,8 @@ const NOTIFICATIONS_ENDPOINT = '/api/notifications';
 const MARK_ALL_ENDPOINT = '/api/notifications/read-all';
 
 const FRIEND_ACCEPT_EVENT = 'FRIEND_ACCEPT';
+const POOL_INVITATION_ACCEPT_EVENT = 'POOL_INVITATION_ACCEPT';
+const POOL_INVITATION_DECLINE_EVENT = 'POOL_INVITATION_DECLINE';
 
 type PendingActionKey = `${string}:${string}`;
 type NotificationTranslator = ReturnType<typeof useTranslation>['t'];
@@ -105,15 +108,21 @@ function NotificationRowActions({
     <div className="flex items-center gap-2 px-4 pb-3">
       {notification.actions.map((action) => {
         const actionKey: PendingActionKey = `${notification.id}:${action.kind}`;
-        const isPending = pendingActionKeys.has(actionKey);
+        const isPending = [...pendingActionKeys].some((key) =>
+          key.startsWith(`${notification.id}:`),
+        );
 
         return (
           <Button
             key={actionKey}
             size="sm"
             variant={
-              action.kind === FRIEND_ACCEPT_EVENT ? 'default' : 'secondary'
+              action.kind === FRIEND_ACCEPT_EVENT ||
+              action.kind === POOL_INVITATION_ACCEPT_EVENT
+                ? 'default'
+                : 'secondary'
             }
+            className="min-h-11"
             onClick={() => onAction(notification, action)}
             disabled={isPending}
           >
@@ -604,6 +613,68 @@ export const NotificationBell = () => {
     [pendingActionKeys, setUnreadCount, t],
   );
 
+  const handlePoolInvitationAction = useCallback(
+    async (
+      notification: ApiNotification,
+      action: NotificationActionPayload,
+    ) => {
+      if (!notification.poolInvitationId) return;
+      const actionKey: PendingActionKey = `${notification.id}:${action.kind}`;
+      if (pendingActionKeys.has(actionKey)) return;
+      setPendingActionKeys((prev) => new Set(prev).add(actionKey));
+      const operation =
+        action.kind === POOL_INVITATION_ACCEPT_EVENT ? 'accept' : 'decline';
+      try {
+        const response = await fetch(
+          `/api/pool-invitations/${notification.poolInvitationId}/${operation}`,
+          {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: { Accept: 'application/json' },
+          },
+        );
+        if (!response.ok) throw new Error('Pool invitation action failed');
+        const payload = (await response.json()) as {
+          unreadCount?: number;
+          poolId?: string;
+        };
+        setNotifications((prev) =>
+          prev.filter((item) => item.id !== notification.id),
+        );
+        if (typeof payload.unreadCount === 'number') {
+          setUnreadCount(payload.unreadCount);
+        }
+        track('notification_action_completed', {
+          kind: action.kind,
+          success: true,
+        });
+        toast.success(
+          operation === 'accept'
+            ? t('notifications.poolInvitation.acceptSuccess')
+            : t('notifications.poolInvitation.declineSuccess'),
+        );
+        if (operation === 'accept' && payload.poolId) {
+          setOpen(false);
+          await Promise.resolve(navigate(`/pools/${payload.poolId}`));
+        }
+      } catch (err) {
+        console.error(err);
+        track('notification_action_completed', {
+          kind: action.kind,
+          success: false,
+        });
+        toast.error(t('toasts.genericError'));
+      } finally {
+        setPendingActionKeys((prev) => {
+          const next = new Set(prev);
+          next.delete(actionKey);
+          return next;
+        });
+      }
+    },
+    [navigate, pendingActionKeys, setUnreadCount, t],
+  );
+
   const displayCount = unreadCount > 9 ? '9+' : unreadCount.toString();
 
   const handleDeleteNotificationClick = useCallback(
@@ -619,11 +690,18 @@ export const NotificationBell = () => {
     },
     [handleNotificationClick],
   );
-  const handleFriendNotificationAction = useCallback(
+  const handleNotificationAction = useCallback(
     (notification: ApiNotification, action: NotificationActionPayload) => {
+      if (
+        action.kind === POOL_INVITATION_ACCEPT_EVENT ||
+        action.kind === POOL_INVITATION_DECLINE_EVENT
+      ) {
+        handlePoolInvitationAction(notification, action).catch(() => {});
+        return;
+      }
       handleFriendAction(notification, action).catch(() => {});
     },
-    [handleFriendAction],
+    [handleFriendAction, handlePoolInvitationAction],
   );
   const handleLoadMore = useCallback(() => {
     loadNotifications({
@@ -687,7 +765,7 @@ export const NotificationBell = () => {
           notifications={notifications}
           onDelete={handleDeleteNotificationClick}
           onOpen={handleNotificationOpen}
-          onAction={handleFriendNotificationAction}
+          onAction={handleNotificationAction}
           pendingActionKeys={pendingActionKeys}
           pendingDeleteIds={pendingDeleteIds}
           t={t}

--- a/app/components/ui/confirm-dialog.tsx
+++ b/app/components/ui/confirm-dialog.tsx
@@ -1,15 +1,15 @@
 import { isValidElement, type ReactNode, useState } from 'react';
 import { Button } from './button';
 import {
-  Dialog,
-  DialogClose,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from './dialog';
+  ResponsiveDialog as Dialog,
+  ResponsiveDialogClose as DialogClose,
+  ResponsiveDialogContent as DialogContent,
+  ResponsiveDialogDescription as DialogDescription,
+  ResponsiveDialogFooter as DialogFooter,
+  ResponsiveDialogHeader as DialogHeader,
+  ResponsiveDialogTitle as DialogTitle,
+  ResponsiveDialogTrigger as DialogTrigger,
+} from './responsive-dialog';
 
 function renderDialogDescription(description?: ReactNode) {
   if (!description) {

--- a/app/emails/pool-invitation-received.test.tsx
+++ b/app/emails/pool-invitation-received.test.tsx
@@ -1,0 +1,30 @@
+/**
+ * @vitest-environment node
+ */
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import { PoolInvitationReceivedEmail } from './pool-invitation-received.tsx';
+
+describe('PoolInvitationReceivedEmail', () => {
+  it('renders invitation context and both destination links', () => {
+    const html = renderToStaticMarkup(
+      <PoolInvitationReceivedEmail
+        appName="Gift Pool"
+        inviterDisplayName="Wade"
+        poolTitle="Birthday surprise"
+        recipientLabel="Alex"
+        invitationUrl="https://giftpool.app/pools/invitations/invitation-1"
+        managePreferencesUrl="https://giftpool.app/settings/profile/notifications"
+      />,
+    );
+
+    expect(html).toContain('Wade invited you to a gift pool');
+    expect(html).toContain('This gift pool is for Alex');
+    expect(html).toContain(
+      'href="https://giftpool.app/pools/invitations/invitation-1"',
+    );
+    expect(html).toContain(
+      'href="https://giftpool.app/settings/profile/notifications"',
+    );
+  });
+});

--- a/app/emails/pool-invitation-received.tsx
+++ b/app/emails/pool-invitation-received.tsx
@@ -16,7 +16,7 @@ export function PoolInvitationReceivedEmail({
   recipientLabel,
   invitationUrl,
   managePreferencesUrl,
-}: PoolInvitationReceivedEmailProps) {
+}: Readonly<PoolInvitationReceivedEmailProps>) {
   return (
     <E.Html lang="en" dir="ltr">
       <E.Container>

--- a/app/emails/pool-invitation-received.tsx
+++ b/app/emails/pool-invitation-received.tsx
@@ -1,0 +1,59 @@
+import * as E from '@react-email/components';
+
+type PoolInvitationReceivedEmailProps = {
+  appName: string;
+  inviterDisplayName: string;
+  poolTitle: string;
+  recipientLabel: string;
+  invitationUrl: string;
+  managePreferencesUrl: string;
+};
+
+export function PoolInvitationReceivedEmail({
+  appName,
+  inviterDisplayName,
+  poolTitle,
+  recipientLabel,
+  invitationUrl,
+  managePreferencesUrl,
+}: PoolInvitationReceivedEmailProps) {
+  return (
+    <E.Html lang="en" dir="ltr">
+      <E.Container>
+        <E.Heading as="h1">
+          {inviterDisplayName} invited you to a gift pool
+        </E.Heading>
+        <E.Text>
+          Review {poolTitle}. This gift pool is for {recipientLabel}. You can
+          decide whether to join after reviewing the invitation.
+        </E.Text>
+        <E.Button
+          href={invitationUrl}
+          style={{
+            backgroundColor: '#0f172a',
+            color: '#ffffff',
+            padding: '12px 24px',
+            borderRadius: '9999px',
+            display: 'inline-block',
+            textDecoration: 'none',
+            fontWeight: 600,
+          }}
+        >
+          Review invitation
+        </E.Button>
+        <E.Text
+          style={{ marginTop: '32px', fontSize: '12px', color: '#64748b' }}
+        >
+          You are receiving this email because you have enabled pool invitation
+          emails on {appName}. You can update your preferences at any time.
+        </E.Text>
+        <E.Link
+          href={managePreferencesUrl}
+          style={{ fontSize: '12px', color: '#0f172a' }}
+        >
+          Manage notification preferences
+        </E.Link>
+      </E.Container>
+    </E.Html>
+  );
+}

--- a/app/i18n/dictionaries/en.ts
+++ b/app/i18n/dictionaries/en.ts
@@ -33,6 +33,14 @@ export const en = {
       pushTitle: 'Friend request accepted',
       fallbackName: 'Someone',
     },
+    poolInvitation: {
+      message: '{{name}} invited you to join {{pool}}',
+      pushTitle: 'New pool invitation',
+      accept: 'Accept',
+      decline: 'Decline',
+      acceptSuccess: 'You joined the pool.',
+      declineSuccess: 'Invitation declined.',
+    },
     upcomingBirthday: {
       // `when` is 'today' | 'tomorrow' | 'on Jul 18' — date-based so the
       // message can't go stale while it sits in the bell for the rest of the

--- a/app/routes/api.notifications.ts
+++ b/app/routes/api.notifications.ts
@@ -35,6 +35,7 @@ function serializeNotification(record: NotificationRecord, locale: Locale) {
     metadata: record.metadata ?? {},
     actions,
     friendRequestId: record.friendRequestId,
+    poolInvitationId: record.poolInvitationId,
   };
 }
 export async function loader({ request }: LoaderFunctionArgs) {

--- a/app/routes/api.pool-invitations.$invitationId.accept.ts
+++ b/app/routes/api.pool-invitations.$invitationId.accept.ts
@@ -1,0 +1,39 @@
+import { data, type ActionFunctionArgs } from 'react-router';
+import { requireUserId } from '#app/utils/auth.server.ts';
+import { prisma } from '#app/utils/db.server.ts';
+import {
+  acceptPoolInvitation,
+  PoolInvitationError,
+} from '#app/utils/pool-invitations.server.ts';
+
+export async function action({ request, params }: ActionFunctionArgs) {
+  if (request.method !== 'POST') {
+    throw new Response('Method not allowed', { status: 405 });
+  }
+  const userId = await requireUserId(request);
+  if (!params.invitationId) {
+    return data({ error: 'Invitation not found.' }, { status: 404 });
+  }
+  try {
+    const result = await acceptPoolInvitation(params.invitationId, userId);
+    return data({
+      success: true,
+      ...result,
+      unreadCount: await unreadCount(userId),
+    });
+  } catch (error) {
+    return invitationErrorResponse(error);
+  }
+}
+
+function unreadCount(userId: string) {
+  return prisma.notification.count({ where: { userId, status: 'UNREAD' } });
+}
+
+function invitationErrorResponse(error: unknown) {
+  if (!(error instanceof PoolInvitationError)) throw error;
+  return data(
+    { error: error.message, code: error.code },
+    { status: error.status },
+  );
+}

--- a/app/routes/api.pool-invitations.$invitationId.cancel.ts
+++ b/app/routes/api.pool-invitations.$invitationId.cancel.ts
@@ -1,0 +1,31 @@
+import { data, type ActionFunctionArgs } from 'react-router';
+import { requireUserId } from '#app/utils/auth.server.ts';
+import {
+  cancelPoolInvitation,
+  PoolInvitationError,
+} from '#app/utils/pool-invitations.server.ts';
+
+export async function action({ request, params }: ActionFunctionArgs) {
+  if (request.method !== 'POST') {
+    throw new Response('Method not allowed', { status: 405 });
+  }
+  const managerId = await requireUserId(request);
+  if (!params.invitationId) {
+    return data({ error: 'Invitation not found.' }, { status: 404 });
+  }
+  try {
+    return data({
+      success: true,
+      ...(await cancelPoolInvitation({
+        invitationId: params.invitationId,
+        managerId,
+      })),
+    });
+  } catch (error) {
+    if (!(error instanceof PoolInvitationError)) throw error;
+    return data(
+      { error: error.message, code: error.code },
+      { status: error.status },
+    );
+  }
+}

--- a/app/routes/api.pool-invitations.$invitationId.decline.ts
+++ b/app/routes/api.pool-invitations.$invitationId.decline.ts
@@ -1,0 +1,37 @@
+import { data, type ActionFunctionArgs } from 'react-router';
+import { requireUserId } from '#app/utils/auth.server.ts';
+import { prisma } from '#app/utils/db.server.ts';
+import {
+  declinePoolInvitation,
+  PoolInvitationError,
+} from '#app/utils/pool-invitations.server.ts';
+
+export async function action({ request, params }: ActionFunctionArgs) {
+  if (request.method !== 'POST') {
+    throw new Response('Method not allowed', { status: 405 });
+  }
+  const userId = await requireUserId(request);
+  if (!params.invitationId) {
+    return data({ error: 'Invitation not found.' }, { status: 404 });
+  }
+  try {
+    const result = await declinePoolInvitation(params.invitationId, userId);
+    return data({
+      success: true,
+      ...result,
+      unreadCount: await prisma.notification.count({
+        where: { userId, status: 'UNREAD' },
+      }),
+    });
+  } catch (error) {
+    return invitationErrorResponse(error);
+  }
+}
+
+function invitationErrorResponse(error: unknown) {
+  if (!(error instanceof PoolInvitationError)) throw error;
+  return data(
+    { error: error.message, code: error.code },
+    { status: error.status },
+  );
+}

--- a/app/routes/api.pool-invitations.test.ts
+++ b/app/routes/api.pool-invitations.test.ts
@@ -1,0 +1,231 @@
+/**
+ * @vitest-environment node
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PoolInvitationError } from '#app/utils/pool-invitations.server.ts';
+import {
+  getRouteResultData,
+  getRouteResultStatus,
+  toActionArgs,
+} from '#tests/route-module-test-utils.ts';
+
+const requireUserId = vi.fn();
+const notificationCount = vi.fn();
+const sendPoolInvitations = vi.fn();
+const acceptPoolInvitation = vi.fn();
+const declinePoolInvitation = vi.fn();
+const cancelPoolInvitation = vi.fn();
+
+vi.mock('#app/utils/auth.server.ts', () => ({
+  requireUserId: (...args: Array<unknown>) => requireUserId(...args),
+}));
+
+vi.mock('#app/utils/db.server.ts', () => ({
+  prisma: {
+    notification: {
+      count: (...args: Array<unknown>) => notificationCount(...args),
+    },
+  },
+}));
+
+vi.mock('#app/utils/pool-invitations.server.ts', () => ({
+  PoolInvitationError: class PoolInvitationError extends Error {
+    constructor(
+      public readonly code: string,
+      message: string,
+      public readonly status: number,
+    ) {
+      super(message);
+      this.name = 'PoolInvitationError';
+    }
+  },
+  sendPoolInvitations: (...args: Array<unknown>) =>
+    sendPoolInvitations(...args),
+  acceptPoolInvitation: (...args: Array<unknown>) =>
+    acceptPoolInvitation(...args),
+  declinePoolInvitation: (...args: Array<unknown>) =>
+    declinePoolInvitation(...args),
+  cancelPoolInvitation: (...args: Array<unknown>) =>
+    cancelPoolInvitation(...args),
+}));
+
+import { action as acceptAction } from './api.pool-invitations.$invitationId.accept.ts';
+import { action as cancelAction } from './api.pool-invitations.$invitationId.cancel.ts';
+import { action as declineAction } from './api.pool-invitations.$invitationId.decline.ts';
+import { action as sendAction } from './api.pools.$poolId.invitations.ts';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  requireUserId.mockResolvedValue('user-1');
+  notificationCount.mockResolvedValue(2);
+  sendPoolInvitations.mockResolvedValue([
+    { id: 'invitation-1', inviteeId: 'invitee-1' },
+  ]);
+  acceptPoolInvitation.mockResolvedValue({ poolId: 'pool-1' });
+  declinePoolInvitation.mockResolvedValue({ poolId: 'pool-1' });
+  cancelPoolInvitation.mockResolvedValue({ poolId: 'pool-1' });
+});
+
+describe('pool invitation resource actions', () => {
+  it('sends a validated batch through the invitation module', async () => {
+    const result = await sendAction(
+      toActionArgs({
+        context: {},
+        params: { poolId: 'pool-1' },
+        request: jsonRequest('/api/pools/pool-1/invitations', {
+          inviteeIds: ['invitee-1'],
+        }),
+      }),
+    );
+
+    expect(getRouteResultStatus(result)).toBe(200);
+    expect(await getRouteResultData(result)).toMatchObject({ success: true });
+    expect(sendPoolInvitations).toHaveBeenCalledWith({
+      poolId: 'pool-1',
+      managerId: 'user-1',
+      inviteeIds: ['invitee-1'],
+    });
+  });
+
+  it('rejects an invalid send payload before calling the module', async () => {
+    const result = await sendAction(
+      toActionArgs({
+        context: {},
+        params: { poolId: 'pool-1' },
+        request: jsonRequest('/api/pools/pool-1/invitations', {
+          inviteeIds: [],
+        }),
+      }),
+    );
+
+    expect(getRouteResultStatus(result)).toBe(400);
+    expect(sendPoolInvitations).not.toHaveBeenCalled();
+  });
+
+  it('maps invitation-domain errors to their public status and code', async () => {
+    sendPoolInvitations.mockRejectedValue(
+      new PoolInvitationError('INVITEE_NOT_ELIGIBLE', 'Not eligible.', 409),
+    );
+    const result = await sendAction(
+      toActionArgs({
+        context: {},
+        params: { poolId: 'pool-1' },
+        request: jsonRequest('/api/pools/pool-1/invitations', {
+          inviteeIds: ['invitee-1'],
+        }),
+      }),
+    );
+
+    expect(getRouteResultStatus(result)).toBe(409);
+    expect(await getRouteResultData(result)).toMatchObject({
+      code: 'INVITEE_NOT_ELIGIBLE',
+    });
+  });
+
+  it('accepts and returns the updated unread count', async () => {
+    const result = await acceptAction(
+      invitationActionArgs('/accept'),
+    );
+
+    expect(getRouteResultStatus(result)).toBe(200);
+    expect(await getRouteResultData(result)).toMatchObject({
+      poolId: 'pool-1',
+      unreadCount: 2,
+    });
+    expect(acceptPoolInvitation).toHaveBeenCalledWith(
+      'invitation-1',
+      'user-1',
+    );
+  });
+
+  it('declines and returns the updated unread count', async () => {
+    const result = await declineAction(
+      invitationActionArgs('/decline'),
+    );
+
+    expect(getRouteResultStatus(result)).toBe(200);
+    expect(await getRouteResultData(result)).toMatchObject({ unreadCount: 2 });
+    expect(declinePoolInvitation).toHaveBeenCalledWith(
+      'invitation-1',
+      'user-1',
+    );
+  });
+
+  it('lets a manager cancel a pending invitation', async () => {
+    const result = await cancelAction(
+      invitationActionArgs('/cancel'),
+    );
+
+    expect(getRouteResultStatus(result)).toBe(200);
+    expect(cancelPoolInvitation).toHaveBeenCalledWith({
+      invitationId: 'invitation-1',
+      managerId: 'user-1',
+    });
+  });
+
+  it('preserves invitation-domain statuses for every response action', async () => {
+    for (const [operation, routeAction] of [
+      [acceptPoolInvitation, acceptAction],
+      [declinePoolInvitation, declineAction],
+      [cancelPoolInvitation, cancelAction],
+    ] as const) {
+      operation.mockRejectedValueOnce(
+        new PoolInvitationError(
+          'INVITATION_NOT_PENDING',
+          'No longer pending.',
+          409,
+        ),
+      );
+      const result = await routeAction(invitationActionArgs('/response'));
+      expect(getRouteResultStatus(result)).toBe(409);
+      expect(await getRouteResultData(result)).toMatchObject({
+        code: 'INVITATION_NOT_PENDING',
+      });
+    }
+  });
+
+  it('returns not found when a required route id is absent', async () => {
+    for (const routeAction of [acceptAction, declineAction, cancelAction]) {
+      const result = await routeAction(
+        toActionArgs({
+          context: {},
+          params: {},
+          request: new Request('https://giftpool.app/api/pool-invitations', {
+            method: 'POST',
+          }),
+        }),
+      );
+      expect(getRouteResultStatus(result)).toBe(404);
+    }
+
+    const sendResult = await sendAction(
+      toActionArgs({
+        context: {},
+        params: {},
+        request: jsonRequest('/api/pools/missing/invitations', {
+          inviteeIds: ['invitee-1'],
+        }),
+      }),
+    );
+    expect(getRouteResultStatus(sendResult)).toBe(404);
+  });
+});
+
+function jsonRequest(path: string, body: unknown) {
+  return new Request(`https://giftpool.app${path}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function invitationActionArgs(path: string) {
+  return toActionArgs({
+    context: {},
+    params: { invitationId: 'invitation-1' },
+    request: new Request(
+      `https://giftpool.app/api/pool-invitations/invitation-1${path}`,
+      { method: 'POST' },
+    ),
+  });
+}

--- a/app/routes/api.pools.$poolId.invitations.ts
+++ b/app/routes/api.pools.$poolId.invitations.ts
@@ -1,0 +1,46 @@
+import { data, type ActionFunctionArgs } from 'react-router';
+import { z } from 'zod';
+import { requireUserId } from '#app/utils/auth.server.ts';
+import {
+  PoolInvitationError,
+  sendPoolInvitations,
+} from '#app/utils/pool-invitations.server.ts';
+
+const SendInvitationsSchema = z.object({
+  inviteeIds: z.array(z.string().min(1)).min(1).max(50),
+});
+
+export async function action({ request, params }: ActionFunctionArgs) {
+  if (request.method !== 'POST') {
+    throw new Response('Method not allowed', { status: 405 });
+  }
+  const managerId = await requireUserId(request);
+  const poolId = params.poolId;
+  if (!poolId) return data({ error: 'Pool not found.' }, { status: 404 });
+
+  const parsed = SendInvitationsSchema.safeParse(await request.json());
+  if (!parsed.success) {
+    return data(
+      { error: 'Choose at least one eligible person.' },
+      { status: 400 },
+    );
+  }
+  try {
+    const invitations = await sendPoolInvitations({
+      poolId,
+      managerId,
+      inviteeIds: parsed.data.inviteeIds,
+    });
+    return data({ success: true, invitations });
+  } catch (error) {
+    return invitationErrorResponse(error);
+  }
+}
+
+function invitationErrorResponse(error: unknown) {
+  if (!(error instanceof PoolInvitationError)) throw error;
+  return data(
+    { error: error.message, code: error.code },
+    { status: error.status },
+  );
+}

--- a/app/routes/pools+/$poolId+/settings.test.tsx
+++ b/app/routes/pools+/$poolId+/settings.test.tsx
@@ -11,6 +11,14 @@ const loaderDataSnapshot = {
   // True only for an empty "mistake" pool the organizer may hard-delete;
   // anything with memory shows Cancel instead. See settings loader.
   canHardDelete: true,
+  invitationState: {
+    poolId: 'pool-1',
+    poolTitle: 'Alex Birthday Pool',
+    recipientLabel: 'Alex',
+    isActive: true,
+    candidates: [],
+    pendingInvitations: [],
+  },
   pool: {
     id: 'pool-1',
     title: 'Alex Birthday Pool',

--- a/app/routes/pools+/$poolId+/settings.test.tsx
+++ b/app/routes/pools+/$poolId+/settings.test.tsx
@@ -2,9 +2,29 @@
  * @vitest-environment jsdom
  */
 import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type InvitationPerson = {
+  id: string;
+  username: string;
+  name: string | null;
+  image: { id: string; altText: string | null } | null;
+};
+
+type InvitationCandidate = InvitationPerson & {
+  contributionCents: number | null;
+};
+
+type PendingInvitation = {
+  id: string;
+  createdAt: Date;
+  invitee: InvitationPerson;
+};
+
+const fetchMock = vi.fn<typeof fetch>();
 
 const loaderDataSnapshot = {
   inviteUrl: 'https://giftpool.app/pools/join/invite-1' as string | null,
@@ -16,8 +36,8 @@ const loaderDataSnapshot = {
     poolTitle: 'Alex Birthday Pool',
     recipientLabel: 'Alex',
     isActive: true,
-    candidates: [],
-    pendingInvitations: [],
+    candidates: [] as InvitationCandidate[],
+    pendingInvitations: [] as PendingInvitation[],
   },
   pool: {
     id: 'pool-1',
@@ -58,9 +78,13 @@ function renderRoute() {
 
 describe('app/routes/pools+/$poolId+/settings.tsx', () => {
   beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
     loaderDataSnapshot.pool.status = 'OPEN';
     loaderDataSnapshot.canHardDelete = true;
     loaderDataSnapshot.inviteUrl = 'https://giftpool.app/pools/join/invite-1';
+    loaderDataSnapshot.invitationState.candidates = [];
+    loaderDataSnapshot.invitationState.pendingInvitations = [];
   });
 
   it('opens pool details in read mode and surfaces invite + danger zone', () => {
@@ -125,4 +149,70 @@ describe('app/routes/pools+/$poolId+/settings.tsx', () => {
       screen.getByRole('button', { name: 'Cancel pool' }),
     ).toBeInTheDocument();
   });
+
+  it('selects and sends eligible people from the responsive picker', async () => {
+    const candidate = invitationPerson('naomi', 'Naomi');
+    loaderDataSnapshot.invitationState.candidates = [
+      { ...candidate, contributionCents: null },
+    ];
+    fetchMock.mockResolvedValue(
+      Response.json({
+        success: true,
+        invitations: [{ id: 'invitation-1', inviteeId: candidate.id }],
+      }),
+    );
+
+    renderRoute();
+    await userEvent.click(screen.getByRole('button', { name: 'Invite people' }));
+    await userEvent.click(
+      screen.getByRole('checkbox', { name: 'Invite Naomi' }),
+    );
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Send 1 invitation' }),
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/pools/pool-1/invitations',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ inviteeIds: ['naomi'] }),
+      }),
+    );
+    expect(await screen.findByText('Awaiting response')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Everyone eligible is already a contributor or has been invited.',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('returns a cancelled invitation to the eligible picker', async () => {
+    const invitee = invitationPerson('marco', 'Marco');
+    loaderDataSnapshot.invitationState.pendingInvitations = [
+      { id: 'invitation-1', createdAt: new Date(), invitee },
+    ];
+    fetchMock.mockResolvedValue(
+      Response.json({ success: true, poolId: 'pool-1' }),
+    );
+
+    renderRoute();
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Cancel invitation' }),
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/pool-invitations/invitation-1/cancel',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(screen.queryByText('Awaiting response')).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: 'Invite people' }));
+    expect(
+      screen.getByRole('checkbox', { name: 'Invite Marco' }),
+    ).toBeInTheDocument();
+  });
 });
+
+function invitationPerson(id: string, name: string): InvitationPerson {
+  return { id, username: id, name, image: null };
+}

--- a/app/routes/pools+/$poolId+/settings.tsx
+++ b/app/routes/pools+/$poolId+/settings.tsx
@@ -5,13 +5,14 @@ import {
 	type SubmissionResult,
 } from '@conform-to/react';
 import { getZodConstraint, parseWithZod } from '@conform-to/zod';
-import { useCallback, useEffect, useState } from 'react';
-import { LuClipboard, LuLink } from 'react-icons/lu';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { LuClipboard, LuLink, LuSearch, LuUserPlus } from 'react-icons/lu';
 import {
 	useFetcher,
 	useLoaderData,
 	type LoaderFunctionArgs,
 } from 'react-router';
+import { toast } from 'sonner';
 import { z } from 'zod';
 import {
 	EditableSection,
@@ -19,11 +20,22 @@ import {
 	useExitOnSubmitSuccess,
 } from '#app/components/editable-section.tsx';
 import { ErrorList, Field } from '#app/components/forms.tsx';
+import { Avatar } from '#app/components/ui/avatar.tsx';
 import { Button } from '#app/components/ui/button.tsx';
 import { Card } from '#app/components/ui/card.tsx';
+import { Checkbox } from '#app/components/ui/checkbox.tsx';
 import { ConfirmDialog } from '#app/components/ui/confirm-dialog.tsx';
 import { Input } from '#app/components/ui/input.tsx';
 import { Label } from '#app/components/ui/label.tsx';
+import {
+	ResponsiveDialog,
+	ResponsiveDialogContent,
+	ResponsiveDialogDescription,
+	ResponsiveDialogFooter,
+	ResponsiveDialogHeader,
+	ResponsiveDialogTitle,
+	ResponsiveDialogTrigger,
+} from '#app/components/ui/responsive-dialog.tsx';
 import { StatusButton } from '#app/components/ui/status-button.tsx';
 import { Flex, Stack, Text } from '#app/components/ui-kit';
 import { requireUserId } from '#app/utils/auth.server.ts';
@@ -36,6 +48,7 @@ import {
 	type DecisionMode,
 	type OccasionType,
 } from '#app/utils/pool-constants.ts';
+import { getPoolInvitationManagerState } from '#app/utils/pool-invitations.server.ts';
 import {
 	canManagePool,
 	isPoolOrganizer,
@@ -95,11 +108,13 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 		: null;
 
 	const isOrganizer = isPoolOrganizer(userId, poolForPerms);
+	const invitationState = await getPoolInvitationManagerState(pool.id, userId);
 
 	return {
 		pool,
 		inviteUrl,
 		isOrganizer,
+		invitationState,
 		// Hard delete is only offered for an empty "mistake" pool (no ideas, no
 		// contributors beyond the organizer). Anything with memory shows Cancel.
 		canHardDelete: isOrganizer && (await isPoolEmptyForDeletion(pool.id)),
@@ -125,7 +140,8 @@ function toDateInputValue(value: Date | string | null | undefined) {
 }
 
 const PoolSettings = () => {
-	const { pool, inviteUrl, canHardDelete } = useLoaderData<typeof loader>();
+	const { pool, inviteUrl, invitationState, canHardDelete } =
+		useLoaderData<typeof loader>();
 	const isClosed =
 		pool.status === POOL_STATUS.DELIVERED ||
 		pool.status === POOL_STATUS.CANCELLED;
@@ -143,7 +159,11 @@ const PoolSettings = () => {
 			</div>
 
 			<PoolDetailsCard pool={pool} isClosed={isClosed} />
-			<InviteSection poolId={pool.id} inviteUrl={inviteUrl} />
+			<InviteSection
+				poolId={pool.id}
+				inviteUrl={inviteUrl}
+				invitationState={invitationState}
+			/>
 			{!isClosed && (
 				<DangerZone
 					poolId={pool.id}
@@ -320,11 +340,22 @@ function PoolDetailsCard({
 const InviteSection = ({
 	poolId,
 	inviteUrl,
+	invitationState,
 }: {
 	poolId: string;
 	inviteUrl: string | null;
+	invitationState: Awaited<ReturnType<typeof getPoolInvitationManagerState>>;
 }) => {
 	const fetcher = useFetcher<{ inviteUrl?: string }>();
+	const [dialogOpen, setDialogOpen] = useState(false);
+	const [query, setQuery] = useState('');
+	const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+	const [sending, setSending] = useState(false);
+	const [cancellingId, setCancellingId] = useState<string | null>(null);
+	const [candidates, setCandidates] = useState(invitationState.candidates);
+	const [pendingInvitations, setPendingInvitations] = useState(
+		invitationState.pendingInvitations,
+	);
 	const freshUrl =
 		fetcher.data && 'inviteUrl' in (fetcher.data as object)
 			? (fetcher.data as { inviteUrl: string }).inviteUrl
@@ -341,44 +372,295 @@ const InviteSection = ({
 		}
 	}, [fetcher.state, fetcher.data]);
 
+	const filteredCandidates = useMemo(() => {
+		const normalized = query.trim().toLowerCase();
+		if (!normalized) return candidates;
+		return candidates.filter(
+			(candidate) =>
+				(candidate.name ?? '').toLowerCase().includes(normalized) ||
+				candidate.username.toLowerCase().includes(normalized),
+		);
+	}, [candidates, query]);
+
+	const sendInvitations = async () => {
+		if (selectedIds.size === 0 || sending) return;
+		setSending(true);
+		try {
+			const response = await fetch(`/api/pools/${poolId}/invitations`, {
+				method: 'POST',
+				credentials: 'same-origin',
+				headers: {
+					Accept: 'application/json',
+					'Content-Type': 'application/json',
+				},
+				body: JSON.stringify({ inviteeIds: [...selectedIds] }),
+			});
+			const payload = (await response.json()) as {
+				error?: string;
+				invitations?: Array<{ id: string; inviteeId: string }>;
+			};
+			if (!response.ok) {
+				throw new Error(payload.error ?? 'Unable to invite people.');
+			}
+			const sentCount = selectedIds.size;
+			const candidateById = new Map(
+				candidates.map((candidate) => [candidate.id, candidate]),
+			);
+			const sentRows = (payload.invitations ?? []).flatMap((invitation) => {
+				const invitee = candidateById.get(invitation.inviteeId);
+				return invitee
+					? [{ ...invitation, createdAt: new Date(), invitee }]
+					: [];
+			});
+			setCandidates((previous) =>
+				previous.filter((candidate) => !selectedIds.has(candidate.id)),
+			);
+			setPendingInvitations((previous) => [...sentRows, ...previous]);
+			toast.success(
+				sentCount === 1 ? 'Invitation sent.' : `${sentCount} invitations sent.`,
+			);
+			setDialogOpen(false);
+			setSelectedIds(new Set());
+			setQuery('');
+		} catch (error) {
+			toast.error(
+				error instanceof Error ? error.message : 'Unable to invite people.',
+			);
+		} finally {
+			setSending(false);
+		}
+	};
+
+	const cancelInvitation = async (invitationId: string) => {
+		if (cancellingId) return;
+		const cancelledInvitation = pendingInvitations.find(
+			(invitation) => invitation.id === invitationId,
+		);
+		setCancellingId(invitationId);
+		try {
+			const response = await fetch(
+				`/api/pool-invitations/${invitationId}/cancel`,
+				{
+					method: 'POST',
+					credentials: 'same-origin',
+					headers: { Accept: 'application/json' },
+				},
+			);
+			if (!response.ok) throw new Error('Unable to cancel the invitation.');
+			setPendingInvitations((previous) =>
+				previous.filter((invitation) => invitation.id !== invitationId),
+			);
+			if (cancelledInvitation) {
+				setCandidates((previous) => [
+					...previous,
+					{ ...cancelledInvitation.invitee, contributionCents: null },
+				]);
+			}
+			toast.success('Invitation cancelled.');
+		} catch (error) {
+			toast.error(
+				error instanceof Error
+					? error.message
+					: 'Unable to cancel the invitation.',
+			);
+		} finally {
+			setCancellingId(null);
+		}
+	};
+
 	return (
 		<Card className="p-4">
-			<Stack gap={3}>
+			<Stack gap={4}>
 				<Text size="lg" weight="semibold">
 					Invite contributors
 				</Text>
-				<p className="text-xs text-muted-foreground">
-					Anyone with this link can join as a contributor.
+				<p className="text-sm text-muted-foreground">
+					Send a private invitation to eligible people, or share a link.
 				</p>
-				{freshUrl ? (
-					<Flex gap={2}>
-						<Input value={freshUrl} readOnly className="flex-1 text-xs" />
+
+				<ResponsiveDialog open={dialogOpen} onOpenChange={setDialogOpen}>
+					<ResponsiveDialogTrigger asChild>
 						<Button
 							type="button"
-							size="sm"
-							variant="outline"
-							onClick={() => navigator.clipboard.writeText(freshUrl)}
-							className="shrink-0 gap-1.5"
+							className="w-full gap-2 sm:w-fit"
+							disabled={!invitationState.isActive || candidates.length === 0}
 						>
-							<LuClipboard size={13} /> Copy
+							<LuUserPlus className="size-4" aria-hidden />
+							Invite people
 						</Button>
-					</Flex>
-				) : (
-					<fetcher.Form method="post">
-						<input type="hidden" name="intent" value="generate-invite" />
-						<input type="hidden" name="poolId" value={poolId} />
-						<Button
-							type="submit"
-							size="sm"
-							variant="outline"
-							className="gap-1.5"
-							disabled={fetcher.state !== 'idle'}
-						>
-							<LuLink size={13} />
-							Generate invite link
-						</Button>
-					</fetcher.Form>
-				)}
+					</ResponsiveDialogTrigger>
+					<ResponsiveDialogContent className="sm:max-w-lg">
+						<ResponsiveDialogHeader>
+							<ResponsiveDialogTitle>Invite people</ResponsiveDialogTitle>
+							<ResponsiveDialogDescription>
+								Choose eligible people to invite to {invitationState.poolTitle}.
+								They decide whether to join.
+							</ResponsiveDialogDescription>
+						</ResponsiveDialogHeader>
+
+						<div className="relative">
+							<LuSearch
+								className="absolute left-3 top-3 size-4 text-muted-foreground"
+								aria-hidden
+							/>
+							<Input
+								value={query}
+								onChange={(event) => setQuery(event.target.value)}
+								placeholder="Search by name or username"
+								className="pl-9"
+							/>
+						</div>
+
+						<div className="max-h-72 overflow-y-auto rounded-md border">
+							{filteredCandidates.length > 0 ? (
+								filteredCandidates.map((candidate) => {
+									const checked = selectedIds.has(candidate.id);
+									const displayName = candidate.name ?? candidate.username;
+									return (
+										<label
+											key={candidate.id}
+											className="flex min-h-14 cursor-pointer items-center gap-3 border-b px-3 py-2 last:border-b-0 hover:bg-muted/50"
+										>
+											<Checkbox
+												checked={checked}
+												onCheckedChange={(next) => {
+													setSelectedIds((previous) => {
+														const updated = new Set(previous);
+														if (next) updated.add(candidate.id);
+														else updated.delete(candidate.id);
+														return updated;
+													});
+												}}
+												aria-label={`Invite ${displayName}`}
+											/>
+											<Avatar
+												user={candidate}
+												image={candidate.image}
+												size="s"
+											/>
+											<span className="min-w-0">
+												<span className="block truncate text-sm font-medium">
+													{displayName}
+												</span>
+												<span className="block truncate text-xs text-muted-foreground">
+													@{candidate.username}
+												</span>
+											</span>
+										</label>
+									);
+								})
+							) : (
+								<p className="p-6 text-center text-sm text-muted-foreground">
+									No eligible people match your search.
+								</p>
+							)}
+						</div>
+
+						<ResponsiveDialogFooter>
+							<Button
+								type="button"
+								onClick={() => void sendInvitations()}
+								disabled={selectedIds.size === 0 || sending}
+								className="min-h-11"
+							>
+								{sending
+									? 'Sending…'
+									: `Send ${selectedIds.size || ''} invitation${
+											selectedIds.size === 1 ? '' : 's'
+										}`}
+							</Button>
+						</ResponsiveDialogFooter>
+					</ResponsiveDialogContent>
+				</ResponsiveDialog>
+
+				{candidates.length === 0 && invitationState.isActive ? (
+					<p className="text-xs text-muted-foreground">
+						Everyone eligible is already a contributor or has been invited.
+					</p>
+				) : null}
+
+				{pendingInvitations.length > 0 ? (
+					<div className="space-y-2 border-t pt-4">
+						<p className="text-sm font-medium">Pending invitations</p>
+						{pendingInvitations.map((invitation) => {
+							const displayName =
+								invitation.invitee.name ?? invitation.invitee.username;
+							return (
+								<div
+									key={invitation.id}
+									className="flex items-center justify-between gap-3 rounded-lg border p-3"
+								>
+									<div className="flex min-w-0 items-center gap-3">
+										<Avatar
+											user={invitation.invitee}
+											image={invitation.invitee.image}
+											size="s"
+										/>
+										<div className="min-w-0">
+											<p className="truncate text-sm font-medium">
+												{displayName}
+											</p>
+											<p className="text-xs text-muted-foreground">
+												Awaiting response
+											</p>
+										</div>
+									</div>
+									<ConfirmDialog
+										title="Cancel this invitation?"
+										description={`${displayName} will no longer be able to accept it.`}
+										confirmText="Cancel invitation"
+										onConfirm={() => void cancelInvitation(invitation.id)}
+									>
+										<Button
+											type="button"
+											variant="ghost"
+											size="sm"
+											disabled={cancellingId === invitation.id}
+										>
+											Cancel
+										</Button>
+									</ConfirmDialog>
+								</div>
+							);
+						})}
+					</div>
+				) : null}
+
+				<div className="space-y-2 border-t pt-4">
+					<p className="text-sm font-medium">Share a link instead</p>
+					<p className="text-xs text-muted-foreground">
+						Anyone with the link can join as a contributor.
+					</p>
+					{freshUrl ? (
+						<Flex gap={2}>
+							<Input value={freshUrl} readOnly className="flex-1 text-xs" />
+							<Button
+								type="button"
+								size="sm"
+								variant="outline"
+								onClick={() => navigator.clipboard.writeText(freshUrl)}
+								className="shrink-0 gap-1.5"
+							>
+								<LuClipboard size={13} /> Copy
+							</Button>
+						</Flex>
+					) : (
+						<fetcher.Form method="post">
+							<input type="hidden" name="intent" value="generate-invite" />
+							<input type="hidden" name="poolId" value={poolId} />
+							<Button
+								type="submit"
+								size="sm"
+								variant="outline"
+								className="gap-1.5"
+								disabled={fetcher.state !== 'idle'}
+							>
+								<LuLink size={13} />
+								Generate invite link
+							</Button>
+						</fetcher.Form>
+					)}
+				</div>
 			</Stack>
 		</Card>
 	);

--- a/app/routes/pools+/$poolId+/settings.tsx
+++ b/app/routes/pools+/$poolId+/settings.tsx
@@ -381,6 +381,11 @@ const InviteSection = ({
 				candidate.username.toLowerCase().includes(normalized),
 		);
 	}, [candidates, query]);
+	const sendButtonLabel = sending
+		? 'Sending…'
+		: `Send ${selectedIds.size || ''} invitation${
+				selectedIds.size === 1 ? '' : 's'
+			}`;
 
 	const sendInvitations = async () => {
 		if (selectedIds.size === 0 || sending) return;
@@ -563,11 +568,7 @@ const InviteSection = ({
 								disabled={selectedIds.size === 0 || sending}
 								className="min-h-11"
 							>
-								{sending
-									? 'Sending…'
-									: `Send ${selectedIds.size || ''} invitation${
-											selectedIds.size === 1 ? '' : 's'
-										}`}
+								{sendButtonLabel}
 							</Button>
 						</ResponsiveDialogFooter>
 					</ResponsiveDialogContent>

--- a/app/routes/pools_.invitations.$invitationId.test.tsx
+++ b/app/routes/pools_.invitations.$invitationId.test.tsx
@@ -1,0 +1,178 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import {
+  createMemoryRouter,
+  redirect,
+  RouterProvider,
+} from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PoolInvitationError } from '#app/utils/pool-invitations.server.ts';
+import {
+  getRouteResultStatus,
+  toActionArgs,
+  toLoaderArgs,
+} from '#tests/route-module-test-utils.ts';
+
+const requireUserId = vi.fn();
+const getPoolInvitationForInvitee = vi.fn();
+const acceptPoolInvitation = vi.fn();
+const declinePoolInvitation = vi.fn();
+
+vi.mock('#app/utils/auth.server.ts', () => ({
+  requireUserId: (...args: Array<unknown>) => requireUserId(...args),
+}));
+
+vi.mock('#app/utils/pool-invitations.server.ts', () => ({
+  PoolInvitationError: class PoolInvitationError extends Error {
+    constructor(
+      public readonly code: string,
+      message: string,
+      public readonly status: number,
+    ) {
+      super(message);
+      this.name = 'PoolInvitationError';
+    }
+  },
+  getPoolInvitationForInvitee: (...args: Array<unknown>) =>
+    getPoolInvitationForInvitee(...args),
+  acceptPoolInvitation: (...args: Array<unknown>) =>
+    acceptPoolInvitation(...args),
+  declinePoolInvitation: (...args: Array<unknown>) =>
+    declinePoolInvitation(...args),
+}));
+
+vi.mock('#app/utils/toast.server.ts', () => ({
+  redirectWithToast: (to: string) => redirect(to),
+}));
+
+import PoolInvitationReviewPage, {
+  action,
+  loader,
+} from './pools_.invitations.$invitationId.tsx';
+
+const invitation = {
+  id: 'invitation-1',
+  status: 'PENDING',
+  poolId: 'pool-1',
+  poolTitle: 'Birthday surprise',
+  poolStatus: 'OPEN',
+  recipientLabel: 'Alex',
+  contributorCount: 2,
+  isActive: true,
+  inviter: {
+    id: 'manager-1',
+    username: 'wade',
+    name: 'Wade',
+    image: null,
+  },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  requireUserId.mockResolvedValue('invitee-1');
+  getPoolInvitationForInvitee.mockResolvedValue(invitation);
+  acceptPoolInvitation.mockResolvedValue({ poolId: 'pool-1' });
+  declinePoolInvitation.mockResolvedValue({ poolId: 'pool-1' });
+});
+
+describe('pool invitation review route', () => {
+  it('loads only the invitation owned by the signed-in user', async () => {
+    const result = await loader(
+      toLoaderArgs({
+        context: {},
+        params: { invitationId: 'invitation-1' },
+        request: new Request(
+          'https://giftpool.app/pools/invitations/invitation-1',
+        ),
+      }),
+    );
+
+    expect(result).toEqual({ invitation });
+    expect(getPoolInvitationForInvitee).toHaveBeenCalledWith(
+      'invitation-1',
+      'invitee-1',
+    );
+  });
+
+  it('turns an ownership failure into a generic 404', async () => {
+    getPoolInvitationForInvitee.mockRejectedValue(
+      new PoolInvitationError('INVITATION_NOT_FOUND', 'Private detail.', 404),
+    );
+
+    await expect(
+      loader(
+        toLoaderArgs({
+          context: {},
+          params: { invitationId: 'invitation-1' },
+          request: new Request(
+            'https://giftpool.app/pools/invitations/invitation-1',
+          ),
+        }),
+      ),
+    ).rejects.toMatchObject({ status: 404 });
+  });
+
+  it('renders only aggregate pre-acceptance pool context', async () => {
+    const router = createMemoryRouter(
+      [
+        {
+          path: '/pools/invitations/:invitationId',
+          element: <PoolInvitationReviewPage />,
+          loader: () => ({ invitation }),
+        },
+      ],
+      { initialEntries: ['/pools/invitations/invitation-1'] },
+    );
+
+    render(<RouterProvider router={router} />);
+
+    expect(
+      await screen.findByRole('heading', {
+        name: 'You’re invited to contribute',
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Gift pool for Alex')).toBeInTheDocument();
+    expect(screen.getByText(/2 people have joined so far/)).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Accept and join' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Decline' })).toBeInTheDocument();
+  });
+
+  it('accepts and declines through the invitation module', async () => {
+    const accepted = await action(
+      invitationActionArgs(new URLSearchParams({ intent: 'accept' })),
+    );
+    expect(getRouteResultStatus(accepted)).toBe(302);
+    expect(acceptPoolInvitation).toHaveBeenCalledWith(
+      'invitation-1',
+      'invitee-1',
+    );
+
+    const declined = await action(
+      invitationActionArgs(new URLSearchParams({ intent: 'decline' })),
+    );
+    expect(getRouteResultStatus(declined)).toBe(302);
+    expect(declinePoolInvitation).toHaveBeenCalledWith(
+      'invitation-1',
+      'invitee-1',
+    );
+  });
+});
+
+function invitationActionArgs(body: URLSearchParams) {
+  return toActionArgs({
+    context: {},
+    params: { invitationId: 'invitation-1' },
+    request: new Request(
+      'https://giftpool.app/pools/invitations/invitation-1',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+        body: body.toString(),
+      },
+    ),
+  });
+}

--- a/app/routes/pools_.invitations.$invitationId.tsx
+++ b/app/routes/pools_.invitations.$invitationId.tsx
@@ -42,7 +42,8 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 export async function action({ request, params }: ActionFunctionArgs) {
   const userId = await requireUserId(request);
   if (!params.invitationId) throw new Response('Not Found', { status: 404 });
-  const intent = String((await request.formData()).get('intent'));
+  const rawIntent = (await request.formData()).get('intent');
+  const intent = typeof rawIntent === 'string' ? rawIntent : '';
   try {
     if (intent === 'accept') {
       const { poolId } = await acceptPoolInvitation(

--- a/app/routes/pools_.invitations.$invitationId.tsx
+++ b/app/routes/pools_.invitations.$invitationId.tsx
@@ -1,0 +1,159 @@
+import { LuGift, LuUsers } from 'react-icons/lu';
+import {
+  Form,
+  redirect,
+  useLoaderData,
+  useNavigation,
+  type ActionFunctionArgs,
+  type LoaderFunctionArgs,
+} from 'react-router';
+import { Avatar } from '#app/components/ui/avatar.tsx';
+import { Button } from '#app/components/ui/button.tsx';
+import { Card } from '#app/components/ui/card.tsx';
+import { requireUserId } from '#app/utils/auth.server.ts';
+import {
+  acceptPoolInvitation,
+  declinePoolInvitation,
+  getPoolInvitationForInvitee,
+  PoolInvitationError,
+} from '#app/utils/pool-invitations.server.ts';
+import { redirectWithToast } from '#app/utils/toast.server.ts';
+
+export async function loader({ request, params }: LoaderFunctionArgs) {
+  const userId = await requireUserId(request);
+  if (!params.invitationId) throw new Response('Not Found', { status: 404 });
+  try {
+    const invitation = await getPoolInvitationForInvitee(
+      params.invitationId,
+      userId,
+    );
+    if (invitation.status === 'ACCEPTED') {
+      return redirect(`/pools/${invitation.poolId}`);
+    }
+    return { invitation };
+  } catch (error) {
+    if (error instanceof PoolInvitationError && error.status < 500) {
+      throw new Response('Not Found', { status: 404 });
+    }
+    throw error;
+  }
+}
+
+export async function action({ request, params }: ActionFunctionArgs) {
+  const userId = await requireUserId(request);
+  if (!params.invitationId) throw new Response('Not Found', { status: 404 });
+  const intent = String((await request.formData()).get('intent'));
+  try {
+    if (intent === 'accept') {
+      const { poolId } = await acceptPoolInvitation(
+        params.invitationId,
+        userId,
+      );
+      return redirectWithToast(`/pools/${poolId}`, {
+        type: 'success',
+        description: 'You joined the pool.',
+      });
+    }
+    if (intent === 'decline') {
+      await declinePoolInvitation(params.invitationId, userId);
+      return redirectWithToast('/pools', {
+        type: 'success',
+        description: 'Invitation declined.',
+      });
+    }
+    throw new Response('Invalid action.', { status: 400 });
+  } catch (error) {
+    if (error instanceof PoolInvitationError) {
+      throw new Response(error.message, { status: error.status });
+    }
+    throw error;
+  }
+}
+
+export default function PoolInvitationReviewPage() {
+  const { invitation } = useLoaderData<typeof loader>();
+  const navigation = useNavigation();
+  const submittedIntent = navigation.formData?.get('intent');
+  const pending = navigation.state !== 'idle';
+  const inviterName = invitation.inviter.name ?? invitation.inviter.username;
+  const available = invitation.status === 'PENDING' && invitation.isActive;
+
+  return (
+    <main className="mx-auto flex min-h-[calc(100vh-5rem)] max-w-2xl items-center px-4 py-10 sm:px-6">
+      <Card className="w-full overflow-hidden">
+        <div className="bg-primary/5 px-6 py-8 text-center sm:px-10">
+          <div className="mx-auto mb-4 flex size-12 items-center justify-center rounded-full bg-primary/10 text-primary">
+            <LuGift className="size-6" aria-hidden />
+          </div>
+          <p className="text-sm font-medium text-primary">Pool invitation</p>
+          <h1 className="mt-2 text-2xl font-bold tracking-tight sm:text-3xl">
+            You’re invited to contribute
+          </h1>
+          <p className="mt-3 text-lg font-semibold">{invitation.poolTitle}</p>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Gift pool for {invitation.recipientLabel}
+          </p>
+        </div>
+
+        <div className="space-y-6 px-6 py-6 sm:px-10 sm:py-8">
+          <div className="flex items-center gap-3">
+            <Avatar
+              user={invitation.inviter}
+              image={invitation.inviter.image}
+              size="s"
+            />
+            <div>
+              <p className="text-sm font-semibold">Invited by {inviterName}</p>
+              <p className="text-xs text-muted-foreground">
+                Review the invitation before choosing.
+              </p>
+            </div>
+          </div>
+
+          <div className="flex items-center gap-3 rounded-lg border bg-muted/30 p-4">
+            <LuUsers className="size-5 text-muted-foreground" aria-hidden />
+            <p className="text-sm">
+              {invitation.contributorCount}{' '}
+              {invitation.contributorCount === 1 ? 'person has' : 'people have'}{' '}
+              joined so far. Contributor identities and gift details stay
+              private until you accept.
+            </p>
+          </div>
+
+          {available ? (
+            <Form method="post" className="grid gap-3 sm:grid-cols-2">
+              <Button
+                type="submit"
+                name="intent"
+                value="accept"
+                className="min-h-11"
+                disabled={pending}
+              >
+                {submittedIntent === 'accept' ? 'Joining…' : 'Accept and join'}
+              </Button>
+              <Button
+                type="submit"
+                name="intent"
+                value="decline"
+                variant="outline"
+                className="min-h-11"
+                disabled={pending}
+              >
+                {submittedIntent === 'decline' ? 'Declining…' : 'Decline'}
+              </Button>
+            </Form>
+          ) : (
+            <p className="rounded-lg border p-4 text-sm text-muted-foreground">
+              This invitation is no longer available.
+            </p>
+          )}
+
+          <p className="text-xs text-muted-foreground">
+            If the pool uses a group contribution default, you can review or
+            change your amount after joining.
+          </p>
+        </div>
+      </Card>
+    </main>
+  );
+}

--- a/app/utils/analytics.ts
+++ b/app/utils/analytics.ts
@@ -18,6 +18,9 @@ export const ANALYTIC_EVENT_NAMES = [
   // Phase 1.5 — gifting workflow instrumentation
   'pool_created',
   'pool_contributor_joined',
+  'pool_invitation_sent',
+  'pool_invitation_accepted',
+  'pool_invitation_declined',
   'pool_vote_called',
   'pool_vote_cast',
   'pool_decided',
@@ -193,6 +196,9 @@ export const USER_REQUIRED_EVENTS: Set<AnalyticEventName> = new Set([
   // Phase 1.5 — every workflow event has a known actor (the acting user).
   'pool_created',
   'pool_contributor_joined',
+  'pool_invitation_sent',
+  'pool_invitation_accepted',
+  'pool_invitation_declined',
   'pool_vote_called',
   'pool_vote_cast',
   'pool_decided',

--- a/app/utils/notification-catalog.test.ts
+++ b/app/utils/notification-catalog.test.ts
@@ -25,9 +25,10 @@ describe('notification catalog', () => {
     ).toBe(NOTIFICATION_TOPICS.FRIEND_REQUESTS);
   });
 
-  it('keeps email opt-in for new topics except grandfathered friend defaults', () => {
+  it('keeps email opt-in except for consent-bearing social invitations', () => {
     const grandfatheredEmailDefaults = new Set<string>([
       NOTIFICATION_TOPICS.FRIEND_REQUESTS,
+      NOTIFICATION_TOPICS.POOL_INVITATIONS,
     ]);
 
     for (const [topic, definition] of Object.entries(

--- a/app/utils/notification-catalog.ts
+++ b/app/utils/notification-catalog.ts
@@ -1,6 +1,7 @@
 export const NOTIFICATION_TYPES = {
   FRIEND_REQUEST_RECEIVED: 'FRIEND_REQUEST_RECEIVED',
   FRIEND_REQUEST_ACCEPTED: 'FRIEND_REQUEST_ACCEPTED',
+  POOL_INVITATION_RECEIVED: 'POOL_INVITATION_RECEIVED',
   UPCOMING_BIRTHDAY: 'UPCOMING_BIRTHDAY',
   POOL_VOTE_STARTED: 'POOL_VOTE_STARTED',
   POOL_GIFT_CHOSEN: 'POOL_GIFT_CHOSEN',
@@ -102,6 +103,7 @@ export const NOTIFICATION_CATEGORY_CATALOG = {
 
 export const NOTIFICATION_TOPICS = {
   FRIEND_REQUESTS: 'FRIEND_REQUESTS',
+  POOL_INVITATIONS: 'POOL_INVITATIONS',
   BIRTHDAY_REMINDERS: 'BIRTHDAY_REMINDERS',
   IDEAS_AND_VOTING: 'IDEAS_AND_VOTING',
   POOL_PROGRESS: 'POOL_PROGRESS',
@@ -167,6 +169,16 @@ export const NOTIFICATION_TOPIC_CATALOG = {
       pushEnabled: false,
     },
   },
+  [NOTIFICATION_TOPICS.POOL_INVITATIONS]: {
+    category: NOTIFICATION_CATEGORIES.POOL_COORDINATION,
+    label: 'Pool invitations',
+    description: 'When someone invites you to contribute to a gift pool.',
+    defaults: {
+      inAppEnabled: true,
+      emailEnabled: true,
+      pushEnabled: false,
+    },
+  },
   [NOTIFICATION_TOPICS.IDEAS_AND_VOTING]: {
     category: NOTIFICATION_CATEGORIES.POOL_COORDINATION,
     label: 'Ideas and voting',
@@ -223,6 +235,13 @@ export const NOTIFICATION_EVENT_CATALOG = {
   },
   [NOTIFICATION_TYPES.FRIEND_REQUEST_ACCEPTED]: {
     topic: NOTIFICATION_TOPICS.FRIEND_REQUESTS,
+    importance: 'IMPORTANT',
+    context: 'NONE',
+    supportedChannels: allChannels,
+    deliveryStrategy: 'ONE_SHOT',
+  },
+  [NOTIFICATION_TYPES.POOL_INVITATION_RECEIVED]: {
+    topic: NOTIFICATION_TOPICS.POOL_INVITATIONS,
     importance: 'IMPORTANT',
     context: 'NONE',
     supportedChannels: allChannels,
@@ -424,6 +443,16 @@ type PoolActivityPayload = {
   actorUserId: string;
 };
 
+type PoolInvitationPayload = {
+  invitationId: string;
+  poolId: string;
+  poolTitle: string;
+  recipientLabel: string;
+  inviterUserId: string;
+  inviterDisplayName: string;
+  inviterAvatarId?: string | null;
+};
+
 type OrganizerNudgePayload = {
   nudgeId: string;
   poolId: string;
@@ -435,6 +464,7 @@ type OrganizerNudgePayload = {
 type PayloadByType = {
   [NOTIFICATION_TYPES.FRIEND_REQUEST_RECEIVED]: FriendRequestPayload;
   [NOTIFICATION_TYPES.FRIEND_REQUEST_ACCEPTED]: FriendRequestPayload;
+  [NOTIFICATION_TYPES.POOL_INVITATION_RECEIVED]: PoolInvitationPayload;
   [NOTIFICATION_TYPES.UPCOMING_BIRTHDAY]: {
     targetUserId: string;
     birthdayUserId: string;

--- a/app/utils/notification-channel-adapters.server.ts
+++ b/app/utils/notification-channel-adapters.server.ts
@@ -62,6 +62,7 @@ const inAppAdapter: NotificationChannelAdapter<'IN_APP'> = {
         metadata: message.metadata,
         actions: message.actions,
         friendRequestId: message.friendRequestId,
+        poolInvitationId: message.poolInvitationId,
       },
     });
     return { status: 'delivered' };

--- a/app/utils/notification-dispatcher.server.test.tsx
+++ b/app/utils/notification-dispatcher.server.test.tsx
@@ -151,6 +151,50 @@ describe('notification dispatcher', () => {
     expect(emailMock).toHaveBeenCalledTimes(1);
   });
 
+  it('delivers a consent-bearing pool invitation by in-app and email', async () => {
+    const recipient = await createUser();
+    const inviter = await createUser();
+    const pool = await prisma.pool.create({
+      data: {
+        title: 'Birthday surprise',
+        organizerId: inviter.id,
+        contributors: { create: { userId: inviter.id } },
+      },
+    });
+    const invitation = await prisma.poolInvitation.create({
+      data: {
+        poolId: pool.id,
+        invitedById: inviter.id,
+        inviteeId: recipient.id,
+      },
+    });
+
+    await dispatchNotification({
+      userId: recipient.id,
+      type: NOTIFICATION_TYPES.POOL_INVITATION_RECEIVED,
+      payload: {
+        invitationId: invitation.id,
+        poolId: pool.id,
+        poolTitle: pool.title,
+        recipientLabel: 'Taylor',
+        inviterUserId: inviter.id,
+        inviterDisplayName: inviter.name ?? inviter.username,
+        inviterAvatarId: null,
+      },
+    });
+
+    await expect(
+      prisma.notification.findUnique({
+        where: { poolInvitationId: invitation.id },
+      }),
+    ).resolves.toMatchObject({
+      userId: recipient.id,
+      type: NOTIFICATION_TYPES.POOL_INVITATION_RECEIVED,
+      targetUrl: `/pools/invitations/${invitation.id}`,
+    });
+    expect(emailMock).toHaveBeenCalledTimes(1);
+  });
+
   it('respects email preference toggles', async () => {
     const recipient = await createUser();
     const actor = await createUser();

--- a/app/utils/notification-events.server.tsx
+++ b/app/utils/notification-events.server.tsx
@@ -2,6 +2,7 @@ import { type ReactElement } from 'react';
 import { FriendRequestAcceptedEmail } from '#app/emails/friend-request-accepted.tsx';
 import { FriendRequestReceivedEmail } from '#app/emails/friend-request-received.tsx';
 import { PoolActivityEmail } from '#app/emails/pool-activity.tsx';
+import { PoolInvitationReceivedEmail } from '#app/emails/pool-invitation-received.tsx';
 import { UpcomingBirthdayEmail } from '#app/emails/upcoming-birthday.tsx';
 import { queueLogEvent } from '#app/utils/analytics.server.ts';
 import { OCCASION_REMINDER_EMAIL_SRC } from '#app/utils/analytics.ts';
@@ -34,6 +35,7 @@ export type InAppNotificationMessage = {
   metadata?: string | null;
   actions?: string | null;
   friendRequestId?: string | null;
+  poolInvitationId?: string | null;
 };
 
 export type EmailNotificationMessage = {
@@ -63,6 +65,8 @@ export function getNotificationOccurrenceKey(
       return `friend-request:${intent.payload.friendRequestId}:received`;
     case NOTIFICATION_TYPES.FRIEND_REQUEST_ACCEPTED:
       return `friend-request:${intent.payload.friendRequestId}:accepted`;
+    case NOTIFICATION_TYPES.POOL_INVITATION_RECEIVED:
+      return `pool-invitation:${intent.payload.invitationId}:received`;
     case NOTIFICATION_TYPES.UPCOMING_BIRTHDAY:
       return `birthday:${intent.payload.birthdayUserId}:${formatLocalDateKey(intent.payload.birthdayDate)}`;
     case NOTIFICATION_TYPES.POOL_VOTE_STARTED:
@@ -89,6 +93,8 @@ export async function renderNotificationChannel<C extends NotificationChannel>(
       return renderFriendRequestReceived(intent, channel);
     case NOTIFICATION_TYPES.FRIEND_REQUEST_ACCEPTED:
       return renderFriendRequestAccepted(intent, channel);
+    case NOTIFICATION_TYPES.POOL_INVITATION_RECEIVED:
+      return renderPoolInvitationReceived(intent, channel);
     case NOTIFICATION_TYPES.UPCOMING_BIRTHDAY:
       return renderUpcomingBirthday(intent, channel);
     case NOTIFICATION_TYPES.POOL_VOTE_STARTED:
@@ -101,6 +107,73 @@ export async function renderNotificationChannel<C extends NotificationChannel>(
     case NOTIFICATION_TYPES.POOL_PURCHASE_REMINDER:
     case NOTIFICATION_TYPES.POOL_DELIVERY_REMINDER:
       return renderPoolActivity(intent, channel);
+  }
+}
+
+async function renderPoolInvitationReceived<C extends NotificationChannel>(
+  intent: NotificationIntent<'POOL_INVITATION_RECEIVED'>,
+  channel: C,
+): Promise<NotificationChannelMessageMap[C]> {
+  const { payload } = intent;
+  const invitationPath = `/pools/invitations/${payload.invitationId}`;
+  const messageParams = {
+    name: payload.inviterDisplayName,
+    pool: payload.poolTitle,
+  };
+  switch (channel) {
+    case NOTIFICATION_CHANNELS.IN_APP:
+      return {
+        status: 'UNREAD',
+        messageKey: 'notifications.poolInvitation.message',
+        messageParams: JSON.stringify(messageParams),
+        targetUrl: invitationPath,
+        metadata: JSON.stringify({
+          poolId: payload.poolId,
+          poolTitle: payload.poolTitle,
+          recipientLabel: payload.recipientLabel,
+          senderUserId: payload.inviterUserId,
+          senderDisplayName: payload.inviterDisplayName,
+          senderAvatarId: payload.inviterAvatarId ?? null,
+        }),
+        actions: JSON.stringify([
+          {
+            kind: 'POOL_INVITATION_ACCEPT',
+            labelKey: 'notifications.poolInvitation.accept',
+          },
+          {
+            kind: 'POOL_INVITATION_DECLINE',
+            labelKey: 'notifications.poolInvitation.decline',
+          },
+        ]),
+        poolInvitationId: payload.invitationId,
+      } as NotificationChannelMessageMap[C];
+    case NOTIFICATION_CHANNELS.EMAIL: {
+      const managePreferencesUrl = await buildManagePreferencesUrl(intent);
+      return {
+        subject: `${payload.inviterDisplayName} invited you to ${payload.poolTitle} on ${appName}`,
+        react: (
+          <PoolInvitationReceivedEmail
+            appName={appName}
+            inviterDisplayName={payload.inviterDisplayName}
+            poolTitle={payload.poolTitle}
+            recipientLabel={payload.recipientLabel}
+            invitationUrl={buildAppUrl(invitationPath)}
+            managePreferencesUrl={managePreferencesUrl}
+          />
+        ),
+      } as NotificationChannelMessageMap[C];
+    }
+    case NOTIFICATION_CHANNELS.WEB_PUSH:
+      return {
+        title: translate('en', 'notifications.poolInvitation.pushTitle'),
+        body: translate(
+          'en',
+          'notifications.poolInvitation.message',
+          messageParams,
+        ),
+        url: invitationPath,
+        tag: getNotificationOccurrenceKey(intent),
+      } as NotificationChannelMessageMap[C];
   }
 }
 

--- a/app/utils/notifications.server.ts
+++ b/app/utils/notifications.server.ts
@@ -18,6 +18,7 @@ export interface NotificationRecord {
   metadata?: Record<string, unknown> | null;
   actions: NotificationActionPayload[];
   friendRequestId?: string | null;
+  poolInvitationId?: string | null;
 }
 
 interface ListNotificationsOptions {
@@ -79,6 +80,7 @@ export async function listNotifications({
           notification.actions ?? undefined,
         ) ?? [],
       friendRequestId: notification.friendRequestId,
+      poolInvitationId: notification.poolInvitationId,
     } satisfies NotificationRecord;
   });
 

--- a/app/utils/pool-invitations.server.test.ts
+++ b/app/utils/pool-invitations.server.test.ts
@@ -147,6 +147,47 @@ describe('pool invitation module', () => {
     });
   });
 
+  it('re-invites an accepted contributor after they leave the pool', async () => {
+    const manager = await createUser('manager');
+    const friend = await createUser('friend');
+    await createFriendship(manager.id, friend.id);
+    const pool = await createPool(manager.id);
+    const [first] = await sendPoolInvitations({
+      poolId: pool.id,
+      managerId: manager.id,
+      inviteeIds: [friend.id],
+    });
+    await prisma.notification.create({
+      data: {
+        userId: friend.id,
+        type: 'POOL_INVITATION_RECEIVED',
+        status: 'UNREAD',
+        messageKey: 'notifications.poolInvitation.message',
+        poolInvitationId: first!.id,
+      },
+    });
+    await acceptPoolInvitation(first!.id, friend.id);
+    await prisma.poolContributor.delete({
+      where: { poolId_userId: { poolId: pool.id, userId: friend.id } },
+    });
+
+    const [second] = await sendPoolInvitations({
+      poolId: pool.id,
+      managerId: manager.id,
+      inviteeIds: [friend.id],
+    });
+
+    expect(second!.id).toBe(first!.id);
+    await expect(
+      prisma.poolInvitation.findUnique({ where: { id: first!.id } }),
+    ).resolves.toMatchObject({ status: 'PENDING', respondedAt: null });
+    await expect(
+      prisma.notification.findUnique({
+        where: { poolInvitationId: first!.id },
+      }),
+    ).resolves.toBeNull();
+  });
+
   it('accepts with the current group default and clears the notification', async () => {
     const organizer = await createUser('organizer');
     const invitee = await createUser('invitee');

--- a/app/utils/pool-invitations.server.test.ts
+++ b/app/utils/pool-invitations.server.test.ts
@@ -1,0 +1,263 @@
+/**
+ * @vitest-environment node
+ */
+import { randomUUID } from 'node:crypto';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { prisma } from '#app/utils/db.server.ts';
+
+const queueNotification = vi.fn();
+const queueLogEvent = vi.fn().mockReturnValue({ eventId: 'test-event' });
+const recordContributorJoined = vi.fn();
+
+vi.mock('#app/utils/notification-dispatcher.server.ts', () => ({
+  queueNotification: (...args: Array<unknown>) => queueNotification(...args),
+}));
+vi.mock('#app/utils/analytics.server.ts', () => ({
+  queueLogEvent: (...args: Array<unknown>) => queueLogEvent(...args),
+}));
+vi.mock('#app/utils/pool.server.ts', () => ({
+  recordContributorJoined: (...args: Array<unknown>) =>
+    recordContributorJoined(...args),
+}));
+
+import {
+  acceptPoolInvitation,
+  cancelPoolInvitation,
+  declinePoolInvitation,
+  getPoolInvitationForInvitee,
+  getPoolInvitationManagerState,
+  sendPoolInvitations,
+} from './pool-invitations.server.ts';
+
+beforeEach(() => {
+  queueNotification.mockReset();
+  queueLogEvent.mockReset().mockReturnValue({ eventId: 'test-event' });
+  recordContributorJoined.mockReset();
+});
+
+describe('pool invitation module', () => {
+  it("lists only the standalone manager's direct friends", async () => {
+    const manager = await createUser('manager');
+    const managerFriend = await createUser('manager-friend');
+    const recipient = await createUser('recipient');
+    const recipientOnlyFriend = await createUser('recipient-friend');
+    await createFriendship(manager.id, managerFriend.id);
+    await createFriendship(recipient.id, recipientOnlyFriend.id);
+    const pool = await createPool(manager.id, recipient.id);
+
+    const state = await getPoolInvitationManagerState(pool.id, manager.id);
+
+    expect(state.candidates.map(({ id }) => id)).toEqual([managerFriend.id]);
+    expect(state.candidates.map(({ id }) => id)).not.toContain(
+      recipientOnlyFriend.id,
+    );
+  });
+
+  it('lists only active eligible group members and permits a group admin', async () => {
+    const organizer = await createUser('organizer');
+    const admin = await createUser('admin');
+    const eligible = await createUser('eligible');
+    const removed = await createUser('removed');
+    const recipient = await createUser('recipient');
+    const group = await prisma.giftGroup.create({
+      data: { name: 'Gift group', createdById: organizer.id },
+    });
+    await prisma.usersInGiftGroups.createMany({
+      data: [
+        membership(group.id, organizer.id, 'MEMBER'),
+        membership(group.id, admin.id, 'ADMIN'),
+        membership(group.id, eligible.id, 'MEMBER', {
+          contributionCents: 2500,
+        }),
+        membership(group.id, removed.id, 'MEMBER', { removedAt: new Date() }),
+        membership(group.id, recipient.id, 'MEMBER'),
+      ],
+    });
+    const pool = await createPool(organizer.id, recipient.id, group.id);
+
+    const state = await getPoolInvitationManagerState(pool.id, admin.id);
+
+    expect(state.candidates).toEqual([
+      expect.objectContaining({ id: eligible.id, contributionCents: 2500 }),
+    ]);
+  });
+
+  it('makes a decline final for direct invitations to that pool', async () => {
+    const manager = await createUser('manager');
+    const friend = await createUser('friend');
+    await createFriendship(manager.id, friend.id);
+    const pool = await createPool(manager.id);
+    const [invitation] = await sendPoolInvitations({
+      poolId: pool.id,
+      managerId: manager.id,
+      inviteeIds: [friend.id],
+    });
+
+    await declinePoolInvitation(invitation!.id, friend.id);
+
+    await expect(
+      sendPoolInvitations({
+        poolId: pool.id,
+        managerId: manager.id,
+        inviteeIds: [friend.id],
+      }),
+    ).rejects.toMatchObject({
+      code: 'ALREADY_INVITED',
+      status: 409,
+    });
+    await expect(
+      prisma.poolInvitation.findUnique({ where: { id: invitation!.id } }),
+    ).resolves.toMatchObject({ status: 'DECLINED' });
+    expect(queueNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: friend.id,
+        type: 'POOL_INVITATION_RECEIVED',
+        payload: expect.objectContaining({ invitationId: invitation!.id }),
+      }),
+    );
+  });
+
+  it('reopens the same durable row after a manager cancellation', async () => {
+    const manager = await createUser('manager');
+    const friend = await createUser('friend');
+    await createFriendship(manager.id, friend.id);
+    const pool = await createPool(manager.id);
+    const [first] = await sendPoolInvitations({
+      poolId: pool.id,
+      managerId: manager.id,
+      inviteeIds: [friend.id],
+    });
+
+    await cancelPoolInvitation({
+      invitationId: first!.id,
+      managerId: manager.id,
+    });
+    const [second] = await sendPoolInvitations({
+      poolId: pool.id,
+      managerId: manager.id,
+      inviteeIds: [friend.id],
+    });
+
+    expect(second!.id).toBe(first!.id);
+    await expect(
+      prisma.poolInvitation.findUnique({ where: { id: first!.id } }),
+    ).resolves.toMatchObject({
+      status: 'PENDING',
+      cancelledAt: null,
+    });
+  });
+
+  it('accepts with the current group default and clears the notification', async () => {
+    const organizer = await createUser('organizer');
+    const invitee = await createUser('invitee');
+    const group = await prisma.giftGroup.create({
+      data: { name: 'Gift group', createdById: organizer.id },
+    });
+    await prisma.usersInGiftGroups.createMany({
+      data: [
+        membership(group.id, organizer.id, 'OWNER'),
+        membership(group.id, invitee.id, 'MEMBER', {
+          contributionCents: 1800,
+        }),
+      ],
+    });
+    const pool = await createPool(organizer.id, null, group.id);
+    const [invitation] = await sendPoolInvitations({
+      poolId: pool.id,
+      managerId: organizer.id,
+      inviteeIds: [invitee.id],
+    });
+    await prisma.notification.create({
+      data: {
+        userId: invitee.id,
+        type: 'POOL_INVITATION_RECEIVED',
+        status: 'UNREAD',
+        messageKey: 'notifications.poolInvitation.message',
+        actions: JSON.stringify([{ kind: 'POOL_INVITATION_ACCEPT' }]),
+        poolInvitationId: invitation!.id,
+      },
+    });
+
+    await acceptPoolInvitation(invitation!.id, invitee.id);
+
+    await expect(
+      prisma.poolContributor.findUnique({
+        where: { poolId_userId: { poolId: pool.id, userId: invitee.id } },
+      }),
+    ).resolves.toMatchObject({ contributionCents: 1800 });
+    await expect(
+      prisma.notification.findUnique({
+        where: { poolInvitationId: invitation!.id },
+      }),
+    ).resolves.toMatchObject({ status: 'READ', actions: '[]' });
+    expect(recordContributorJoined).toHaveBeenCalledWith(
+      pool.id,
+      invitee.id,
+      expect.objectContaining({ via: 'direct_invitation' }),
+    );
+  });
+
+  it('returns a generic not-found result to the wrong signed-in user', async () => {
+    const manager = await createUser('manager');
+    const friend = await createUser('friend');
+    const stranger = await createUser('stranger');
+    await createFriendship(manager.id, friend.id);
+    const pool = await createPool(manager.id);
+    const [invitation] = await sendPoolInvitations({
+      poolId: pool.id,
+      managerId: manager.id,
+      inviteeIds: [friend.id],
+    });
+
+    await expect(
+      getPoolInvitationForInvitee(invitation!.id, stranger.id),
+    ).rejects.toMatchObject({
+      code: 'INVITATION_NOT_FOUND',
+      status: 404,
+    });
+  });
+});
+
+async function createUser(label: string) {
+  const suffix = randomUUID().slice(0, 8);
+  return prisma.user.create({
+    data: {
+      email: `${label}-${suffix}@example.com`,
+      username: `${label.replaceAll('-', '_')}_${suffix}`,
+      name: label,
+    },
+    select: { id: true, name: true, username: true },
+  });
+}
+
+async function createFriendship(firstId: string, secondId: string) {
+  const [userAId, userBId] = [firstId, secondId].sort();
+  return prisma.friendship.create({
+    data: { userAId: userAId!, userBId: userBId! },
+  });
+}
+
+async function createPool(
+  organizerId: string,
+  recipientUserId: string | null = null,
+  giftGroupId: string | null = null,
+) {
+  return prisma.pool.create({
+    data: {
+      title: 'Birthday surprise',
+      organizerId,
+      recipientUserId,
+      giftGroupId,
+      contributors: { create: { userId: organizerId } },
+    },
+  });
+}
+
+function membership(
+  giftGroupId: string,
+  userId: string,
+  role: string,
+  overrides: { contributionCents?: number; removedAt?: Date } = {},
+) {
+  return { giftGroupId, userId, role, ...overrides };
+}

--- a/app/utils/pool-invitations.server.ts
+++ b/app/utils/pool-invitations.server.ts
@@ -1,0 +1,574 @@
+import { type Prisma } from '@prisma/client';
+import { queueLogEvent } from '#app/utils/analytics.server.ts';
+import { prisma } from '#app/utils/db.server.ts';
+import { NOTIFICATION_TYPES } from '#app/utils/notification-catalog.ts';
+import { queueNotification } from '#app/utils/notification-dispatcher.server.ts';
+import {
+  ACTIVE_POOL_STATUSES,
+  type PoolStatus,
+} from '#app/utils/pool-constants.ts';
+import { recordContributorJoined } from '#app/utils/pool.server.ts';
+
+export type PoolInvitationStatus =
+  | 'PENDING'
+  | 'ACCEPTED'
+  | 'DECLINED'
+  | 'CANCELLED';
+
+const userSummarySelect = {
+  id: true,
+  username: true,
+  name: true,
+  image: { select: { id: true, altText: true } },
+} as const;
+
+type TransactionClient = Prisma.TransactionClient;
+
+export class PoolInvitationError extends Error {
+  constructor(
+    public readonly code:
+      | 'POOL_NOT_FOUND'
+      | 'NOT_MANAGER'
+      | 'POOL_CLOSED'
+      | 'INVITATION_NOT_FOUND'
+      | 'INVITATION_NOT_PENDING'
+      | 'INVITEE_NOT_ELIGIBLE'
+      | 'ALREADY_INVITED',
+    message: string,
+    public readonly status: number,
+  ) {
+    super(message);
+    this.name = 'PoolInvitationError';
+  }
+}
+
+function isActivePoolStatus(status: string): status is PoolStatus {
+  return ACTIVE_POOL_STATUSES.includes(status as PoolStatus);
+}
+
+function recipientLabel(pool: {
+  recipientName: string | null;
+  recipientUser: { name: string | null; username: string } | null;
+}) {
+  return (
+    pool.recipientUser?.name ??
+    pool.recipientUser?.username ??
+    pool.recipientName ??
+    'the recipient'
+  );
+}
+
+async function requireManager(
+  tx: TransactionClient,
+  pool: {
+    organizerId: string;
+    giftGroupId: string | null;
+  },
+  userId: string,
+) {
+  if (pool.organizerId === userId) return;
+  if (!pool.giftGroupId) {
+    throw new PoolInvitationError(
+      'NOT_MANAGER',
+      'Only a pool manager can manage invitations.',
+      403,
+    );
+  }
+
+  const membership = await tx.usersInGiftGroups.findUnique({
+    where: {
+      userId_giftGroupId: {
+        userId,
+        giftGroupId: pool.giftGroupId,
+      },
+    },
+    select: { role: true, removedAt: true, bannedUntil: true },
+  });
+  const active =
+    membership &&
+    membership.removedAt === null &&
+    (membership.bannedUntil === null || membership.bannedUntil <= new Date());
+  if (!active || (membership.role !== 'OWNER' && membership.role !== 'ADMIN')) {
+    throw new PoolInvitationError(
+      'NOT_MANAGER',
+      'Only a pool manager can manage invitations.',
+      403,
+    );
+  }
+}
+
+async function getPoolForManager(tx: TransactionClient, poolId: string) {
+  const pool = await tx.pool.findUnique({
+    where: { id: poolId },
+    select: {
+      id: true,
+      title: true,
+      status: true,
+      organizerId: true,
+      giftGroupId: true,
+      recipientUserId: true,
+      recipientName: true,
+      recipientUser: { select: { name: true, username: true } },
+    },
+  });
+  if (!pool) {
+    throw new PoolInvitationError('POOL_NOT_FOUND', 'Pool not found.', 404);
+  }
+  return pool;
+}
+
+async function listEligibleCandidates(
+  tx: TransactionClient,
+  pool: Awaited<ReturnType<typeof getPoolForManager>>,
+  managerId: string,
+) {
+  const excludedIds = new Set<string>([pool.recipientUserId ?? '', managerId]);
+  const [contributors, invitations] = await Promise.all([
+    tx.poolContributor.findMany({
+      where: { poolId: pool.id },
+      select: { userId: true },
+    }),
+    tx.poolInvitation.findMany({
+      where: { poolId: pool.id, status: { not: 'CANCELLED' } },
+      select: { inviteeId: true },
+    }),
+  ]);
+  contributors.forEach(({ userId }) => excludedIds.add(userId));
+  invitations.forEach(({ inviteeId }) => excludedIds.add(inviteeId));
+
+  if (pool.giftGroupId) {
+    const memberships = await tx.usersInGiftGroups.findMany({
+      where: {
+        giftGroupId: pool.giftGroupId,
+        removedAt: null,
+        OR: [{ bannedUntil: null }, { bannedUntil: { lte: new Date() } }],
+        userId: { notIn: [...excludedIds] },
+      },
+      select: {
+        contributionCents: true,
+        user: { select: userSummarySelect },
+      },
+    });
+    return memberships.map(({ user, contributionCents }) => ({
+      ...user,
+      contributionCents: contributionCents > 0 ? contributionCents : null,
+    }));
+  }
+
+  const friendships = await tx.friendship.findMany({
+    where: {
+      OR: [{ userAId: managerId }, { userBId: managerId }],
+    },
+    select: {
+      userAId: true,
+      userBId: true,
+      userA: { select: userSummarySelect },
+      userB: { select: userSummarySelect },
+    },
+  });
+  return friendships
+    .map((friendship) =>
+      friendship.userAId === managerId ? friendship.userB : friendship.userA,
+    )
+    .filter((user) => !excludedIds.has(user.id))
+    .map((user) => ({ ...user, contributionCents: null }));
+}
+
+export async function getPoolInvitationManagerState(
+  poolId: string,
+  managerId: string,
+) {
+  return prisma.$transaction(async (tx) => {
+    const pool = await getPoolForManager(tx, poolId);
+    await requireManager(tx, pool, managerId);
+    const [candidates, pendingInvitations] = await Promise.all([
+      isActivePoolStatus(pool.status)
+        ? listEligibleCandidates(tx, pool, managerId)
+        : Promise.resolve([]),
+      tx.poolInvitation.findMany({
+        where: { poolId, status: 'PENDING' },
+        orderBy: { createdAt: 'desc' },
+        select: {
+          id: true,
+          createdAt: true,
+          invitee: { select: userSummarySelect },
+        },
+      }),
+    ]);
+    return {
+      poolId: pool.id,
+      poolTitle: pool.title,
+      recipientLabel: recipientLabel(pool),
+      isActive: isActivePoolStatus(pool.status),
+      candidates,
+      pendingInvitations,
+    };
+  });
+}
+
+export async function sendPoolInvitations({
+  poolId,
+  managerId,
+  inviteeIds,
+}: {
+  poolId: string;
+  managerId: string;
+  inviteeIds: string[];
+}) {
+  const uniqueInviteeIds = [...new Set(inviteeIds)].filter(Boolean);
+  if (uniqueInviteeIds.length === 0 || uniqueInviteeIds.length > 50) {
+    throw new PoolInvitationError(
+      'INVITEE_NOT_ELIGIBLE',
+      'Choose between 1 and 50 eligible people.',
+      400,
+    );
+  }
+
+  const result = await prisma.$transaction(async (tx) => {
+    const pool = await getPoolForManager(tx, poolId);
+    await requireManager(tx, pool, managerId);
+    if (!isActivePoolStatus(pool.status)) {
+      throw new PoolInvitationError(
+        'POOL_CLOSED',
+        'This pool is no longer accepting invitations.',
+        410,
+      );
+    }
+
+    const candidates = await listEligibleCandidates(tx, pool, managerId);
+    const eligibleIds = new Set(candidates.map(({ id }) => id));
+    if (uniqueInviteeIds.some((id) => !eligibleIds.has(id))) {
+      const existing = await tx.poolInvitation.findFirst({
+        where: { poolId, inviteeId: { in: uniqueInviteeIds } },
+        select: { id: true },
+      });
+      throw new PoolInvitationError(
+        existing ? 'ALREADY_INVITED' : 'INVITEE_NOT_ELIGIBLE',
+        existing
+          ? 'One or more people have already been invited to this pool.'
+          : 'One or more people are no longer eligible for this pool.',
+        409,
+      );
+    }
+
+    const inviter = await tx.user.findUniqueOrThrow({
+      where: { id: managerId },
+      select: userSummarySelect,
+    });
+    const invitations = [];
+    for (const inviteeId of uniqueInviteeIds) {
+      invitations.push(
+        await tx.poolInvitation.upsert({
+          where: { poolId_inviteeId: { poolId, inviteeId } },
+          create: { poolId, invitedById: managerId, inviteeId },
+          update: {
+            invitedById: managerId,
+            status: 'PENDING',
+            respondedAt: null,
+            cancelledAt: null,
+          },
+          select: { id: true, inviteeId: true },
+        }),
+      );
+    }
+    return {
+      invitations,
+      inviter,
+      poolTitle: pool.title,
+      recipientLabel: recipientLabel(pool),
+    };
+  });
+
+  for (const invitation of result.invitations) {
+    queueNotification({
+      userId: invitation.inviteeId,
+      type: NOTIFICATION_TYPES.POOL_INVITATION_RECEIVED,
+      payload: {
+        invitationId: invitation.id,
+        poolId,
+        poolTitle: result.poolTitle,
+        recipientLabel: result.recipientLabel,
+        inviterUserId: result.inviter.id,
+        inviterDisplayName: result.inviter.name ?? result.inviter.username,
+        inviterAvatarId: result.inviter.image?.id ?? null,
+      },
+      sourceIdentifier: `pool-invitation:${invitation.id}:received`,
+    });
+    queueLogEvent({
+      name: 'pool_invitation_sent',
+      userId: managerId,
+      source: 'server',
+      properties: {
+        poolId,
+        invitationId: invitation.id,
+        inviteeId: invitation.inviteeId,
+      },
+    });
+  }
+
+  return result.invitations;
+}
+
+export async function cancelPoolInvitation({
+  invitationId,
+  managerId,
+}: {
+  invitationId: string;
+  managerId: string;
+}) {
+  return prisma.$transaction(async (tx) => {
+    const invitation = await tx.poolInvitation.findUnique({
+      where: { id: invitationId },
+      include: { pool: true, notification: true },
+    });
+    if (!invitation) {
+      throw new PoolInvitationError(
+        'INVITATION_NOT_FOUND',
+        'Invitation not found.',
+        404,
+      );
+    }
+    await requireManager(tx, invitation.pool, managerId);
+    if (invitation.status !== 'PENDING') {
+      throw new PoolInvitationError(
+        'INVITATION_NOT_PENDING',
+        'This invitation is no longer pending.',
+        409,
+      );
+    }
+    await tx.poolInvitation.update({
+      where: { id: invitationId },
+      data: { status: 'CANCELLED', cancelledAt: new Date() },
+    });
+    await deleteNotification(tx, invitation.notification?.id);
+    return { poolId: invitation.poolId };
+  });
+}
+
+export async function getPoolInvitationForInvitee(
+  invitationId: string,
+  inviteeId: string,
+) {
+  const invitation = await prisma.poolInvitation.findFirst({
+    where: { id: invitationId, inviteeId },
+    select: {
+      id: true,
+      status: true,
+      pool: {
+        select: {
+          id: true,
+          title: true,
+          status: true,
+          recipientName: true,
+          recipientUser: { select: { name: true, username: true } },
+          _count: { select: { contributors: true } },
+        },
+      },
+      invitedBy: { select: userSummarySelect },
+    },
+  });
+  if (!invitation) {
+    throw new PoolInvitationError(
+      'INVITATION_NOT_FOUND',
+      'Invitation not found.',
+      404,
+    );
+  }
+  return {
+    id: invitation.id,
+    status: invitation.status as PoolInvitationStatus,
+    poolId: invitation.pool.id,
+    poolTitle: invitation.pool.title,
+    poolStatus: invitation.pool.status,
+    recipientLabel: recipientLabel(invitation.pool),
+    contributorCount: invitation.pool._count.contributors,
+    inviter: invitation.invitedBy,
+    isActive: isActivePoolStatus(invitation.pool.status),
+  };
+}
+
+export async function acceptPoolInvitation(
+  invitationId: string,
+  inviteeId: string,
+) {
+  const result = await prisma.$transaction(async (tx) => {
+    const invitation = await getOwnedInvitation(tx, invitationId, inviteeId);
+    if (invitation.status === 'ACCEPTED') {
+      return { poolId: invitation.poolId, joined: false, idempotent: true };
+    }
+    requirePendingAndActive(invitation);
+
+    let contributionCents: number | null = null;
+    if (invitation.pool.giftGroupId) {
+      const membership = await tx.usersInGiftGroups.findUnique({
+        where: {
+          userId_giftGroupId: {
+            userId: inviteeId,
+            giftGroupId: invitation.pool.giftGroupId,
+          },
+        },
+        select: {
+          contributionCents: true,
+          removedAt: true,
+          bannedUntil: true,
+        },
+      });
+      const active =
+        membership &&
+        membership.removedAt === null &&
+        (membership.bannedUntil === null ||
+          membership.bannedUntil <= new Date());
+      if (!active) throwInviteeNotEligible();
+      contributionCents =
+        membership.contributionCents > 0 ? membership.contributionCents : null;
+    } else {
+      const friendship = await tx.friendship.findFirst({
+        where: {
+          OR: [
+            { userAId: invitation.invitedById, userBId: inviteeId },
+            { userAId: inviteeId, userBId: invitation.invitedById },
+          ],
+        },
+        select: { id: true },
+      });
+      if (!friendship) throwInviteeNotEligible();
+    }
+
+    const existingContributor = await tx.poolContributor.findUnique({
+      where: {
+        poolId_userId: { poolId: invitation.poolId, userId: inviteeId },
+      },
+      select: { id: true },
+    });
+    if (!existingContributor) {
+      await tx.poolContributor.create({
+        data: {
+          poolId: invitation.poolId,
+          userId: inviteeId,
+          contributionCents,
+        },
+      });
+    }
+    await tx.poolInvitation.update({
+      where: { id: invitationId },
+      data: { status: 'ACCEPTED', respondedAt: new Date() },
+    });
+    await clearNotification(tx, invitation.notification?.id);
+    return {
+      poolId: invitation.poolId,
+      joined: existingContributor === null,
+      idempotent: false,
+    };
+  });
+
+  if (result.joined) {
+    await recordContributorJoined(result.poolId, inviteeId, {
+      via: 'direct_invitation',
+      poolInvitationId: invitationId,
+    });
+  }
+  if (!result.idempotent) {
+    queueLogEvent({
+      name: 'pool_invitation_accepted',
+      userId: inviteeId,
+      source: 'server',
+      properties: { poolId: result.poolId, invitationId },
+    });
+  }
+  return { poolId: result.poolId };
+}
+
+export async function declinePoolInvitation(
+  invitationId: string,
+  inviteeId: string,
+) {
+  const result = await prisma.$transaction(async (tx) => {
+    const invitation = await getOwnedInvitation(tx, invitationId, inviteeId);
+    requirePendingAndActive(invitation);
+    await tx.poolInvitation.update({
+      where: { id: invitationId },
+      data: { status: 'DECLINED', respondedAt: new Date() },
+    });
+    await clearNotification(tx, invitation.notification?.id);
+    return { poolId: invitation.poolId };
+  });
+  queueLogEvent({
+    name: 'pool_invitation_declined',
+    userId: inviteeId,
+    source: 'server',
+    properties: { poolId: result.poolId, invitationId },
+  });
+  return result;
+}
+
+async function getOwnedInvitation(
+  tx: TransactionClient,
+  invitationId: string,
+  inviteeId: string,
+) {
+  const invitation = await tx.poolInvitation.findFirst({
+    where: { id: invitationId, inviteeId },
+    include: { pool: true, notification: true },
+  });
+  if (!invitation) {
+    throw new PoolInvitationError(
+      'INVITATION_NOT_FOUND',
+      'Invitation not found.',
+      404,
+    );
+  }
+  return invitation;
+}
+
+function requirePendingAndActive(
+  invitation: Awaited<ReturnType<typeof getOwnedInvitation>>,
+) {
+  if (invitation.status !== 'PENDING') {
+    throw new PoolInvitationError(
+      'INVITATION_NOT_PENDING',
+      'This invitation is no longer pending.',
+      409,
+    );
+  }
+  if (!isActivePoolStatus(invitation.pool.status)) {
+    throw new PoolInvitationError(
+      'POOL_CLOSED',
+      'This pool is no longer accepting invitations.',
+      410,
+    );
+  }
+  if (invitation.pool.recipientUserId === invitation.inviteeId) {
+    throwInviteeNotEligible();
+  }
+}
+
+function throwInviteeNotEligible(): never {
+  throw new PoolInvitationError(
+    'INVITEE_NOT_ELIGIBLE',
+    'This invitation is no longer available.',
+    410,
+  );
+}
+
+async function clearNotification(
+  tx: TransactionClient,
+  notificationId: string | undefined,
+) {
+  if (!notificationId) return;
+  await tx.notification.update({
+    where: { id: notificationId },
+    data: {
+      status: 'READ',
+      readAt: new Date(),
+      actions: JSON.stringify([]),
+    },
+  });
+}
+
+async function deleteNotification(
+  tx: TransactionClient,
+  notificationId: string | undefined,
+) {
+  if (!notificationId) return;
+  await tx.notification.delete({ where: { id: notificationId } });
+}

--- a/app/utils/pool-invitations.server.ts
+++ b/app/utils/pool-invitations.server.ts
@@ -128,7 +128,10 @@ async function listEligibleCandidates(
       select: { userId: true },
     }),
     tx.poolInvitation.findMany({
-      where: { poolId: pool.id, status: { not: 'CANCELLED' } },
+      where: {
+        poolId: pool.id,
+        status: { in: ['PENDING', 'DECLINED'] },
+      },
       select: { inviteeId: true },
     }),
   ]);
@@ -256,19 +259,24 @@ export async function sendPoolInvitations({
     });
     const invitations = [];
     for (const inviteeId of uniqueInviteeIds) {
-      invitations.push(
-        await tx.poolInvitation.upsert({
-          where: { poolId_inviteeId: { poolId, inviteeId } },
-          create: { poolId, invitedById: managerId, inviteeId },
-          update: {
-            invitedById: managerId,
-            status: 'PENDING',
-            respondedAt: null,
-            cancelledAt: null,
-          },
-          select: { id: true, inviteeId: true },
-        }),
-      );
+      const invitation = await tx.poolInvitation.upsert({
+        where: { poolId_inviteeId: { poolId, inviteeId } },
+        create: { poolId, invitedById: managerId, inviteeId },
+        update: {
+          invitedById: managerId,
+          status: 'PENDING',
+          respondedAt: null,
+          cancelledAt: null,
+        },
+        select: { id: true, inviteeId: true },
+      });
+      // Accepted invitations may be reopened after the contributor leaves.
+      // Remove the old read notification so ONE_SHOT delivery can create a
+      // fresh actionable row for the renewed invitation.
+      await tx.notification.deleteMany({
+        where: { poolInvitationId: invitation.id },
+      });
+      invitations.push(invitation);
     }
     return {
       invitations,

--- a/app/utils/pool-invitations.server.ts
+++ b/app/utils/pool-invitations.server.ts
@@ -85,8 +85,7 @@ async function requireManager(
     select: { role: true, removedAt: true, bannedUntil: true },
   });
   const active =
-    membership &&
-    membership.removedAt === null &&
+    membership?.removedAt === null &&
     (membership.bannedUntil === null || membership.bannedUntil <= new Date());
   if (!active || (membership.role !== 'OWNER' && membership.role !== 'ADMIN')) {
     throw new PoolInvitationError(
@@ -414,8 +413,7 @@ export async function acceptPoolInvitation(
         },
       });
       const active =
-        membership &&
-        membership.removedAt === null &&
+        membership?.removedAt === null &&
         (membership.bannedUntil === null ||
           membership.bannedUntil <= new Date());
       if (!active) throwInviteeNotEligible();

--- a/app/utils/pool.server.ts
+++ b/app/utils/pool.server.ts
@@ -250,6 +250,16 @@ export async function addContributor(
 		data: { poolId, userId, contributionCents: contributionCents ?? null },
 	})
 
+	await recordContributorJoined(poolId, userId)
+
+	return contributor
+}
+
+export async function recordContributorJoined(
+	poolId: string,
+	userId: string,
+	properties: Record<string, unknown> = {},
+) {
 	await logPoolActivity(poolId, POOL_ACTIVITY_TYPE.CONTRIBUTOR_JOINED, {
 		actorId: userId,
 		payload: { userId },
@@ -259,10 +269,8 @@ export async function addContributor(
 		name: 'pool_contributor_joined',
 		userId,
 		source: 'server',
-		properties: { poolId },
+		properties: { poolId, ...properties },
 	})
-
-	return contributor
 }
 
 export async function removeContributor(

--- a/prisma/migrations/20260714190000_add_pool_invitations/migration.sql
+++ b/prisma/migrations/20260714190000_add_pool_invitations/migration.sql
@@ -1,0 +1,62 @@
+-- CreateTable
+CREATE TABLE "PoolInvitation" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'PENDING',
+    "respondedAt" DATETIME,
+    "cancelledAt" DATETIME,
+    "poolId" TEXT NOT NULL,
+    "invitedById" TEXT NOT NULL,
+    "inviteeId" TEXT NOT NULL,
+    CONSTRAINT "PoolInvitation_poolId_fkey" FOREIGN KEY ("poolId") REFERENCES "Pool" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "PoolInvitation_invitedById_fkey" FOREIGN KEY ("invitedById") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "PoolInvitation_inviteeId_fkey" FOREIGN KEY ("inviteeId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- Add the owned invitation relation to actionable notifications.
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Notification" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "readAt" DATETIME,
+    "userId" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'UNREAD',
+    "messageKey" TEXT NOT NULL,
+    "messageParams" TEXT,
+    "targetUrl" TEXT,
+    "metadata" TEXT,
+    "actions" TEXT,
+    "friendRequestId" TEXT,
+    "poolInvitationId" TEXT,
+    "sourceIdentifier" TEXT,
+    CONSTRAINT "Notification_friendRequestId_fkey" FOREIGN KEY ("friendRequestId") REFERENCES "FriendRequest" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "Notification_poolInvitationId_fkey" FOREIGN KEY ("poolInvitationId") REFERENCES "PoolInvitation" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "Notification_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+INSERT INTO "new_Notification" (
+    "actions", "createdAt", "friendRequestId", "id", "messageKey",
+    "messageParams", "metadata", "readAt", "sourceIdentifier", "status",
+    "targetUrl", "type", "userId"
+)
+SELECT
+    "actions", "createdAt", "friendRequestId", "id", "messageKey",
+    "messageParams", "metadata", "readAt", "sourceIdentifier", "status",
+    "targetUrl", "type", "userId"
+FROM "Notification";
+DROP TABLE "Notification";
+ALTER TABLE "new_Notification" RENAME TO "Notification";
+CREATE UNIQUE INDEX "Notification_friendRequestId_key" ON "Notification"("friendRequestId");
+CREATE UNIQUE INDEX "Notification_poolInvitationId_key" ON "Notification"("poolInvitationId");
+CREATE INDEX "Notification_userId_createdAt_idx" ON "Notification"("userId", "createdAt");
+CREATE INDEX "Notification_userId_status_idx" ON "Notification"("userId", "status");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PoolInvitation_poolId_inviteeId_key" ON "PoolInvitation"("poolId", "inviteeId");
+CREATE INDEX "PoolInvitation_poolId_status_idx" ON "PoolInvitation"("poolId", "status");
+CREATE INDEX "PoolInvitation_inviteeId_status_idx" ON "PoolInvitation"("inviteeId", "status");
+CREATE INDEX "PoolInvitation_invitedById_idx" ON "PoolInvitation"("invitedById");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -69,6 +69,8 @@ model User {
   poolMessages                 PoolMessage[]
   organizerNudgesSent          OrganizerNudge[]               @relation("OrganizerNudge_Sender")
   organizerNudgeRecipients     OrganizerNudgeRecipient[]
+  poolInvitationsSent          PoolInvitation[]                @relation("PoolInvitation_Inviter")
+  poolInvitationsReceived      PoolInvitation[]                @relation("PoolInvitation_Invitee")
   feedback                     Feedback[]
   consents                     Consent[]
   // Person-surface memory relations
@@ -137,8 +139,10 @@ model Notification {
   metadata         String?
   actions          String?
   friendRequestId  String?       @unique
+  poolInvitationId String?       @unique
   sourceIdentifier String?
   friendRequest    FriendRequest? @relation("FriendRequestNotification", fields: [friendRequestId], references: [id], onDelete: Cascade)
+  poolInvitation   PoolInvitation? @relation("PoolInvitationNotification", fields: [poolInvitationId], references: [id], onDelete: Cascade)
   user             User          @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@index([userId, createdAt])
@@ -404,6 +408,7 @@ model Pool {
   activities    PoolActivity[]
   messages      PoolMessage[]
   organizerNudges OrganizerNudge[]
+  directInvitations PoolInvitation[]
   notificationPreferences PoolNotificationPreference[]
 
   @@index([giftGroupId])
@@ -469,6 +474,32 @@ model PoolContributor {
   @@unique([poolId, userId])
   @@index([poolId])
   @@index([userId])
+}
+
+// A consent-bearing invitation for one existing user to join one pool.
+// Valid statuses are PENDING | ACCEPTED | DECLINED | CANCELLED. The unique
+// pool+invitee key makes a decline final for direct invitations to that pool.
+model PoolInvitation {
+  id          String    @id @default(cuid())
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+  status      String    @default("PENDING")
+  respondedAt DateTime?
+  cancelledAt DateTime?
+
+  poolId      String
+  invitedById String
+  inviteeId   String
+
+  pool         Pool          @relation(fields: [poolId], references: [id], onDelete: Cascade)
+  invitedBy    User          @relation("PoolInvitation_Inviter", fields: [invitedById], references: [id], onDelete: Cascade)
+  invitee      User          @relation("PoolInvitation_Invitee", fields: [inviteeId], references: [id], onDelete: Cascade)
+  notification Notification? @relation("PoolInvitationNotification")
+
+  @@unique([poolId, inviteeId])
+  @@index([poolId, status])
+  @@index([inviteeId, status])
+  @@index([invitedById])
 }
 
 // A proposed gift within a pool.


### PR DESCRIPTION
## Summary

- add a durable consent-based pool invitation lifecycle with send, cancel, accept, and final decline states
- derive eligible invitees server-side: active group members for group pools and direct friends of the acting manager for standalone pools
- deliver actionable in-app and email notifications, with a privacy-limited invitation review route
- add a responsive manager picker and pending invitation controls while keeping invite links available

## Privacy and behavior

- recipients and current contributors are never eligible
- standalone pools never enumerate the gift recipient private friend graph
- authenticated wrong-account invitation views return a generic 404
- invitations remain actionable through PURCHASED and close at DELIVERED or CANCELLED
- accepting creates contributor membership; declining is final for direct invitations to that pool
- cancelling reopens the same durable row for a later invitation

## Migration

Adds PoolInvitation and an optional one-to-one Notification.poolInvitationId relation. No environment changes.

## Test Plan

- npm test -- --run: 207 files, 1,300 tests passed
- npm run typecheck
- npm run lint
- npm run build
- npm run test:e2e:run: 109 passed, 6 skipped
- post-rebase focused suite: 5 files, 43 tests passed
- clean migration reset/deploy and Prisma validation
- manual desktop and 390x844 QA for manager send/cancel, pending state, bell actions, mobile bottom sheet, and invitation review

## Checklist

- [x] Tests updated
- [x] Documentation reviewed; no user-facing documentation change required
- [x] Migration included
- [x] Responsive visual QA completed

## Screenshots

Desktop and 390x844 states were captured and inspected during local QA, including the mobile bottom sheet, notification actions, and privacy-limited review screen.