### PR TITLE
fix(monitoring): stop reporting router-internal 4xx errors to Sentry

### DIFF
--- a/app/entry.server.test.tsx
+++ b/app/entry.server.test.tsx
@@ -1,0 +1,74 @@
+import {
+  UNSAFE_ErrorResponseImpl,
+  type LoaderFunctionArgs,
+} from 'react-router';
+import { describe, expect, it, vi } from 'vitest';
+import { testConsole } from '#tests/setup/setup-test-env.ts';
+import { handleError } from './entry.server.tsx';
+
+const captureException = vi.fn();
+vi.mock('@sentry/react-router', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    captureException: (...args: Array<unknown>) => captureException(...args),
+  };
+});
+
+function loaderArgs(request: Request) {
+  return { request, params: {}, context: {} } as unknown as LoaderFunctionArgs;
+}
+
+describe('handleError', () => {
+  it('does not report router-internal 404s (e.g. scanner URLs with encoded newlines)', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // Shape produced by react-router's getInternalRouterError when no route
+    // matches — not even the splat, whose regex can't cross newlines.
+    const error = new UNSAFE_ErrorResponseImpl(
+      404,
+      'Not Found',
+      new Error('No route matches URL "/.env%0d%0a"'),
+      true,
+    );
+
+    handleError(error, loaderArgs(new Request('https://localhost/.env%0d%0a')));
+
+    expect(captureException).not.toHaveBeenCalled();
+    expect(console.warn).toHaveBeenCalledOnce();
+  });
+
+  it('still reports 5xx route error responses', () => {
+    testConsole.error.mockImplementation(() => {});
+    const error = new UNSAFE_ErrorResponseImpl(
+      500,
+      'Internal Server Error',
+      new Error('Unexpected Server Error'),
+      true,
+    );
+
+    handleError(error, loaderArgs(new Request('https://localhost/')));
+
+    expect(captureException).toHaveBeenCalledOnce();
+  });
+
+  it('reports unexpected errors', () => {
+    testConsole.error.mockImplementation(() => {});
+    const error = new Error('boom');
+
+    handleError(error, loaderArgs(new Request('https://localhost/')));
+
+    expect(captureException).toHaveBeenCalledWith(error);
+  });
+
+  it('skips aborted requests entirely', () => {
+    const controller = new AbortController();
+    controller.abort();
+    const request = new Request('https://localhost/', {
+      signal: controller.signal,
+    });
+
+    handleError(new Error('boom'), loaderArgs(request));
+
+    expect(captureException).not.toHaveBeenCalled();
+  });
+});

--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -6,6 +6,7 @@ import chalk from 'chalk';
 import { isbot } from 'isbot';
 import { renderToPipeableStream } from 'react-dom/server';
 import {
+  isRouteErrorResponse,
   ServerRouter,
   type LoaderFunctionArgs,
   type ActionFunctionArgs,
@@ -101,6 +102,17 @@ export function handleError(
 ): void {
   // Skip capturing if the request was aborted.
   if (request.signal.aborted) {
+    return;
+  }
+  // Router-internal client errors are not app failures — e.g. a scanner URL
+  // with encoded newlines matches no route (not even the splat, whose regex
+  // can't cross newlines) and surfaces here as an internal 404 ErrorResponse.
+  if (isRouteErrorResponse(error) && error.status < 500) {
+    console.warn(
+      chalk.yellow(
+        `Client error ${error.status} for ${request.method} ${request.url}: ${error.data}`,
+      ),
+    );
     return;
   }
   if (error instanceof Error) {


### PR DESCRIPTION
## Summary

Sentry issue [GIFTPOOL-UI-1J](https://giftpool-k0.sentry.io/issues/7615306431/) — `Error: No route matches URL "/.env%0d%0a"` — is a vulnerability scanner probing for `.env` with an encoded CRLF appended.

**Root cause (two layers):**
1. React Router compiles route paths to regexes using `.`/`.+`, which don't match newlines. `%0d%0a` decodes to `\r\n` in the pathname, so **no route matches — not even the `$.tsx` splat** (verified: `matchRoutes([{path:'*'}], '/.env\r\n')` → `null`). The static handler throws its internal 404 `ErrorResponse`.
2. `handleError` in `app/entry.server.tsx` captured everything that wasn't an aborted request, including router-internal 4xx `ErrorResponse`s.

**Fix:** skip Sentry capture in `handleError` for `isRouteErrorResponse(error) && error.status < 500` (also covers the router's internal 405/400 noise); log a console warning so probes stay visible in Fly logs. 5xx route error responses and real errors still report. This mirrors Sentry's own Remix SDK behavior. User-thrown 404 Responses never reach `handleError`, so nothing real is hidden.

Fixes GIFTPOOL-UI-1J

## Test plan
- [x] New colocated `app/entry.server.test.tsx`: internal 404 → not captured (warn logged); internal 500 → captured; plain `Error` → captured; aborted request → skipped
- [x] `npm test -- entry.server --run` (4 passing), typecheck, eslint + prettier clean
- [x] E2E against dev server: `curl 'http://localhost:3000/.env%0d%0a'` → 404 response, yellow client-error warn line, no error stack / no capture