### PR TITLE
fix(groups): stabilize calendar date hydration

### DIFF
--- a/app/components/groups/members-list.hydration.test.tsx
+++ b/app/components/groups/members-list.hydration.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act, render, screen } from '@testing-library/react';
+import React from 'react';
+import { hydrateRoot } from 'react-dom/client';
+import { renderToString } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('react-router', () => ({
+  Link: ({
+    to,
+    children,
+    ...rest
+  }: {
+    to: string;
+    children?: React.ReactNode;
+  }) => (
+    <a href={to} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('./member-actions-menu.tsx', () => ({
+  MemberActionsMenu: () => null,
+}));
+
+import { MembersList, type MemberListEntry } from './members-list.tsx';
+
+const legacyMember: MemberListEntry = {
+  user: {
+    id: 'legacy',
+    username: 'legacy',
+    name: 'Legacy Birthday',
+    birthday: '1990-05-01T00:00:00.000Z',
+    image: null,
+  },
+  role: 'MEMBER',
+};
+
+const currentMember: MemberListEntry = {
+  user: {
+    id: 'current',
+    username: 'current',
+    name: 'Current Birthday',
+    birthday: '1992-05-26T12:00:00.000Z',
+    image: null,
+  },
+  role: 'MEMBER',
+};
+
+const members: Array<MemberListEntry> = [legacyMember, currentMember];
+
+const renderMembers = (entries: Array<MemberListEntry> = members) => (
+  <MembersList
+    giftGroupId="group-1"
+    viewerRole="MEMBER"
+    viewerId="viewer-1"
+    members={entries}
+  />
+);
+
+describe('MembersList birthday hydration', () => {
+  it('preserves missing and invalid birthday fallbacks', () => {
+    render(
+      renderMembers([
+        {
+          ...legacyMember,
+          user: { ...legacyMember.user, birthday: null },
+        },
+        {
+          ...currentMember,
+          user: { ...currentMember.user, birthday: 'not-a-date' },
+        },
+      ]),
+    );
+
+    expect(screen.getAllByText('Birthday not set')).toHaveLength(2);
+  });
+
+  it('hydrates legacy and current birthday dates without shifting days', async () => {
+    const originalTimeZone = process.env.TZ;
+    const container = document.createElement('div');
+    document.body.append(container);
+    const recoverableErrors: Array<unknown> = [];
+    let root: ReturnType<typeof hydrateRoot> | undefined;
+
+    try {
+      process.env.TZ = 'UTC';
+      container.innerHTML = renderToString(renderMembers());
+
+      process.env.TZ = 'America/New_York';
+      await act(async () => {
+        root = hydrateRoot(container, renderMembers(), {
+          onRecoverableError: (error) => recoverableErrors.push(error),
+        });
+        await Promise.resolve();
+      });
+
+      expect(container).toHaveTextContent('May 1');
+      expect(container).toHaveTextContent('May 26');
+      expect(container).not.toHaveTextContent('Apr 30');
+      expect(container).not.toHaveTextContent('May 25');
+      expect(recoverableErrors).toEqual([]);
+    } finally {
+      if (root) {
+        await act(async () => root?.unmount());
+      }
+      container.remove();
+      if (originalTimeZone === undefined) delete process.env.TZ;
+      else process.env.TZ = originalTimeZone;
+    }
+  });
+});

--- a/app/components/groups/members-list.tsx
+++ b/app/components/groups/members-list.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router';
 
 import { Avatar } from '#app/components/ui/avatar.tsx';
 import { SystemLabel } from '#app/components/ui/system-label.tsx';
+import { formatMonthDay } from '#app/utils/dates.ts';
 import { type GroupRole } from '#app/utils/group-role.ts';
 import { MemberActionsMenu } from './member-actions-menu.tsx';
 import { RoleBadge } from './RoleBadge.tsx';
@@ -22,7 +23,7 @@ function formatBirthday(birthday: Date | string | null): string {
   if (!birthday) return 'Birthday not set';
   const date = birthday instanceof Date ? birthday : new Date(birthday);
   if (Number.isNaN(date.getTime())) return 'Birthday not set';
-  return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  return formatMonthDay(date);
 }
 
 function MemberRow({

--- a/app/components/groups/profile-preview-card.tsx
+++ b/app/components/groups/profile-preview-card.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router';
 
 import { Avatar } from '#app/components/ui/avatar.tsx';
 import { SystemLabel } from '#app/components/ui/system-label.tsx';
+import { formatMonthDay } from '#app/utils/dates.ts';
 import { type GroupRole } from '#app/utils/group-role.ts';
 import { RoleBadge } from './RoleBadge.tsx';
 
@@ -20,7 +21,7 @@ function formatBirthday(birthday: Date | string | null): string {
   if (!birthday) return 'Not set';
   const date = birthday instanceof Date ? birthday : new Date(birthday);
   if (Number.isNaN(date.getTime())) return 'Not set';
-  return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  return formatMonthDay(date);
 }
 
 /**

--- a/app/components/home/HomeLoggedIn.tsx
+++ b/app/components/home/HomeLoggedIn.tsx
@@ -3,6 +3,7 @@ import { LuActivity, LuCalendar, LuGift, LuUsers } from 'react-icons/lu';
 import { Link, useFetcher } from 'react-router';
 import { Button } from '#app/components/ui/button.tsx';
 import { Card } from '#app/components/ui/card.tsx';
+import { formatMonthDay } from '#app/utils/dates.ts';
 import { Flex } from '../ui-kit/flex.tsx';
 import { type UpcomingBirthday, type RecentActivityItem } from './HomePanels';
 import { HOME_COPY } from './home-copy';
@@ -49,13 +50,6 @@ const statusLabels: Record<string, string> = {
   PURCHASED: 'Purchased',
 };
 
-const formatPoolEventDate = (eventDate: string) =>
-  new Intl.DateTimeFormat('en-US', {
-    month: 'short',
-    day: 'numeric',
-    timeZone: 'UTC',
-  }).format(new Date(eventDate));
-
 // ── Pool card ────────────────────────────────────────────────────────────────
 
 const PoolCard = ({ pool }: { pool: ActivePool }) => {
@@ -100,7 +94,7 @@ const PoolCard = ({ pool }: { pool: ActivePool }) => {
             <span>·</span>
             <span className="flex items-center gap-1">
               <LuCalendar size={11} />
-              {formatPoolEventDate(pool.eventDate)}
+              {formatMonthDay(pool.eventDate)}
             </span>
           </>
         )}

--- a/app/routes/groups+/$giftGroupId_+/index.test.tsx
+++ b/app/routes/groups+/$giftGroupId_+/index.test.tsx
@@ -1,9 +1,11 @@
 /**
  * @vitest-environment jsdom
  */
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
+import { hydrateRoot } from 'react-dom/client';
+import { renderToString } from 'react-dom/server';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const clipboardWriteText = vi.fn();
@@ -342,8 +344,58 @@ describe('group detail overview route', () => {
     expect(screen.getByText('Active pools')).toBeInTheDocument();
     expect(screen.getByText("Marco's Birthday")).toBeInTheDocument();
     expect(screen.getByText(/birthday for/i)).toBeInTheDocument();
+    expect(screen.getByText('May 3')).toBeInTheDocument();
     expect(screen.getByText('Open')).toBeInTheDocument();
     expect(screen.getByText('Organizing')).toBeInTheDocument();
+  });
+
+  it('hydrates midnight-UTC pool dates without shifting the calendar day', async () => {
+    overviewData.activePools = [
+      {
+        id: 'pool-1',
+        title: "Marco's Birthday",
+        occasionType: 'BIRTHDAY',
+        eventDate: '2026-05-03T00:00:00.000Z',
+        status: 'OPEN',
+        recipientName: 'Marco',
+        recipientUsername: 'marco',
+        ideaCount: 3,
+        contributorCount: 4,
+        paidCount: 0,
+        viewerRole: 'organizing' as const,
+        viewerContributionCents: 2500,
+      },
+    ];
+
+    const originalTimeZone = process.env.TZ;
+    const container = document.createElement('div');
+    document.body.append(container);
+    const recoverableErrors: Array<unknown> = [];
+    let root: ReturnType<typeof hydrateRoot> | undefined;
+
+    try {
+      process.env.TZ = 'UTC';
+      container.innerHTML = renderToString(<GroupsDetailOverview />);
+
+      process.env.TZ = 'America/New_York';
+      await act(async () => {
+        root = hydrateRoot(container, <GroupsDetailOverview />, {
+          onRecoverableError: (error) => recoverableErrors.push(error),
+        });
+        await Promise.resolve();
+      });
+
+      expect(container).toHaveTextContent('May 3');
+      expect(container).not.toHaveTextContent('May 2');
+      expect(recoverableErrors).toEqual([]);
+    } finally {
+      if (root) {
+        await act(async () => root?.unmount());
+      }
+      container.remove();
+      if (originalTimeZone === undefined) delete process.env.TZ;
+      else process.env.TZ = originalTimeZone;
+    }
   });
 
   it('renders the upcoming occasions section with start-pool links', () => {

--- a/app/routes/groups+/$giftGroupId_+/index.tsx
+++ b/app/routes/groups+/$giftGroupId_+/index.tsx
@@ -32,6 +32,7 @@ import { Icon } from '#app/components/ui/icon.tsx';
 import { Input } from '#app/components/ui/input.tsx';
 import { Flex, Stack, Text } from '#app/components/ui-kit';
 import { track } from '#app/utils/analytics.client.ts';
+import { formatMonthDay } from '#app/utils/dates.ts';
 import {
   ACTION_TYPE,
   type ActionItem,
@@ -419,10 +420,7 @@ const PoolRow = ({ pool }: { pool: PoolSummary }) => {
                 <>
                   <span className="text-muted-foreground">·</span>
                   <Text size="xs" className="text-muted-foreground">
-                    {new Date(pool.eventDate).toLocaleDateString('en-US', {
-                      month: 'short',
-                      day: 'numeric',
-                    })}
+                    {formatMonthDay(pool.eventDate)}
                   </Text>
                 </>
               )}

--- a/app/routes/pools+/$poolId+/settings.test.tsx
+++ b/app/routes/pools+/$poolId+/settings.test.tsx
@@ -96,6 +96,7 @@ describe('app/routes/pools+/$poolId+/settings.tsx', () => {
     // Read mode: values shown, no title input yet.
     expect(screen.getByText('Alex Birthday Pool')).toBeInTheDocument();
     expect(screen.getByText('Organizer chooses')).toBeInTheDocument();
+    expect(screen.getByText('May 1, 2026')).toBeInTheDocument();
     expect(
       document.querySelector('input[name="title"]'),
     ).not.toBeInTheDocument();

--- a/app/routes/pools+/$poolId+/settings.tsx
+++ b/app/routes/pools+/$poolId+/settings.tsx
@@ -39,6 +39,7 @@ import {
 import { StatusButton } from '#app/components/ui/status-button.tsx';
 import { Flex, Stack, Text } from '#app/components/ui-kit';
 import { requireUserId } from '#app/utils/auth.server.ts';
+import { formatAbsoluteDate } from '#app/utils/dates.ts';
 import { prisma } from '#app/utils/db.server.ts';
 import {
 	DECISION_MODE_LABELS,
@@ -227,7 +228,7 @@ function PoolDetailsCard({
 		pool.recipientUser?.username ??
 		'Someone special';
 	const eventDateDisplay = pool.eventDate
-		? new Date(pool.eventDate).toLocaleDateString()
+		? formatAbsoluteDate(pool.eventDate)
 		: 'Not set';
 
 	return (

--- a/app/routes/pools+/index.test.tsx
+++ b/app/routes/pools+/index.test.tsx
@@ -151,11 +151,6 @@ describe('app/routes/pools+/index.tsx', () => {
 
   it('renders active and completed pool sections', () => {
     const eventDate = '2026-06-14T00:00:00.000Z';
-    const expectedEventDate = new Date(eventDate).toLocaleDateString('en-US', {
-      month: 'long',
-      day: 'numeric',
-      year: 'numeric',
-    });
 
     renderRoute({
       active: [
@@ -199,7 +194,7 @@ describe('app/routes/pools+/index.tsx', () => {
     expect(
       screen.getByText((_, element) => element?.textContent === 'Birthday for Alex'),
     ).toBeInTheDocument();
-    expect(screen.getByText(expectedEventDate)).toBeInTheDocument();
+    expect(screen.getByText('June 14, 2026')).toBeInTheDocument();
     expect(screen.getByText('Open')).toBeInTheDocument();
 
     // Switch to Past tab — shows completed pool

--- a/app/utils/dates.test.ts
+++ b/app/utils/dates.test.ts
@@ -1,0 +1,30 @@
+/**
+ * @vitest-environment node
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { formatAbsoluteDate, formatMonthDay } from './dates.ts';
+
+const originalTimeZone = process.env.TZ;
+
+beforeAll(() => {
+  process.env.TZ = 'America/New_York';
+});
+
+afterAll(() => {
+  if (originalTimeZone === undefined) delete process.env.TZ;
+  else process.env.TZ = originalTimeZone;
+});
+
+describe('UTC calendar-date formatting', () => {
+  it('keeps a midnight-UTC date on its stored month and day', () => {
+    expect(formatMonthDay('2026-05-03T00:00:00.000Z')).toBe('May 3');
+  });
+
+  it('keeps a noon-UTC birthday on its stored month and day', () => {
+    expect(formatMonthDay('1992-07-04T12:00:00.000Z')).toBe('Jul 4');
+  });
+
+  it('formats long dates in UTC as well', () => {
+    expect(formatAbsoluteDate('2026-05-03T00:00:00.000Z')).toBe('May 3, 2026');
+  });
+});

--- a/app/utils/dates.ts
+++ b/app/utils/dates.ts
@@ -1,3 +1,17 @@
+const CALENDAR_DATE_TIME_ZONE = 'UTC';
+
+/**
+ * Formats a date-only value without allowing the runtime timezone to shift it.
+ * Output: "Apr 4"
+ */
+export function formatMonthDay(date: Date | string): string {
+  return new Date(date).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    timeZone: CALENDAR_DATE_TIME_ZONE,
+  });
+}
+
 /**
  * Formats an absolute date where the year is meaningful.
  * Output: "April 4, 2026"
@@ -7,6 +21,6 @@ export function formatAbsoluteDate(date: Date | string): string {
     month: 'long',
     day: 'numeric',
     year: 'numeric',
-  })
+    timeZone: CALENDAR_DATE_TIME_ZONE,
+  });
 }
-


### PR DESCRIPTION
## Summary
- format calendar-only dates with a fixed en-US locale and UTC timezone
- reuse the shared formatters across group, pool, and Home surfaces
- add UTC-server to New York-client hydration regressions for pool dates and birthdays

Fixes GIFTPOOL-UI-1H

## Test plan
- [x] Focused Vitest suite: 6 files, 45 tests
- [x] npm run typecheck
- [x] npm run lint (zero errors; existing warning baseline)
- [x] npm run build
- [x] npm run validate with local test environment: 1,327 unit tests and 109 Playwright tests passed; 6 Playwright tests skipped

## Checklist
- [x] No Prisma migration
- [x] No environment or public data-contract change
- [x] No visual layout change; screenshots not applicable