### PR TITLE
fix(dates): preserve viewer-local timestamps

### DIFF
--- a/app/components/groups/GroupCard.tsx
+++ b/app/components/groups/GroupCard.tsx
@@ -2,7 +2,6 @@ import { LuSettings } from 'react-icons/lu';
 import { Link } from 'react-router';
 import { RoleBadge } from '#app/components/groups/RoleBadge.tsx';
 import { Card } from '#app/components/ui/card.tsx';
-import { formatAbsoluteDate } from '#app/utils/dates.ts';
 import { Stack, Text } from '#app/components/ui-kit';
 import { usePressFeedback } from '#app/components/wishlist/hooks/use-press-feedback.ts';
 import { type GroupRole } from '#app/utils/group-role.ts';
@@ -12,7 +11,7 @@ export type GroupCardData = {
   name: string;
   description?: string | null;
   memberCount: number;
-  createdAt: string | Date;
+  createdAtDisplay: string;
   myRole: GroupRole;
 };
 
@@ -67,9 +66,7 @@ export function GroupCard({
           <div className="h-px w-full" />
           <div className="flex items-center justify-between text-sm">
             <div className="text-muted-foreground">Created</div>
-            <div className="font-medium">
-              {formatAbsoluteDate(g.createdAt)}
-            </div>
+            <div className="font-medium">{g.createdAtDisplay}</div>
           </div>
         </Stack>
       </Stack>

--- a/app/components/groups/groups-surface.test.tsx
+++ b/app/components/groups/groups-surface.test.tsx
@@ -96,7 +96,7 @@ describe('group surface components', () => {
     renderWithRouter(
       <GroupCard
         g={{
-          createdAt: '2026-03-31T00:00:00.000Z',
+          createdAtDisplay: 'March 30, 2026',
           description: 'Birthday planning',
           id: 'group-1',
           memberCount: 4,
@@ -110,6 +110,7 @@ describe('group surface components', () => {
     expect(screen.getByText('Birthday planning')).toBeInTheDocument();
     expect(screen.getByText('Members')).toBeInTheDocument();
     expect(screen.getByText('4')).toBeInTheDocument();
+    expect(screen.getByText('March 30, 2026')).toBeInTheDocument();
     expect(
       screen.getByRole('link', { name: /manage/i }),
     ).toHaveAttribute('href', '/groups/group-1');
@@ -129,7 +130,7 @@ describe('group surface components', () => {
     renderWithRouter(
       <GroupCard
         g={{
-          createdAt: '2026-03-31T00:00:00.000Z',
+          createdAtDisplay: 'March 30, 2026',
           description: null,
           id: 'group-2',
           memberCount: 2,

--- a/app/routes/groups+/$giftGroupId_+/members_.$userId.history.component.test.tsx
+++ b/app/routes/groups+/$giftGroupId_+/members_.$userId.history.component.test.tsx
@@ -44,8 +44,7 @@ describe('MemberGiftHistoryPage component', () => {
           id: 'pool-1',
           title: "Marco's 30th",
           occasionType: 'BIRTHDAY',
-          eventDate: '2025-05-03T00:00:00.000Z',
-          deliveredAt: '2025-05-04T00:00:00.000Z',
+          dateDisplay: 'May 3, 2025',
           giftName: 'Sony WH-1000XM5',
           totalCents: 12500,
         },
@@ -53,8 +52,7 @@ describe('MemberGiftHistoryPage component', () => {
           id: 'pool-2',
           title: 'Anniversary thing',
           occasionType: 'ANNIVERSARY',
-          eventDate: null,
-          deliveredAt: '2024-12-01T00:00:00.000Z',
+          dateDisplay: 'November 30, 2024',
           giftName: null,
           totalCents: 0,
         },
@@ -64,6 +62,8 @@ describe('MemberGiftHistoryPage component', () => {
     expect(await screen.findByText("Marco's 30th")).toBeInTheDocument();
     expect(screen.getByText('Sony WH-1000XM5')).toBeInTheDocument();
     expect(screen.getByText('$125.00')).toBeInTheDocument();
+    expect(screen.getByText('May 3, 2025')).toBeInTheDocument();
+    expect(screen.getByText('November 30, 2024')).toBeInTheDocument();
     expect(
       screen.getByText('No specific gift recorded'),
     ).toBeInTheDocument();

--- a/app/routes/groups+/$giftGroupId_+/members_.$userId.history.test.ts
+++ b/app/routes/groups+/$giftGroupId_+/members_.$userId.history.test.ts
@@ -103,6 +103,7 @@ describe('member gift history loader', () => {
         params: { giftGroupId: 'group-1', userId: 'marco' },
         request: new Request(
           'https://giftpool.app/groups/group-1/members/marco/history',
+          { headers: { Cookie: 'CH-time-zone=America%2FNew_York' } },
         ),
       }),
     );
@@ -114,6 +115,7 @@ describe('member gift history loader', () => {
           id: 'pool-1',
           title: "Marco's 30th Birthday",
           occasionType: 'BIRTHDAY',
+          dateDisplay: 'May 3, 2025',
           giftName: 'Sony headphones',
           totalCents: 15000,
         },
@@ -161,7 +163,7 @@ describe('member gift history loader', () => {
         title: 'Old pool',
         occasionType: 'BIRTHDAY',
         eventDate: null,
-        updatedAt: new Date('2025-01-01'),
+        updatedAt: new Date('2025-01-01T01:00:00.000Z'),
         finalPriceCents: null,
         chosenIdea: null,
         contributors: [
@@ -178,10 +180,12 @@ describe('member gift history loader', () => {
         params: { giftGroupId: 'group-1', userId: 'marco' },
         request: new Request(
           'https://giftpool.app/groups/group-1/members/marco/history',
+          { headers: { Cookie: 'CH-time-zone=America%2FNew_York' } },
         ),
       }),
     );
 
     expect(result.gifts[0]?.totalCents).toBe(5000);
+    expect(result.gifts[0]?.dateDisplay).toBe('December 31, 2024');
   });
 });

--- a/app/routes/groups+/$giftGroupId_+/members_.$userId.history.tsx
+++ b/app/routes/groups+/$giftGroupId_+/members_.$userId.history.tsx
@@ -1,12 +1,9 @@
 import { LuChevronLeft, LuGift } from 'react-icons/lu';
-import {
-  type LoaderFunctionArgs,
-  Link,
-  useLoaderData,
-} from 'react-router';
+import { type LoaderFunctionArgs, Link, useLoaderData } from 'react-router';
 import { Card } from '#app/components/ui/card.tsx';
 import { Flex, Stack, Text } from '#app/components/ui-kit';
-import { formatAbsoluteDate } from '#app/utils/dates.ts';
+import { getHints } from '#app/utils/client-hints.tsx';
+import { formatCalendarDate, formatTimestampDate } from '#app/utils/dates.ts';
 import {
   OCCASION_TYPE_LABELS,
   POOL_STATUS,
@@ -16,12 +13,11 @@ import {
 export async function loader({ params, request }: LoaderFunctionArgs) {
   const groupId = params.giftGroupId!;
   const memberUserId = params.userId!;
-  const { requireUserIdInGroup } = await import(
-    '#app/utils/groups.server.ts'
-  );
+  const { requireUserIdInGroup } = await import('#app/utils/groups.server.ts');
   const { prisma } = await import('#app/utils/db.server.ts');
 
   const viewerId = await requireUserIdInGroup(request, groupId);
+  const { timeZone } = getHints(request);
 
   // Privacy: the target member must never see their own gift history.
   // 404 (indistinguishable from nonexistent route).
@@ -74,15 +70,13 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
     id: pool.id,
     title: pool.title,
     occasionType: pool.occasionType,
-    eventDate: pool.eventDate,
-    deliveredAt: pool.updatedAt,
+    dateDisplay: pool.eventDate
+      ? formatCalendarDate(pool.eventDate)
+      : formatTimestampDate(pool.updatedAt, timeZone),
     giftName: pool.chosenIdea?.name ?? null,
     totalCents:
       pool.finalPriceCents ??
-      pool.contributors.reduce(
-        (sum, c) => sum + (c.contributionCents ?? 0),
-        0,
-      ),
+      pool.contributors.reduce((sum, c) => sum + (c.contributionCents ?? 0), 0),
   }));
 
   return {
@@ -147,17 +141,12 @@ const GiftHistoryRow = ({
     id: string;
     title: string;
     occasionType: string;
-    eventDate: Date | string | null;
-    deliveredAt: Date | string;
+    dateDisplay: string;
     giftName: string | null;
     totalCents: number;
   };
 }) => {
   const occasion = OCCASION_TYPE_LABELS[gift.occasionType as OccasionType];
-  const eventLabel = gift.eventDate
-    ? formatAbsoluteDate(gift.eventDate)
-    : formatAbsoluteDate(gift.deliveredAt);
-
   return (
     <Link to={`/pools/${gift.id}`} className="block">
       <Card padding="md" className="transition-shadow hover:shadow-md">
@@ -184,7 +173,7 @@ const GiftHistoryRow = ({
               )}
             </Text>
             <Text size="xs" className="text-muted-foreground">
-              {eventLabel}
+              {gift.dateDisplay}
             </Text>
           </Stack>
           {gift.totalCents > 0 && (

--- a/app/routes/groups+/index.test.tsx
+++ b/app/routes/groups+/index.test.tsx
@@ -12,7 +12,7 @@ const requireUserId = vi.fn();
 const findMany = vi.fn();
 const loaderDataSnapshot: {
   groups: Array<{
-    createdAt: string;
+    createdAtDisplay: string;
     description?: string | null;
     id: string;
     memberCount: number;
@@ -66,10 +66,11 @@ beforeEach(() => {
   requireUserId.mockReset();
   findMany.mockReset();
   loaderDataSnapshot.groups = [];
+  document.cookie = 'CH-time-zone=America%2FNew_York; path=/';
 });
 
 function renderGroupsRoute(groups: Array<{
-  createdAt: string;
+  createdAtDisplay: string;
   description?: string | null;
   id: string;
   memberCount: number;
@@ -91,7 +92,7 @@ describe('app/routes/groups+/index.tsx', () => {
     findMany.mockResolvedValue([
       {
         _count: { groupMembers: 3 },
-        createdAt: new Date('2026-03-31T12:00:00.000Z'),
+        createdAt: new Date('2026-03-31T01:00:00.000Z'),
         description: 'Birthday planning',
         groupMembers: [{ role: 'OWNER' }],
         id: 'group-1',
@@ -99,7 +100,7 @@ describe('app/routes/groups+/index.tsx', () => {
       },
       {
         _count: { groupMembers: 2 },
-        createdAt: new Date('2026-02-01T12:00:00.000Z'),
+        createdAt: new Date('2026-02-01T01:00:00.000Z'),
         description: null,
         groupMembers: [{ role: 'NOT_A_REAL_ROLE' }],
         id: 'group-2',
@@ -111,12 +112,14 @@ describe('app/routes/groups+/index.tsx', () => {
       loader({
         context: {},
         params: {},
-        request: new Request('https://example.com/groups'),
+        request: new Request('https://example.com/groups', {
+          headers: { Cookie: 'CH-time-zone=America%2FNew_York' },
+        }),
       } as never),
     ).resolves.toEqual({
       groups: [
         {
-          createdAt: new Date('2026-03-31T12:00:00.000Z'),
+          createdAtDisplay: 'March 30, 2026',
           description: 'Birthday planning',
           id: 'group-1',
           memberCount: 3,
@@ -124,7 +127,7 @@ describe('app/routes/groups+/index.tsx', () => {
           name: 'Family',
         },
         {
-          createdAt: new Date('2026-02-01T12:00:00.000Z'),
+          createdAtDisplay: 'January 31, 2026',
           description: null,
           id: 'group-2',
           memberCount: 2,
@@ -177,7 +180,7 @@ describe('app/routes/groups+/index.tsx', () => {
   it('renders group cards and navigates to the selected group', async () => {
     renderGroupsRoute([
       {
-        createdAt: '2026-03-30T12:00:00.000Z',
+        createdAtDisplay: 'March 30, 2026',
         description: 'Birthday planning',
         id: 'group-1',
         memberCount: 3,
@@ -185,7 +188,7 @@ describe('app/routes/groups+/index.tsx', () => {
         name: 'Family',
       },
       {
-        createdAt: '2026-03-29T12:00:00.000Z',
+        createdAtDisplay: 'March 29, 2026',
         description: null,
         id: 'group-2',
         memberCount: 5,

--- a/app/routes/groups+/index.tsx
+++ b/app/routes/groups+/index.tsx
@@ -13,11 +13,14 @@ import {
 } from '#app/components/ui/dialog.tsx';
 import { Flex, Text } from '#app/components/ui-kit';
 import { requireUserId } from '#app/utils/auth.server.ts';
+import { getHints } from '#app/utils/client-hints.tsx';
+import { formatTimestampDate } from '#app/utils/dates.ts';
 import { prisma } from '#app/utils/db.server.ts';
 import { GroupRoleSchema, type GroupRole } from '#app/utils/group-role.ts';
 import { CreateGroupCompactForm } from './__group-editor.tsx';
 export async function loader({ request }: LoaderFunctionArgs) {
   const userId = await requireUserId(request);
+  const { timeZone } = getHints(request);
   const groups = await prisma.giftGroup.findMany({
     where: {
       groupMembers: {
@@ -56,7 +59,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
       id: g.id,
       name: g.name,
       description: g.description,
-      createdAt: g.createdAt,
+      createdAtDisplay: formatTimestampDate(g.createdAt, timeZone),
       memberCount: g._count.groupMembers,
       myRole: parsedRole as GroupRole,
     };

--- a/app/routes/pools+/$poolId+/settings.tsx
+++ b/app/routes/pools+/$poolId+/settings.tsx
@@ -39,7 +39,7 @@ import {
 import { StatusButton } from '#app/components/ui/status-button.tsx';
 import { Flex, Stack, Text } from '#app/components/ui-kit';
 import { requireUserId } from '#app/utils/auth.server.ts';
-import { formatAbsoluteDate } from '#app/utils/dates.ts';
+import { formatCalendarDate } from '#app/utils/dates.ts';
 import { prisma } from '#app/utils/db.server.ts';
 import {
 	DECISION_MODE_LABELS,
@@ -228,7 +228,7 @@ function PoolDetailsCard({
 		pool.recipientUser?.username ??
 		'Someone special';
 	const eventDateDisplay = pool.eventDate
-		? formatAbsoluteDate(pool.eventDate)
+		? formatCalendarDate(pool.eventDate)
 		: 'Not set';
 
 	return (

--- a/app/routes/pools+/index.tsx
+++ b/app/routes/pools+/index.tsx
@@ -7,7 +7,7 @@ import { Button } from '#app/components/ui/button.tsx'
 import { Card } from '#app/components/ui/card.tsx'
 import { Flex, Stack, Text } from '#app/components/ui-kit'
 import { requireUserId } from '#app/utils/auth.server.ts'
-import { formatAbsoluteDate } from '#app/utils/dates.ts'
+import { formatCalendarDate } from '#app/utils/dates.ts'
 import { prisma } from '#app/utils/db.server.ts'
 import { cn } from '#app/utils/misc.tsx'
 import {
@@ -90,7 +90,7 @@ const PoolCard = ({ pool }: { pool: Pool }) => {
 						</Text>
 						{pool.eventDate && (
 							<Text size="xs" className="text-muted-foreground">
-								{formatAbsoluteDate(pool.eventDate)}
+								{formatCalendarDate(pool.eventDate)}
 							</Text>
 						)}
 						<Flex gap={2} align="center" className="mt-1">

--- a/app/routes/profile+/index.loader.test.ts
+++ b/app/routes/profile+/index.loader.test.ts
@@ -2,7 +2,7 @@
  * @vitest-environment node
  */
 import { describe, expect, it, vi } from 'vitest';
-import { formatAbsoluteDate } from '#app/utils/dates.ts';
+import { formatTimestampDate } from '#app/utils/dates.ts';
 
 const requireUserId = vi.fn();
 const findFirst = vi.fn();
@@ -31,7 +31,7 @@ describe('app/routes/profile+/index.tsx loader', () => {
   it('loads the signed-in profile summary with wishlist preview', async () => {
     requireUserId.mockResolvedValue('user-1');
     findFirst.mockResolvedValue({
-      createdAt: new Date('2024-05-12T00:00:00.000Z'),
+      createdAt: new Date('2024-05-12T01:00:00.000Z'),
       id: 'user-1',
       image: { id: 'image-1' },
       name: 'Taylor',
@@ -54,7 +54,9 @@ describe('app/routes/profile+/index.tsx loader', () => {
     const result = await loader({
       context: {},
       params: {},
-      request: new Request('https://giftpool.app/me'),
+      request: new Request('https://giftpool.app/me', {
+        headers: { Cookie: 'CH-time-zone=America%2FNew_York' },
+      }),
     } as never);
 
     expect(findFirst).toHaveBeenCalledWith({
@@ -73,7 +75,7 @@ describe('app/routes/profile+/index.tsx loader', () => {
 
     expect(result).toEqual({
       user: {
-        createdAt: new Date('2024-05-12T00:00:00.000Z'),
+        createdAt: new Date('2024-05-12T01:00:00.000Z'),
         id: 'user-1',
         image: { id: 'image-1' },
         name: 'Taylor',
@@ -82,7 +84,10 @@ describe('app/routes/profile+/index.tsx loader', () => {
         birthday: null,
         birthdayVisibility: 'FRIENDS',
       },
-      userJoinedDisplay: formatAbsoluteDate(new Date('2024-05-12T00:00:00.000Z')),
+      userJoinedDisplay: formatTimestampDate(
+        new Date('2024-05-12T01:00:00.000Z'),
+        'America/New_York',
+      ),
       wishlistPreview: {
         items: [
           {

--- a/app/routes/profile+/index.tsx
+++ b/app/routes/profile+/index.tsx
@@ -18,11 +18,13 @@ import {
   formatBirthdayLabel,
   getUpcomingBirthday,
 } from '#app/utils/birthday.ts';
-import { formatAbsoluteDate } from '#app/utils/dates.ts';
+import { getHints } from '#app/utils/client-hints.tsx';
+import { formatTimestampDate } from '#app/utils/dates.ts';
 import { prisma } from '#app/utils/db.server.ts';
 
 export async function loader({ request }: LoaderFunctionArgs) {
   const userId = await requireUserId(request);
+  const { timeZone } = getHints(request);
   const user = await prisma.user.findFirst({
     select: {
       id: true,
@@ -74,7 +76,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
   return {
     user,
-    userJoinedDisplay: formatAbsoluteDate(user.createdAt),
+    userJoinedDisplay: formatTimestampDate(user.createdAt, timeZone),
     wishlistPreview: {
       items: wishlistItems,
       totalCount: wishlistTotalCount,

--- a/app/utils/dates.test.ts
+++ b/app/utils/dates.test.ts
@@ -2,7 +2,11 @@
  * @vitest-environment node
  */
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { formatAbsoluteDate, formatMonthDay } from './dates.ts';
+import {
+  formatCalendarDate,
+  formatMonthDay,
+  formatTimestampDate,
+} from './dates.ts';
 
 const originalTimeZone = process.env.TZ;
 
@@ -24,7 +28,27 @@ describe('UTC calendar-date formatting', () => {
     expect(formatMonthDay('1992-07-04T12:00:00.000Z')).toBe('Jul 4');
   });
 
-  it('formats long dates in UTC as well', () => {
-    expect(formatAbsoluteDate('2026-05-03T00:00:00.000Z')).toBe('May 3, 2026');
+  it('formats long calendar dates in UTC as well', () => {
+    expect(formatCalendarDate('2026-05-03T00:00:00.000Z')).toBe('May 3, 2026');
+  });
+});
+
+describe('viewer-local timestamp formatting', () => {
+  it('uses the explicit viewer timezone near midnight UTC', () => {
+    expect(
+      formatTimestampDate('2026-05-03T01:00:00.000Z', 'America/New_York'),
+    ).toBe('May 2, 2026');
+  });
+
+  it('does not depend on the runtime timezone', () => {
+    expect(
+      formatTimestampDate('2026-05-03T01:00:00.000Z', 'Europe/Paris'),
+    ).toBe('May 3, 2026');
+  });
+
+  it('falls back to UTC for a malformed timezone hint', () => {
+    expect(
+      formatTimestampDate('2026-05-03T01:00:00.000Z', 'Not/A_Time_Zone'),
+    ).toBe('May 3, 2026');
   });
 });

--- a/app/utils/dates.ts
+++ b/app/utils/dates.ts
@@ -1,5 +1,11 @@
 const CALENDAR_DATE_TIME_ZONE = 'UTC';
 
+const LONG_DATE_OPTIONS = {
+  month: 'long',
+  day: 'numeric',
+  year: 'numeric',
+} as const;
+
 /**
  * Formats a date-only value without allowing the runtime timezone to shift it.
  * Output: "Apr 4"
@@ -12,15 +18,35 @@ export function formatMonthDay(date: Date | string): string {
   });
 }
 
-/**
- * Formats an absolute date where the year is meaningful.
- * Output: "April 4, 2026"
- */
-export function formatAbsoluteDate(date: Date | string): string {
+/** Formats a date-only value with its year. Output: "April 4, 2026" */
+export function formatCalendarDate(date: Date | string): string {
   return new Date(date).toLocaleDateString('en-US', {
-    month: 'long',
-    day: 'numeric',
-    year: 'numeric',
+    ...LONG_DATE_OPTIONS,
     timeZone: CALENDAR_DATE_TIME_ZONE,
   });
+}
+
+/**
+ * Formats a real timestamp on the viewer's local calendar.
+ * The explicit timezone keeps server rendering and hydration deterministic.
+ */
+export function formatTimestampDate(
+  date: Date | string,
+  timeZone: string,
+): string {
+  const value = new Date(date);
+
+  try {
+    return value.toLocaleDateString('en-US', {
+      ...LONG_DATE_OPTIONS,
+      timeZone,
+    });
+  } catch (error) {
+    if (!(error instanceof RangeError)) throw error;
+
+    return value.toLocaleDateString('en-US', {
+      ...LONG_DATE_OPTIONS,
+      timeZone: CALENDAR_DATE_TIME_ZONE,
+    });
+  }
 }

--- a/stories/GroupCard.stories.tsx
+++ b/stories/GroupCard.stories.tsx
@@ -9,7 +9,7 @@ const base: GroupCardData = {
   name: 'Family Gift Exchange',
   description: 'Annual holiday exchange with the whole family.',
   memberCount: 8,
-  createdAt: new Date('2024-07-15'),
+  createdAtDisplay: 'July 15, 2024',
   myRole: 'MEMBER',
 };
 

--- a/stories/Groups.stories.tsx
+++ b/stories/Groups.stories.tsx
@@ -82,7 +82,7 @@ const sampleGroups: GroupCardData[] = [
     name: 'Family Gift Exchange',
     description: 'Annual holiday exchange with the whole family.',
     memberCount: 8,
-    createdAt: new Date('2024-11-15'),
+    createdAtDisplay: 'November 15, 2024',
     myRole: 'OWNER',
   },
   {
@@ -90,7 +90,7 @@ const sampleGroups: GroupCardData[] = [
     name: 'Office Secret Santa',
     description: 'Coworkers-only gift swap. $25 limit.',
     memberCount: 12,
-    createdAt: new Date('2024-10-01'),
+    createdAtDisplay: 'October 1, 2024',
     myRole: 'ADMIN',
   },
   {
@@ -98,7 +98,7 @@ const sampleGroups: GroupCardData[] = [
     name: 'Neighborhood Potluck',
     description: null,
     memberCount: 6,
-    createdAt: new Date('2024-08-20'),
+    createdAtDisplay: 'August 20, 2024',
     myRole: 'MEMBER',
   },
 ];


### PR DESCRIPTION
## Summary\n\n- split UTC calendar-date formatting from viewer-local timestamp formatting\n- format group creation, profile join, and delivery fallback dates with the existing timezone client hint\n- keep pool event dates deterministic in UTC and guard malformed timezone hints with a UTC fallback\n- update route, component, and Storybook data contracts to pass preformatted timestamp labels\n\nFollow-up to the unresolved timestamp-semantics review on #490.\n\n## Test plan\n\n- [x] focused Vitest regression suite (8 files, 33 tests)\n- [x] full Vitest suite\n- [x] npm run lint (0 errors; existing warnings only)\n- [x] npm run typecheck\n- [x] production build\n\n## Release notes\n\n- No migration\n- No environment change\n- No visual layout change; screenshots not applicable