### PR TITLE
fix(security): re-encode profile photos and harden image serving

### DIFF
--- a/app/routes/resources+/user-images.$imageId.test.ts
+++ b/app/routes/resources+/user-images.$imageId.test.ts
@@ -79,6 +79,39 @@ describe('app/routes/resources+/user-images.$imageId.tsx', () => {
     expect(response.headers.get('content-length')).toBe(String(blob.byteLength));
   });
 
+  it('serves the raw branch as an attachment under an enforced restrictive CSP', async () => {
+    requireUserId.mockResolvedValueOnce('user-1');
+    const blob = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]);
+    findUnique.mockResolvedValueOnce({ contentType: 'image/png', blob });
+
+    const response = await loader(makeArgs('img-1'));
+
+    expect(response.headers.get('content-disposition')).toBe(
+      'attachment; filename="img-1"',
+    );
+    expect(response.headers.get('content-security-policy')).toBe(
+      "default-src 'none'; sandbox",
+    );
+    expect(response.headers.get('x-content-type-options')).toBe('nosniff');
+  });
+
+  it('downgrades a legacy non-raster stored content type so it cannot render as a document', async () => {
+    requireUserId.mockResolvedValueOnce('user-1');
+    // A legacy row whose stored contentType is an active-content type.
+    const blob = Buffer.from('<svg xmlns="http://www.w3.org/2000/svg"><script>1</script></svg>');
+    findUnique.mockResolvedValueOnce({ contentType: 'image/svg+xml', blob });
+
+    const response = await loader(makeArgs('legacy-svg'));
+
+    expect(response.headers.get('content-type')).toBe('application/octet-stream');
+    expect(response.headers.get('content-disposition')).toBe(
+      'attachment; filename="legacy-svg"',
+    );
+    expect(response.headers.get('content-security-policy')).toBe(
+      "default-src 'none'; sandbox",
+    );
+  });
+
   it('returns a resized webp with private cache headers when ?size is provided', async () => {
     requireUserId.mockResolvedValueOnce('user-1');
     const imageBuffer = await fs.readFile(

--- a/app/routes/resources+/user-images.$imageId.tsx
+++ b/app/routes/resources+/user-images.$imageId.tsx
@@ -7,6 +7,17 @@ import { USER_IMAGE_SIZES } from '#app/utils/misc.tsx';
 
 const ALLOWED_IMAGE_SIZES = new Set<number>(USER_IMAGE_SIZES);
 
+// New uploads are always re-encoded to webp, but legacy rows may carry an
+// arbitrary stored contentType. Only serve a known-inert raster type as-is;
+// anything else (e.g. a legacy image/svg+xml or text/html row) is downgraded
+// so it can never render as an active, same-origin document.
+const SAFE_RASTER_CONTENT_TYPES = new Set([
+  'image/png',
+  'image/jpeg',
+  'image/webp',
+  'image/gif',
+]);
+
 function parseRequestedSize(request: Request) {
   const sizeParam = new URL(request.url).searchParams.get('size');
   if (!sizeParam) return null;
@@ -36,12 +47,21 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
 
   if (!requestedSize) {
     const body = new Uint8Array(image.blob).buffer;
+    const safeContentType = SAFE_RASTER_CONTENT_TYPES.has(image.contentType)
+      ? image.contentType
+      : 'application/octet-stream';
 
     return new Response(body, {
       headers: {
-        'Content-Type': image.contentType,
+        'Content-Type': safeContentType,
         'Content-Length': String(image.blob.byteLength),
-        'Content-Disposition': `inline; filename="${params.imageId}"`,
+        // Force download rather than inline render, and pin an enforced,
+        // maximally-restrictive CSP on this response specifically (the global
+        // app CSP is report-only). Together with nosniff this prevents a
+        // stored SVG/HTML blob from executing as a same-origin document.
+        'Content-Disposition': `attachment; filename="${params.imageId}"`,
+        'Content-Security-Policy': "default-src 'none'; sandbox",
+        'X-Content-Type-Options': 'nosniff',
         'Cache-Control': 'private, max-age=31536000, immutable',
       },
     });

--- a/app/routes/settings+/profile.photo.test.ts
+++ b/app/routes/settings+/profile.photo.test.ts
@@ -1,0 +1,111 @@
+/**
+ * @vitest-environment node
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const requireUserId = vi.fn();
+const deleteMany = vi.fn();
+const create = vi.fn();
+const $transaction = vi.fn();
+const processImageFromFile = vi.fn();
+
+vi.mock('#app/utils/auth.server.ts', () => ({
+  requireUserId: (...args: Array<unknown>) => requireUserId(...args),
+}));
+
+vi.mock('#app/utils/db.server.ts', () => ({
+  prisma: {
+    userImage: {
+      deleteMany: (...args: Array<unknown>) => deleteMany(...args),
+      create: (...args: Array<unknown>) => create(...args),
+    },
+    $transaction: (...args: Array<unknown>) => $transaction(...args),
+  },
+}));
+
+vi.mock('#app/utils/wishlist-images.server.ts', () => ({
+  processImageFromFile: (...args: Array<unknown>) => processImageFromFile(...args),
+}));
+
+import { action } from './profile.photo.tsx';
+
+function makeArgs(formData: FormData) {
+  return {
+    context: {},
+    params: {},
+    request: new Request('https://giftpool.app/settings/profile/photo', {
+      method: 'POST',
+      body: formData,
+    }),
+  } as never;
+}
+
+beforeEach(() => {
+  requireUserId.mockReset().mockResolvedValue('user-1');
+  deleteMany.mockReset();
+  create.mockReset();
+  $transaction.mockReset().mockResolvedValue(undefined);
+  processImageFromFile.mockReset();
+});
+
+describe('profile.photo action', () => {
+  it('rejects an svg upload at the schema before any processing', async () => {
+    const formData = new FormData();
+    formData.set('intent', 'submit');
+    formData.set(
+      'photoFile',
+      new File(['<svg><script>1</script></svg>'], 'x.svg', {
+        type: 'image/svg+xml',
+      }),
+    );
+
+    const response = await action(makeArgs(formData));
+
+    // `data(...)` wrapper carries its status on `.init`, not `.status`.
+    expect((response as { init?: ResponseInit }).init?.status).toBe(400);
+    expect(processImageFromFile).not.toHaveBeenCalled();
+    expect($transaction).not.toHaveBeenCalled();
+  });
+
+  it('re-encodes a valid upload and stores the server-derived webp content type', async () => {
+    processImageFromFile.mockResolvedValueOnce({
+      data: Buffer.from([1, 2, 3]),
+      contentType: 'image/webp',
+    });
+    const formData = new FormData();
+    formData.set('intent', 'submit');
+    formData.set(
+      'photoFile',
+      new File([Buffer.from([0xff, 0xd8, 0xff])], 'x.jpg', {
+        type: 'image/jpeg',
+      }),
+    );
+
+    const response = await action(makeArgs(formData));
+
+    // Redirect on success.
+    expect((response as Response).status).toBe(302);
+    expect(processImageFromFile).toHaveBeenCalledTimes(1);
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ contentType: 'image/webp' }),
+      }),
+    );
+  });
+
+  it('returns a validation error when processing fails (non-image bytes)', async () => {
+    processImageFromFile.mockRejectedValueOnce(new Error('unsupported image'));
+    const formData = new FormData();
+    formData.set('intent', 'submit');
+    // Passes the MIME allowlist but is not a real image; sharp will throw.
+    formData.set(
+      'photoFile',
+      new File(['not an image'], 'x.png', { type: 'image/png' }),
+    );
+
+    const response = await action(makeArgs(formData));
+
+    expect((response as { init?: ResponseInit }).init?.status).toBe(400);
+    expect($transaction).not.toHaveBeenCalled();
+  });
+});

--- a/app/routes/settings+/profile.photo.tsx
+++ b/app/routes/settings+/profile.photo.tsx
@@ -10,6 +10,7 @@ import {
 import { z } from 'zod';
 import { requireUserId } from '#app/utils/auth.server.ts';
 import { prisma } from '#app/utils/db.server.ts';
+import { processImageFromFile } from '#app/utils/wishlist-images.server.ts';
 
 // Action-only resource route. The photo editor UI lives inline in the
 // settings hub as `ProfilePhotoSheet`; the sheet's fetcher POSTs here to
@@ -22,6 +23,16 @@ export const handle: SEOHandle = {
 
 const MAX_SIZE = 1024 * 1024 * 3; // 3MB
 
+// Raster types only. SVG and HTML are deliberately excluded: they can carry
+// active content, and every stored upload is additionally re-encoded to webp
+// via `processImageFromFile` so the persisted bytes are never a live document.
+const ALLOWED_UPLOAD_CONTENT_TYPES = new Set([
+  'image/png',
+  'image/jpeg',
+  'image/webp',
+  'image/gif',
+]);
+
 const DeleteImageSchema = z.object({
   intent: z.literal('delete'),
 });
@@ -33,6 +44,10 @@ const NewImageSchema = z.object({
     .refine(
       (file) => file.size <= MAX_SIZE,
       'Image size must be less than 3MB',
+    )
+    .refine(
+      (file) => ALLOWED_UPLOAD_CONTENT_TYPES.has(file.type),
+      'Unsupported image type. Use PNG, JPEG, WebP, or GIF.',
     ),
 });
 const PhotoFormSchema = z.discriminatedUnion('intent', [
@@ -49,17 +64,7 @@ export async function action({ request }: ActionFunctionArgs) {
   const userId = await requireUserId(request);
   const formData = await request.formData();
   const submission = await parseWithZod(formData, {
-    schema: PhotoFormSchema.transform(async (value) => {
-      if (value.intent === 'delete') return { intent: 'delete' as const };
-      if (value.photoFile.size <= 0) return z.NEVER;
-      return {
-        intent: value.intent,
-        image: {
-          contentType: value.photoFile.type,
-          blob: Buffer.from(await value.photoFile.arrayBuffer()),
-        },
-      };
-    }),
+    schema: PhotoFormSchema,
     async: true,
   });
   if (submission.status !== 'success') {
@@ -68,19 +73,36 @@ export async function action({ request }: ActionFunctionArgs) {
       { status: submission.status === 'error' ? 400 : 200 },
     );
   }
-  const { image, intent } = submission.value;
-  if (intent === 'delete') {
+  if (submission.value.intent === 'delete') {
     await prisma.userImage.deleteMany({ where: { userId } });
     return redirect('/settings/profile');
   }
-  invariantResponse(image, 'Image is required');
+
+  // Re-encode to a fixed raster format so a crafted upload (e.g. an SVG or
+  // HTML disguised with an image MIME) can never be persisted as active,
+  // same-origin-executable content. `processImageFromFile` returns webp bytes
+  // and a server-derived `contentType` — we never trust the client's MIME.
+  let processed;
+  try {
+    processed = await processImageFromFile(submission.value.photoFile);
+  } catch {
+    return data(
+      {
+        result: submission.reply({
+          formErrors: ['Could not process image. Please try a different file.'],
+        }),
+      },
+      { status: 400 },
+    );
+  }
+  invariantResponse(processed, 'Image is required');
   await prisma.$transaction([
     prisma.userImage.deleteMany({ where: { userId } }),
     prisma.userImage.create({
       data: {
         userId,
-        contentType: image.contentType,
-        blob: image.blob,
+        contentType: processed.contentType,
+        blob: processed.data,
       },
     }),
   ]);


### PR DESCRIPTION
## Summary
Closes the HIGH-severity stored-XSS via profile-photo upload (audit finding #1). The upload action stored the client-supplied blob and MIME verbatim (schema checked only size), and the raw image-serving branch returned them `inline` — a crafted SVG/HTML upload could execute as a same-origin document because the global CSP is report-only.

## Changes
- **Upload** (`settings+/profile.photo.tsx`): allowlist raster MIME types and re-encode every upload to webp via the existing `processImageFromFile` helper. Stored bytes are never active content, and the persisted `contentType` is server-derived (never `file.type`).
- **Serve** (`resources+/user-images.$imageId.tsx`, raw branch): force `Content-Disposition: attachment`, pin an **enforced** restrictive CSP (`default-src 'none'; sandbox`) plus `nosniff` on this response specifically, and downgrade any non-raster legacy stored `contentType` to `application/octet-stream`.

## Test plan
- `npm run typecheck` — clean
- New unit tests (write + read side):
  - upload: svg rejected at schema; valid image re-encoded to webp; non-image bytes → 400
  - serve: raw branch is `attachment` + sandbox CSP + nosniff; legacy `image/svg+xml` row downgraded to `application/octet-stream`
- Manual: upload an SVG-with-`<script>` → rejected; `curl -I` a raw `/resources/user-images/<id>` shows `attachment` + CSP.

## Follow-up (separate)
Global CSP enforcement (flip `reportOnly:false`) is tracked separately — it's blocked on propagating a nonce to React Router streaming continuation scripts.

Audit finding: #1 (HIGH). See remediation plan.