### PR TITLE
feat(person): UI rework PR 3b — continue planning, not duplicate pools

### DIFF
--- a/app/components/users/person-surface.test.tsx
+++ b/app/components/users/person-surface.test.tsx
@@ -22,7 +22,9 @@ import {
 } from './person-surface.tsx';
 
 // Shared capture slot — the mocked <form> writes the submitted FormData here.
-const captured = vi.hoisted(() => ({ formData: undefined as FormData | undefined }));
+const captured = vi.hoisted(() => ({
+  formData: undefined as FormData | undefined,
+}));
 
 vi.mock('react-router', async (importOriginal) => {
   const actual = await importOriginal<typeof ReactRouter>();
@@ -59,7 +61,9 @@ vi.mock('react-router', async (importOriginal) => {
 });
 
 vi.mock('#app/components/ui/responsive-dialog.tsx', () => {
-  const Pass = ({ children }: { children?: React.ReactNode }) => <>{children}</>;
+  const Pass = ({ children }: { children?: React.ReactNode }) => (
+    <>{children}</>
+  );
   return {
     ResponsiveDialog: Pass,
     ResponsiveDialogContent: ({ children }: { children?: React.ReactNode }) => (
@@ -121,6 +125,7 @@ function baseData(
     wishlistSource: [],
     ideation: emptyIdeation,
     openPools: [],
+    continuePool: null,
     postOccasion: null,
     ...overrides,
   };
@@ -214,7 +219,10 @@ describe('PersonSurface form emission', () => {
     // renders a second SaveIdeaDialog and the "Idea" control is ambiguous.
     renderSurface(
       baseData({
-        ideation: { ...emptyIdeation, notes: [{ id: 'n1', body: 'Likes tea' }] },
+        ideation: {
+          ...emptyIdeation,
+          notes: [{ id: 'n1', body: 'Likes tea' }],
+        },
       }),
     );
 
@@ -251,5 +259,37 @@ describe('PersonSurface form emission', () => {
     expect(fd).toBeDefined();
     expect(fd.get('intent')).toBe('solo-commit');
     expect(fd.get('name')).toBe('Handmade mug');
+  });
+});
+
+describe('PersonSurface pool continuation (§6.3)', () => {
+  it('replaces Organize with Continue planning when an active pool exists', () => {
+    renderSurface(
+      baseData({
+        continuePool: {
+          id: 'p1',
+          title: "Casey's 30th",
+          status: 'VOTING',
+          contributorCount: 3,
+        },
+      }),
+    );
+
+    expect(
+      screen.getByRole('link', { name: /continue planning/i }),
+    ).toHaveAttribute('href', '/pools/p1');
+    expect(screen.getByText('3 friends in')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /organize/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('keeps the Organize path when no active pool exists', () => {
+    renderSurface(baseData());
+
+    expect(
+      screen.getByRole('button', { name: /organize a gift/i }),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId('continue-planning')).not.toBeInTheDocument();
   });
 });

--- a/app/components/users/person-surface.tsx
+++ b/app/components/users/person-surface.tsx
@@ -20,6 +20,7 @@ import {
 } from 'react-icons/lu';
 import { Form, Link, useFetcher, useNavigate } from 'react-router';
 import { FriendActionButton } from '#app/components/friends/friend-action-button.tsx';
+import { PoolStatusBadge } from '#app/components/pools/pool-status-badge.tsx';
 import { Avatar } from '#app/components/ui/avatar.tsx';
 import { Button } from '#app/components/ui/button.tsx';
 import { Input } from '#app/components/ui/input.tsx';
@@ -118,6 +119,14 @@ export type PersonSurfaceViewData = {
     }>;
   };
   openPools: OpenPool[];
+  // §6.3 continuation: the active pool the viewer already participates in
+  // for this recipient — when present, Organize becomes Continue planning.
+  continuePool: {
+    id: string;
+    title: string;
+    status: string;
+    contributorCount: number;
+  } | null;
   postOccasion: PostOccasion | null;
 };
 
@@ -396,7 +405,14 @@ function ActionRow({
 }) {
   return (
     <div>
-      <OrganizeButton recipientId={data.user.id} groups={data.organizeGroups} />
+      {data.continuePool ? (
+        <ContinuePlanningCard pool={data.continuePool} />
+      ) : (
+        <OrganizeButton
+          recipientId={data.user.id}
+          groups={data.organizeGroups}
+        />
+      )}
       <div className="mt-2.5 flex gap-2">
         <SoloCommitDialog
           displayName={displayName}
@@ -412,6 +428,43 @@ function ActionRow({
         />
         <DeclineButton />
       </div>
+    </div>
+  );
+}
+
+// §6.3: when a pool already exists, show a compact status/participation
+// summary with Continue planning — never a second Organize path (a
+// wrong-duplicate in a secrecy product is the worst bug class), and never
+// pool controls reproduced on the person page.
+function ContinuePlanningCard({
+  pool,
+}: {
+  pool: NonNullable<PersonSurfaceViewData['continuePool']>;
+}) {
+  return (
+    <div data-testid="continue-planning" className="rounded-xl bg-pool/10 p-4">
+      <div className="flex items-center justify-between gap-3">
+        <p className="min-w-0 truncate text-sm font-semibold">{pool.title}</p>
+        <PoolStatusBadge
+          status={
+            pool.status as Parameters<typeof PoolStatusBadge>[0]['status']
+          }
+        />
+      </div>
+      <p className="mt-1 text-xs text-muted-foreground">
+        {pool.contributorCount === 1
+          ? 'Just you so far'
+          : `${pool.contributorCount} friends in`}
+      </p>
+      <Button
+        asChild
+        className="mt-3 h-12 w-full rounded-full bg-pool text-base font-extrabold text-pool-foreground hover:bg-pool/90"
+      >
+        <Link to={`/pools/${pool.id}`} prefetch="intent">
+          <LuGift size={20} className="mr-2" />
+          Continue planning
+        </Link>
+      </Button>
     </div>
   );
 }

--- a/app/routes/users+/$username_+/index.loader.test.ts
+++ b/app/routes/users+/$username_+/index.loader.test.ts
@@ -390,3 +390,55 @@ describe('person surface loader — post-occasion memory write', () => {
     expect(result.temporalState).toBe('cold');
   });
 });
+
+describe('person surface loader — pool continuation (§6.3)', () => {
+  it('returns the active pool the viewer contributes to for this recipient', async () => {
+    const viewer = await createUserRecord();
+    const target = await createUserRecord({ birthday: soon() });
+    await makeFriends(viewer.id, target.id);
+
+    const pool = await createDecidedPool({
+      recipientId: target.id,
+      contributorIds: [viewer.id],
+      chosenName: 'Vintage camera',
+      eventDate: null,
+      status: 'VOTING',
+    });
+
+    const result = (await runLoader(viewer.id, target.username)) as any;
+    expect(result.unlocked).toBe(true);
+    expect(result.continuePool).toMatchObject({
+      id: pool.id,
+      status: 'VOTING',
+      contributorCount: 1,
+    });
+  });
+
+  it('returns null for pools the viewer is not part of and for completed pools', async () => {
+    const viewer = await createUserRecord();
+    const target = await createUserRecord({ birthday: soon() });
+    const other = await createUserRecord();
+    await makeFriends(viewer.id, target.id);
+
+    // Someone else's pool for the same recipient must not leak here…
+    await createDecidedPool({
+      recipientId: target.id,
+      contributorIds: [other.id],
+      chosenName: 'Secret pool',
+      eventDate: null,
+      status: 'OPEN',
+    });
+    // …and the viewer's own completed pool is memory, not a continuation.
+    await createDecidedPool({
+      recipientId: target.id,
+      contributorIds: [viewer.id],
+      chosenName: 'Old delivered gift',
+      eventDate: null,
+      status: 'DELIVERED',
+    });
+
+    const result = (await runLoader(viewer.id, target.username)) as any;
+    expect(result.unlocked).toBe(true);
+    expect(result.continuePool).toBeNull();
+  });
+});

--- a/app/routes/users+/$username_+/index.tsx
+++ b/app/routes/users+/$username_+/index.tsx
@@ -37,6 +37,7 @@ import {
   declineOccasion,
   getOccasionYear,
   getPersonSurfaceAccess,
+  loadContinuePool,
   loadOpenPoolsForRecipient,
   loadPersonIdeation,
   loadPersonWishlistSource,
@@ -234,13 +235,16 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
     : null;
 
   // ── Ideation block (circle-keyed reads, §7) ──
-  const [ideation, wishlistSource, openPools] = await Promise.all([
-    loadPersonIdeation(userId, user.id),
-    canViewWishlist
-      ? loadPersonWishlistSource(userId, user.id)
-      : Promise.resolve([]),
-    loadOpenPoolsForRecipient(userId, user.id),
-  ]);
+  const [ideation, wishlistSource, openPools, continuePool] = await Promise.all(
+    [
+      loadPersonIdeation(userId, user.id),
+      canViewWishlist
+        ? loadPersonWishlistSource(userId, user.id)
+        : Promise.resolve([]),
+      loadOpenPoolsForRecipient(userId, user.id),
+      loadContinuePool(userId, user.id),
+    ],
+  );
 
   return {
     unlocked: true,
@@ -260,6 +264,7 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
     wishlistSource,
     ideation,
     openPools,
+    continuePool,
     postOccasion,
   } as const;
 }
@@ -501,6 +506,7 @@ const ProfileRoute = () => {
       wishlistSource={data.wishlistSource}
       ideation={data.ideation}
       openPools={data.openPools}
+      continuePool={data.continuePool}
       postOccasion={data.postOccasion}
     />
   );

--- a/app/utils/person-surface.server.ts
+++ b/app/utils/person-surface.server.ts
@@ -7,7 +7,10 @@ import {
 } from '#app/utils/birthday.ts';
 import { prisma } from '#app/utils/db.server.ts';
 import { getRelationshipDetails } from '#app/utils/friends.server.ts';
-import { POOL_STATUS } from '#app/utils/pool-constants.ts';
+import {
+  ACTIVE_POOL_STATUSES,
+  POOL_STATUS,
+} from '#app/utils/pool-constants.ts';
 import { createPool, proposeIdea } from '#app/utils/pool.server.ts';
 
 // Post-occasion detection window (spec §4): 14 days after the occasion.
@@ -495,6 +498,43 @@ export async function loadOpenPoolsForRecipient(
     select: { id: true, title: true },
     orderBy: { createdAt: 'desc' },
   });
+}
+
+// §6.3 continuation: the pool the viewer should continue rather than
+// duplicate. Any active-status pool for this recipient that the viewer
+// contributes to — visibility is contribution-scoped, so a pool the viewer
+// isn't in never surfaces here (and the recipient can never be a
+// contributor, so their own page never leaks a concealed pool).
+export async function loadContinuePool(
+  viewerId: string,
+  targetUserId: string,
+): Promise<{
+  id: string;
+  title: string;
+  status: string;
+  contributorCount: number;
+} | null> {
+  const pool = await prisma.pool.findFirst({
+    where: {
+      recipientUserId: targetUserId,
+      status: { in: ACTIVE_POOL_STATUSES },
+      contributors: { some: { userId: viewerId } },
+    },
+    select: {
+      id: true,
+      title: true,
+      status: true,
+      _count: { select: { contributors: true } },
+    },
+    orderBy: { updatedAt: 'desc' },
+  });
+  if (!pool) return null;
+  return {
+    id: pool.id,
+    title: pool.title,
+    status: pool.status,
+    contributorCount: pool._count.contributors,
+  };
 }
 
 // Propose an idea (from the wishlist or a saved GiftListItem) into an existing


### PR DESCRIPTION
## Summary

Completes handoff §6.3's person-page contract (deferred from #502): when an active pool for this recipient exists that the viewer contributes to, the person page shows a compact status/participation summary with **Continue planning** instead of the Organize path — closing a real product bug where a returning organizer could create a duplicate pool for the same person.

- New `loadContinuePool` in the person-surface server module: most recent ACTIVE-status pool for the recipient, **contribution-scoped** (pools the viewer isn't in never surface; the recipient can never be a contributor, so concealment holds on their own page; DELIVERED/CANCELLED are memory, not continuations).
- `ContinuePlanningCard`: title + shared `PoolStatusBadge` + participation count + Continue planning → pool workspace. No pool controls reproduced on the person page. Just me / Save idea / Not this time remain available.

## Test plan

- [x] Loader integration tests: continuation returned for the viewer's active pool; someone-else's pool and the viewer's completed pool both excluded
- [x] Component tests: card replaces Organize (link → /pools/:id); Organize path intact when no pool exists
- [x] `npm run lint` 155 (baseline) / typecheck clean / unit 1391 / e2e 117, 0 skipped

## Migrations / environment

None.

https://claude.ai/code/session_01JohGjBa3mo3NvVXdkGjX6W