### PR TITLE
feat(pools): UI rework PR 4b — stage-adaptive workspace

### DIFF
--- a/app/components/home/home-surfaces.test.tsx
+++ b/app/components/home/home-surfaces.test.tsx
@@ -214,10 +214,10 @@ describe('home surface components', () => {
       ],
     });
 
-    expect(screen.getByText('Open')).toBeInTheDocument();
-    expect(screen.getByText('Decided')).toBeInTheDocument();
-    expect(screen.getByText('Voting')).toBeInTheDocument();
-    expect(screen.getByText('Purchased')).toBeInTheDocument();
+    expect(screen.getByText('Collect ideas')).toBeInTheDocument();
+    expect(screen.getByText('Buy the gift')).toBeInTheDocument();
+    expect(screen.getByText('Choose the gift')).toBeInTheDocument();
+    expect(screen.getByText('Deliver it')).toBeInTheDocument();
   });
 
   it('pool card shows formatted event date when eventDate is non-null', () => {

--- a/app/components/pools/pool-status-badge.tsx
+++ b/app/components/pools/pool-status-badge.tsx
@@ -1,13 +1,15 @@
 import { cn } from '#app/utils/misc.tsx';
 import {
-  POOL_STATUS_LABELS,
+  POOL_STAGE_LABELS,
   type PoolStatus,
 } from '#app/utils/pool-constants.ts';
 
-// Shared pool status presentation (handoff §9 "Pool stage indicator" seam).
-// Semantic roles: teal = coordination underway, amber = waiting on people,
-// green = decision made, muted = historical. Labels always accompany color,
-// so two waiting states may share amber. Dark values flip via the tokens.
+// Shared pool stage indicator (handoff §9 seam). Consumer surfaces show the
+// task-oriented Pool Stage names (Collect ideas / Choose the gift / …), the
+// one user-facing mapping per §10.4. Semantic roles: teal = coordination
+// underway, amber = waiting on people, green = decision made, muted =
+// historical. Labels always accompany color, so two waiting states may
+// share amber. Dark values flip via the tokens.
 export const poolStatusBadgeClasses: Record<PoolStatus, string> = {
   OPEN: 'bg-pool/15 text-pool',
   VOTING: 'bg-warning-muted text-warning',
@@ -31,6 +33,6 @@ export const PoolStatusBadge = ({
       className,
     )}
   >
-    {POOL_STATUS_LABELS[status]}
+    {POOL_STAGE_LABELS[status]}
   </span>
 );

--- a/app/routes/groups+/$giftGroupId_+/index.test.tsx
+++ b/app/routes/groups+/$giftGroupId_+/index.test.tsx
@@ -362,7 +362,7 @@ describe('group detail overview route', () => {
     expect(screen.getByText("Marco's Birthday")).toBeInTheDocument();
     expect(screen.getByText(/birthday for/i)).toBeInTheDocument();
     expect(screen.getByText('May 3')).toBeInTheDocument();
-    expect(screen.getByText('Open')).toBeInTheDocument();
+    expect(screen.getByText('Collect ideas')).toBeInTheDocument();
     expect(screen.getByText('Organizing')).toBeInTheDocument();
   });
 

--- a/app/routes/pools+/$poolId+/_layout.test.tsx
+++ b/app/routes/pools+/$poolId+/_layout.test.tsx
@@ -77,7 +77,7 @@ describe('app/routes/pools+/$poolId+/_layout.tsx', () => {
     expect(
       screen.getByText((_, element) => element?.textContent === 'Birthday for Alex'),
     ).toBeInTheDocument();
-    expect(screen.getByText('Voting')).toBeInTheDocument();
+    expect(screen.getByText('Choose the gift')).toBeInTheDocument();
     expect(
       screen.getByRole('button', { name: 'Important' }),
     ).toBeInTheDocument();

--- a/app/routes/pools+/$poolId+/index.test.tsx
+++ b/app/routes/pools+/$poolId+/index.test.tsx
@@ -310,6 +310,35 @@ describe('app/routes/pools+/$poolId+/index.tsx', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('Buy stage shows the available-budget-vs-price comparison', () => {
+    loaderDataSnapshot.pool.status = 'DECIDED';
+    loaderDataSnapshot.pool.chosenIdeaId = 'idea-1';
+    loaderDataSnapshot.pool.finalPriceCents = 10000;
+    loaderDataSnapshot.availableBudgetCents = 7500;
+    loaderDataSnapshot.viewer.userId = 'viewer-1';
+
+    renderRoute();
+
+    const card = screen.getByTestId('budget-vs-price');
+    expect(card).toHaveTextContent('$75.00 of $100.00 gift price');
+  });
+
+  it('hides the budget comparison without a price or without any limits set', () => {
+    loaderDataSnapshot.pool.status = 'DECIDED';
+    loaderDataSnapshot.pool.chosenIdeaId = 'idea-1';
+    loaderDataSnapshot.pool.finalPriceCents = null;
+    loaderDataSnapshot.availableBudgetCents = 7500;
+
+    const { unmount } = renderRoute();
+    expect(screen.queryByTestId('budget-vs-price')).not.toBeInTheDocument();
+    unmount();
+
+    loaderDataSnapshot.pool.finalPriceCents = 10000;
+    loaderDataSnapshot.availableBudgetCents = 0;
+    renderRoute();
+    expect(screen.queryByTestId('budget-vs-price')).not.toBeInTheDocument();
+  });
+
   it('Complete stage: memory leads, history collapses, settled settlement hidden (§6.5)', () => {
     loaderDataSnapshot.pool.status = 'DELIVERED';
     loaderDataSnapshot.pool.chosenIdeaId = 'idea-1';

--- a/app/routes/pools+/$poolId+/index.test.tsx
+++ b/app/routes/pools+/$poolId+/index.test.tsx
@@ -310,6 +310,50 @@ describe('app/routes/pools+/$poolId+/index.tsx', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('Complete stage: memory leads, history collapses, settled settlement hidden (§6.5)', () => {
+    loaderDataSnapshot.pool.status = 'DELIVERED';
+    loaderDataSnapshot.pool.chosenIdeaId = 'idea-1';
+    loaderDataSnapshot.pool.finalPriceCents = 2500;
+    loaderDataSnapshot.pool.purchaserId = 'buyer-1';
+    loaderDataSnapshot.viewer.userId = 'viewer-1';
+    loaderDataSnapshot.contributionBreakdown = {
+      kind: 'contributor',
+      viewerShare: { owedCents: 1200, hasPaid: true },
+      shortfallCents: 0,
+      allReceived: true,
+    };
+
+    renderRoute();
+
+    // Factual memory leads.
+    expect(screen.getByTestId('gift-memory-summary')).toBeInTheDocument();
+    // Prior work is collapsed into history, not gone.
+    expect(screen.getByTestId('pool-history')).toBeInTheDocument();
+    expect(screen.getByText('How it came together')).toBeInTheDocument();
+    // Settled settlement is inside history only (nothing operationally
+    // pending), so the share card is not shown at the top level twice.
+    expect(screen.getAllByTestId('viewer-share-card')).toHaveLength(1);
+  });
+
+  it('Complete stage keeps unsettled shares visible outside history', () => {
+    loaderDataSnapshot.pool.status = 'DELIVERED';
+    loaderDataSnapshot.pool.chosenIdeaId = 'idea-1';
+    loaderDataSnapshot.pool.finalPriceCents = 2500;
+    loaderDataSnapshot.pool.purchaserId = 'buyer-1';
+    loaderDataSnapshot.viewer.userId = 'viewer-1';
+    loaderDataSnapshot.contributionBreakdown = {
+      kind: 'contributor',
+      viewerShare: { owedCents: 1200, hasPaid: false },
+      shortfallCents: 0,
+      allReceived: false,
+    };
+
+    renderRoute();
+
+    expect(screen.getByTestId('gift-memory-summary')).toBeInTheDocument();
+    expect(screen.getByTestId('viewer-share-card')).toBeInTheDocument();
+  });
+
   it('renders the decided purchaser UI with contribution breakdown and role assignment', () => {
     loaderDataSnapshot.pool.status = 'DECIDED';
     loaderDataSnapshot.pool.chosenIdeaId = 'idea-1';

--- a/app/routes/pools+/$poolId+/index.tsx
+++ b/app/routes/pools+/$poolId+/index.tsx
@@ -867,6 +867,96 @@ const PoolIndex = () => {
 
   const navigation = useNavigation();
 
+  // ── Stage-adaptive composition (§6.5): the shell is stable, the main
+  // column changes by stage. In Complete, factual memory dominates and the
+  // operational sections collapse into history.
+  const chosenBanner = chosenIdea ? (
+    <ChosenGiftBanner
+      idea={chosenIdea}
+      finalPriceCents={pool.finalPriceCents}
+      poolId={pool.id}
+      canManage={canManage}
+    />
+  ) : null;
+
+  const settlementPending = contributionBreakdown
+    ? contributionBreakdown.kind === 'purchaser'
+      ? contributionBreakdown.breakdown.some((b) => !b.hasPaid)
+      : contributionBreakdown.viewerShare?.hasPaid === false
+    : false;
+
+  const settlement = contributionBreakdown ? (
+    <ContributionBreakdown
+      breakdown={contributionBreakdown}
+      poolId={pool.id}
+      purchaserName={
+        pool.purchaser ? (pool.purchaser.name ?? pool.purchaser.username) : null
+      }
+    />
+  ) : null;
+
+  const ideasRecap =
+    !isActive && pool.ideas.length > 1 ? (
+      <Card className="overflow-hidden p-0">
+        <div className="px-4 pb-2 pt-4">
+          <SectionHeading>Other ideas that were proposed</SectionHeading>
+        </div>
+        <div className="divide-y">
+          {pool.ideas
+            .filter((i) => i.id !== pool.chosenIdeaId)
+            .map((idea) => (
+              <div
+                key={idea.id}
+                className="flex items-center justify-between px-4 py-2.5 opacity-60"
+              >
+                <Text size="sm">{idea.name}</Text>
+                {idea.estimatedPriceCents !== null && (
+                  <Text
+                    size="xs"
+                    className="shrink-0 pl-3 text-muted-foreground"
+                  >
+                    {formatCents(idea.estimatedPriceCents)}
+                  </Text>
+                )}
+              </div>
+            ))}
+        </div>
+      </Card>
+    ) : null;
+
+  const contributorsSection = (
+    <ContributorsList
+      contributors={pool.contributors}
+      poolId={pool.id}
+      viewerUserId={viewer?.userId ?? ''}
+      viewerContributionCents={viewer?.contributionCents ?? null}
+      availableBudgetCents={availableBudgetCents}
+      organizerId={pool.organizerId}
+      purchaserId={pool.purchaserId}
+      delivererId={pool.delivererId}
+      canManage={canManage}
+      isDecided={isDecided || isPurchased || isDelivered}
+      reminderAction={
+        canManage && isActive && organizerReminderStates.CONTRIBUTION ? (
+          <OrganizerReminderAction
+            availability={organizerReminderStates.CONTRIBUTION}
+            kind="CONTRIBUTION"
+            poolId={pool.id}
+            poolTitle={pool.title}
+            senderDisplayName={senderDisplayName}
+            className="items-end"
+          />
+        ) : undefined
+      }
+    />
+  );
+
+  const recipientLabel =
+    pool.recipientName ??
+    pool.recipientUser?.name ??
+    pool.recipientUser?.username ??
+    null;
+
   return (
     <Stack gap={6}>
       {/* ── Organizer controls — only shown when there's a voting action to take ── */}
@@ -911,14 +1001,53 @@ const PoolIndex = () => {
           </Card>
         )}
 
-      {/* ── Chosen gift (DECIDED+) ── */}
-      {chosenIdea && (
-        <ChosenGiftBanner
-          idea={chosenIdea}
-          finalPriceCents={pool.finalPriceCents}
-          poolId={pool.id}
-          canManage={canManage}
-        />
+      {/* ── Chosen gift (Buy/Deliver stages) ── */}
+      {!isDelivered && chosenBanner}
+
+      {/* ── Buy stage: Available Budget vs the gift's price (§6.5 — the
+            price is the denominator; never a pool goal). ── */}
+      {isDecided &&
+        pool.finalPriceCents !== null &&
+        availableBudgetCents > 0 && (
+          <Card className="p-4" data-testid="budget-vs-price">
+            <div className="flex items-baseline justify-between gap-3 text-sm">
+              <span className="text-muted-foreground">Available together</span>
+              <span className="font-semibold">
+                {formatCents(availableBudgetCents)} of{' '}
+                {formatCents(pool.finalPriceCents)} gift price
+              </span>
+            </div>
+            <div className="mt-2 h-1.5 w-full overflow-hidden rounded-full bg-muted">
+              <div
+                className="h-full rounded-full bg-pool"
+                style={{
+                  width: `${Math.min(100, Math.round((availableBudgetCents / pool.finalPriceCents) * 100))}%`,
+                }}
+              />
+            </div>
+          </Card>
+        )}
+
+      {/* ── Complete: factual Gift Memory leads (§6.5) ── */}
+      {isDelivered && (
+        <Card className="p-5" data-testid="gift-memory-summary">
+          <Stack gap={2}>
+            <SectionHeading>Gift memory</SectionHeading>
+            <p className="text-base font-semibold">
+              {chosenIdea?.name ?? pool.title}
+            </p>
+            <p className="text-sm text-muted-foreground">
+              {recipientLabel ? `Given to ${recipientLabel}` : 'Given'}
+              {pool.finalPriceCents !== null
+                ? ` · ${formatCents(pool.finalPriceCents)}`
+                : ''}
+              {' · '}
+              {pool.contributors.length === 1
+                ? 'a solo gift'
+                : `${pool.contributors.length} gave together`}
+            </p>
+          </Stack>
+        </Card>
       )}
 
       {/* ── Purchaser CTA — right after the chosen gift so it's the next action ── */}
@@ -961,18 +1090,9 @@ const PoolIndex = () => {
           </Card>
         )}
 
-      {/* ── Contribution breakdown (DECIDED+) ── */}
-      {contributionBreakdown && (
-        <ContributionBreakdown
-          breakdown={contributionBreakdown}
-          poolId={pool.id}
-          purchaserName={
-            pool.purchaser
-              ? (pool.purchaser.name ?? pool.purchaser.username)
-              : null
-          }
-        />
-      )}
+      {/* ── Settlement — inline until Complete; after delivery it stays
+            visible only while operationally necessary (something unpaid). ── */}
+      {(!isDelivered || settlementPending) && settlement}
 
       {/* ── Deliverer CTA — shown after purchase is confirmed ── */}
       {isPurchased && isDeliverer && (
@@ -1071,60 +1191,27 @@ const PoolIndex = () => {
         </Stack>
       )}
 
-      {/* ── Ideas recap (DECIDED+, non-chosen ideas) ── */}
-      {!isActive && pool.ideas.length > 1 && (
-        <Card className="overflow-hidden p-0">
-          <div className="px-4 pb-2 pt-4">
-            <SectionHeading>Other ideas that were proposed</SectionHeading>
-          </div>
-          <div className="divide-y">
-            {pool.ideas
-              .filter((i) => i.id !== pool.chosenIdeaId)
-              .map((idea) => (
-                <div
-                  key={idea.id}
-                  className="flex items-center justify-between px-4 py-2.5 opacity-60"
-                >
-                  <Text size="sm">{idea.name}</Text>
-                  {idea.estimatedPriceCents !== null && (
-                    <Text
-                      size="xs"
-                      className="shrink-0 pl-3 text-muted-foreground"
-                    >
-                      {formatCents(idea.estimatedPriceCents)}
-                    </Text>
-                  )}
-                </div>
-              ))}
-          </div>
-        </Card>
-      )}
+      {/* ── Operational sections — inline until Complete ── */}
+      {!isDelivered && ideasRecap}
+      {!isDelivered && contributorsSection}
 
-      {/* ── Contributors ── */}
-      <ContributorsList
-        contributors={pool.contributors}
-        poolId={pool.id}
-        viewerUserId={viewer?.userId ?? ''}
-        viewerContributionCents={viewer?.contributionCents ?? null}
-        availableBudgetCents={availableBudgetCents}
-        organizerId={pool.organizerId}
-        purchaserId={pool.purchaserId}
-        delivererId={pool.delivererId}
-        canManage={canManage}
-        isDecided={isDecided || isPurchased || isDelivered}
-        reminderAction={
-          canManage && isActive && organizerReminderStates.CONTRIBUTION ? (
-            <OrganizerReminderAction
-              availability={organizerReminderStates.CONTRIBUTION}
-              kind="CONTRIBUTION"
-              poolId={pool.id}
-              poolTitle={pool.title}
-              senderDisplayName={senderDisplayName}
-              className="items-end"
-            />
-          ) : undefined
-        }
-      />
+      {/* ── Complete: prior work collapses into history (§6.5) ── */}
+      {isDelivered && (
+        <details
+          className="rounded-xl border border-border/60"
+          data-testid="pool-history"
+        >
+          <summary className="cursor-pointer select-none px-4 py-3 text-sm font-semibold text-muted-foreground">
+            How it came together
+          </summary>
+          <Stack gap={4} className="px-4 pb-4 pt-1">
+            {chosenBanner}
+            {!settlementPending && settlement}
+            {ideasRecap}
+            {contributorsSection}
+          </Stack>
+        </details>
+      )}
 
       {/* ── Assign roles (organizer, DECIDED+, while roles still need setting) ── */}
       {canManage && (isDecided || isPurchased) && (

--- a/app/routes/pools+/$poolId+/index.tsx
+++ b/app/routes/pools+/$poolId+/index.tsx
@@ -505,6 +505,77 @@ const ChosenGiftBanner = ({
   );
 };
 
+// Flat settlement check (viewer-scoped breakdown from the loader).
+function hasPendingSettlement(
+  breakdown: LoaderData['contributionBreakdown'],
+): boolean {
+  if (!breakdown) return false;
+  if (breakdown.kind === 'purchaser') {
+    return breakdown.breakdown.some((b) => !b.hasPaid);
+  }
+  return breakdown.viewerShare?.hasPaid === false;
+}
+
+// Buy stage (§6.5): Available Budget compared against the gift's price — the
+// price is the denominator, never a pool goal. Single teal fill.
+const BuyBudgetComparison = ({
+  availableBudgetCents,
+  finalPriceCents,
+}: {
+  availableBudgetCents: number;
+  finalPriceCents: number | null;
+}) => {
+  if (finalPriceCents === null || availableBudgetCents <= 0) return null;
+  return (
+    <Card className="p-4" data-testid="budget-vs-price">
+      <div className="flex items-baseline justify-between gap-3 text-sm">
+        <span className="text-muted-foreground">Available together</span>
+        <span className="font-semibold">
+          {formatCents(availableBudgetCents)} of {formatCents(finalPriceCents)}{' '}
+          gift price
+        </span>
+      </div>
+      <div className="mt-2 h-1.5 w-full overflow-hidden rounded-full bg-muted">
+        <div
+          className="h-full rounded-full bg-pool"
+          style={{
+            width: `${Math.min(100, Math.round((availableBudgetCents / finalPriceCents) * 100))}%`,
+          }}
+        />
+      </div>
+    </Card>
+  );
+};
+
+// Complete stage (§6.5): factual memory — gift, recipient, price, headcount.
+// Never invented recipient sentiment.
+const GiftMemorySummary = ({
+  giftName,
+  recipientLabel,
+  finalPriceCents,
+  contributorCount,
+}: {
+  giftName: string;
+  recipientLabel: string | null;
+  finalPriceCents: number | null;
+  contributorCount: number;
+}) => (
+  <Card className="p-5" data-testid="gift-memory-summary">
+    <Stack gap={2}>
+      <SectionHeading>Gift memory</SectionHeading>
+      <p className="text-base font-semibold">{giftName}</p>
+      <p className="text-sm text-muted-foreground">
+        {recipientLabel ? `Given to ${recipientLabel}` : 'Given'}
+        {finalPriceCents !== null ? ` · ${formatCents(finalPriceCents)}` : ''}
+        {' · '}
+        {contributorCount === 1
+          ? 'a solo gift'
+          : `${contributorCount} gave together`}
+      </p>
+    </Stack>
+  </Card>
+);
+
 // Contribution breakdown (shown when DECIDED+). The purchaser sees every
 // share and Received status owed to them; every other contributor sees only
 // their own share (ADR 0001 — payment coordination is private between
@@ -879,11 +950,7 @@ const PoolIndex = () => {
     />
   ) : null;
 
-  const settlementPending = contributionBreakdown
-    ? contributionBreakdown.kind === 'purchaser'
-      ? contributionBreakdown.breakdown.some((b) => !b.hasPaid)
-      : contributionBreakdown.viewerShare?.hasPaid === false
-    : false;
+  const settlementPending = hasPendingSettlement(contributionBreakdown);
 
   const settlement = contributionBreakdown ? (
     <ContributionBreakdown
@@ -1004,50 +1071,22 @@ const PoolIndex = () => {
       {/* ── Chosen gift (Buy/Deliver stages) ── */}
       {!isDelivered && chosenBanner}
 
-      {/* ── Buy stage: Available Budget vs the gift's price (§6.5 — the
-            price is the denominator; never a pool goal). ── */}
-      {isDecided &&
-        pool.finalPriceCents !== null &&
-        availableBudgetCents > 0 && (
-          <Card className="p-4" data-testid="budget-vs-price">
-            <div className="flex items-baseline justify-between gap-3 text-sm">
-              <span className="text-muted-foreground">Available together</span>
-              <span className="font-semibold">
-                {formatCents(availableBudgetCents)} of{' '}
-                {formatCents(pool.finalPriceCents)} gift price
-              </span>
-            </div>
-            <div className="mt-2 h-1.5 w-full overflow-hidden rounded-full bg-muted">
-              <div
-                className="h-full rounded-full bg-pool"
-                style={{
-                  width: `${Math.min(100, Math.round((availableBudgetCents / pool.finalPriceCents) * 100))}%`,
-                }}
-              />
-            </div>
-          </Card>
-        )}
+      {/* ── Buy stage: Available Budget vs the gift's price (§6.5) ── */}
+      {isDecided && (
+        <BuyBudgetComparison
+          availableBudgetCents={availableBudgetCents}
+          finalPriceCents={pool.finalPriceCents}
+        />
+      )}
 
       {/* ── Complete: factual Gift Memory leads (§6.5) ── */}
       {isDelivered && (
-        <Card className="p-5" data-testid="gift-memory-summary">
-          <Stack gap={2}>
-            <SectionHeading>Gift memory</SectionHeading>
-            <p className="text-base font-semibold">
-              {chosenIdea?.name ?? pool.title}
-            </p>
-            <p className="text-sm text-muted-foreground">
-              {recipientLabel ? `Given to ${recipientLabel}` : 'Given'}
-              {pool.finalPriceCents !== null
-                ? ` · ${formatCents(pool.finalPriceCents)}`
-                : ''}
-              {' · '}
-              {pool.contributors.length === 1
-                ? 'a solo gift'
-                : `${pool.contributors.length} gave together`}
-            </p>
-          </Stack>
-        </Card>
+        <GiftMemorySummary
+          giftName={chosenIdea?.name ?? pool.title}
+          recipientLabel={recipientLabel}
+          finalPriceCents={pool.finalPriceCents}
+          contributorCount={pool.contributors.length}
+        />
       )}
 
       {/* ── Purchaser CTA — right after the chosen gift so it's the next action ── */}

--- a/app/routes/pools+/index.test.tsx
+++ b/app/routes/pools+/index.test.tsx
@@ -195,11 +195,11 @@ describe('app/routes/pools+/index.tsx', () => {
       screen.getByText((_, element) => element?.textContent === 'Birthday for Alex'),
     ).toBeInTheDocument();
     expect(screen.getByText('June 14, 2026')).toBeInTheDocument();
-    expect(screen.getByText('Open')).toBeInTheDocument();
+    expect(screen.getByText('Collect ideas')).toBeInTheDocument();
 
     // Switch to Past tab — shows completed pool
     fireEvent.click(screen.getByRole('tab', { name: /^Past/ }));
-    expect(screen.getByText('Delivered')).toBeInTheDocument();
+    expect(screen.getByText('Complete')).toBeInTheDocument();
     expect(screen.getByText('Family')).toBeInTheDocument();
   });
 });

--- a/app/utils/analytics.server.ts
+++ b/app/utils/analytics.server.ts
@@ -245,6 +245,17 @@ export async function logClientEnvironmentObservation({
  * callers that genuinely need the persisted row before returning — e.g.
  * the `api.analytics` endpoint, which fans out from a `sendBeacon`.
  */
+// In-flight background writes, so tests can drain them before resetting the
+// database — an un-awaited create colliding with cleanup's DELETE transaction
+// produced CI-only failures in whichever test ran next. Negligible runtime
+// cost in production (one Set add/delete per queued event).
+const inFlightWrites = new Set<Promise<unknown>>();
+
+/** Await every queued background write (test hook — see db-setup). */
+export async function drainQueuedAnalytics(): Promise<void> {
+  await Promise.allSettled([...inFlightWrites]);
+}
+
 export function queueLogEvent(input: LogEventInput): { eventId: string } {
   // Run validation synchronously so misuse surfaces as a fast throw in dev
   // instead of a silent Sentry-only failure.
@@ -253,9 +264,11 @@ export function queueLogEvent(input: LogEventInput): { eventId: string } {
     throw new Error(`userId is required for analytics event "${input.name}"`);
   }
   const eventId = input.eventId ?? randomUUID();
-  void logEvent({ ...input, eventId }).catch((error: unknown) => {
+  const write = logEvent({ ...input, eventId }).catch((error: unknown) => {
     captureException(error);
   });
+  inFlightWrites.add(write);
+  void write.finally(() => inFlightWrites.delete(write));
   return { eventId };
 }
 

--- a/app/utils/pool-constants.ts
+++ b/app/utils/pool-constants.ts
@@ -2,90 +2,104 @@
 // Flow: OPEN → (VOTING) → DECIDED → PURCHASED → DELIVERED
 //                                              ↘ CANCELLED (from any stage)
 export const POOL_STATUS = {
-	OPEN: 'OPEN',
-	VOTING: 'VOTING',
-	DECIDED: 'DECIDED',
-	PURCHASED: 'PURCHASED',
-	DELIVERED: 'DELIVERED',
-	CANCELLED: 'CANCELLED',
-} as const
+  OPEN: 'OPEN',
+  VOTING: 'VOTING',
+  DECIDED: 'DECIDED',
+  PURCHASED: 'PURCHASED',
+  DELIVERED: 'DELIVERED',
+  CANCELLED: 'CANCELLED',
+} as const;
 
-export type PoolStatus = (typeof POOL_STATUS)[keyof typeof POOL_STATUS]
+export type PoolStatus = (typeof POOL_STATUS)[keyof typeof POOL_STATUS];
 
 export const POOL_STATUS_LABELS: Record<PoolStatus, string> = {
-	OPEN: 'Open',
-	VOTING: 'Voting',
-	DECIDED: 'Decided',
-	PURCHASED: 'Purchased',
-	DELIVERED: 'Delivered',
-	CANCELLED: 'Cancelled',
-}
+  OPEN: 'Open',
+  VOTING: 'Voting',
+  DECIDED: 'Decided',
+  PURCHASED: 'Purchased',
+  DELIVERED: 'Delivered',
+  CANCELLED: 'Cancelled',
+};
+
+// User-facing Pool Stages (glossary/handoff §10.4) — the ONE mapping from
+// internal statuses to the accepted task-oriented stage names. Consumer
+// surfaces use these; POOL_STATUS_LABELS above stays for the internal
+// vocabulary (admin/calm-operations density). "Cancelled" is a separate
+// terminal state, not a stage; contributor joining is not a stage.
+export const POOL_STAGE_LABELS: Record<PoolStatus, string> = {
+  OPEN: 'Collect ideas',
+  VOTING: 'Choose the gift',
+  DECIDED: 'Buy the gift',
+  PURCHASED: 'Deliver it',
+  DELIVERED: 'Complete',
+  CANCELLED: 'Cancelled',
+};
 
 // Which statuses allow contributors to still interact (propose ideas, vote, etc.)
 export const ACTIVE_POOL_STATUSES: PoolStatus[] = [
-	POOL_STATUS.OPEN,
-	POOL_STATUS.VOTING,
-	POOL_STATUS.DECIDED,
-	POOL_STATUS.PURCHASED,
-]
+  POOL_STATUS.OPEN,
+  POOL_STATUS.VOTING,
+  POOL_STATUS.DECIDED,
+  POOL_STATUS.PURCHASED,
+];
 
 // Decision mode — how the pool arrives at a chosen gift.
 export const DECISION_MODE = {
-	ORGANIZER_PICKS: 'ORGANIZER_PICKS',
-	VOTE: 'VOTE',
-} as const
+  ORGANIZER_PICKS: 'ORGANIZER_PICKS',
+  VOTE: 'VOTE',
+} as const;
 
-export type DecisionMode = (typeof DECISION_MODE)[keyof typeof DECISION_MODE]
+export type DecisionMode = (typeof DECISION_MODE)[keyof typeof DECISION_MODE];
 
 export const DECISION_MODE_LABELS: Record<DecisionMode, string> = {
-	ORGANIZER_PICKS: 'Organizer chooses',
-	VOTE: 'Group vote',
-}
+  ORGANIZER_PICKS: 'Organizer chooses',
+  VOTE: 'Group vote',
+};
 
 // Occasion type — what the pool is celebrating.
 export const OCCASION_TYPE = {
-	BIRTHDAY: 'BIRTHDAY',
-	ANNIVERSARY: 'ANNIVERSARY',
-	WEDDING: 'WEDDING',
-	FAREWELL: 'FAREWELL',
-	GRADUATION: 'GRADUATION',
-	HOLIDAY: 'HOLIDAY',
-	OTHER: 'OTHER',
-} as const
+  BIRTHDAY: 'BIRTHDAY',
+  ANNIVERSARY: 'ANNIVERSARY',
+  WEDDING: 'WEDDING',
+  FAREWELL: 'FAREWELL',
+  GRADUATION: 'GRADUATION',
+  HOLIDAY: 'HOLIDAY',
+  OTHER: 'OTHER',
+} as const;
 
-export type OccasionType = (typeof OCCASION_TYPE)[keyof typeof OCCASION_TYPE]
+export type OccasionType = (typeof OCCASION_TYPE)[keyof typeof OCCASION_TYPE];
 
 export const OCCASION_TYPE_LABELS: Record<OccasionType, string> = {
-	BIRTHDAY: 'Birthday',
-	ANNIVERSARY: 'Anniversary',
-	WEDDING: 'Wedding',
-	FAREWELL: 'Farewell',
-	GRADUATION: 'Graduation',
-	HOLIDAY: 'Holiday',
-	OTHER: 'Other',
-}
+  BIRTHDAY: 'Birthday',
+  ANNIVERSARY: 'Anniversary',
+  WEDDING: 'Wedding',
+  FAREWELL: 'Farewell',
+  GRADUATION: 'Graduation',
+  HOLIDAY: 'Holiday',
+  OTHER: 'Other',
+};
 
 // Activity event types — used in the PoolActivity audit log.
 export const POOL_ACTIVITY_TYPE = {
-	POOL_CREATED: 'pool.created',
-	POOL_UPDATED: 'pool.updated',
-	POOL_CANCELLED: 'pool.cancelled',
-	POOL_DELETED: 'pool.deleted',
-	CONTRIBUTOR_JOINED: 'contributor.joined',
-	CONTRIBUTOR_LEFT: 'contributor.left',
-	CONTRIBUTOR_REMOVED: 'contributor.removed',
-	CONTRIBUTOR_UPDATED: 'contributor.updated',
-	IDEA_PROPOSED: 'idea.proposed',
-	IDEA_DELETED: 'idea.deleted',
-	VOTE_CALLED: 'vote.called',
-	VOTE_CAST: 'vote.cast',
-	VOTE_CLOSED: 'vote.closed',
-	IDEA_CHOSEN: 'idea.chosen',
-	PURCHASER_ASSIGNED: 'purchaser.assigned',
-	DELIVERER_ASSIGNED: 'deliverer.assigned',
-	MARKED_PURCHASED: 'pool.purchased',
-	MARKED_DELIVERED: 'pool.delivered',
-} as const
+  POOL_CREATED: 'pool.created',
+  POOL_UPDATED: 'pool.updated',
+  POOL_CANCELLED: 'pool.cancelled',
+  POOL_DELETED: 'pool.deleted',
+  CONTRIBUTOR_JOINED: 'contributor.joined',
+  CONTRIBUTOR_LEFT: 'contributor.left',
+  CONTRIBUTOR_REMOVED: 'contributor.removed',
+  CONTRIBUTOR_UPDATED: 'contributor.updated',
+  IDEA_PROPOSED: 'idea.proposed',
+  IDEA_DELETED: 'idea.deleted',
+  VOTE_CALLED: 'vote.called',
+  VOTE_CAST: 'vote.cast',
+  VOTE_CLOSED: 'vote.closed',
+  IDEA_CHOSEN: 'idea.chosen',
+  PURCHASER_ASSIGNED: 'purchaser.assigned',
+  DELIVERER_ASSIGNED: 'deliverer.assigned',
+  MARKED_PURCHASED: 'pool.purchased',
+  MARKED_DELIVERED: 'pool.delivered',
+} as const;
 
 export type PoolActivityType =
-	(typeof POOL_ACTIVITY_TYPE)[keyof typeof POOL_ACTIVITY_TYPE]
+  (typeof POOL_ACTIVITY_TYPE)[keyof typeof POOL_ACTIVITY_TYPE];

--- a/tests/db-utils.ts
+++ b/tests/db-utils.ts
@@ -70,14 +70,20 @@ export async function cleanupDb(prisma: PrismaClient) {
   >`SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' AND name NOT LIKE '_prisma_migrations';`;
 
   try {
-    // Disable FK constraints to avoid relation conflicts during deletion,
-    // and wait out transient SQLITE_BUSY from still-settling background
-    // writes instead of failing — a failed cleanup console.errors, which the
-    // console-error guard turns into a spurious failure of the NEXT test.
-    // queryRaw, not executeRaw: this PRAGMA returns the new value as a row.
+    // Wait out transient SQLITE_BUSY from still-settling background writes
+    // instead of failing — a failed cleanup console.errors, and the strict
+    // console-error guard turns that into a spurious failure of the NEXT
+    // test. (queryRaw, not executeRaw: this PRAGMA returns a row.)
     await prisma.$queryRawUnsafe(`PRAGMA busy_timeout = 5000`);
-    await prisma.$executeRawUnsafe(`PRAGMA foreign_keys = OFF`);
     await prisma.$transaction([
+      // FK handling must live INSIDE the transaction: Prisma pools
+      // connections, so a standalone `PRAGMA foreign_keys = OFF` can run on
+      // a different connection than the deletes — the nondeterministic
+      // "Error cleaning up database: FOREIGN KEY constraint failed" in CI.
+      // defer_foreign_keys works within a transaction (checks run at
+      // commit, by which point every table is empty) and auto-resets on
+      // commit — the same approach Prisma's generated SQLite migrations use.
+      prisma.$executeRawUnsafe(`PRAGMA defer_foreign_keys = ON`),
       // Delete all rows from each table, preserving table structures
       ...tables.map(({ name }) =>
         prisma.$executeRawUnsafe(`DELETE from "${name}"`),
@@ -85,7 +91,5 @@ export async function cleanupDb(prisma: PrismaClient) {
     ]);
   } catch (error) {
     console.error('Error cleaning up database:', error);
-  } finally {
-    await prisma.$executeRawUnsafe(`PRAGMA foreign_keys = ON`);
   }
 }

--- a/tests/db-utils.ts
+++ b/tests/db-utils.ts
@@ -70,7 +70,12 @@ export async function cleanupDb(prisma: PrismaClient) {
   >`SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' AND name NOT LIKE '_prisma_migrations';`;
 
   try {
-    // Disable FK constraints to avoid relation conflicts during deletion
+    // Disable FK constraints to avoid relation conflicts during deletion,
+    // and wait out transient SQLITE_BUSY from still-settling background
+    // writes instead of failing — a failed cleanup console.errors, which the
+    // console-error guard turns into a spurious failure of the NEXT test.
+    // queryRaw, not executeRaw: this PRAGMA returns the new value as a row.
+    await prisma.$queryRawUnsafe(`PRAGMA busy_timeout = 5000`);
     await prisma.$executeRawUnsafe(`PRAGMA foreign_keys = OFF`);
     await prisma.$transaction([
       // Delete all rows from each table, preserving table structures

--- a/tests/e2e/dashboard.test.ts
+++ b/tests/e2e/dashboard.test.ts
@@ -116,7 +116,7 @@ test.describe('dashboard', () => {
       await expect(
         page.getByRole('link', { name: /Summer Pool/i }),
       ).toBeVisible();
-      await expect(page.getByText('Open')).toBeVisible();
+      await expect(page.getByText('Collect ideas')).toBeVisible();
       await expect(page.getByText('Jun 14')).toBeVisible();
     } finally {
       await prisma.pool.deleteMany({ where: { id: { in: createdPoolIds } } });

--- a/tests/e2e/nav-chrome.test.ts
+++ b/tests/e2e/nav-chrome.test.ts
@@ -54,42 +54,74 @@ test.describe('navigation chrome', () => {
       const friendRows = page.getByTestId('friend-row');
 
       await expect(topBar).toHaveAttribute('data-hidden', 'false');
+      await expect(friendRows.first()).toBeVisible({ timeout: 10000 });
 
-      await scrollArea.evaluate((el) =>
-        el.scrollTo({ top: 900, behavior: 'auto' }),
-      );
+      // The hide/show listener attaches in a client useEffect — a single
+      // scrollTo fired before hydration completes is lost forever (the
+      // CI-only line-65 timeout). Re-drive the scroll gesture inside the
+      // poll so a late listener catches a later iteration. Two rAFs between
+      // positions force two distinct scroll events (a lone jump can coalesce
+      // into a delta-0 no-op against the previous iteration's position).
+      const scrollGesture = (from: number, to: number) =>
+        scrollArea.evaluate(
+          async (el, positions) => {
+            el.scrollTop = positions.from;
+            await new Promise((resolve) =>
+              requestAnimationFrame(() => requestAnimationFrame(resolve)),
+            );
+            el.scrollTop = positions.to;
+            await new Promise((resolve) =>
+              requestAnimationFrame(() => requestAnimationFrame(resolve)),
+            );
+          },
+          { from, to },
+        );
+
       await expect
-        .poll(async () => topBar.evaluate((node) => node.dataset.hidden), {
-          message: 'top bar should hide after scrolling down',
-        })
+        .poll(
+          async () => {
+            await scrollGesture(700, 900); // downward delta → hide
+            return topBar.evaluate((node) => node.dataset.hidden);
+          },
+          { message: 'top bar should hide after scrolling down' },
+        )
         .toBe('true');
 
-      await scrollArea.evaluate((el) =>
-        el.scrollTo({ top: 50, behavior: 'auto' }),
-      );
       await expect
-        .poll(async () => topBar.evaluate((node) => node.dataset.hidden), {
-          message: 'top bar should reappear after scrolling up',
-        })
+        .poll(
+          async () => {
+            await scrollGesture(900, 50); // upward delta → reveal
+            return topBar.evaluate((node) => node.dataset.hidden);
+          },
+          { message: 'top bar should reappear after scrolling up' },
+        )
         .toBe('false');
 
-      await expect(friendRows.first()).toBeVisible({ timeout: 10000 });
-      await friendRows.last().scrollIntoViewIfNeeded();
-
-      const nav = page.getByTestId('bottom-nav');
-      const [navBox, lastFriendBox] = await Promise.all([
-        nav.boundingBox(),
-        friendRows.last().boundingBox(),
-      ]);
-
-      expect(navBox).not.toBeNull();
-      expect(lastFriendBox).not.toBeNull();
-
-      if (navBox && lastFriendBox) {
-        const navTop = navBox.y;
-        const friendBottom = lastFriendBox.y + lastFriendBox.height;
-        expect(friendBottom - navTop).toBeLessThanOrEqual(1);
-      }
+      // Measure both rects in ONE evaluate (project rule: separate awaited
+      // boundingBox() calls get invalidated by hydration-driven layout
+      // shifts like the PWA install banner) — and poll it, since the banner
+      // can land mid-assertion.
+      await expect
+        .poll(
+          () =>
+            page.evaluate(() => {
+              const rows = Array.from(
+                document.querySelectorAll('[data-testid="friend-row"]'),
+              );
+              const last = rows[rows.length - 1] as HTMLElement | undefined;
+              const nav = document.querySelector(
+                '[data-testid="bottom-nav"]',
+              ) as HTMLElement | null;
+              if (!last || !nav) return Number.POSITIVE_INFINITY;
+              last.scrollIntoView({ block: 'end' });
+              return (
+                last.getBoundingClientRect().bottom -
+                nav.getBoundingClientRect().top
+              );
+            }),
+          { message: 'bottom nav should sit below the last friend row' },
+        )
+        .toBeLessThanOrEqual(1);
 
       // Scroll deep, navigate away, and confirm scroll resets to top
       await scrollArea.evaluate((el) =>

--- a/tests/setup/db-setup.ts
+++ b/tests/setup/db-setup.ts
@@ -25,6 +25,19 @@ beforeAll(async () => {
 // we *must* use dynamic imports here so the process.env.DATABASE_URL is set
 // before prisma is imported and initialized
 afterEach(async () => {
+  // Drain fire-and-forget analytics writes BEFORE deleting rows — an
+  // in-flight create colliding with the cleanup transaction logs a prisma
+  // error mid-flight and the console-error guard then fails whichever test
+  // runs next (the CI-only rotating-victim flake).
+  // try/catch rather than optional chaining: files that vi.mock the
+  // analytics module get a proxy that THROWS on missing-export access — and
+  // a mocked module has no real queued writes to drain anyway.
+  try {
+    const analytics = await import('#app/utils/analytics.server.ts');
+    await analytics.drainQueuedAnalytics();
+  } catch {
+    // Module mocked without the drain hook — nothing real in flight.
+  }
   await cleanupDb(getPrisma());
 });
 

--- a/tests/setup/setup-test-env.ts
+++ b/tests/setup/setup-test-env.ts
@@ -4,6 +4,13 @@ process.env.LITEFS_DIR ??= '/tmp';
 process.env.SESSION_SECRET ??= 'SESSION_SECRET';
 process.env.INTERNAL_COMMAND_TOKEN ??= 'INTERNAL_COMMAND_TOKEN';
 process.env.HONEYPOT_SECRET ??= 'HONEYPOT_SECRET';
+// Emails in tests must go through the MSW resend mock. Without a key,
+// sendEmail's fallback branch calls console.error — and because email fanout
+// is fire-and-forget, that async tail lands during whichever test happens to
+// be running and its console-error guard fails it. Locally .env supplies a
+// key via dotenv below; CI has no .env, which made this a CI-only,
+// random-victim flake (the "dismisses one mute cycle" failures).
+process.env.RESEND_API_KEY ??= 'test-resend-key';
 process.env.DATABASE_PATH ??= `./tests/prisma/data.${process.env.VITEST_POOL_ID || 0}.db`;
 process.env.CACHE_DATABASE_PATH ??= `./tests/prisma/cache.${process.env.VITEST_POOL_ID || 0}.db`;
 


### PR DESCRIPTION
## Summary

The visual half of the Groups-and-Pools milestone (handoff §6.5/§10.4), on top of the privacy projections from #504.

- **User-facing Pool Stages**: `POOL_STAGE_LABELS` is the single §10.4 mapping (Collect ideas / Choose the gift / Buy the gift / Deliver it / Complete — Cancelled separate, joining is not a stage); the shared badge speaks stages on all consumer surfaces while admin keeps the internal vocabulary.
- **Buy stage**: Available Budget vs gift price comparison — the gift's price as denominator, never a pool goal, single teal fill per the no-gradient-progress rule.
- **Complete stage**: factual Gift Memory leads; chosen-gift banner, settled settlement, ideas recap, and contributors collapse into a `<details>` "How it came together" history. Unsettled shares stay visible outside history (payment status only where operationally necessary). Nothing is removed — collapsed, not dropped.
- OPEN→PURCHASED ordering was already stage-dominant (organizer controls → ideas → contributors; chosen gift → purchaser CTA → settlement → delivery), so those stages needed no reordering — recorded in the capability inventory.

## Test plan

- [x] 2 new Complete-stage unit tests (memory leads + history collapses; unsettled share stays surfaced)
- [x] Stage-label assertions updated across home/pools/groups unit suites + dashboard e2e
- [x] Unit 1396 / e2e 117, 0 skipped / lint 155 baseline / typecheck clean

## Migrations / environment

None.

https://claude.ai/code/session_01JohGjBa3mo3NvVXdkGjX6W