### PR TITLE
fix(settings): UI rework PR 6 — responsive-dialog + token fixes

### DIFF
--- a/app/components/notifications/context-notification-controls.tsx
+++ b/app/components/notifications/context-notification-controls.tsx
@@ -114,7 +114,7 @@ export function ContextNotificationControl({
           className={cn(
             'inline-flex min-h-11 items-center gap-1.5 rounded-full border px-3 text-sm font-medium outline-none ring-ring focus-visible:ring-2',
             awareness.notificationOff
-              ? 'border-amber-300 bg-amber-50 text-amber-900 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-100'
+              ? 'border-warning/30 bg-warning-muted text-warning'
               : 'border-border bg-background text-foreground hover:bg-muted',
           )}
           aria-label={`Notifications for ${contextLabel}: ${displayLabel}`}
@@ -319,7 +319,7 @@ export function ContextNotificationAwarenessNotice({
     inheritedFromLabel,
   );
   return (
-    <div className="flex gap-3 rounded-xl border border-amber-300 bg-amber-50 px-3 py-3 text-amber-950 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-100">
+    <div className="flex gap-3 rounded-xl border border-warning/30 bg-warning-muted px-3 py-3 text-warning">
       <LuBellOff className="mt-1 h-5 w-5 shrink-0" aria-hidden="true" />
       <div className="min-w-0 flex-1">
         <p className="font-medium">{copy.title}</p>

--- a/app/routes/settings+/__danger-zone-delete-dialog.tsx
+++ b/app/routes/settings+/__danger-zone-delete-dialog.tsx
@@ -1,17 +1,17 @@
 import { useEffect, useState } from 'react';
 import { useFetcher } from 'react-router';
 import { Button } from '#app/components/ui/button.tsx';
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '#app/components/ui/dialog.tsx';
 import { Icon } from '#app/components/ui/icon.tsx';
 import { Input } from '#app/components/ui/input.tsx';
 import { Label } from '#app/components/ui/label.tsx';
+import {
+  ResponsiveDialog as Dialog,
+  ResponsiveDialogContent as DialogContent,
+  ResponsiveDialogDescription as DialogDescription,
+  ResponsiveDialogFooter as DialogFooter,
+  ResponsiveDialogHeader as DialogHeader,
+  ResponsiveDialogTitle as DialogTitle,
+} from '#app/components/ui/responsive-dialog.tsx';
 import { StatusButton } from '#app/components/ui/status-button.tsx';
 
 type DangerZoneDeleteDialogProps = Readonly<{

--- a/app/routes/settings+/__profile-photo-sheet.tsx
+++ b/app/routes/settings+/__profile-photo-sheet.tsx
@@ -11,13 +11,13 @@ import { useFetcher } from 'react-router';
 import { Button, buttonVariants } from '#app/components/ui/button.tsx';
 import { Icon } from '#app/components/ui/icon.tsx';
 import {
-  MobileBottomSheet,
-  MobileBottomSheetContent,
-  MobileBottomSheetDescription,
-  MobileBottomSheetFooter,
-  MobileBottomSheetHeader,
-  MobileBottomSheetTitle,
-} from '#app/components/ui/mobile-bottom-sheet.tsx';
+  ResponsiveDialog as MobileBottomSheet,
+  ResponsiveDialogContent as MobileBottomSheetContent,
+  ResponsiveDialogDescription as MobileBottomSheetDescription,
+  ResponsiveDialogFooter as MobileBottomSheetFooter,
+  ResponsiveDialogHeader as MobileBottomSheetHeader,
+  ResponsiveDialogTitle as MobileBottomSheetTitle,
+} from '#app/components/ui/responsive-dialog.tsx';
 import { StatusButton } from '#app/components/ui/status-button.tsx';
 import { cn, getUserImgSrc, useDoubleCheck } from '#app/utils/misc.tsx';
 import {


### PR DESCRIPTION
## Summary

Part of the app-wide UI rework (see `docs/product/giftpool-ui-rework-handoff.md` §6.8, §PR 6). The capability inventory for this milestone found that the bulk of "effective notification-policy UI" was already shipped in an earlier milestone — `ContextNotificationControl` and `ContextNotificationAwarenessNotice` (`app/components/notifications/context-notification-controls.tsx`) already provide the full Group/Pool activity-level picker, inherited-from-group copy, reset-to-parent, and dismissible awareness notices, wired up on both the Group and Pool page headers. The rest of the settings surface (profile hub, privacy, account, change-email, password, two-factor, danger zone) was also already using semantic tokens and `ResponsiveDialog`-composed primitives correctly.

Three real gaps remained, and this PR fixes them:

- **Hard-rule fix**: `__danger-zone-delete-dialog.tsx` (the typed-confirmation "delete my account" dialog) used the raw `Dialog` primitive directly — centered at every width, no bottom sheet on mobile. Now goes through `ResponsiveDialog`.
- **Hard-rule fix**: `__profile-photo-sheet.tsx` (avatar upload/crop UI) used `MobileBottomSheet` directly and unconditionally — always a bottom sheet, even on desktop ≥640px. Now goes through `ResponsiveDialog`, so desktop gets a centered dialog.
- **Token fix**: `context-notification-controls.tsx` had two raw `amber-*` color blocks (the "notifications off" trigger-button state and the dismissible awareness-notice banner) instead of the shared `warning`/`warning-muted` semantic tokens used everywhere else in the app for this state.

Both `ResponsiveDialog` swaps alias the import to match each file's existing JSX naming (`as Dialog`/`as DialogContent` for the delete dialog, `as MobileBottomSheet`/etc. for the photo sheet), so no JSX changed — only what the tags render to.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` — 0 errors, 155 warnings (at baseline)
- [x] `npm test -- --run` — 1425/1425 unit tests pass, including the three directly-touched component test files (`__profile-photo-sheet.test.tsx`, `__danger-zone-delete-dialog.test.tsx`, `context-notification-controls.test.tsx`)
- [x] `npm run test:e2e:run` — 117/117 e2e specs pass, full suite
- [x] Ad hoc Playwright visual sweep — light + dark × 390/1280: danger-zone dialog and photo sheet render as a bottom sheet (with drag handle) at 390px and a centered dialog at 1280px in both themes; the pool notification control and muted-inherited awareness notice render with the new `warning` token consistently in light and dark

https://claude.ai/code/session_01JohGjBa3mo3NvVXdkGjX6W