### PR TITLE
fix(ops): UI rework PR 7 — admin/error-system tokens, ResponsiveDialog audit, terminology

### DIFF
--- a/app/components/error-boundary.test.tsx
+++ b/app/components/error-boundary.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import { type ComponentProps } from 'react';
+import { createRoutesStub } from 'react-router';
+import { describe, expect, it, vi } from 'vitest';
+import { testConsole } from '#tests/setup/setup-test-env.ts';
+import { ErrorFallback, GeneralErrorBoundary } from './error-boundary.tsx';
+
+const captureException = vi.fn();
+vi.mock('@sentry/react-router', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    captureException: (...args: Array<unknown>) => captureException(...args),
+  };
+});
+
+function renderAtRoute(loader: () => never) {
+  const Stub = createRoutesStub([
+    {
+      path: '/',
+      loader,
+      Component: () => null,
+      ErrorBoundary: () => <GeneralErrorBoundary />,
+    },
+  ]);
+  return render(<Stub initialEntries={['/']} />);
+}
+
+// ErrorFallback renders a react-router <Link>, which needs a Router context
+// — render it via createRoutesStub rather than a bare render().
+function renderFallback(props: ComponentProps<typeof ErrorFallback>) {
+  const Stub = createRoutesStub([
+    { path: '/', Component: () => <ErrorFallback {...props} /> },
+  ]);
+  return render(<Stub initialEntries={['/']} />);
+}
+
+describe('ErrorFallback', () => {
+  it('renders an icon, title, description, and a link back home', () => {
+    renderFallback({
+      icon: 'magnifying-glass',
+      title: "We can't find this page",
+      description: 'It may have moved or never existed.',
+    });
+
+    expect(
+      screen.getByRole('heading', { name: "We can't find this page" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('It may have moved or never existed.'),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Back to home' })).toHaveAttribute(
+      'href',
+      '/',
+    );
+  });
+
+  it('omits the description paragraph when none is given', () => {
+    renderFallback({ icon: 'lock-closed', title: 'Not allowed' });
+
+    expect(screen.getByRole('heading', { name: 'Not allowed' })).toBeInTheDocument();
+    expect(
+      screen.queryByText('It may have moved or never existed.'),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe('GeneralErrorBoundary default handlers', () => {
+  it('renders a not-found fallback for a 404 with the response body as description', async () => {
+    renderAtRoute(() => {
+      throw new Response('That page does not exist.', { status: 404 });
+    });
+
+    expect(
+      await screen.findByRole('heading', { name: "We can't find this page" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('That page does not exist.')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Back to home' })).toBeInTheDocument();
+  });
+
+  it('renders a generic fallback naming the status code for other error responses', async () => {
+    renderAtRoute(() => {
+      throw new Response('Server had a bad day.', { status: 500 });
+    });
+
+    expect(
+      await screen.findByRole('heading', { name: 'Something went wrong (500)' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Server had a bad day.')).toBeInTheDocument();
+  });
+
+  it('renders the generic unexpected-error fallback for thrown non-Response errors', async () => {
+    testConsole.error.mockImplementation(() => {});
+
+    renderAtRoute(() => {
+      throw new Error('boom');
+    });
+
+    expect(
+      await screen.findByRole('heading', { name: 'Something went wrong' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Please try again, or head back home.'),
+    ).toBeInTheDocument();
+    expect(captureException).toHaveBeenCalled();
+  });
+
+  it('still honors a caller-provided statusHandlers override', async () => {
+    const Stub = createRoutesStub([
+      {
+        path: '/',
+        loader() {
+          throw new Response('nope', { status: 404 });
+        },
+        Component: () => null,
+        ErrorBoundary: () => (
+          <GeneralErrorBoundary
+            statusHandlers={{
+              404: () => <p>Custom not-found copy</p>,
+            }}
+          />
+        ),
+      },
+    ]);
+    render(<Stub initialEntries={['/']} />);
+
+    expect(await screen.findByText('Custom not-found copy')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { name: "We can't find this page" }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/app/components/error-boundary.tsx
+++ b/app/components/error-boundary.tsx
@@ -3,24 +3,65 @@ import { useEffect } from 'react';
 import {
   type ErrorResponse,
   isRouteErrorResponse,
+  Link,
   useParams,
   useRouteError,
 } from 'react-router';
-import { getErrorMessage } from '#app/utils/misc.tsx';
+import { Icon } from '#app/components/ui/icon.tsx';
 
 type StatusHandler = (info: {
   error: ErrorResponse;
   params: Record<string, string | undefined>;
 }) => JSX.Element | null;
 
+export const ErrorFallback = ({
+  icon,
+  title,
+  description,
+}: {
+  icon: 'magnifying-glass' | 'question-mark-circled' | 'lock-closed' | 'clock';
+  title: string;
+  description?: string;
+}) => (
+  <div className="flex flex-col items-center gap-4 text-center">
+    <Icon name={icon} className="h-10 w-10 text-muted-foreground" />
+    <div className="flex flex-col gap-2">
+      <h1 className="text-h3">{title}</h1>
+      {description ? (
+        <p className="text-body-md text-muted-foreground">{description}</p>
+      ) : null}
+    </div>
+    <Link
+      to="/"
+      className="text-body-md font-medium text-primary underline underline-offset-4"
+    >
+      Back to home
+    </Link>
+  </div>
+);
+
 export const GeneralErrorBoundary = ({
   defaultStatusHandler = ({ error }) => (
-    <p>
-      {error.status} {error.data}
-    </p>
+    <ErrorFallback
+      icon={error.status === 404 ? 'magnifying-glass' : 'question-mark-circled'}
+      title={
+        error.status === 404
+          ? "We can't find this page"
+          : `Something went wrong (${error.status})`
+      }
+      description={
+        typeof error.data === 'string' ? error.data : undefined
+      }
+    />
   ),
   statusHandlers,
-  unexpectedErrorHandler = (error) => <p>{getErrorMessage(error)}</p>,
+  unexpectedErrorHandler = () => (
+    <ErrorFallback
+      icon="question-mark-circled"
+      title="Something went wrong"
+      description="Please try again, or head back home."
+    />
+  ),
 }: {
   defaultStatusHandler?: StatusHandler;
   statusHandlers?: Record<number, StatusHandler>;
@@ -41,7 +82,7 @@ export const GeneralErrorBoundary = ({
   }, [error]);
 
   return (
-    <div className="container flex items-center justify-center p-20 text-h2">
+    <div className="container flex min-h-[50vh] items-center justify-center p-8">
       {isRouteErrorResponse(error)
         ? (statusHandlers?.[error.status] ?? defaultStatusHandler)({
             error,

--- a/app/components/feedback/feedback-form.tsx
+++ b/app/components/feedback/feedback-form.tsx
@@ -83,7 +83,7 @@ export const FeedbackForm = ({
         )}
         role="status"
       >
-        <LuCircleCheck className="h-10 w-10 text-green-500" aria-hidden />
+        <LuCircleCheck className="h-10 w-10 text-success" aria-hidden />
         <p className="text-body-md font-semibold">Thanks for the feedback!</p>
         <p className="text-sm text-muted-foreground">
           We read every message. If you left an email, we&apos;ll be in touch.

--- a/app/components/feedback/feedback-widget.tsx
+++ b/app/components/feedback/feedback-widget.tsx
@@ -2,13 +2,13 @@ import { useState } from 'react';
 import { LuMessageSquarePlus } from 'react-icons/lu';
 import { useLocation } from 'react-router';
 import {
-  MobileBottomSheet,
-  MobileBottomSheetContent,
-  MobileBottomSheetDescription,
-  MobileBottomSheetHeader,
-  MobileBottomSheetTitle,
-  MobileBottomSheetTrigger,
-} from '#app/components/ui/mobile-bottom-sheet.tsx';
+  ResponsiveDialog as MobileBottomSheet,
+  ResponsiveDialogContent as MobileBottomSheetContent,
+  ResponsiveDialogDescription as MobileBottomSheetDescription,
+  ResponsiveDialogHeader as MobileBottomSheetHeader,
+  ResponsiveDialogTitle as MobileBottomSheetTitle,
+  ResponsiveDialogTrigger as MobileBottomSheetTrigger,
+} from '#app/components/ui/responsive-dialog.tsx';
 import { FeedbackForm } from './feedback-form.tsx';
 
 // Routes where a floating "give feedback" button would be redundant or get in
@@ -34,8 +34,9 @@ export const FeedbackWidget = () => {
   if (suppressed) return null;
 
   return (
-    // MobileBottomSheet renders a bottom sheet on mobile and a centered dialog
-    // on desktop — the preferred mobile pattern for transient content.
+    // ResponsiveDialog (aliased as MobileBottomSheet) renders a bottom sheet on
+    // mobile and a centered dialog on desktop — the preferred mobile pattern
+    // for transient content.
     <MobileBottomSheet open={open} onOpenChange={setOpen}>
       {/* Lives in the top-bar cluster next to the bell/theme/avatar — a
           secondary-weight icon, not a floating FAB. A floating button at the

--- a/app/components/forms.tsx
+++ b/app/components/forms.tsx
@@ -58,7 +58,7 @@ export const Field = ({
       <Label htmlFor={id} {...labelProps}>
         {labelProps.children}
         {inputProps.required && (
-          <span className="ml-1 text-red-500" aria-hidden="true">
+          <span className="ml-1 text-muted-foreground" aria-hidden="true">
             *
           </span>
         )}

--- a/app/components/friends/friend-action-button.test.tsx
+++ b/app/components/friends/friend-action-button.test.tsx
@@ -55,23 +55,25 @@ vi.mock('#app/components/ui/dropdown-menu.tsx', () => ({
   ),
 }));
 
-vi.mock('#app/components/ui/dialog.tsx', () => ({
-  Dialog: ({ children }: { children: React.ReactNode }) => (
+vi.mock('#app/components/ui/responsive-dialog.tsx', () => ({
+  ResponsiveDialog: ({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
   ),
-  DialogContent: ({ children }: { children: React.ReactNode }) => (
+  ResponsiveDialogContent: ({ children }: { children: React.ReactNode }) => (
     <div role="dialog">{children}</div>
   ),
-  DialogDescription: ({ children }: { children: React.ReactNode }) => (
+  ResponsiveDialogDescription: ({
+    children,
+  }: {
+    children: React.ReactNode;
+  }) => <div>{children}</div>,
+  ResponsiveDialogFooter: ({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
   ),
-  DialogFooter: ({ children }: { children: React.ReactNode }) => (
+  ResponsiveDialogHeader: ({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
   ),
-  DialogHeader: ({ children }: { children: React.ReactNode }) => (
-    <div>{children}</div>
-  ),
-  DialogTitle: ({ children }: { children: React.ReactNode }) => (
+  ResponsiveDialogTitle: ({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
   ),
 }));

--- a/app/components/friends/friend-action-button.tsx
+++ b/app/components/friends/friend-action-button.tsx
@@ -4,19 +4,19 @@ import { toast } from 'sonner';
 import { useNotificationsStore } from '#app/components/notifications/notifications-context.tsx';
 import { Button, type ButtonProps } from '#app/components/ui/button.tsx';
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '#app/components/ui/dialog.tsx';
-import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '#app/components/ui/dropdown-menu.tsx';
+import {
+  ResponsiveDialog as Dialog,
+  ResponsiveDialogContent as DialogContent,
+  ResponsiveDialogDescription as DialogDescription,
+  ResponsiveDialogFooter as DialogFooter,
+  ResponsiveDialogHeader as DialogHeader,
+  ResponsiveDialogTitle as DialogTitle,
+} from '#app/components/ui/responsive-dialog.tsx';
 import { type RelationshipState } from '#app/utils/friends.ts';
 import {
   dispatchFriendshipUpdate,

--- a/app/components/friends/friend-row.tsx
+++ b/app/components/friends/friend-row.tsx
@@ -12,20 +12,20 @@ import { Avatar } from '#app/components/ui/avatar.tsx';
 import { Button } from '#app/components/ui/button.tsx';
 import { Card } from '#app/components/ui/card.tsx';
 import {
-  Dialog,
-  DialogClose,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '#app/components/ui/dialog.tsx';
-import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '#app/components/ui/dropdown-menu.tsx';
+import {
+  ResponsiveDialog as Dialog,
+  ResponsiveDialogClose as DialogClose,
+  ResponsiveDialogContent as DialogContent,
+  ResponsiveDialogDescription as DialogDescription,
+  ResponsiveDialogFooter as DialogFooter,
+  ResponsiveDialogHeader as DialogHeader,
+  ResponsiveDialogTitle as DialogTitle,
+} from '#app/components/ui/responsive-dialog.tsx';
 import {
   BIRTHDAY_VISIBILITY_DAYS,
   formatBirthdayLabel,

--- a/app/components/groups/RoleBadge.tsx
+++ b/app/components/groups/RoleBadge.tsx
@@ -9,13 +9,13 @@ const roleMeta: Record<
 > = {
   OWNER: {
     label: 'owner',
-    icon: <LuCrown className="text-amber-300" />,
+    icon: <LuCrown className="text-warning" />,
     bg: 'bg-primary',
     text: 'text-primary-foreground',
   },
   ADMIN: {
     label: 'admin',
-    icon: <LuShield className="text-blue-500" />,
+    icon: <LuShield />,
     bg: 'bg-muted',
     text: 'text-muted-foreground',
   },

--- a/app/components/groups/member-actions-menu.test.tsx
+++ b/app/components/groups/member-actions-menu.test.tsx
@@ -72,24 +72,28 @@ vi.mock('#app/components/ui/mobile-bottom-sheet.tsx', () => ({
   }) => <div>{children}</div>,
 }));
 
-vi.mock('#app/components/ui/dialog.tsx', () => ({
-  Dialog: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  DialogContent: ({ children }: { children: React.ReactNode }) => (
+vi.mock('#app/components/ui/responsive-dialog.tsx', () => ({
+  ResponsiveDialog: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  ResponsiveDialogContent: ({ children }: { children: React.ReactNode }) => (
     <div role="dialog">{children}</div>
   ),
-  DialogHeader: ({ children }: { children: React.ReactNode }) => (
+  ResponsiveDialogHeader: ({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
   ),
-  DialogTitle: ({ children }: { children: React.ReactNode }) => (
+  ResponsiveDialogTitle: ({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
   ),
-  DialogDescription: ({ children }: { children: React.ReactNode }) => (
+  ResponsiveDialogDescription: ({
+    children,
+  }: {
+    children: React.ReactNode;
+  }) => <div>{children}</div>,
+  ResponsiveDialogFooter: ({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
   ),
-  DialogFooter: ({ children }: { children: React.ReactNode }) => (
-    <div>{children}</div>
-  ),
-  DialogClose: ({ children }: { children: React.ReactNode }) => (
+  ResponsiveDialogClose: ({ children }: { children: React.ReactNode }) => (
     <>{children}</>
   ),
 }));

--- a/app/components/groups/member-actions-menu.tsx
+++ b/app/components/groups/member-actions-menu.tsx
@@ -10,15 +10,6 @@ import { useFetcher } from 'react-router';
 import { Avatar } from '#app/components/ui/avatar.tsx';
 import { Button } from '#app/components/ui/button.tsx';
 import {
-  Dialog,
-  DialogClose,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '#app/components/ui/dialog.tsx';
-import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -32,6 +23,15 @@ import {
   MobileBottomSheetTitle,
   MobileBottomSheetTrigger,
 } from '#app/components/ui/mobile-bottom-sheet.tsx';
+import {
+  ResponsiveDialog as Dialog,
+  ResponsiveDialogClose as DialogClose,
+  ResponsiveDialogContent as DialogContent,
+  ResponsiveDialogDescription as DialogDescription,
+  ResponsiveDialogFooter as DialogFooter,
+  ResponsiveDialogHeader as DialogHeader,
+  ResponsiveDialogTitle as DialogTitle,
+} from '#app/components/ui/responsive-dialog.tsx';
 import {
   type MemberMenuAction,
   memberMenuActions,
@@ -153,7 +153,7 @@ export function MemberActionsMenu({
                   key={action}
                   className={cn(
                     'gap-2 px-2 py-2 text-sm',
-                    meta.destructive && 'text-red-600 focus:text-red-700',
+                    meta.destructive && 'text-destructive focus:text-destructive',
                   )}
                   onSelect={(event) => {
                     // preventDefault stops Radix's own close+focus-restore from
@@ -217,7 +217,7 @@ export function MemberActionsMenu({
                   type="button"
                   className={cn(
                     'flex w-full items-center gap-3.5 px-5 py-4 text-left text-base font-medium transition-colors hover:bg-muted',
-                    meta.destructive ? 'text-red-600' : 'text-foreground',
+                    meta.destructive ? 'text-destructive' : 'text-foreground',
                   )}
                   onClick={() => {
                     setSheetOpen(false);

--- a/app/components/pools/organizer-reminder-action.tsx
+++ b/app/components/pools/organizer-reminder-action.tsx
@@ -451,7 +451,7 @@ function OrganizerReminderSendOutcome({
   return (
     <>
       <ResponsiveDialogHeader>
-        <div className="mb-2 flex h-10 w-10 items-center justify-center rounded-full bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300">
+        <div className="mb-2 flex h-10 w-10 items-center justify-center rounded-full bg-success-muted text-success">
           <LuCheck className="h-5 w-5" aria-hidden />
         </div>
         <ResponsiveDialogTitle>Reminder queued</ResponsiveDialogTitle>

--- a/app/components/ui/responsive-dialog.tsx
+++ b/app/components/ui/responsive-dialog.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext } from 'react';
+import { createContext, forwardRef, useContext } from 'react';
 import { useIsDesktop } from '#app/components/wishlist/hooks/use-is-desktop.ts';
 import {
   Dialog,
@@ -44,14 +44,19 @@ export function ResponsiveDialog(props: React.ComponentProps<typeof Dialog>) {
   );
 }
 
-export function ResponsiveDialogTrigger(
-  props: React.ComponentProps<typeof DialogTrigger>,
-) {
+// forwardRef so this composes with other asChild ref-consumers (e.g. a
+// Tooltip wrapping the dialog trigger) — Slot cloning attaches a ref
+// directly to whatever renders here.
+export const ResponsiveDialogTrigger = forwardRef<
+  React.ElementRef<typeof DialogTrigger>,
+  React.ComponentPropsWithoutRef<typeof DialogTrigger>
+>((props, ref) => {
   const Cmp = useContext(IsDesktopContext)
     ? DialogTrigger
     : MobileBottomSheetTrigger;
-  return <Cmp {...props} />;
-}
+  return <Cmp ref={ref} {...props} />;
+});
+ResponsiveDialogTrigger.displayName = 'ResponsiveDialogTrigger';
 
 export function ResponsiveDialogContent(
   props: React.ComponentProps<typeof DialogContent>,

--- a/app/components/users/person-surface.tsx
+++ b/app/components/users/person-surface.tsx
@@ -510,7 +510,7 @@ function OrganizeButton({
       <Dialog open={pickerOpen} onOpenChange={setPickerOpen}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Organize with which circle?</DialogTitle>
+            <DialogTitle>Organize with which group?</DialogTitle>
             <DialogDescription>
               Your call, every time — we never pick for you.
             </DialogDescription>
@@ -1418,7 +1418,7 @@ function PostOccasionFlow({
           </span>
           <div className="min-w-0 flex-1">
             <div className="text-[13.5px] font-extrabold">
-              The circle's pool — recorded
+              The group's pool — recorded
             </div>
             <div className="mt-px text-xs font-semibold text-muted-foreground">
               {postOccasion.recordedGroupPoolName} · saved to memory

--- a/app/components/users/profile-header.tsx
+++ b/app/components/users/profile-header.tsx
@@ -75,7 +75,7 @@ export function ProfileHeader({
         <div className="flex flex-wrap items-center justify-center gap-2">
           {birthdayLabel ? (
             <span
-              className="inline-flex items-center gap-1.5 rounded-full bg-amber-100 px-3 py-1 text-xs font-semibold text-amber-900 ring-1 ring-inset ring-amber-200"
+              className="inline-flex items-center gap-1.5 rounded-full bg-warning-muted px-3 py-1 text-xs font-semibold text-warning ring-1 ring-inset ring-warning/20"
               aria-label={`Birthday ${birthdayLabel}`}
             >
               <LuCake className="h-3.5 w-3.5" aria-hidden />

--- a/app/components/wishlist/wishlist-share-dialog.tsx
+++ b/app/components/wishlist/wishlist-share-dialog.tsx
@@ -6,23 +6,15 @@ import { toast } from 'sonner';
 import { useToast } from '#app/components/toaster.tsx';
 import { Badge } from '#app/components/ui/badge';
 import { Button } from '#app/components/ui/button';
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from '#app/components/ui/dialog';
 import { Input } from '#app/components/ui/input';
 import {
-  MobileBottomSheet,
-  MobileBottomSheetContent,
-  MobileBottomSheetDescription,
-  MobileBottomSheetHeader,
-  MobileBottomSheetTitle,
-  MobileBottomSheetTrigger,
-} from '#app/components/ui/mobile-bottom-sheet';
+  ResponsiveDialog as Dialog,
+  ResponsiveDialogContent as DialogContent,
+  ResponsiveDialogDescription as DialogDescription,
+  ResponsiveDialogHeader as DialogHeader,
+  ResponsiveDialogTitle as DialogTitle,
+  ResponsiveDialogTrigger as DialogTrigger,
+} from '#app/components/ui/responsive-dialog';
 import {
   Tooltip,
   TooltipContent,
@@ -33,7 +25,6 @@ import { type action as shareAction } from '#app/routes/wishlist+/share';
 import { useOptionalRequestInfo } from '#app/utils/request-info.ts';
 
 import { Stack } from '../ui-kit';
-import { useIsDesktop } from './hooks/use-is-desktop';
 
 type WishlistPublicShare = { token: string; createdAt: Date };
 
@@ -285,7 +276,6 @@ export const WishlistShareDialog = ({
 
   const hasPublicLink = Boolean(activeShare);
   const [confirmingRevoke, setConfirmingRevoke] = useState(false);
-  const isDesktop = useIsDesktop();
   const handleCopyPrivateLink = () => copyLink(privateLink, 'private');
   const handleCopyPublicLink = () => copyLink(publicLink, 'public');
   const handleStartRevoke = () => setConfirmingRevoke(true);
@@ -338,52 +328,25 @@ export const WishlistShareDialog = ({
     </>
   );
 
-  if (isDesktop) {
-    return (
-      <Dialog open={open} onOpenChange={setOpen}>
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <DialogTrigger asChild>{triggerButton}</DialogTrigger>
-            </TooltipTrigger>
-            <TooltipContent className="text-xs">Share wishlist</TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
-        <DialogContent className="sm:max-w-lg">
-          <DialogHeader>
-            <DialogTitle>Share wishlist</DialogTitle>
-            <DialogDescription>
-              Send a private link for friends or a public view-only link.
-            </DialogDescription>
-          </DialogHeader>
-          {shareBody}
-        </DialogContent>
-      </Dialog>
-    );
-  }
-
   return (
-    <MobileBottomSheet open={open} onOpenChange={setOpen}>
+    <Dialog open={open} onOpenChange={setOpen}>
       <TooltipProvider>
         <Tooltip>
           <TooltipTrigger asChild>
-            <MobileBottomSheetTrigger asChild>
-              {triggerButton}
-            </MobileBottomSheetTrigger>
+            <DialogTrigger asChild>{triggerButton}</DialogTrigger>
           </TooltipTrigger>
           <TooltipContent className="text-xs">Share wishlist</TooltipContent>
         </Tooltip>
       </TooltipProvider>
-
-      <MobileBottomSheetContent className="sm:max-w-lg">
-        <MobileBottomSheetHeader>
-          <MobileBottomSheetTitle>Share wishlist</MobileBottomSheetTitle>
-          <MobileBottomSheetDescription>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Share wishlist</DialogTitle>
+          <DialogDescription>
             Send a private link for friends or a public view-only link.
-          </MobileBottomSheetDescription>
-        </MobileBottomSheetHeader>
+          </DialogDescription>
+        </DialogHeader>
         {shareBody}
-      </MobileBottomSheetContent>
-    </MobileBottomSheet>
+      </DialogContent>
+    </Dialog>
   );
 };

--- a/app/routes/_marketing+/about.tsx
+++ b/app/routes/_marketing+/about.tsx
@@ -122,7 +122,7 @@ const AboutRoute = () => {
 
       <section className="mt-16 rounded-xl border border-border/60 bg-card px-6 py-8 text-center">
         <LuCoffee
-          className="mx-auto h-8 w-8 text-yellow-600 dark:text-yellow-500"
+          className="mx-auto h-8 w-8 text-warning"
           aria-hidden
         />
         <h2 className="mt-3 text-lg font-semibold tracking-tight">
@@ -136,7 +136,7 @@ const AboutRoute = () => {
           href="https://buymeacoffee.com/twoplustwoone"
           target="_blank"
           rel="noopener noreferrer"
-          className="mt-4 inline-flex items-center gap-2 rounded-lg bg-yellow-500 px-5 py-2.5 text-sm font-semibold text-neutral-900 shadow-sm transition-colors hover:bg-yellow-400"
+          className="mt-4 inline-flex items-center gap-2 rounded-lg bg-warning px-5 py-2.5 text-sm font-semibold text-warning-foreground shadow-sm transition-colors hover:opacity-90"
         >
           <LuCoffee className="h-4 w-4" aria-hidden />
           Buy me a coffee

--- a/app/routes/_marketing+/support.tsx
+++ b/app/routes/_marketing+/support.tsx
@@ -69,7 +69,7 @@ const SupportRoute = () => {
       </section>
 
       <section className="mt-16">
-        <h2 className="text-center text-xl font-semibold tracking-tight md:text-2xl">
+        <h2 className="text-center text-h5">
           Frequently asked questions
         </h2>
         <dl className="mt-6 divide-y divide-border">
@@ -87,7 +87,7 @@ const SupportRoute = () => {
       </section>
 
       <section className="mt-16" id="affiliate">
-        <h2 className="text-center text-xl font-semibold tracking-tight md:text-2xl">
+        <h2 className="text-center text-h5">
           Affiliate links
         </h2>
         <p className="mx-auto mt-4 max-w-xl text-center text-body-md leading-relaxed text-muted-foreground">

--- a/app/routes/admin+/analytics.tsx
+++ b/app/routes/admin+/analytics.tsx
@@ -162,7 +162,7 @@ const EventTable = ({
     <div className="mb-3 flex items-center justify-between">
       <h3 className="text-lg font-semibold">{title}</h3>
     </div>
-    <div className="overflow-hidden rounded-md border border-border/50">
+    <div className="overflow-x-auto rounded-md border border-border/50">
       <table className="min-w-full divide-y divide-border/60">
         <thead className="bg-muted/40">
           <tr>
@@ -450,7 +450,7 @@ const BreakdownTable = ({
   rows: EnvironmentAnalytics['browsers'];
   showPercent?: boolean;
 }) => (
-  <div className="overflow-hidden rounded-md border border-border/50">
+  <div className="overflow-x-auto rounded-md border border-border/50">
     <div className="bg-muted/40 px-4 py-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
       {title}
     </div>
@@ -572,7 +572,7 @@ const DropOffSection = ({ dropOff }: { dropOff: DropOffFunnels }) => {
       {/* Invite landings → joins */}
       <div className="space-y-2">
         <h3 className="text-sm font-semibold">Invite links</h3>
-        <div className="overflow-hidden rounded-md border border-border/50">
+        <div className="overflow-x-auto rounded-md border border-border/50">
           <table className="min-w-full divide-y divide-border/60 text-sm">
             <thead className="bg-muted/40">
               <tr>
@@ -710,7 +710,7 @@ const EnrichmentSection = ({
       {/* Failure breakdown */}
       {failures.byOutcome.length > 0 ? (
         <div className="grid gap-4 lg:grid-cols-2">
-          <div className="overflow-hidden rounded-md border border-border/50">
+          <div className="overflow-x-auto rounded-md border border-border/50">
             <table className="min-w-full divide-y divide-border/60 text-sm">
               <thead className="bg-muted/40">
                 <tr>
@@ -736,7 +736,7 @@ const EnrichmentSection = ({
               </tbody>
             </table>
           </div>
-          <div className="overflow-hidden rounded-md border border-border/50">
+          <div className="overflow-x-auto rounded-md border border-border/50">
             <table className="min-w-full divide-y divide-border/60 text-sm">
               <thead className="bg-muted/40">
                 <tr>
@@ -779,7 +779,7 @@ const EnrichmentSection = ({
           />
         </div>
         {linkClicks.perDay.length > 0 ? (
-          <div className="overflow-hidden rounded-md border border-border/50">
+          <div className="overflow-x-auto rounded-md border border-border/50">
             <table className="min-w-full divide-y divide-border/60 text-sm">
               <thead className="bg-muted/40">
                 <tr>
@@ -906,7 +906,7 @@ const RetentionGrid = ({ cohorts }: { cohorts: RetentionCohort[] }) => (
 // ---------------------------------------------------------------------------
 
 const OptOutTable = ({ rows }: { rows: NotificationOptOutRow[] }) => (
-  <div className="overflow-hidden rounded-md border border-border/50">
+  <div className="overflow-x-auto rounded-md border border-border/50">
     <table className="min-w-full divide-y divide-border/60 text-sm">
       <thead className="bg-muted/40">
         <tr>

--- a/app/routes/admin+/cache.dom.test.tsx
+++ b/app/routes/admin+/cache.dom.test.tsx
@@ -4,7 +4,7 @@
 import { render, screen } from '@testing-library/react';
 import { type FormHTMLAttributes, type ReactNode } from 'react';
 import type * as ReactRouter from 'react-router';
-import { MemoryRouter } from 'react-router';
+import { createRoutesStub, data, MemoryRouter } from 'react-router';
 import { describe, expect, it, vi } from 'vitest';
 
 const loaderDataSnapshot = {
@@ -61,7 +61,7 @@ vi.mock('#app/utils/permissions.server.ts', () => ({
   requireUserWithRole: vi.fn(),
 }));
 
-import CacheAdminRoute from './cache.tsx';
+import CacheAdminRoute, { ErrorBoundary } from './cache.tsx';
 
 const renderCache = () =>
   render(
@@ -91,5 +91,30 @@ describe('admin cache page', () => {
     expect(screen.getByText('admin:overview:counts:v1')).toBeInTheDocument();
     expect(screen.getByText('admin:dropoff:v1:30')).toBeInTheDocument();
     expect(screen.getAllByRole('link', { name: 'View' })).toHaveLength(3);
+  });
+});
+
+describe('admin cache page error boundary', () => {
+  it('renders a lock icon and the permission message on a 403', async () => {
+    const Stub = createRoutesStub([
+      {
+        path: '/admin/cache',
+        loader() {
+          throw data({ message: 'Unauthorized: required role admin' }, { status: 403 });
+        },
+        Component: () => null,
+        ErrorBoundary,
+      },
+    ]);
+    render(<Stub initialEntries={['/admin/cache']} />);
+
+    expect(
+      await screen.findByRole('heading', {
+        name: 'You are not allowed to do that',
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Unauthorized: required role admin'),
+    ).toBeInTheDocument();
   });
 });

--- a/app/routes/admin+/cache.tsx
+++ b/app/routes/admin+/cache.tsx
@@ -25,7 +25,7 @@ import {
   SectionCard,
   SummaryCard,
 } from '#app/components/admin-ui.tsx';
-import { GeneralErrorBoundary } from '#app/components/error-boundary';
+import { ErrorFallback, GeneralErrorBoundary } from '#app/components/error-boundary';
 import { Button } from '#app/components/ui/button.tsx';
 import { Input } from '#app/components/ui/input.tsx';
 import {
@@ -317,10 +317,7 @@ const CacheKeyRow = ({
         <div className="flex flex-wrap items-center gap-2">
           <span
             className={cn(
-              'inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium',
-              type === 'sqlite'
-                ? 'bg-sky-100 text-sky-900 dark:bg-sky-950/40 dark:text-sky-200'
-                : 'bg-amber-100 text-amber-900 dark:bg-amber-950/40 dark:text-amber-200',
+              'inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground',
             )}
           >
             {type === 'sqlite' ? (
@@ -375,7 +372,11 @@ export const ErrorBoundary = () => {
     <GeneralErrorBoundary
       statusHandlers={{
         403: ({ error }) => (
-          <p>You are not allowed to do that: {error?.data.message}</p>
+          <ErrorFallback
+            icon="lock-closed"
+            title="You are not allowed to do that"
+            description={error?.data?.message}
+          />
         ),
       }}
     />

--- a/app/routes/admin+/feedback.tsx
+++ b/app/routes/admin+/feedback.tsx
@@ -178,10 +178,9 @@ const FeedbackRoute = () => {
 };
 
 const TYPE_BADGE: Record<FeedbackType, string> = {
-  BUG: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300',
-  FEATURE:
-    'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300',
-  QUESTION: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300',
+  BUG: 'bg-warning-muted text-warning',
+  FEATURE: 'bg-success-muted text-success',
+  QUESTION: 'bg-pool/15 text-pool',
 };
 
 const FeedbackCard = ({

--- a/app/routes/admin+/ops.tsx
+++ b/app/routes/admin+/ops.tsx
@@ -214,7 +214,7 @@ const OpsRoute = () => {
         </div>
       ) : null}
       {justIntent ? (
-        <div className="rounded-md border border-emerald-400/50 bg-emerald-50/60 p-3 text-sm text-emerald-900 dark:bg-emerald-950/20 dark:text-emerald-200">
+        <div className="rounded-md border border-success/40 bg-success-muted p-3 text-sm text-success">
           {INTENT_LABEL[justIntent]}: {justCount}{' '}
           {justCount === 1 ? 'row' : 'rows'}{' '}
           {justIntent === 'expire_group_bans' ? 'lifted' : 'deleted'}.
@@ -289,7 +289,7 @@ const OpsRoute = () => {
                         </span>
                       ) : null}
                       {isPrimary ? (
-                        <span className="rounded-md bg-emerald-500/10 px-2 py-0.5 font-semibold text-emerald-700 dark:text-emerald-300">
+                        <span className="rounded-md bg-success-muted px-2 py-0.5 font-semibold text-success">
                           primary
                         </span>
                       ) : null}
@@ -363,7 +363,7 @@ const CleanupJobCard = ({
           className={
             isEmpty
               ? 'rounded-md bg-muted px-2 py-0.5 text-xs font-semibold tabular-nums text-muted-foreground'
-              : 'rounded-md bg-amber-500/10 px-2 py-0.5 text-xs font-semibold tabular-nums text-amber-700 dark:text-amber-300'
+              : 'rounded-md bg-warning-muted px-2 py-0.5 text-xs font-semibold tabular-nums text-warning'
           }
         >
           {total.toLocaleString()}

--- a/app/routes/admin+/pools.tsx
+++ b/app/routes/admin+/pools.tsx
@@ -113,7 +113,7 @@ const PoolsRoute = () => {
               : 'No pools match this filter.'}
           </EmptyRow>
         ) : (
-          <div className="overflow-hidden rounded-md border border-border/50">
+          <div className="overflow-x-auto rounded-md border border-border/50">
             <table className="min-w-full divide-y divide-border/60">
               <thead className="bg-muted/40">
                 <tr>

--- a/app/routes/admin+/pools_.$poolId.tsx
+++ b/app/routes/admin+/pools_.$poolId.tsx
@@ -104,7 +104,7 @@ const PoolDetailRoute = () => {
         <div
           className={
             fetcher.data.ok
-              ? 'rounded-md border border-emerald-400/50 bg-emerald-50/60 p-3 text-sm text-emerald-900 dark:bg-emerald-950/20 dark:text-emerald-200'
+              ? 'rounded-md border border-success/40 bg-success-muted p-3 text-sm text-success'
               : 'rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive'
           }
         >
@@ -154,7 +154,7 @@ const PoolDetailRoute = () => {
           {pool.contributors.length === 0 ? (
             <EmptyRow>No contributors yet.</EmptyRow>
           ) : (
-            <div className="overflow-hidden rounded-md border border-border/50">
+            <div className="overflow-x-auto rounded-md border border-border/50">
               <table className="min-w-full divide-y divide-border/60 text-sm">
                 <thead className="bg-muted/40">
                   <tr>
@@ -183,8 +183,8 @@ const PoolDetailRoute = () => {
                           className={cn(
                             'inline-block rounded px-1.5 py-0.5 text-xs font-semibold',
                             c.hasPaid
-                              ? 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300'
-                              : 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300',
+                              ? 'bg-success-muted text-success'
+                              : 'bg-muted text-muted-foreground',
                           )}
                         >
                           {c.hasPaid ? 'paid' : 'unpaid'}
@@ -210,7 +210,7 @@ const PoolDetailRoute = () => {
                   className={cn(
                     'flex items-center justify-between py-2',
                     idea.id === pool.chosenIdeaId &&
-                      'rounded bg-emerald-50/60 px-2 dark:bg-emerald-950/20',
+                      'rounded bg-success-muted px-2',
                   )}
                 >
                   <div>
@@ -219,7 +219,7 @@ const PoolDetailRoute = () => {
                       by {idea.proposedBy.username}
                     </span>
                     {idea.id === pool.chosenIdeaId ? (
-                      <span className="ml-2 text-xs font-semibold text-emerald-700 dark:text-emerald-300">
+                      <span className="ml-2 text-xs font-semibold text-success">
                         chosen
                       </span>
                     ) : null}

--- a/app/routes/admin+/users.tsx
+++ b/app/routes/admin+/users.tsx
@@ -78,7 +78,7 @@ const UsersRoute = () => {
         description={resultDescription}
       >
         {resultContent ?? (
-          <div className="overflow-hidden rounded-md border border-border/50">
+          <div className="overflow-x-auto rounded-md border border-border/50">
             <table className="min-w-full divide-y divide-border/60">
               <thead className="bg-muted/40">
                 <tr>

--- a/app/routes/admin+/users_.$userId.tsx
+++ b/app/routes/admin+/users_.$userId.tsx
@@ -298,7 +298,7 @@ const AdminUserDetailRoute = () => {
         {user.notificationPreferences.length === 0 ? (
           <EmptyRow>No preferences recorded (using defaults).</EmptyRow>
         ) : (
-          <div className="overflow-hidden rounded-md border border-border/50">
+          <div className="overflow-x-auto rounded-md border border-border/50">
             <table className="min-w-full divide-y divide-border/60 text-sm">
               <thead className="bg-muted/40">
                 <tr>
@@ -378,7 +378,7 @@ const ActionBanner = ({ data }: { data: ActionResult }) => (
   <div
     className={
       data.ok
-        ? 'rounded-md border border-emerald-400/50 bg-emerald-50/60 p-3 text-sm text-emerald-900 dark:bg-emerald-950/20 dark:text-emerald-200'
+        ? 'rounded-md border border-success/40 bg-success-muted p-3 text-sm text-success'
         : 'rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive'
     }
   >

--- a/app/routes/friends.test.tsx
+++ b/app/routes/friends.test.tsx
@@ -166,8 +166,8 @@ vi.mock('#app/components/ui/confirm-dialog.tsx', () => ({
   ),
 }));
 
-vi.mock('#app/components/ui/dialog.tsx', () => ({
-  Dialog: ({
+vi.mock('#app/components/ui/responsive-dialog.tsx', () => ({
+  ResponsiveDialog: ({
     children,
     open,
     onOpenChange,
@@ -183,16 +183,24 @@ vi.mock('#app/components/ui/dialog.tsx', () => ({
       {open === false ? null : children}
     </div>
   ),
-  DialogContent: ({ children }: { children: React.ReactNode }) => (
+  ResponsiveDialogContent: ({ children }: { children: React.ReactNode }) => (
     <div role="dialog">{children}</div>
   ),
-  DialogDescription: ({ children }: { children: React.ReactNode }) => (
+  ResponsiveDialogDescription: ({ children }: { children: React.ReactNode }) => (
     <p>{children}</p>
   ),
-  DialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  DialogTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  DialogClose: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  ResponsiveDialogFooter: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  ResponsiveDialogHeader: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  ResponsiveDialogTitle: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  ResponsiveDialogClose: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
 }));
 
 vi.mock('#app/components/ui/empty-state.tsx', () => ({

--- a/app/routes/friends.tsx
+++ b/app/routes/friends.tsx
@@ -16,15 +16,11 @@ import {
 } from '#app/components/friends/friend-action-button.tsx';
 import { FriendRow as FriendRowCard } from '#app/components/friends/friend-row.tsx';
 import { useNotificationsStore } from '#app/components/notifications/notifications-context.tsx';
+import { PageHeader } from '#app/components/page-header.tsx';
 import { Avatar } from '#app/components/ui/avatar.tsx';
 import { Button } from '#app/components/ui/button.tsx';
-import {
-  Dialog,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '#app/components/ui/dialog.tsx';
+import { EmptyState } from '#app/components/ui/empty-state.tsx';
+import { Input } from '#app/components/ui/input.tsx';
 import {
   MobileBottomSheet,
   MobileBottomSheetContent,
@@ -32,9 +28,13 @@ import {
   MobileBottomSheetHeader,
   MobileBottomSheetTitle,
 } from '#app/components/ui/mobile-bottom-sheet.tsx';
-import { EmptyState } from '#app/components/ui/empty-state.tsx';
-import { PageHeader } from '#app/components/page-header.tsx';
-import { Input } from '#app/components/ui/input.tsx';
+import {
+  ResponsiveDialog as Dialog,
+  ResponsiveDialogContent as DialogContent,
+  ResponsiveDialogFooter as DialogFooter,
+  ResponsiveDialogHeader as DialogHeader,
+  ResponsiveDialogTitle as DialogTitle,
+} from '#app/components/ui/responsive-dialog.tsx';
 import { Skeleton } from '#app/components/ui/skeleton.tsx';
 import { Stack } from '#app/components/ui-kit/stack.tsx';
 import { useFriendWishlistPrefetch } from '#app/hooks/use-background-route-prefetch.ts';

--- a/app/routes/groups+/$giftGroupId_+/index.tsx
+++ b/app/routes/groups+/$giftGroupId_+/index.tsx
@@ -67,20 +67,22 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
 // ─── Action queue icon map ───────────────────────────────────────────────────
 
 const actionIcons: Record<ActionType, React.ReactNode> = {
-  [ACTION_TYPE.CAST_VOTE]: <LuVote className="text-violet-500" />,
-  [ACTION_TYPE.CLOSE_VOTE]: <LuHand className="text-violet-500" />,
-  [ACTION_TYPE.CALL_VOTE]: <LuVote className="text-violet-500" />,
-  [ACTION_TYPE.CHOOSE_GIFT]: <LuGift className="text-blue-500" />,
-  [ACTION_TYPE.MARK_PAID]: <LuWallet className="text-emerald-500" />,
-  [ACTION_TYPE.MARK_PURCHASED]: <LuPackage className="text-amber-500" />,
-  [ACTION_TYPE.MARK_DELIVERED]: <LuTruck className="text-amber-500" />,
+  [ACTION_TYPE.CAST_VOTE]: <LuVote className="text-pool" />,
+  [ACTION_TYPE.CLOSE_VOTE]: <LuHand className="text-pool" />,
+  [ACTION_TYPE.CALL_VOTE]: <LuVote className="text-pool" />,
+  [ACTION_TYPE.CHOOSE_GIFT]: <LuGift className="text-success" />,
+  [ACTION_TYPE.MARK_PAID]: <LuWallet className="text-success" />,
+  [ACTION_TYPE.MARK_PURCHASED]: <LuPackage className="text-warning" />,
+  [ACTION_TYPE.MARK_DELIVERED]: <LuTruck className="text-warning" />,
   [ACTION_TYPE.SET_CONTRIBUTION]: (
     <LuWallet className="text-muted-foreground" />
   ),
-  [ACTION_TYPE.PROPOSE_IDEA]: <LuLightbulb className="text-yellow-500" />,
-  [ACTION_TYPE.IDEA_CHOSEN]: <LuStar className="text-blue-500" />,
-  [ACTION_TYPE.UPCOMING_OCCASION]: <LuCake className="text-pink-500" />,
-  [ACTION_TYPE.POOL_STUCK]: <LuTriangleAlert className="text-orange-500" />,
+  [ACTION_TYPE.PROPOSE_IDEA]: <LuLightbulb className="text-pool" />,
+  [ACTION_TYPE.IDEA_CHOSEN]: <LuStar className="text-success" />,
+  [ACTION_TYPE.UPCOMING_OCCASION]: (
+    <LuCake className="text-muted-foreground" />
+  ),
+  [ACTION_TYPE.POOL_STUCK]: <LuTriangleAlert className="text-warning" />,
 };
 
 // ─── Page component ──────────────────────────────────────────────────────────
@@ -217,7 +219,7 @@ const ForYouSection = ({
     ) : (
       <Card padding="md">
         <Flex gap={3} align="center">
-          <LuCheck className="shrink-0 text-emerald-500" size={20} />
+          <LuCheck className="shrink-0 text-success" size={20} />
           <Text size="sm" className="text-muted-foreground">
             {nextOccasion
               ? `All caught up. Next: ${nextOccasion.name}'s birthday in ${nextOccasion.daysUntil} days.`
@@ -241,7 +243,7 @@ const ActionQueueItem = ({ item }: { item: ActionItem }) => {
         padding="md"
         className={cn(
           'transition-shadow hover:shadow-md',
-          isUrgent && 'border-amber-300 dark:border-amber-700',
+          isUrgent && 'border-warning/40',
         )}
       >
         <Flex justify="between" align="center" gap={3}>
@@ -253,11 +255,8 @@ const ActionQueueItem = ({ item }: { item: ActionItem }) => {
               </Text>
               {isUrgent && item.daysUntilEvent !== null && (
                 <Flex gap={1} align="center">
-                  <LuAlarmClock className="text-amber-500" size={12} />
-                  <Text
-                    size="xs"
-                    className="text-amber-600 dark:text-amber-400"
-                  >
+                  <LuAlarmClock className="text-warning" size={12} />
+                  <Text size="xs" className="text-warning">
                     in {item.daysUntilEvent}{' '}
                     {item.daysUntilEvent === 1 ? 'day' : 'days'}
                   </Text>

--- a/app/routes/groups+/__group-editor.tsx
+++ b/app/routes/groups+/__group-editor.tsx
@@ -2,9 +2,12 @@ import { useState, type ReactNode } from 'react';
 import { Form } from 'react-router';
 import { z } from 'zod';
 import { Button } from '#app/components/ui/button.tsx';
-import { DialogFooter, DialogClose } from '#app/components/ui/dialog.tsx';
 import { Input } from '#app/components/ui/input.tsx';
 import { Label } from '#app/components/ui/label.tsx';
+import {
+  ResponsiveDialogFooter as DialogFooter,
+  ResponsiveDialogClose as DialogClose,
+} from '#app/components/ui/responsive-dialog.tsx';
 import { Textarea } from '#app/components/ui/textarea.tsx';
 
 const nameMinLength = 1;

--- a/app/routes/groups+/index.test.tsx
+++ b/app/routes/groups+/index.test.tsx
@@ -45,14 +45,22 @@ vi.mock('#app/utils/db.server.ts', () => ({
   },
 }));
 
-vi.mock('#app/components/ui/dialog.tsx', () => ({
-  Dialog: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  DialogContent: ({ children }: { children: React.ReactNode }) => (
+vi.mock('#app/components/ui/responsive-dialog.tsx', () => ({
+  ResponsiveDialog: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  ResponsiveDialogContent: ({ children }: { children: React.ReactNode }) => (
     <div role="dialog">{children}</div>
   ),
-  DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  DialogTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  DialogTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  ResponsiveDialogHeader: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  ResponsiveDialogTitle: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  ResponsiveDialogTrigger: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
 }));
 
 vi.mock('./__group-editor.tsx', () => ({

--- a/app/routes/groups+/index.tsx
+++ b/app/routes/groups+/index.tsx
@@ -5,12 +5,12 @@ import { PageHeader } from '#app/components/page-header.tsx';
 import { Button } from '#app/components/ui/button.tsx';
 import { Card } from '#app/components/ui/card.tsx';
 import {
-  Dialog,
-  DialogTrigger,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from '#app/components/ui/dialog.tsx';
+  ResponsiveDialog as Dialog,
+  ResponsiveDialogTrigger as DialogTrigger,
+  ResponsiveDialogContent as DialogContent,
+  ResponsiveDialogHeader as DialogHeader,
+  ResponsiveDialogTitle as DialogTitle,
+} from '#app/components/ui/responsive-dialog.tsx';
 import { Flex, Text } from '#app/components/ui-kit';
 import { requireUserId } from '#app/utils/auth.server.ts';
 import { getHints } from '#app/utils/client-hints.tsx';

--- a/app/routes/pools+/$poolId+/index.tsx
+++ b/app/routes/pools+/$poolId+/index.tsx
@@ -187,7 +187,7 @@ const IdeaCard = ({
             </a>
           )}
           {idea.wishlistItem && (
-            <span className="inline-flex items-center rounded-full border border-teal-200 bg-teal-50 px-2.5 py-0.5 text-xs font-medium text-teal-700 dark:border-teal-800 dark:bg-teal-950 dark:text-teal-300">
+            <span className="inline-flex items-center rounded-full border border-pool/30 bg-pool/15 px-2.5 py-0.5 text-xs font-medium text-pool">
               From wishlist
             </span>
           )}
@@ -765,12 +765,12 @@ const ContributorsList = ({
                           </Badge>
                         )}
                         {isPurchaser && (
-                          <Badge className="h-4 bg-amber-100 px-1.5 text-[10px] text-amber-800 dark:bg-amber-900 dark:text-amber-200">
+                          <Badge className="h-4 bg-warning-muted px-1.5 text-[10px] text-warning">
                             Buyer
                           </Badge>
                         )}
                         {isDeliverer && (
-                          <Badge className="h-4 bg-blue-100 px-1.5 text-[10px] text-blue-800 dark:bg-blue-900 dark:text-blue-200">
+                          <Badge className="h-4 bg-pool/15 px-1.5 text-[10px] text-pool">
                             Delivery
                           </Badge>
                         )}
@@ -834,7 +834,7 @@ const AssignRolesSection = ({
         {/* Who's buying */}
         <Stack gap={2}>
           <div className="flex items-center gap-1.5 text-sm font-medium">
-            <LuPackage size={14} className="text-amber-600" />
+            <LuPackage size={14} className="text-warning" />
             Who's buying the gift?
           </div>
           <div className="flex flex-col gap-1.5">
@@ -850,14 +850,14 @@ const AssignRolesSection = ({
                     disabled={isCurrentBuyer}
                     className={`flex w-full items-center gap-2.5 rounded-lg border px-3 py-2 text-left text-sm transition-colors ${
                       isCurrentBuyer
-                        ? 'border-amber-200 bg-amber-50 dark:border-amber-800 dark:bg-amber-950'
+                        ? 'border-warning/40 bg-warning-muted'
                         : 'hover:bg-muted/50'
                     }`}
                   >
                     <Avatar size={7} image={c.user.image} user={c.user} />
                     <span className="flex-1">{getUserDisplayName(c.user)}</span>
                     {isCurrentBuyer && (
-                      <LuCheck size={14} className="text-amber-600" />
+                      <LuCheck size={14} className="text-warning" />
                     )}
                   </button>
                 </buyerFetcher.Form>
@@ -869,7 +869,7 @@ const AssignRolesSection = ({
         {/* Who's delivering */}
         <Stack gap={2}>
           <div className="flex items-center gap-1.5 text-sm font-medium">
-            <LuTruck size={14} className="text-blue-600" />
+            <LuTruck size={14} className="text-pool" />
             Who's delivering?
             <span className="text-xs font-normal text-muted-foreground">
               (optional)
@@ -888,14 +888,14 @@ const AssignRolesSection = ({
                     disabled={isCurrentDeliverer}
                     className={`flex w-full items-center gap-2.5 rounded-lg border px-3 py-2 text-left text-sm transition-colors ${
                       isCurrentDeliverer
-                        ? 'border-blue-200 bg-blue-50 dark:border-blue-800 dark:bg-blue-950'
+                        ? 'border-pool/30 bg-pool/15'
                         : 'hover:bg-muted/50'
                     }`}
                   >
                     <Avatar size={7} image={c.user.image} user={c.user} />
                     <span className="flex-1">{getUserDisplayName(c.user)}</span>
                     {isCurrentDeliverer && (
-                      <LuCheck size={14} className="text-blue-600" />
+                      <LuCheck size={14} className="text-pool" />
                     )}
                   </button>
                 </delivererFetcher.Form>
@@ -1108,7 +1108,7 @@ const PoolIndex = () => {
           <Card className="border-dashed bg-muted/20 p-4">
             <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
               <div className="flex min-w-0 items-start gap-3">
-                <LuPackage className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" />
+                <LuPackage className="mt-0.5 h-4 w-4 shrink-0 text-warning" />
                 <div>
                   <p className="text-sm font-medium">Waiting for the buyer</p>
                   <p className="text-xs text-muted-foreground">
@@ -1153,7 +1153,7 @@ const PoolIndex = () => {
           <Card className="border-dashed bg-muted/20 p-4">
             <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
               <div className="flex min-w-0 items-start gap-3">
-                <LuTruck className="mt-0.5 h-4 w-4 shrink-0 text-blue-600" />
+                <LuTruck className="mt-0.5 h-4 w-4 shrink-0 text-pool" />
                 <div>
                   <p className="text-sm font-medium">Waiting for delivery</p>
                   <p className="text-xs text-muted-foreground">
@@ -1182,7 +1182,7 @@ const PoolIndex = () => {
               Ideas{pool.ideas.length > 0 && ` (${pool.ideas.length})`}
             </SectionHeading>
             {isVoting && (
-              <Badge className="bg-violet-100 text-xs text-violet-800">
+              <Badge className="bg-warning-muted text-xs text-warning">
                 Voting open
               </Badge>
             )}

--- a/app/routes/w.public.$token.test.tsx
+++ b/app/routes/w.public.$token.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import { createRoutesStub } from 'react-router';
+import { describe, expect, it } from 'vitest';
+import { ErrorBoundary } from './w.public.$token.tsx';
+
+function renderAtRoute(loader: () => never) {
+  const Stub = createRoutesStub([
+    {
+      path: '/w/public/:token',
+      loader,
+      Component: () => null,
+      ErrorBoundary,
+    },
+  ]);
+  return render(<Stub initialEntries={['/w/public/abc123']} />);
+}
+
+describe('public wishlist route error boundary', () => {
+  it('renders a not-found fallback when the share link is missing or revoked', async () => {
+    renderAtRoute(() => {
+      throw new Response(null, { status: 404 });
+    });
+
+    expect(
+      await screen.findByRole('heading', {
+        name: 'Public wishlist link not found or revoked',
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders a rate-limit fallback on 429', async () => {
+    renderAtRoute(() => {
+      throw new Response(null, { status: 429 });
+    });
+
+    expect(
+      await screen.findByRole('heading', { name: 'Too many requests' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Please try again soon.')).toBeInTheDocument();
+  });
+});

--- a/app/routes/w.public.$token.tsx
+++ b/app/routes/w.public.$token.tsx
@@ -8,7 +8,7 @@ import {
   data,
   useLoaderData,
 } from 'react-router';
-import { GeneralErrorBoundary } from '#app/components/error-boundary.tsx';
+import { ErrorFallback, GeneralErrorBoundary } from '#app/components/error-boundary.tsx';
 import {
   ShareConversionBanner,
   ShareConversionCard,
@@ -234,8 +234,19 @@ export const ErrorBoundary = () => {
   return (
     <GeneralErrorBoundary
       statusHandlers={{
-        404: () => <p>Public wishlist link not found or revoked.</p>,
-        429: () => <p>Too many requests. Please try again soon.</p>,
+        404: () => (
+          <ErrorFallback
+            icon="magnifying-glass"
+            title="Public wishlist link not found or revoked"
+          />
+        ),
+        429: () => (
+          <ErrorFallback
+            icon="clock"
+            title="Too many requests"
+            description="Please try again soon."
+          />
+        ),
       }}
     />
   );

--- a/app/routes/wishlist+/__wishlist-item-editor.tsx
+++ b/app/routes/wishlist+/__wishlist-item-editor.tsx
@@ -28,7 +28,6 @@ import {
 } from 'react-icons/lu';
 import { Form, useActionData, useFetcher } from 'react-router';
 import { z } from 'zod';
-import { GeneralErrorBoundary } from '#app/components/error-boundary.tsx';
 import { Field, TextareaField } from '#app/components/forms.tsx';
 import { useToast } from '#app/components/toaster.tsx';
 import { Button } from '#app/components/ui/button';
@@ -56,6 +55,7 @@ import {
 } from '#app/components/ui/mobile-bottom-sheet';
 import { StatusButton } from '#app/components/ui/status-button.tsx';
 import { Flex, Text } from '#app/components/ui-kit';
+import { useIsDesktop } from '#app/components/wishlist/hooks/use-is-desktop.ts';
 import { track } from '#app/utils/analytics.client.ts';
 import { createClientMutationId } from '#app/utils/client-mutation-id.ts';
 import { cn, getWishlistItemImgSrc, useIsPending } from '#app/utils/misc.tsx';
@@ -111,27 +111,6 @@ export function looksLikeWishlistUrl(url: string): boolean {
 const ImageActionSchema = z
   .enum(['none', 'upload', 'url', 'auto-detect', 'remove'])
   .default('none');
-
-const useIsDesktop = () => {
-  const [isDesktop, setIsDesktop] = useState(() => {
-    if (typeof window === 'undefined') return false;
-    return window.matchMedia('(min-width: 640px)').matches;
-  });
-
-  useEffect(() => {
-    const mediaQuery = window.matchMedia('(min-width: 640px)');
-
-    const handleChange = (event: MediaQueryListEvent) => {
-      setIsDesktop(event.matches);
-    };
-
-    setIsDesktop(mediaQuery.matches);
-    mediaQuery.addEventListener('change', handleChange);
-    return () => mediaQuery.removeEventListener('change', handleChange);
-  }, []);
-
-  return isDesktop;
-};
 
 export const WishlistItemSchema = z
   .object({
@@ -256,7 +235,7 @@ function UrlFieldWithSuggestion({
         errors={errors}
       />
       {showSuggestion ? (
-        <div className="flex items-start gap-2 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-xs text-blue-800 dark:border-blue-800 dark:bg-blue-950/40 dark:text-blue-300">
+        <div className="flex items-start gap-2 rounded-md border border-border bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
           <LuInfo className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden />
           <span className="flex-1">
             Looks like an external wishlist. Switch to{' '}
@@ -1766,7 +1745,7 @@ function EditorFormSection({
           </Text>
         ) : null}
         {imageWarning ? (
-          <Text size="sm" className="text-amber-600">
+          <Text size="sm" className="text-warning">
             {imageWarning}
           </Text>
         ) : null}
@@ -2269,13 +2248,3 @@ export const WishlistItemEditor = React.forwardRef<
 );
 
 WishlistItemEditor.displayName = 'WishlistItemEditor';
-
-export const ErrorBoundary = () => (
-  <GeneralErrorBoundary
-    statusHandlers={{
-      404: ({ params }) => (
-        <p>No wishlist item with the id "{params.wishlistId}" exists</p>
-      ),
-    }}
-  />
-);

--- a/app/routes/wishlist+/index.tsx
+++ b/app/routes/wishlist+/index.tsx
@@ -114,14 +114,4 @@ const WishlistIndex = () => {
   );
 };
 export default WishlistIndex;
-export const ErrorBoundary = () => {
-  return (
-    <GeneralErrorBoundary
-      statusHandlers={{
-        404: ({ params }) => (
-          <p>No user with the username "{params.username}" exists</p>
-        ),
-      }}
-    />
-  );
-};
+export const ErrorBoundary = () => <GeneralErrorBoundary />;

--- a/tests/e2e/person-surface.test.ts
+++ b/tests/e2e/person-surface.test.ts
@@ -128,7 +128,7 @@ test.describe('Organize routing', () => {
       await login(page, viewer);
       await page.goto(`/users/${target.username}`);
 
-      // No picker for a single group — the button names the circle directly.
+      // No picker for a single group — the button names the group directly.
       await page
         .getByRole('button', { name: 'Organize with Weekend Crew' })
         .click();
@@ -161,7 +161,7 @@ test.describe('Organize routing', () => {
       // Generic label — clicking must NOT auto-navigate; it opens a chooser.
       await page.getByRole('button', { name: 'Organize a gift' }).click();
       await expect(
-        page.getByRole('heading', { name: 'Organize with which circle?' }),
+        page.getByRole('heading', { name: 'Organize with which group?' }),
       ).toBeVisible();
       await expect(page).toHaveURL(new RegExp(`/users/${target.username}`));
 


### PR DESCRIPTION
## Summary

Final milestone of the Gift Pool UI rework (see `.agents/plans/ui-rework/plan.md` and `docs/product/giftpool-ui-rework-handoff.md` §6.9/§12/§13/§14). Scope per the handoff: admin expression, secondary routes, error-system completion, and an app-wide terminology/accessibility/responsive/light-dark audit. Built via a capability-inventory research pass followed by targeted fixes — no new UI surfaces, no domain behavior changes.

- **Admin surface**: recolored hardcoded emerald/amber/red/sky/yellow/blue across all 7 admin tabs to the shared success/warning/pool/muted tokens (action banners, paid/unpaid badges, cache-type badges, feedback-type badges, ops counts); switched data tables from `overflow-hidden` (clips columns on narrow viewports) to `overflow-x-auto` (scrolls).
- **Error system**: `GeneralErrorBoundary`'s default fallback was a bare `<p>` inside a container that forced giant `text-h2` sizing on every unhandled error — now a real fallback (icon, heading, description, back-to-home link), applied automatically to every route using the bare default (admin, auth, root, etc.). Fixed two stale copy-paste bugs found during the audit: the own-wishlist route's 404 handler referenced a non-existent `username` param (would render `"undefined"`), and `__wishlist-item-editor.tsx` exported an unreachable `ErrorBoundary` (dead code — the file is routing-excluded) — both removed/fixed.
- **Secondary routes**: about/support pages recolored to tokens, support's FAQ headings normalized to the shared `text-h5` type-scale role, feedback success icon → `success` token, feedback widget onto `ResponsiveDialog`.
- **ResponsiveDialog audit**: 6 remaining confirmation/share dialogs were still on the raw, always-centered `Dialog` primitive (member-actions-menu, friend-row, friend-action-button, friends.tsx invite-QR, groups create-group) — converted to `ResponsiveDialog`. `wishlist-share-dialog.tsx`'s hand-rolled `isDesktop ? Dialog : MobileBottomSheet` branch collapsed into a single `ResponsiveDialog` render. Along the way, found and fixed a real gap: `ResponsiveDialogTrigger` wasn't a `forwardRef` component, breaking composition with a `Tooltip` wrapping the share trigger.
- **Terminology**: fixed two "circle" usages in `person-surface.tsx` that functioned as the operative noun for a specific Group (a dialog title picker and a named-pool summary) — the canonical noun is "Group"; remaining prose uses of "circle" (describing a person's broader social context) are left as intentional conversational flavor.
- **App-wide token sweep**: RoleBadge, profile birthday badge, reminder-queued icon, the shared required-field asterisk, Group activity-feed icons (11 action types), and Pool detail's buyer/deliverer badges/icons/tags — all moved off raw Tailwind palette colors onto the existing success/warning/pool/muted tokens, gaining dark-mode parity where none existed. Confirmed via `grep` that no raw Tailwind color literals remain anywhere in `app/` outside emails/tests.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 152 warnings (at/below the 155 baseline), 0 errors
- [x] `npm test -- --run` — 1425/1425 unit tests passing (220 files)
- [x] `npm run test:e2e:run` — 117/117 e2e passing
- [x] Ad hoc Playwright visual check (light+dark): 404 page, about page (coffee button/icon), support page (FAQ heading scale) — all render correctly with proper dark-mode contrast
- [x] Manually verified no raw Tailwind color literals remain in `app/` (excluding `app/emails/*` and test files, both explicitly out of scope)

https://claude.ai/code/session_01JohGjBa3mo3NvVXdkGjX6W