### PR TITLE
fix: mobile heading padding + PWA sticky-hover

### DIFF
--- a/app/routes/_auth+/login.tsx
+++ b/app/routes/_auth+/login.tsx
@@ -110,7 +110,7 @@ const LoginPage = () => {
     shouldRevalidate: 'onBlur',
   });
   return (
-    <div className="flex min-h-full flex-col justify-center pb-32 pt-20">
+    <div className="container flex min-h-full flex-col justify-center pb-32 pt-20">
       <div className="mx-auto w-full max-w-md">
         <div className="flex flex-col gap-3 text-center">
           <h1 className="text-h1">Welcome back!</h1>
@@ -120,98 +120,94 @@ const LoginPage = () => {
         </div>
         <Spacer size="xs" />
 
-        <div>
-          <div className="mx-auto w-full max-w-md px-8">
-            <Form
-              method="POST"
-              {...getFormProps(form)}
-              className="flex flex-col gap-4"
-            >
-              <HoneypotInputs />
-              <Field
-                labelProps={{
-                  children: 'Username',
-                }}
-                inputProps={{
-                  ...getInputProps(fields.username, {
-                    type: 'text',
-                  }),
-                  autoFocus: true,
-                  className: 'lowercase',
-                  autoComplete: 'username',
-                }}
-                errors={fields.username.errors}
-              />
+        <Form
+          method="POST"
+          {...getFormProps(form)}
+          className="flex flex-col gap-4"
+        >
+          <HoneypotInputs />
+          <Field
+            labelProps={{
+              children: 'Username',
+            }}
+            inputProps={{
+              ...getInputProps(fields.username, {
+                type: 'text',
+              }),
+              autoFocus: true,
+              className: 'lowercase',
+              autoComplete: 'username',
+            }}
+            errors={fields.username.errors}
+          />
 
-              <Field
-                labelProps={{
-                  children: 'Password',
-                }}
-                inputProps={{
-                  ...getInputProps(fields.password, {
-                    type: 'password',
-                  }),
-                  autoComplete: 'current-password',
-                }}
-                errors={fields.password.errors}
-              />
+          <Field
+            labelProps={{
+              children: 'Password',
+            }}
+            inputProps={{
+              ...getInputProps(fields.password, {
+                type: 'password',
+              }),
+              autoComplete: 'current-password',
+            }}
+            errors={fields.password.errors}
+          />
 
-              <div className="flex justify-between">
-                <CheckboxField
-                  labelProps={{
-                    htmlFor: fields.remember.id,
-                    children: 'Remember me',
-                  }}
-                  buttonProps={getInputProps(fields.remember, {
-                    type: 'checkbox',
-                  })}
-                  errors={fields.remember.errors}
-                />
-                <div>
-                  <Link
-                    to="/forgot-password"
-                    className="text-body-xs font-semibold"
-                  >
-                    Forgot password?
-                  </Link>
-                </div>
-              </div>
-
-              <input
-                {...getInputProps(fields.redirectTo, {
-                  type: 'hidden',
-                })}
-              />
-              {/* Reserves the error line's height so clearing it on blur can't shift the button mid-click. */}
-              <div className="min-h-5">
-                <ErrorList errors={form.errors} id={form.errorId} />
-              </div>
-
-              <div className="flex items-center justify-between gap-6">
-                <StatusButton
-                  className="w-full"
-                  status={isPending ? 'pending' : (form.status ?? 'idle')}
-                  type="submit"
-                  disabled={isPending}
-                >
-                  Log in
-                </StatusButton>
-              </div>
-            </Form>
-
-            <div className="flex items-center justify-center gap-2 pt-6">
-              <span className="text-muted-foreground">New here?</span>
+          <div className="flex justify-between">
+            <CheckboxField
+              labelProps={{
+                htmlFor: fields.remember.id,
+                children: 'Remember me',
+              }}
+              buttonProps={getInputProps(fields.remember, {
+                type: 'checkbox',
+              })}
+              errors={fields.remember.errors}
+            />
+            <div>
               <Link
-                to={
-                  redirectTo
-                    ? `/signup?redirectTo=${encodeURIComponent(redirectTo)}`
-                    : '/signup'
-                }
+                to="/forgot-password"
+                className="text-body-xs font-semibold"
               >
-                Create an account
+                Forgot password?
               </Link>
             </div>
           </div>
+
+          <input
+            {...getInputProps(fields.redirectTo, {
+              type: 'hidden',
+            })}
+          />
+          {/* Reserves the error line's height so clearing it on blur can't shift the button mid-click. */}
+          <div className="min-h-5">
+            <ErrorList errors={form.errors} id={form.errorId} />
+          </div>
+
+          <div className="flex items-center justify-between gap-6">
+            <StatusButton
+              className="w-full"
+              status={isPending ? 'pending' : (form.status ?? 'idle')}
+              type="submit"
+              disabled={isPending}
+            >
+              Log in
+            </StatusButton>
+          </div>
+        </Form>
+
+        <div className="flex items-center justify-center gap-2 pt-6">
+          <span className="text-muted-foreground">New here?</span>
+          <Link
+            to={
+              redirectTo
+                ? `/signup?redirectTo=${encodeURIComponent(redirectTo)}`
+                : '/signup'
+            }
+          >
+            Create an account
+          </Link>
         </div>
       </div>
     </div>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -35,6 +35,14 @@ export default {
     'inline-flex',
   ],
   darkMode: 'class',
+  future: {
+    // Compiles hover: (and group-hover:/peer-hover:) to
+    // `@media (hover: hover) and (pointer: fine) { &:hover }` instead of
+    // plain `&:hover`. Without this, iOS treats a tap as `:hover` with no
+    // matching mouseleave, so the tapped element stays visually "hovered"
+    // after the finger lifts — worse in standalone PWA mode.
+    hoverOnlyWhenSupported: true,
+  },
   theme: {
     container: {
       center: true,


### PR DESCRIPTION
## Summary
- Login was the only auth screen missing the `container` class, so the "Welcome back!" heading ran edge-to-edge on mobile while the form (with a bolted-on `px-8`) had padding — fixed by matching the pattern every other auth page uses and dropping the now-redundant form wrapper.
- Every `hover:`/`group-hover:` Tailwind utility compiled to plain `&:hover`, so a tap on iOS (esp. in standalone PWA mode) left elements stuck in their hovered state until another tap moved it elsewhere. Enabled Tailwind's built-in `hoverOnlyWhenSupported` future flag so hover utilities only match `@media (hover: hover) and (pointer: fine)`.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint` (login.tsx)
- [x] `npm test -- --run` — 1440 tests passed
- [x] `npm run test:e2e:run -- onboarding.test.ts` — 5 passed (exercises the login form)
- [x] Verified in a resized Chrome tab (390–430px viewport): heading and form both sit at `left: 32px`, zero horizontal overflow (`bodyOverflow: 0`)
- [x] Confirmed via a scratch Tailwind build that `hover:`/`group-hover:` now compile inside `@media (hover: hover) and (pointer: fine)`
- [ ] Manual confirmation on a real iOS PWA install that hover no longer sticks after a drag-off tap (recommend the reporting user verify)

https://claude.ai/code/session_01JohGjBa3mo3NvVXdkGjX6W