### PR TITLE
chore(dev): add owner-only palette comparison switcher

### DIFF
--- a/app/components/dev/palette-switcher.test.tsx
+++ b/app/components/dev/palette-switcher.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  PALETTE_CLASS,
+  PALETTE_STORAGE_KEY,
+  PaletteSwitcher,
+} from './palette-switcher.tsx';
+
+beforeEach(() => {
+  window.localStorage.clear();
+  document.documentElement.classList.remove(PALETTE_CLASS);
+});
+
+afterEach(() => {
+  window.localStorage.clear();
+  document.documentElement.classList.remove(PALETTE_CLASS);
+});
+
+describe('<PaletteSwitcher />', () => {
+  it('defaults to the current palette when nothing is stored', async () => {
+    render(<PaletteSwitcher />);
+
+    const current = await screen.findByRole('button', { name: 'Current' });
+    expect(current).toHaveStyle({ background: '#fff' });
+    expect(document.documentElement).not.toHaveClass(PALETTE_CLASS);
+  });
+
+  it('reads a previously stored palette on mount', async () => {
+    window.localStorage.setItem(PALETTE_STORAGE_KEY, 'fete');
+
+    render(<PaletteSwitcher />);
+
+    const fete = await screen.findByRole('button', { name: 'Fête' });
+    await waitFor(() =>
+      expect(document.documentElement).toHaveClass(PALETTE_CLASS),
+    );
+    expect(fete).toHaveStyle({ background: '#fff' });
+  });
+
+  it('switches palette, toggles the root class, and persists the choice', async () => {
+    const user = userEvent.setup();
+    render(<PaletteSwitcher />);
+
+    await screen.findByRole('button', { name: 'Current' });
+    await user.click(screen.getByRole('button', { name: 'Fête' }));
+
+    await waitFor(() =>
+      expect(document.documentElement).toHaveClass(PALETTE_CLASS),
+    );
+    expect(window.localStorage.getItem(PALETTE_STORAGE_KEY)).toBe('fete');
+
+    await user.click(screen.getByRole('button', { name: 'Current' }));
+
+    await waitFor(() =>
+      expect(document.documentElement).not.toHaveClass(PALETTE_CLASS),
+    );
+    expect(window.localStorage.getItem(PALETTE_STORAGE_KEY)).toBe('current');
+  });
+});

--- a/app/components/dev/palette-switcher.test.tsx
+++ b/app/components/dev/palette-switcher.test.tsx
@@ -60,4 +60,23 @@ describe('<PaletteSwitcher />', () => {
     );
     expect(window.localStorage.getItem(PALETTE_STORAGE_KEY)).toBe('current');
   });
+
+  it('reasserts the palette class after something else overwrites <html>.className', async () => {
+    const user = userEvent.setup();
+    render(<PaletteSwitcher />);
+
+    await user.click(screen.getByRole('button', { name: 'Fête' }));
+    await waitFor(() =>
+      expect(document.documentElement).toHaveClass(PALETTE_CLASS),
+    );
+
+    // Simulate a theme toggle: React rewrites <html>'s className wholesale,
+    // dropping the imperatively-added palette class.
+    document.documentElement.className = 'dark min-h-full overflow-x-hidden';
+    expect(document.documentElement).not.toHaveClass(PALETTE_CLASS);
+
+    await waitFor(() =>
+      expect(document.documentElement).toHaveClass(PALETTE_CLASS),
+    );
+  });
 });

--- a/app/components/dev/palette-switcher.tsx
+++ b/app/components/dev/palette-switcher.tsx
@@ -31,11 +31,19 @@ export const PaletteSwitcher = () => {
 
   useEffect(() => {
     if (palette === null) return;
-    document.documentElement.classList.toggle(
-      PALETTE_CLASS,
-      palette === 'fete',
-    );
+    const shouldHaveClass = palette === 'fete';
+    const root = document.documentElement;
+    root.classList.toggle(PALETTE_CLASS, shouldHaveClass);
     window.localStorage.setItem(PALETTE_STORAGE_KEY, palette);
+
+    // The theme switch re-renders <html>'s className as a single template
+    // string, which silently drops this class since React isn't aware of
+    // it. Reassert it whenever something else touches the class attribute.
+    const observer = new MutationObserver(() => {
+      root.classList.toggle(PALETTE_CLASS, shouldHaveClass);
+    });
+    observer.observe(root, { attributes: true, attributeFilter: ['class'] });
+    return () => observer.disconnect();
   }, [palette]);
 
   if (palette === null) return null;

--- a/app/components/dev/palette-switcher.tsx
+++ b/app/components/dev/palette-switcher.tsx
@@ -1,0 +1,81 @@
+/**
+ * Owner-only live palette comparison tool. NOT a shipped feature — no
+ * cookie/SSR persistence, no Settings UI entry, dev-build only (see the
+ * `import.meta.env.DEV` gate in root.tsx). Safe to delete this file, its
+ * import in root.tsx, and the `.palette-fete` blocks in tailwind.css
+ * wholesale once a palette decision is made.
+ */
+import { useEffect, useState } from 'react';
+
+export const PALETTE_STORAGE_KEY = 'gp-dev-palette';
+export const PALETTE_CLASS = 'palette-fete';
+
+type PaletteId = 'current' | 'fete';
+
+const PALETTES: { id: PaletteId; label: string }[] = [
+  { id: 'current', label: 'Current' },
+  { id: 'fete', label: 'Fête' },
+];
+
+export const PaletteSwitcher = () => {
+  // Start `null` (render nothing) until mount so we never guess the palette
+  // during SSR — the inline no-flash script in root.tsx's <Document> already
+  // applied the right class before hydration; this just needs to agree with
+  // it once it reads localStorage itself.
+  const [palette, setPalette] = useState<PaletteId | null>(null);
+
+  useEffect(() => {
+    const stored = window.localStorage.getItem(PALETTE_STORAGE_KEY);
+    setPalette(stored === 'fete' ? 'fete' : 'current');
+  }, []);
+
+  useEffect(() => {
+    if (palette === null) return;
+    document.documentElement.classList.toggle(
+      PALETTE_CLASS,
+      palette === 'fete',
+    );
+    window.localStorage.setItem(PALETTE_STORAGE_KEY, palette);
+  }, [palette]);
+
+  if (palette === null) return null;
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        bottom: '5.5rem',
+        right: '1rem',
+        zIndex: 9999,
+        display: 'flex',
+        gap: 4,
+        padding: 4,
+        borderRadius: 999,
+        background: 'rgba(24,18,20,0.9)',
+        boxShadow: '0 4px 16px rgba(0,0,0,0.35)',
+      }}
+      data-testid="palette-switcher"
+    >
+      {PALETTES.map(({ id, label }) => (
+        <button
+          key={id}
+          type="button"
+          onClick={() => setPalette(id)}
+          style={{
+            fontSize: 11,
+            fontWeight: 700,
+            lineHeight: 1,
+            padding: '7px 11px',
+            borderRadius: 999,
+            border: 'none',
+            cursor: 'pointer',
+            background: palette === id ? '#fff' : 'transparent',
+            color: palette === id ? '#18121a' : '#fff',
+          }}
+        >
+          {label}
+        </button>
+      ))}
+    </div>
+  );
+};

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -23,6 +23,11 @@ import { useSpinDelay } from 'spin-delay';
 import { z } from 'zod';
 import appleTouchIconAssetUrl from './assets/favicons/apple-touch-icon.png';
 import faviconAssetUrl from './assets/favicons/favicon.svg';
+import {
+  PALETTE_CLASS,
+  PALETTE_STORAGE_KEY,
+  PaletteSwitcher,
+} from './components/dev/palette-switcher.tsx';
 import { GeneralErrorBoundary } from './components/error-boundary.tsx';
 import { FriendsRouteSkeleton } from './components/friends/friends-route-skeleton.tsx';
 import { BottomNav } from './components/nav/bottom/bottom-nav.tsx';
@@ -257,6 +262,18 @@ const Document = ({
         />
         <meta name="csp-nonce" content={nonce} />
         <Links />
+        {import.meta.env.DEV ? (
+          <script
+            nonce={nonce}
+            dangerouslySetInnerHTML={{
+              // Owner-only palette comparison tool (see PaletteSwitcher) —
+              // applies the stored palette before first paint so switching
+              // to Fête and reloading doesn't flash the current palette.
+              // Dev-build only; never runs in the deployed app.
+              __html: `try{if(localStorage.getItem('${PALETTE_STORAGE_KEY}')==='fete'){document.documentElement.classList.add('${PALETTE_CLASS}')}}catch(e){}`,
+            }}
+          />
+        ) : null}
       </head>
       <body className="min-h-screen overflow-hidden bg-background text-foreground">
         {children}
@@ -403,6 +420,7 @@ const App = () => {
           </div>
           <EpicProgress />
           <EpicToaster closeButton position="top-center" theme={theme} />
+          {import.meta.env.DEV ? <PaletteSwitcher /> : null}
         </NotificationsProvider>
       </I18nProvider>
     </Document>

--- a/app/styles/tailwind.css
+++ b/app/styles/tailwind.css
@@ -169,6 +169,95 @@
     --brand-gradient-end: 11 100% 82%;
   }
 
+  /* ---------------------------------------------------------------------
+     "Fête" palette — owner-only live comparison, NOT a shipped feature.
+     Toggled by a temporary floating switcher (see PaletteSwitcher) that
+     writes a `palette-fete` class + localStorage flag; no cookie/SSR
+     persistence, no Settings UI, no per-user rollout. Safe to delete this
+     block and the switcher component wholesale once a palette decision is
+     made — nothing else in the app depends on the class existing.
+
+     Partial override: only tokens that actually differ from :root/.dark
+     are declared. destructive/warning/input-invalid/foreground-destructive/
+     scrim/radius/fonts/success(dark)/success-muted/warning-muted are
+     deliberately omitted so they keep inheriting the current values (the
+     rework brief keeps those semantic roles as-is). Source values are the
+     accepted "Gift Pool Palette Rework" mockup (raspberry primary /
+     periwinkle pool), converted from its explicit hex anchors. --------- */
+  .palette-fete {
+    --background: 336 38% 97%; /* #FBF6F8 */
+    --background-muted: 330 29% 92%; /* #F0E4EA */
+    --foreground: 324 16% 12%; /* #241A20 */
+    --muted: 332 42% 94%; /* #F6E9EF, interpolated between card and background-muted */
+    --muted-foreground: 330 11% 38%; /* #6B5560 */
+    --popover: 0 0% 100%;
+    --popover-foreground: 324 16% 12%;
+    --card: 339 78% 96%; /* #FDEFF4 */
+    --card-foreground: 324 16% 12%;
+    --border: 334 28% 85%; /* #E4CFD8 */
+    --input: 334 28% 85%;
+    --input-bg: 337 52% 95%; /* #F9ECF1, interpolated toward card */
+    --primary: 335 78% 42%; /* #BE185D raspberry */
+    --primary-foreground: 0 0% 100%;
+    --secondary: 332 35% 92%; /* #F1E2E9, = subcard-border (mirrors current light relationship) */
+    --secondary-foreground: 324 16% 12%;
+    --accent: 337 52% 95%; /* = input-bg (mirrors current light relationship) */
+    --accent-foreground: 335 72% 60%; /* #E24E8C, the mockup's vibrant emphasis pink used in avatar gradients */
+    --ring: 335 72% 60%;
+    --surface: 339 78% 96%; /* = card */
+    --surface-foreground: var(--foreground);
+    --surface-border: 334 28% 85%; /* = border */
+    --subcard: 0 0% 100%;
+    --subcard-foreground: 324 16% 12%;
+    --subcard-border: 332 35% 92%; /* #F1E2E9 */
+    --modal: 0 0% 100%; /* = subcard */
+    --modal-border: 334 28% 85%; /* = border */
+    --success: 148 65% 24%; /* #15633A, mockup's harmony-adjusted green (warning/destructive kept byte-identical, so left unoverridden) */
+    --gift: 335 78% 42%; /* = primary */
+    --gift-foreground: 0 0% 100%;
+    --pool: 237 51% 44%; /* #363BA8 periwinkle */
+    --pool-foreground: 0 0% 100%;
+    --pool-badge-foreground: 0 0% 100%;
+    --brand-gradient-start: 335 78% 42%; /* = primary */
+    --brand-gradient-end: 335 72% 60%; /* #E24E8C */
+  }
+  .palette-fete.dark {
+    --background: 315 17% 9%; /* #1B1319 warm plum-black */
+    --background-muted: 316 17% 12%; /* #251A22 */
+    --foreground: 335 68% 95%; /* #FBEAF1 */
+    --muted: 318 16% 15%; /* = subcard, derived */
+    --muted-foreground: 335 23% 79%; /* #D6BEC8 */
+    --popover: 318 16% 15%; /* = modal/subcard */
+    --popover-foreground: 335 68% 95%;
+    --card: 318 16% 12%; /* #241A21 */
+    --card-foreground: 335 68% 95%;
+    --border: 329 17% 24%; /* #47323D */
+    --input: 329 17% 24%;
+    --input-bg: 318 16% 15%; /* = subcard (mirrors current dark relationship) */
+    --primary: 333 100% 83%; /* #FFA6CE */
+    --primary-foreground: 329 90% 15%; /* #4A0428 */
+    --secondary: 327 17% 20%; /* #3D2B35, derived; = accent (mirrors current dark relationship) */
+    --secondary-foreground: 335 68% 95%;
+    --accent: 327 17% 20%;
+    --accent-foreground: 335 72% 60%; /* #E24E8C, constant across modes like current accent-foreground/ring */
+    --ring: 335 72% 60%;
+    --surface: 318 16% 12%; /* = card */
+    --surface-foreground: var(--foreground);
+    --surface-border: 329 17% 24%; /* = border */
+    --subcard: 318 16% 15%; /* #2E212A */
+    --subcard-foreground: 335 68% 95%;
+    --subcard-border: 326 16% 20%; /* #3A2A33 */
+    --modal: 318 16% 15%; /* = subcard */
+    --modal-border: 326 16% 20%; /* = subcard-border */
+    --gift: 333 100% 83%; /* = primary */
+    --gift-foreground: 329 90% 15%;
+    --pool: 234 100% 86%; /* #B7BEFF */
+    --pool-foreground: 236 46% 15%; /* #141636, dark text — the fill is light in dark mode */
+    --pool-badge-foreground: 236 46% 15%;
+    --brand-gradient-start: 333 100% 83%; /* = primary */
+    --brand-gradient-end: 335 72% 60%; /* #E24E8C, constant */
+  }
+
   /* Display face for major headings; body/controls stay on --font-sans.
      Route-family passes opt additional elements in via `font-display`. */
   h1,


### PR DESCRIPTION
## Summary
- Adds a dev-only floating switcher (`PaletteSwitcher`) to live-toggle between the current token set and the "Fête" palette candidate from the UI-rework token appendix
- Adds a no-flash inline script in `root.tsx` that applies the stored palette class before first paint
- Adds the `.palette-fete` / `.palette-fete.dark` token override blocks in `tailwind.css`

Everything is gated behind `import.meta.env.DEV` — no cookie/SSR persistence, no Settings UI entry, never runs in the deployed app. This is a comparison aid for the pending palette decision referenced in the UI-rework plan, not a shipped feature; safe to delete wholesale (this file, its import, and the CSS blocks) once a decision is made.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors, 152 warnings (at/below the 155 baseline, no new issues)
- [ ] CI green

https://claude.ai/code/session_01JohGjBa3mo3NvVXdkGjX6W