### PR TITLE
feat(dev): show palette switcher for admins in production

### DIFF
--- a/app/components/dev/palette-switcher.test.tsx
+++ b/app/components/dev/palette-switcher.test.tsx
@@ -8,6 +8,7 @@ import {
   PALETTE_CLASS,
   PALETTE_STORAGE_KEY,
   PaletteSwitcher,
+  shouldShowPaletteSwitcher,
 } from './palette-switcher.tsx';
 
 beforeEach(() => {
@@ -78,5 +79,29 @@ describe('<PaletteSwitcher />', () => {
     await waitFor(() =>
       expect(document.documentElement).toHaveClass(PALETTE_CLASS),
     );
+  });
+});
+
+describe('shouldShowPaletteSwitcher', () => {
+  it('shows for any user in dev, admin or not', () => {
+    expect(shouldShowPaletteSwitcher(true, null)).toBe(true);
+    expect(shouldShowPaletteSwitcher(true, { roles: [] })).toBe(true);
+  });
+
+  it('hides in production for a signed-out or non-admin user', () => {
+    expect(shouldShowPaletteSwitcher(false, null)).toBe(false);
+    expect(
+      shouldShowPaletteSwitcher(false, {
+        roles: [{ name: 'user', permissions: [] }],
+      }),
+    ).toBe(false);
+  });
+
+  it('shows in production for an admin', () => {
+    expect(
+      shouldShowPaletteSwitcher(false, {
+        roles: [{ name: 'admin', permissions: [] }],
+      }),
+    ).toBe(true);
   });
 });

--- a/app/components/dev/palette-switcher.test.tsx
+++ b/app/components/dev/palette-switcher.test.tsx
@@ -80,6 +80,19 @@ describe('<PaletteSwitcher />', () => {
       expect(document.documentElement).toHaveClass(PALETTE_CLASS),
     );
   });
+
+  it('clears the palette class on unmount (e.g. the admin gate closing)', async () => {
+    window.localStorage.setItem(PALETTE_STORAGE_KEY, 'fete');
+    const { unmount } = render(<PaletteSwitcher />);
+
+    await waitFor(() =>
+      expect(document.documentElement).toHaveClass(PALETTE_CLASS),
+    );
+
+    unmount();
+
+    expect(document.documentElement).not.toHaveClass(PALETTE_CLASS);
+  });
 });
 
 describe('shouldShowPaletteSwitcher', () => {

--- a/app/components/dev/palette-switcher.tsx
+++ b/app/components/dev/palette-switcher.tsx
@@ -52,7 +52,14 @@ export const PaletteSwitcher = () => {
       root.classList.toggle(PALETTE_CLASS, shouldHaveClass);
     });
     observer.observe(root, { attributes: true, attributeFilter: ['class'] });
-    return () => observer.disconnect();
+    return () => {
+      observer.disconnect();
+      // Unmounting (e.g. the admin gate closing on logout or a revoked
+      // role) must not strand the page on the experimental palette with no
+      // switcher left to revert it — <html>'s className is keyed off theme,
+      // not palette, so React won't clear this class on its own.
+      root.classList.remove(PALETTE_CLASS);
+    };
   }, [palette]);
 
   if (palette === null) return null;

--- a/app/components/dev/palette-switcher.tsx
+++ b/app/components/dev/palette-switcher.tsx
@@ -1,14 +1,23 @@
 /**
- * Owner-only live palette comparison tool. NOT a shipped feature — no
- * cookie/SSR persistence, no Settings UI entry, dev-build only (see the
- * `import.meta.env.DEV` gate in root.tsx). Safe to delete this file, its
- * import in root.tsx, and the `.palette-fete` blocks in tailwind.css
- * wholesale once a palette decision is made.
+ * Live palette comparison tool. NOT a shipped feature — no cookie/SSR
+ * persistence, no Settings UI entry. Rendered for any developer in dev and
+ * for admins only in production (see the `showPaletteSwitcher` gate in
+ * root.tsx). Safe to delete this file, its import in root.tsx, and the
+ * `.palette-fete` blocks in tailwind.css wholesale once a palette decision
+ * is made.
  */
 import { useEffect, useState } from 'react';
+import { userHasRole } from '#app/utils/user.ts';
 
 export const PALETTE_STORAGE_KEY = 'gp-dev-palette';
 export const PALETTE_CLASS = 'palette-fete';
+
+export function shouldShowPaletteSwitcher(
+  isDev: boolean,
+  user: Parameters<typeof userHasRole>[0],
+) {
+  return isDev || userHasRole(user, 'admin');
+}
 
 type PaletteId = 'current' | 'fete';
 

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -27,6 +27,7 @@ import {
   PALETTE_CLASS,
   PALETTE_STORAGE_KEY,
   PaletteSwitcher,
+  shouldShowPaletteSwitcher,
 } from './components/dev/palette-switcher.tsx';
 import { GeneralErrorBoundary } from './components/error-boundary.tsx';
 import { FriendsRouteSkeleton } from './components/friends/friends-route-skeleton.tsx';
@@ -244,11 +245,13 @@ const Document = ({
   nonce,
   theme = 'light',
   env = {},
+  showPaletteSwitcher = false,
 }: {
   children: React.ReactNode;
   nonce: string;
   theme?: Theme;
   env?: Record<string, string | undefined>;
+  showPaletteSwitcher?: boolean;
 }) => {
   return (
     <html lang="en" className={`${theme} min-h-full overflow-x-hidden`}>
@@ -262,14 +265,15 @@ const Document = ({
         />
         <meta name="csp-nonce" content={nonce} />
         <Links />
-        {import.meta.env.DEV ? (
+        {showPaletteSwitcher ? (
           <script
             nonce={nonce}
             dangerouslySetInnerHTML={{
-              // Owner-only palette comparison tool (see PaletteSwitcher) —
-              // applies the stored palette before first paint so switching
-              // to Fête and reloading doesn't flash the current palette.
-              // Dev-build only; never runs in the deployed app.
+              // Palette comparison tool (see PaletteSwitcher) — applies the
+              // stored palette before first paint so switching to Fête and
+              // reloading doesn't flash the current palette. Available in
+              // dev for any developer and in production for admins only;
+              // `showPaletteSwitcher` mirrors the same check client-side.
               __html: `try{if(localStorage.getItem('${PALETTE_STORAGE_KEY}')==='fete'){document.documentElement.classList.add('${PALETTE_CLASS}')}}catch(e){}`,
             }}
           />
@@ -303,6 +307,11 @@ const App = () => {
   const data = useLoaderData<typeof loader>();
   const nonce = useNonce();
   const theme = useTheme();
+  // Palette comparison tool: any developer in dev, admins only in prod.
+  const showPaletteSwitcher = shouldShowPaletteSwitcher(
+    import.meta.env.DEV,
+    data.user,
+  );
   useIsomorphicLayoutEffect(() => {
     setPrefetchCacheScope(data.user?.id ?? null);
   }, [data.user?.id]);
@@ -395,7 +404,12 @@ const App = () => {
     }
   }
   return (
-    <Document nonce={nonce} theme={theme} env={data.ENV}>
+    <Document
+      nonce={nonce}
+      theme={theme}
+      env={data.ENV}
+      showPaletteSwitcher={showPaletteSwitcher}
+    >
       <I18nProvider locale={data.requestInfo.locale}>
         <NotificationsProvider
           initialUnreadCount={data.notifications?.unreadCount ?? 0}
@@ -420,7 +434,7 @@ const App = () => {
           </div>
           <EpicProgress />
           <EpicToaster closeButton position="top-center" theme={theme} />
-          {import.meta.env.DEV ? <PaletteSwitcher /> : null}
+          {showPaletteSwitcher ? <PaletteSwitcher /> : null}
         </NotificationsProvider>
       </I18nProvider>
     </Document>

--- a/app/styles/tailwind.css
+++ b/app/styles/tailwind.css
@@ -170,12 +170,14 @@
   }
 
   /* ---------------------------------------------------------------------
-     "Fête" palette — owner-only live comparison, NOT a shipped feature.
-     Toggled by a temporary floating switcher (see PaletteSwitcher) that
-     writes a `palette-fete` class + localStorage flag; no cookie/SSR
-     persistence, no Settings UI, no per-user rollout. Safe to delete this
-     block and the switcher component wholesale once a palette decision is
-     made — nothing else in the app depends on the class existing.
+     "Fête" palette — live comparison, NOT a shipped feature. Rendered for
+     any developer in dev and for admins only in production (see
+     `showPaletteSwitcher` in root.tsx). Toggled by a temporary floating
+     switcher (see PaletteSwitcher) that writes a `palette-fete` class +
+     localStorage flag; no cookie/SSR persistence, no Settings UI, no
+     per-user rollout beyond the admin gate. Safe to delete this block and
+     the switcher component wholesale once a palette decision is made —
+     nothing else in the app depends on the class existing.
 
      Partial override: only tokens that actually differ from :root/.dark
      are declared. destructive/warning/input-invalid/foreground-destructive/


### PR DESCRIPTION
## Summary
- Follow-up to #513: the palette comparison tool was `import.meta.env.DEV`-only, so it never rendered outside local dev. Now it's shown for any developer in dev **and for admins in production**.
- Extracted the render decision into a pure, testable `shouldShowPaletteSwitcher(isDev, user)` helper in `palette-switcher.tsx` instead of inlining the check in `root.tsx` (avoids fighting Vite's static `import.meta.env.DEV` replacement in tests).
- Threaded `showPaletteSwitcher` through to `<Document>` too, so the inline no-flash script (which applies the stored palette class before first paint) also runs for prod admins — not just in dev.
- Updated the doc comments in `palette-switcher.tsx` and `tailwind.css` to describe the new gating.

Still not a shipped feature: no cookie/SSR persistence, no Settings UI entry, safe to delete wholesale once a palette decision is made — only the *visibility* gate changed.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors, 154 warnings (below the 155 baseline)
- [x] `npx vitest run` — 223 files / 1447 tests passed (new `shouldShowPaletteSwitcher` coverage: dev always shows, prod hides for signed-out/non-admin, prod shows for admin)
- [ ] CI green

https://claude.ai/code/session_01JohGjBa3mo3NvVXdkGjX6W