### PR TITLE
fix(ui): card contrast, owner badge, and propose-idea form consistency

### DIFF
--- a/app/components/groups/RoleBadge.tsx
+++ b/app/components/groups/RoleBadge.tsx
@@ -9,7 +9,7 @@ const roleMeta: Record<
 > = {
   OWNER: {
     label: 'owner',
-    icon: <LuCrown className="text-warning" />,
+    icon: <LuCrown />,
     bg: 'bg-primary',
     text: 'text-primary-foreground',
   },

--- a/app/routes/pools+/$poolId+/index.test.tsx
+++ b/app/routes/pools+/$poolId+/index.test.tsx
@@ -288,9 +288,14 @@ describe('app/routes/pools+/$poolId+/index.tsx', () => {
     renderRoute();
 
     const picker = screen.getByTestId('wishlist-item-picker');
-    expect(picker).toHaveTextContent('Espresso machine — $249.99');
+    expect(picker).toHaveTextContent('From their wishlist… (optional)');
 
-    await userEvent.selectOptions(picker, 'wish-9');
+    await userEvent.click(picker);
+    await userEvent.click(
+      await screen.findByRole('option', {
+        name: 'Espresso machine — $249.99',
+      }),
+    );
 
     await screen.findByDisplayValue('Espresso machine');
     expect(

--- a/app/routes/pools+/$poolId+/index.tsx
+++ b/app/routes/pools+/$poolId+/index.tsx
@@ -27,6 +27,13 @@ import { Badge } from '#app/components/ui/badge.tsx';
 import { Button } from '#app/components/ui/button.tsx';
 import { Card } from '#app/components/ui/card.tsx';
 import { Input } from '#app/components/ui/input.tsx';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '#app/components/ui/select.tsx';
 import { SystemLabel } from '#app/components/ui/system-label.tsx';
 import { Textarea } from '#app/components/ui/textarea.tsx';
 import { Flex, Stack, Text } from '#app/components/ui-kit';
@@ -282,6 +289,9 @@ const IdeaCard = ({
 
 // Propose idea form
 type RecipientWishlistItem = LoaderData['recipientWishlistItems'][number];
+// Radix Select reserves an empty string value for "no selection" — this
+// sentinel represents the clearable "From their wishlist…" placeholder item.
+const WISHLIST_ITEM_NONE = '__none__';
 
 const ProposeIdeaForm = ({
   poolId,
@@ -346,23 +356,32 @@ const ProposeIdeaForm = ({
             Propose an idea
           </Text>
           {recipientWishlistItems.length > 0 && (
-            <select
-              value={selectedItemId}
-              onChange={(e) => handlePickItem(e.target.value)}
-              data-testid="wishlist-item-picker"
-              aria-label="Pick from their wishlist"
-              className="h-9 w-full rounded-md border border-input bg-background px-3 text-sm text-muted-foreground"
+            <Select
+              value={selectedItemId || WISHLIST_ITEM_NONE}
+              onValueChange={(value) =>
+                handlePickItem(value === WISHLIST_ITEM_NONE ? '' : value)
+              }
             >
-              <option value="">From their wishlist… (optional)</option>
-              {recipientWishlistItems.map((item) => (
-                <option key={item.id} value={item.id}>
-                  {item.title}
-                  {item.priceCents == null
-                    ? ''
-                    : ` — ${formatCents(item.priceCents, item.currency ?? 'USD')}`}
-                </option>
-              ))}
-            </select>
+              <SelectTrigger
+                data-testid="wishlist-item-picker"
+                aria-label="Pick from their wishlist"
+              >
+                <SelectValue placeholder="From their wishlist… (optional)" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={WISHLIST_ITEM_NONE}>
+                  From their wishlist… (optional)
+                </SelectItem>
+                {recipientWishlistItems.map((item) => (
+                  <SelectItem key={item.id} value={item.id}>
+                    {item.title}
+                    {item.priceCents == null
+                      ? ''
+                      : ` — ${formatCents(item.priceCents, item.currency ?? 'USD')}`}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           )}
           <Stack gap={2}>
             <Input

--- a/app/styles/tailwind.css
+++ b/app/styles/tailwind.css
@@ -27,15 +27,25 @@
     --popover: 0 0% 100%;
     --popover-foreground: 18 18% 11%;
 
-    --card: 16 100% 96%; /* #FFF1EC tonal tint on the canvas */
+    /* Deepened from 16 100% 96% (#FFF1EC) — that value sat 2 lightness points
+       below --background, functionally invisible without the border doing
+       all the work. Every route using the shared <Card> primitive (wishlist
+       items, group cards, pool cards) read as flat and washed out, while
+       Home's hand-rolled subcard rows (--subcard, unchanged below) visibly
+       popped. Matching --card to --subcard gives every <Card> consumer the
+       same real contrast Home already had, continuing the same audit that
+       deepened --background-muted above. */
+    --card: 0 0% 100%; /* = subcard */
     --card-foreground: 18 18% 11%;
 
     --border: 11 37% 80%; /* #DFC0B9 */
     --input: 11 37% 80%;
     --input-invalid: 0 84.2% 60.2%;
-    /* Field fill — distinct from both --background and --card
-       so an input reads as a filled field on any surface (R1.1/R1.4). */
-    --input-bg: 17 68% 94%;
+    /* Field fill — distinct from both --background and the new white --card
+       so an input still reads as a filled, recessed field rather than
+       vanishing into a now-white card (R1.1/R1.4). Reuses --muted's value —
+       already the audited, visibly-distinct tint in this family. */
+    --input-bg: 15 48% 92%; /* = muted */
 
     --primary: 11 67% 39%; /* #A73921 terracotta — AA with white text */
     --primary-foreground: 0 0% 100%;
@@ -115,15 +125,22 @@
     --popover: 19 22% 13%;
     --popover-foreground: 17 84% 95%;
 
-    --card: 18 22% 12%; /* #241B17 — surfaces get lighter and warmer with elevation */
+    /* Deepened (lightened) from 18 22% 12% (#241B17) — only 4 points above
+       --background, same washed-out symptom as light mode's --card fix
+       above. Matched to --subcard (unchanged below) so every <Card>
+       consumer gets the same real "surfaces get lighter with elevation"
+       pop Home's hand-rolled subcard rows already had. */
+    --card: 19 21% 15%; /* = subcard */
     --card-foreground: 17 84% 95%;
 
     --border: 19 18% 21%;
     --input: 19 18% 21%;
     --input-invalid: 0 62.8% 30.6%;
-    /* Field fill — a hair lighter than --card so it reads as a raised,
-       fillable field rather than a hole on dark surfaces (R1.1/R1.4). */
-    --input-bg: 19 21% 15%;
+    /* Field fill — a hair lighter than the new --card so it still reads as
+       a raised, fillable field rather than blending into the card surface
+       it sits on (R1.1/R1.4). Preserves the original +3-lightness-point
+       relationship to --card, recentered on the new value. */
+    --input-bg: 19 20% 18%;
 
     --primary: 11 100% 82%; /* #FFB4A3 light coral — dark surfaces need light accents */
     --primary-foreground: 6 100% 12%; /* #3D0600 */
@@ -194,19 +211,19 @@
     --muted-foreground: 330 11% 38%; /* #6B5560 */
     --popover: 0 0% 100%;
     --popover-foreground: 324 16% 12%;
-    --card: 339 78% 96%; /* #FDEFF4 */
+    --card: 0 0% 100%; /* = subcard — matches the :root card/subcard unification above */
     --card-foreground: 324 16% 12%;
     --border: 334 28% 85%; /* #E4CFD8 */
     --input: 334 28% 85%;
-    --input-bg: 337 52% 95%; /* #F9ECF1, interpolated toward card */
+    --input-bg: 332 42% 94%; /* = muted — matches the :root input-bg fix above */
     --primary: 335 78% 42%; /* #BE185D raspberry */
     --primary-foreground: 0 0% 100%;
     --secondary: 332 35% 92%; /* #F1E2E9, = subcard-border (mirrors current light relationship) */
     --secondary-foreground: 324 16% 12%;
-    --accent: 337 52% 95%; /* = input-bg (mirrors current light relationship) */
+    --accent: 337 52% 95%; /* #F9ECF1 — independent of --input-bg, used for hover/focus states */
     --accent-foreground: 335 72% 60%; /* #E24E8C, the mockup's vibrant emphasis pink used in avatar gradients */
     --ring: 335 72% 60%;
-    --surface: 339 78% 96%; /* = card */
+    --surface: 339 78% 96%; /* #FDEFF4 — page header band; independent of --card now, unchanged on purpose */
     --surface-foreground: var(--foreground);
     --surface-border: 334 28% 85%; /* = border */
     --subcard: 0 0% 100%;
@@ -231,11 +248,14 @@
     --muted-foreground: 335 23% 79%; /* #D6BEC8 */
     --popover: 318 16% 15%; /* = modal/subcard */
     --popover-foreground: 335 68% 95%;
-    --card: 318 16% 12%; /* #241A21 */
+    --card: 318 16% 15%; /* = subcard — matches the .dark card/subcard unification above */
     --card-foreground: 335 68% 95%;
     --border: 329 17% 24%; /* #47323D */
     --input: 329 17% 24%;
-    --input-bg: 318 16% 15%; /* = subcard (mirrors current dark relationship) */
+    /* Was = subcard (318 16% 15%), which is now --card's value too — bumped
+       a hair lighter so the field still reads as raised above the card it
+       sits on, same relationship as the .dark fix above. */
+    --input-bg: 318 16% 18%;
     --primary: 333 100% 83%; /* #FFA6CE */
     --primary-foreground: 329 90% 15%; /* #4A0428 */
     --secondary: 327 17% 20%; /* #3D2B35, derived; = accent (mirrors current dark relationship) */
@@ -243,7 +263,7 @@
     --accent: 327 17% 20%;
     --accent-foreground: 335 72% 60%; /* #E24E8C, constant across modes like current accent-foreground/ring */
     --ring: 335 72% 60%;
-    --surface: 318 16% 12%; /* = card */
+    --surface: 318 16% 12%; /* #241A21 — page header band; independent of --card now, unchanged on purpose */
     --surface-foreground: var(--foreground);
     --surface-border: 329 17% 24%; /* = border */
     --subcard: 318 16% 15%; /* #2E212A */

--- a/tests/setup/setup-test-env.ts
+++ b/tests/setup/setup-test-env.ts
@@ -18,6 +18,18 @@ await import('dotenv/config');
 await import('./db-setup.ts');
 // we need these to be imported first 👆
 
+// jsdom doesn't implement pointer capture or scrollIntoView, which Radix
+// Select (and other Radix primitives using its positioning logic) call
+// unconditionally when opening — without this, clicking a Select trigger in
+// a jsdom-environment test throws "hasPointerCapture is not a function".
+// Guarded because this file also runs for node-environment tests with no DOM.
+if (typeof Element !== 'undefined') {
+  Element.prototype.hasPointerCapture ??= () => false;
+  Element.prototype.setPointerCapture ??= () => {};
+  Element.prototype.releasePointerCapture ??= () => {};
+  Element.prototype.scrollIntoView ??= () => {};
+}
+
 const { cleanup } = await import('@testing-library/react');
 const vitest = await import('vitest');
 const { server } = await import('#tests/mocks/index.ts');


### PR DESCRIPTION
## Summary

Investigated why cards and inputs on non-Home pages look inconsistent with Home's dashboard, plus two other reported visual bugs. All confirmed via code + live browser verification (light/dark, screenshots), not the incomplete Fête comparison palette.

- **Root cause of the "cards don't pop" issue**: the shared `<Card>` primitive uses `bg-card`, tokenized as a subtle "tonal tint on the canvas" only ~2-4 lightness points from `--background` in every palette. Home's dashboard bypasses `<Card>` entirely and hand-rolls `bg-subcard` (a real elevation tier), which is why only Home visibly popped. Unified `--card` (and `--input-bg`) with `--subcard`'s contrast across all 4 palette blocks (production light/dark, Fête light/dark) — one token change fixes every `<Card>`/`Input` consumer app-wide. `--surface` (page header band) and `--accent` (hover highlight) intentionally kept their values; only their now-stale "= card"/"= input-bg" comments were corrected.
- **Owner badge crown contrast**: `RoleBadge.tsx` hardcoded the crown icon to `text-warning` instead of `meta.text`, so on the OWNER badge's `bg-primary` pill, a dark muted-brown icon sat on a similarly dark terracotta/raspberry background. Now inherits `meta.text` like the label does.
- **Native `<select>` in the propose-idea form**: replaced with the app's existing Radix `Select` (already styled to match `Input` exactly) — explains both the native browser chevron and the visual mismatch from the rest of the form. Added the standard jsdom pointer-capture/`scrollIntoView` polyfill to the shared test setup, needed for any Radix Select interaction test going forward.

## Verification
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors, 154 warnings (below the 155 baseline)
- [x] `npx vitest run` — 223 files / 1448 tests passed
- [x] Live browser verification (logged in as seeded users, light + dark, 390px): wishlist items, group cards (including the owner badge crown), and the pool detail propose-idea form (Select open/select/prefill) all confirmed visually fixed
- [ ] CI green

## Test plan
- [ ] CI green (including Codex review, per the updated ship skill)

https://claude.ai/code/session_01JohGjBa3mo3NvVXdkGjX6W