### PR TITLE
fix(pools): stop an unhandled reminders error from blanking the app

### DIFF
--- a/app/routes/api.pools.$poolId.reminders.test.ts
+++ b/app/routes/api.pools.$poolId.reminders.test.ts
@@ -12,10 +12,19 @@ import {
 const requireUserId = vi.fn();
 const previewOrganizerNudge = vi.fn();
 const sendOrganizerNudge = vi.fn();
+const captureException = vi.fn();
 
 vi.mock('#app/utils/auth.server.ts', () => ({
   requireUserId: (...args: Array<unknown>) => requireUserId(...args),
 }));
+
+vi.mock('@sentry/react-router', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    captureException: (...args: Array<unknown>) => captureException(...args),
+  };
+});
 
 vi.mock('#app/utils/organizer-nudges.server.ts', () => ({
   OrganizerNudgeError: class OrganizerNudgeError extends Error {
@@ -39,6 +48,7 @@ import { action, loader } from './api.pools.$poolId.reminders.ts';
 
 beforeEach(() => {
   vi.clearAllMocks();
+  captureException.mockReset();
   requireUserId.mockResolvedValue('manager-1');
   previewOrganizerNudge.mockResolvedValue({
     status: 'AVAILABLE',
@@ -138,6 +148,56 @@ describe('organizer reminder resource route', () => {
       expect(getRouteResultStatus(result)).toBe(status);
       expect(await getRouteResultData(result)).toMatchObject({ code });
     }
+  });
+
+  // Regression for GIFTPOOL-UI-1M: a transient DB timeout (or any exception
+  // that isn't an OrganizerNudgeError) must resolve as a typed error
+  // response, not propagate as an unhandled loader exception. This route's
+  // only route-tree ancestor is root, so an unhandled throw here doesn't
+  // just fail the reminder widget's fetcher.load() call — react-router
+  // renders root's ErrorBoundary in its place, blanking the entire app for
+  // what should have been a recoverable, retry-able preview failure.
+  it('converts an unexpected error into a typed response instead of throwing', async () => {
+    previewOrganizerNudge.mockRejectedValueOnce(
+      new Error('Operations timed out after `N/A`.'),
+    );
+
+    const result = await loader(
+      toLoaderArgs({
+        context: {},
+        params: { poolId: 'pool-1' },
+        request: new Request(
+          'https://giftpool.app/api/pools/pool-1/reminders?kind=VOTE',
+        ),
+      }),
+    );
+
+    expect(getRouteResultStatus(result)).toBe(500);
+    expect(await getRouteResultData(result)).toMatchObject({
+      error: expect.any(String),
+    });
+    expect(captureException).toHaveBeenCalledTimes(1);
+  });
+
+  it('captures and converts an unexpected error on send too', async () => {
+    sendOrganizerNudge.mockRejectedValueOnce(new Error('boom'));
+
+    const result = await action(
+      toActionArgs({
+        context: {},
+        params: { poolId: 'pool-1' },
+        request: formRequest({
+          kind: 'VOTE',
+          idempotencyKey: 'client-mutation-1',
+        }),
+      }),
+    );
+
+    expect(getRouteResultStatus(result)).toBe(500);
+    expect(await getRouteResultData(result)).toMatchObject({
+      error: expect.any(String),
+    });
+    expect(captureException).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/app/routes/api.pools.$poolId.reminders.ts
+++ b/app/routes/api.pools.$poolId.reminders.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react-router';
 import {
   data,
   type ActionFunctionArgs,
@@ -61,9 +62,18 @@ export async function action({ request, params }: ActionFunctionArgs) {
 }
 
 function organizerNudgeErrorResponse(error: unknown) {
-  if (!(error instanceof OrganizerNudgeError)) throw error;
-  const status = organizerNudgeErrorStatus(error.code);
-  return data({ error: error.message, code: error.code }, { status });
+  if (error instanceof OrganizerNudgeError) {
+    const status = organizerNudgeErrorStatus(error.code);
+    return data({ error: error.message, code: error.code }, { status });
+  }
+  // Any other exception (e.g. a transient DB timeout) must not propagate as
+  // an unhandled loader/action error: this route's only route-tree ancestor
+  // is root, so a fetcher.load()/submit() failure here doesn't just fail
+  // OrganizerReminderAction's own request — react-router renders root's
+  // ErrorBoundary in its place, blanking the entire app for what the widget
+  // already knows how to show as a recoverable, retry-able inline error.
+  Sentry.captureException(error);
+  return data({ error: 'Something went wrong. Please try again.' }, { status: 500 });
 }
 
 function organizerNudgeErrorStatus(code: OrganizerNudgeError['code']) {


### PR DESCRIPTION
## Summary

Fixes [GIFTPOOL-UI-1M](https://giftpool-k0.sentry.io/issues/7628161837/) — a production report: tapping "Remind contributors" on a pool sometimes crashed the entire app to the generic "Something went wrong" screen.

**Root cause** (confirmed with a `createRoutesStub` + `useFetcher` reproduction harness, per the diagnosing-bugs discipline): `api.pools.$poolId.reminders.ts`'s `organizerNudgeErrorResponse` only converts `OrganizerNudgeError` into a typed response — any other exception (the actual trigger: a `PrismaClientKnownRequestError` timeout, fanned out per-recipient inside `resolveNotificationPolicy`) it re-threw. `OrganizerReminderAction` already wraps `fetcher.load()`/`submit()` in try/catch expecting to handle failures locally, but that catch never fires for an unhandled route exception — react-router bubbles it to the *erroring* route's own nearest `ErrorBoundary` ancestor, not the calling component's. This resource route's only ancestor is `root`, so any unhandled exception there renders `root`'s `GeneralErrorBoundary` in place of the **entire app**, not just the reminder widget.

**Fix**: any non-`OrganizerNudgeError` exception is now captured to Sentry (observability preserved) and converted to the same typed `{ error, status: 500 }` shape the widget's existing `RecoverableError` UI already renders correctly — no new client-side handling needed, since "retry-able" is the right behavior for a transient DB timeout.

**Not in scope**: the underlying DB-timeout risk itself (an unbounded `Promise.all` fan-out over pool contributors inside `filterPreferenceEligibleRecipients`, each doing 2 more concurrent queries in `resolveNotificationPolicy`) is a latent scaling risk worth hardening separately, but wasn't the reported symptom and this occurrence was a single, non-recurring event (0 users impacted per Sentry). Flagging for a follow-up if it recurs. Also flagging: any other resource route using a similar "typed response for known errors, re-throw everything else" pattern has the same latent crash risk — worth a broader sweep if this class of bug shows up again.

## Verification
- [x] Reproduced the exact bubbling mechanism with a throwaway `createRoutesStub` harness before writing the fix (see diagnosing-bugs Phase 1/2) — confirmed the widget's own try/catch does NOT catch this class of failure, and confirmed the fix pattern (typed `data()` response) resolves it
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors, 155 warnings (at the established baseline)
- [x] `npx vitest run` — 225 files / 1459 tests passed (2 new regression tests: unexpected error on preview GET, unexpected error on send POST — both assert a typed response is returned, not thrown, and that Sentry still captures it)

## Test plan
- [ ] CI green (including Codex review, per the ship skill)

https://claude.ai/code/session_01JohGjBa3mo3NvVXdkGjX6W