### PR TITLE
feat(friends): redesign the Friends page

### DIFF
--- a/app/components/friends/coming-up-section.test.tsx
+++ b/app/components/friends/coming-up-section.test.tsx
@@ -139,10 +139,28 @@ describe('<ComingUpSection />', () => {
     );
   });
 
+  it('names the recipient in each Plan gift link', () => {
+    // Several cards render at once, so a bare "Plan gift" accessible name
+    // leaves a screen reader listing links unable to tell them apart.
+    renderSection([
+      makeFriend('f-1', 'nina', { birthday: birthdayIn(4) }),
+      makeFriend('f-2', 'otto', { birthday: birthdayIn(9) }),
+    ]);
+
+    expect(
+      screen.getByRole('link', { name: 'Plan gift for nina' }),
+    ).toHaveAttribute('href', '/pools/new?recipientId=f-1-user');
+    expect(
+      screen.getByRole('link', { name: 'Plan gift for otto' }),
+    ).toHaveAttribute('href', '/pools/new?recipientId=f-2-user');
+  });
+
   it('links the friend through to their profile and reports the window', () => {
     renderSection([makeFriend('f-1', 'nina', { birthday: birthdayIn(4) })], 30);
 
-    expect(screen.getByRole('link', { name: /nina/i })).toHaveAttribute(
+    // Anchored: the Plan gift link also names the recipient, so a bare
+    // /nina/ matches both.
+    expect(screen.getByRole('link', { name: /^nina/i })).toHaveAttribute(
       'href',
       '/users/nina',
     );

--- a/app/components/friends/coming-up-section.test.tsx
+++ b/app/components/friends/coming-up-section.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { createRoutesStub } from 'react-router';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  ComingUpSection,
+  selectComingUpFriends,
+} from './coming-up-section.tsx';
+import { type FriendRowEntry } from './friend-row.tsx';
+
+vi.mock('../ui/avatar.tsx', () => ({
+  Avatar: ({ user }: { user: { username: string } }) => (
+    <div data-testid="avatar">{user.username}</div>
+  ),
+}));
+
+// Frozen "today" for every case below. Birthdays are stored at noon UTC, so
+// the fixtures construct their dates the same way the app does.
+const TODAY = new Date('2026-04-10T12:00:00.000Z');
+
+function makeFriend(
+  friendshipId: string,
+  username: string,
+  overrides: Partial<FriendRowEntry['user']> = {},
+): FriendRowEntry {
+  return {
+    friendshipId,
+    mutualGroups: [],
+    user: {
+      id: `${friendshipId}-user`,
+      username,
+      name: username,
+      birthday: null,
+      image: null,
+      ...overrides,
+    },
+  };
+}
+
+// A birthday `days` from the frozen today, at noon UTC.
+function birthdayIn(days: number) {
+  const date = new Date(TODAY);
+  date.setUTCDate(date.getUTCDate() + days);
+  return new Date(
+    Date.UTC(1990, date.getUTCMonth(), date.getUTCDate(), 12, 0, 0),
+  );
+}
+
+function renderSection(friends: FriendRowEntry[], windowDays?: number) {
+  const App = createRoutesStub([
+    {
+      path: '/',
+      Component: () => (
+        <ComingUpSection friends={friends} windowDays={windowDays} />
+      ),
+    },
+  ]);
+  render(<App initialEntries={['/']} />);
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(TODAY);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('selectComingUpFriends', () => {
+  it('includes friends inside the window, soonest first', () => {
+    const far = makeFriend('f-far', 'far', { birthday: birthdayIn(40) });
+    const near = makeFriend('f-near', 'near', { birthday: birthdayIn(3) });
+
+    const result = selectComingUpFriends([far, near]);
+
+    expect(result.map((item) => item.entry.user.username)).toEqual([
+      'near',
+      'far',
+    ]);
+  });
+
+  it('excludes friends whose birthday falls outside the window', () => {
+    const outside = makeFriend('f-1', 'outside', { birthday: birthdayIn(90) });
+
+    expect(selectComingUpFriends([outside])).toHaveLength(0);
+  });
+
+  it('honours a narrowed window', () => {
+    const friend = makeFriend('f-1', 'mid', { birthday: birthdayIn(30) });
+
+    expect(selectComingUpFriends([friend], 60)).toHaveLength(1);
+    expect(selectComingUpFriends([friend], 7)).toHaveLength(0);
+  });
+
+  it('excludes friends who hid their birthday from the viewer', () => {
+    // `birthdayVisible: false` is the server's canViewBirthday verdict — a
+    // date the viewer isn't allowed to see must not leak through the rail.
+    const hidden = makeFriend('f-1', 'hidden', {
+      birthday: birthdayIn(3),
+      birthdayVisible: false,
+    });
+
+    expect(selectComingUpFriends([hidden])).toHaveLength(0);
+  });
+
+  it('stays permissive for optimistic entries with an unknown visibility', () => {
+    const optimistic = makeFriend('f-1', 'optimistic', {
+      birthday: birthdayIn(3),
+    });
+
+    expect(selectComingUpFriends([optimistic])).toHaveLength(1);
+  });
+
+  it('ignores friends with no birthday on file', () => {
+    expect(selectComingUpFriends([makeFriend('f-1', 'nobirthday')])).toEqual(
+      [],
+    );
+  });
+});
+
+describe('<ComingUpSection />', () => {
+  it('renders nothing when no birthday is in range', () => {
+    const { container } = render(<ComingUpSection friends={[]} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('points Plan gift at the pool composer with the recipient preselected', () => {
+    renderSection([makeFriend('f-1', 'nina', { birthday: birthdayIn(4) })]);
+
+    expect(screen.getByRole('link', { name: /plan gift/i })).toHaveAttribute(
+      'href',
+      '/pools/new?recipientId=f-1-user',
+    );
+  });
+
+  it('links the friend through to their profile and reports the window', () => {
+    renderSection([makeFriend('f-1', 'nina', { birthday: birthdayIn(4) })], 30);
+
+    expect(screen.getByRole('link', { name: /nina/i })).toHaveAttribute(
+      'href',
+      '/users/nina',
+    );
+    expect(
+      screen.getByText('Birthdays in the next 30 days'),
+    ).toBeInTheDocument();
+  });
+});

--- a/app/components/friends/coming-up-section.tsx
+++ b/app/components/friends/coming-up-section.tsx
@@ -47,7 +47,7 @@ export function selectComingUpFriends(
     .sort((a, b) => a.daysUntil - b.daysUntil);
 }
 
-function ComingUpCard({ daysUntil, entry, label }: ComingUpFriend) {
+function ComingUpCard({ entry, label }: ComingUpFriend) {
   const { user } = entry;
   const displayName = user.name ?? user.username;
 
@@ -69,21 +69,28 @@ function ComingUpCard({ daysUntil, entry, label }: ComingUpFriend) {
           </Text>
           <span className="mt-0.5 flex items-center gap-1 text-xs font-semibold text-gift">
             <LuCake className="h-3 w-3 shrink-0" aria-hidden />
+            {/* The cake icon is decorative, so without this the date reads as
+             * a bare "Jul 28" with no hint of what it refers to. */}
+            <span className="sr-only">Birthday&nbsp;</span>
             <span className="truncate">{label}</span>
           </span>
         </div>
       </Link>
       <Button asChild size="sm" className="w-full">
         {/* `/pools/new` accepts a standalone `?recipientId=` and opens with
-         * the recipient preselected — no dedicated route needed. */}
-        <Link to={`/pools/new?recipientId=${user.id}`}>
+         * the recipient preselected — no dedicated route needed.
+         *
+         * The label has to name the recipient: several of these render at
+         * once, and a screen reader listing links would otherwise announce
+         * "Plan gift" repeatedly with no way to tell them apart. */}
+        <Link
+          to={`/pools/new?recipientId=${user.id}`}
+          aria-label={`Plan gift for ${displayName}`}
+        >
           <LuGift className="mr-1.5 h-3.5 w-3.5" aria-hidden />
           Plan gift
         </Link>
       </Button>
-      <span className="sr-only">
-        {displayName}'s birthday is in {daysUntil} days
-      </span>
     </li>
   );
 }

--- a/app/components/friends/coming-up-section.tsx
+++ b/app/components/friends/coming-up-section.tsx
@@ -1,0 +1,133 @@
+import { LuCake, LuCalendar, LuGift } from 'react-icons/lu';
+import { Link } from 'react-router';
+
+import { Avatar } from '#app/components/ui/avatar.tsx';
+import { Button } from '#app/components/ui/button.tsx';
+import {
+  COMING_UP_WINDOW_DAYS,
+  formatBirthdayLabel,
+  getUpcomingBirthday,
+} from '#app/utils/birthday.ts';
+import { Text } from '../ui-kit/text.tsx';
+import { type FriendRowEntry } from './friend-row.tsx';
+
+type ComingUpFriend = {
+  daysUntil: number;
+  entry: FriendRowEntry;
+  label: string;
+};
+
+// Friends with a birthday inside the window, soonest first.
+//
+// Exported for tests: the visibility rule is the whole point of this
+// component, and it's much cheaper to assert on the derived list than to
+// scrape the rendered rail.
+export function selectComingUpFriends(
+  friends: readonly FriendRowEntry[],
+  windowDays: number = COMING_UP_WINDOW_DAYS,
+): ComingUpFriend[] {
+  return friends
+    .flatMap((entry) => {
+      // `birthdayVisible` is the server-computed `canViewBirthday` result and
+      // is the single source of truth — a friend who hid their birthday must
+      // never surface here, the same guard `friend-row.tsx` applies to the
+      // badge. Optimistic just-accepted entries leave it `undefined`, which
+      // stays permissive until the next loader run fills it in.
+      if (entry.user.birthdayVisible === false) return [];
+      const upcoming = getUpcomingBirthday(entry.user.birthday);
+      if (!upcoming || upcoming.daysUntil > windowDays) return [];
+      return [
+        {
+          daysUntil: upcoming.daysUntil,
+          entry,
+          label: formatBirthdayLabel(upcoming.date, upcoming.daysUntil),
+        },
+      ];
+    })
+    .sort((a, b) => a.daysUntil - b.daysUntil);
+}
+
+function ComingUpCard({ daysUntil, entry, label }: ComingUpFriend) {
+  const { user } = entry;
+  const displayName = user.name ?? user.username;
+
+  return (
+    <li className="flex w-44 shrink-0 snap-start flex-col gap-3 rounded-xl border border-border bg-background p-3 sm:w-48">
+      <Link
+        to={`/users/${user.username}`}
+        prefetch="intent"
+        className="flex min-w-0 items-center gap-2.5 rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-transparent"
+      >
+        <Avatar size={10} image={user.image} user={user} />
+        <div className="min-w-0">
+          <Text
+            size="sm"
+            weight="semibold"
+            className="block truncate text-foreground"
+          >
+            {displayName}
+          </Text>
+          <span className="mt-0.5 flex items-center gap-1 text-xs font-semibold text-gift">
+            <LuCake className="h-3 w-3 shrink-0" aria-hidden />
+            <span className="truncate">{label}</span>
+          </span>
+        </div>
+      </Link>
+      <Button asChild size="sm" className="w-full">
+        {/* `/pools/new` accepts a standalone `?recipientId=` and opens with
+         * the recipient preselected — no dedicated route needed. */}
+        <Link to={`/pools/new?recipientId=${user.id}`}>
+          <LuGift className="mr-1.5 h-3.5 w-3.5" aria-hidden />
+          Plan gift
+        </Link>
+      </Button>
+      <span className="sr-only">
+        {displayName}'s birthday is in {daysUntil} days
+      </span>
+    </li>
+  );
+}
+
+export function ComingUpSection({
+  friends,
+  windowDays = COMING_UP_WINDOW_DAYS,
+}: Readonly<{
+  friends: readonly FriendRowEntry[];
+  windowDays?: number;
+}>) {
+  const comingUp = selectComingUpFriends(friends, windowDays);
+  // Nothing on the horizon is not a state worth a card — stay silent.
+  if (comingUp.length === 0) return null;
+
+  return (
+    <section
+      aria-labelledby="coming-up-heading"
+      className="rounded-xl border border-border bg-card p-4 shadow-sm"
+    >
+      <div className="mb-3 flex items-center gap-3">
+        <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-pool/15 text-pool">
+          <LuCalendar className="h-4 w-4" aria-hidden />
+        </span>
+        <div>
+          <h2
+            id="coming-up-heading"
+            className="text-sm font-semibold text-foreground"
+          >
+            Coming up
+          </h2>
+          <Text size="xs" className="text-muted-foreground">
+            Birthdays in the next {windowDays} days
+          </Text>
+        </div>
+      </div>
+      {/* Horizontal rail on narrow screens; on wide ones it simply stops
+       * overflowing. Scrollbar is styled down rather than hidden so the
+       * affordance survives on desktop. */}
+      <ul className="-mx-1 flex snap-x snap-proximity gap-3 overflow-x-auto px-1 pb-1 [-webkit-overflow-scrolling:touch] [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-border [&::-webkit-scrollbar]:h-1.5">
+        {comingUp.map((item) => (
+          <ComingUpCard key={item.entry.friendshipId} {...item} />
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/app/components/friends/friend-row.test.tsx
+++ b/app/components/friends/friend-row.test.tsx
@@ -29,10 +29,7 @@ const baseFriend: FriendRowEntry = {
   mutualGroups: [],
 };
 
-function renderRow(
-  override: Partial<FriendRowEntry> = {},
-  onRemove = vi.fn(),
-) {
+function renderRow(override: Partial<FriendRowEntry> = {}, onRemove = vi.fn()) {
   const friend: FriendRowEntry = {
     ...baseFriend,
     ...override,

--- a/app/components/friends/friend-row.test.tsx
+++ b/app/components/friends/friend-row.test.tsx
@@ -81,9 +81,9 @@ describe('<FriendRow />', () => {
   it('exposes a click target on the whole card via an aria-labelled link', () => {
     renderRow();
     const link = screen.getByRole('link', {
-      name: "View Alex Carter's wishlist",
+      name: "View Alex Carter's profile",
     });
-    expect(link).toHaveAttribute('href', '/users/alex/wishlist');
+    expect(link).toHaveAttribute('href', '/users/alex');
   });
 
   it('shows a birthday badge for friends within the 60-day window', () => {
@@ -176,5 +176,37 @@ describe('<FriendRow />', () => {
     );
 
     expect(onRemove).toHaveBeenCalledTimes(1);
+  });
+
+  it('offers wishlist, profile and remove in the actions menu — and nothing else', async () => {
+    vi.useRealTimers();
+    const user = userEvent.setup();
+    renderRow();
+
+    await user.click(
+      screen.getByRole('button', { name: 'Actions for Alex Carter' }),
+    );
+
+    expect(
+      await screen.findByRole('menuitem', { name: /view wishlist/i }),
+    ).toHaveAttribute('href', '/users/alex/wishlist');
+    expect(
+      screen.getByRole('menuitem', { name: /view profile/i }),
+    ).toHaveAttribute('href', '/users/alex');
+    expect(
+      screen.getByRole('menuitem', { name: /remove friend/i }),
+    ).toBeInTheDocument();
+
+    // Messaging/nudging a friend is a separate, undecided feature — this
+    // menu must not grow one by accident.
+    expect(
+      screen.queryByRole('menuitem', { name: /message|nudge|remind/i }),
+    ).not.toBeInTheDocument();
+    // And "Add to a group" stays out until a real add-to-group flow exists
+    // (groups are join-by-invite/request only today).
+    expect(
+      screen.queryByRole('menuitem', { name: /add to a group/i }),
+    ).not.toBeInTheDocument();
+    expect(screen.getAllByRole('menuitem')).toHaveLength(3);
   });
 });

--- a/app/components/friends/friend-row.tsx
+++ b/app/components/friends/friend-row.tsx
@@ -71,7 +71,10 @@ export function FriendRow({
       ? upcoming
       : null;
   const visibleGroups = mutualGroups.slice(0, 3);
-  const extraGroupCount = Math.max(0, mutualGroups.length - visibleGroups.length);
+  const extraGroupCount = Math.max(
+    0,
+    mutualGroups.length - visibleGroups.length,
+  );
   const [removeOpen, setRemoveOpen] = useState(false);
 
   return (
@@ -180,7 +183,10 @@ export function FriendRow({
               </DropdownMenuItem>
               <DropdownMenuItem asChild className="gap-2 px-2 py-2 text-sm">
                 <Link to={`/users/${user.username}`}>
-                  <LuUser className="h-4 w-4 text-muted-foreground" aria-hidden />
+                  <LuUser
+                    className="h-4 w-4 text-muted-foreground"
+                    aria-hidden
+                  />
                   View profile
                 </Link>
               </DropdownMenuItem>

--- a/app/components/friends/friend-row.tsx
+++ b/app/components/friends/friend-row.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import {
   LuCake,
   LuEllipsisVertical,
+  LuHeart,
   LuTrash,
   LuUser,
   LuUsers,
@@ -87,19 +88,19 @@ export function FriendRow({
       {/*
        * Whole-card click target. Same absolute click-catcher pattern as
        * the wishlist row primitive: a Link with `inset-0` covers the
-       * entire card so any tap navigates to the friend's wishlist, while
+       * entire card so any tap navigates to the friend's profile, while
        * the action menu in the right slot re-enables pointer events for
        * itself via `pointer-events-auto`.
        */}
       <Link
-        to={`/users/${user.username}/wishlist`}
+        to={`/users/${user.username}`}
         prefetch="intent"
-        aria-label={`View ${displayName}'s wishlist`}
+        aria-label={`View ${displayName}'s profile`}
         className="absolute inset-0 rounded-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-transparent"
       />
 
-      <div className="pointer-events-none relative flex items-center gap-3 p-3 sm:gap-4 sm:p-4">
-        <Avatar size="m" image={user.image} user={user} />
+      <div className="pointer-events-none relative flex items-center gap-3 p-3">
+        <Avatar size={11} image={user.image} user={user} />
         <div className="flex min-w-0 flex-1 flex-col items-start gap-1 text-left">
           <div className="flex w-full min-w-0 flex-wrap items-baseline gap-x-2 gap-y-0.5">
             <Text
@@ -165,6 +166,18 @@ export function FriendRow({
               className="min-w-[12rem]"
               onClick={(event) => event.stopPropagation()}
             >
+              {/* The card itself now routes to the profile, so the wishlist
+               * needs its own entry point — it's the action people actually
+               * come here for. */}
+              <DropdownMenuItem asChild className="gap-2 px-2 py-2 text-sm">
+                <Link to={`/users/${user.username}/wishlist`} prefetch="intent">
+                  <LuHeart
+                    className="h-4 w-4 text-muted-foreground"
+                    aria-hidden
+                  />
+                  View wishlist
+                </Link>
+              </DropdownMenuItem>
               <DropdownMenuItem asChild className="gap-2 px-2 py-2 text-sm">
                 <Link to={`/users/${user.username}`}>
                   <LuUser className="h-4 w-4 text-muted-foreground" aria-hidden />

--- a/app/i18n/dictionaries/en.ts
+++ b/app/i18n/dictionaries/en.ts
@@ -106,6 +106,8 @@ export const en = {
     emptyDescription:
       'Friends can see your wishlist and chip in on group gifts. Share an invite link or search by username.',
     emptyCta: 'Add friend',
+    noMatchTitle: 'No friends match your search',
+    noMatchDescription: 'Try a different name or @username.',
     incomingRequests: 'Incoming requests',
     outgoingRequests: 'Outgoing requests',
     removeSuccess: '{{name}} removed from friends.',

--- a/app/routes/friends.test.tsx
+++ b/app/routes/friends.test.tsx
@@ -50,7 +50,8 @@ vi.mock('#app/components/notifications/notifications-context.tsx', () => ({
 }));
 
 vi.mock('#app/hooks/use-background-route-prefetch.ts', () => ({
-  useFriendWishlistPrefetch: (...args: Array<unknown>) => friendPrefetchSpy(...args),
+  useFriendWishlistPrefetch: (...args: Array<unknown>) =>
+    friendPrefetchSpy(...args),
 }));
 
 vi.mock('#app/components/friends/friend-summary.tsx', () => ({
@@ -186,9 +187,11 @@ vi.mock('#app/components/ui/responsive-dialog.tsx', () => ({
   ResponsiveDialogContent: ({ children }: { children: React.ReactNode }) => (
     <div role="dialog">{children}</div>
   ),
-  ResponsiveDialogDescription: ({ children }: { children: React.ReactNode }) => (
-    <p>{children}</p>
-  ),
+  ResponsiveDialogDescription: ({
+    children,
+  }: {
+    children: React.ReactNode;
+  }) => <p>{children}</p>,
   ResponsiveDialogFooter: ({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
   ),
@@ -302,10 +305,7 @@ function createOutgoing(id: string, username: string, name = username) {
   };
 }
 
-function applyStateUpdate<T>(
-  updater: React.SetStateAction<T>,
-  previous: T,
-): T {
+function applyStateUpdate<T>(updater: React.SetStateAction<T>, previous: T): T {
   return typeof updater === 'function'
     ? (updater as (prev: T) => T)(previous)
     : updater;
@@ -350,7 +350,9 @@ beforeEach(() => {
       const url = typeof input === 'string' ? input : input.toString();
       if (url.includes('/api/friends/invite')) {
         return new Response(
-          JSON.stringify({ inviteUrl: 'https://giftpool.app/friends/accept/abc' }),
+          JSON.stringify({
+            inviteUrl: 'https://giftpool.app/friends/accept/abc',
+          }),
           { status: 200, headers: { 'Content-Type': 'application/json' } },
         );
       }
@@ -407,17 +409,24 @@ describe('/friends route helpers', () => {
     const entry = buildFriendEntry('request-1', user);
     expect(entry.friendshipId).toBe('request-1');
     expect(addFriendIfMissing([], entry)).toEqual([entry]);
-    expect(addFriendIfMissing([entry], buildFriendEntry('request-2', user))).toEqual([
-      entry,
-    ]);
+    expect(
+      addFriendIfMissing([entry], buildFriendEntry('request-2', user)),
+    ).toEqual([entry]);
   });
 
   it('derives birthdayVisible for optimistic entries so a NOBODY friend does not leak', () => {
-    const hiddenUser = { ...createUser('user-2', 'sam', 'Sam'), birthdayVisibility: 'NOBODY' };
-    expect(buildFriendEntry('request-3', hiddenUser).user.birthdayVisible).toBe(false);
+    const hiddenUser = {
+      ...createUser('user-2', 'sam', 'Sam'),
+      birthdayVisibility: 'NOBODY',
+    };
+    expect(buildFriendEntry('request-3', hiddenUser).user.birthdayVisible).toBe(
+      false,
+    );
 
     const friendsUser = createUser('user-3', 'jo', 'Jo'); // birthdayVisibility: 'FRIENDS'
-    expect(buildFriendEntry('request-4', friendsUser).user.birthdayVisible).toBe(true);
+    expect(
+      buildFriendEntry('request-4', friendsUser).user.birthdayVisible,
+    ).toBe(true);
   });
 
   it('submits request mutations and batches failures', async () => {
@@ -435,18 +444,24 @@ describe('/friends route helpers', () => {
         .mockResolvedValueOnce(new Response(null, { status: 200 })),
     );
 
-    await expect(submitRequestMutation('request-1', 'accept')).resolves.toEqual({
-      ok: true,
-      unreadCount: 5,
-    });
-    await expect(submitRequestMutation('request-2', 'reject')).resolves.toEqual({
-      ok: false,
-      unreadCount: null,
-    });
-    await expect(submitRequestMutation('request-3', 'cancel')).resolves.toEqual({
-      ok: true,
-      unreadCount: null,
-    });
+    await expect(submitRequestMutation('request-1', 'accept')).resolves.toEqual(
+      {
+        ok: true,
+        unreadCount: 5,
+      },
+    );
+    await expect(submitRequestMutation('request-2', 'reject')).resolves.toEqual(
+      {
+        ok: false,
+        unreadCount: null,
+      },
+    );
+    await expect(submitRequestMutation('request-3', 'cancel')).resolves.toEqual(
+      {
+        ok: true,
+        unreadCount: null,
+      },
+    );
   });
 
   it('collects failed batch ids and last unread count', async () => {
@@ -466,7 +481,10 @@ describe('/friends route helpers', () => {
       );
 
     await expect(
-      runBatchRequestMutation(['request-1', 'request-2', 'request-3'], 'accept'),
+      runBatchRequestMutation(
+        ['request-1', 'request-2', 'request-3'],
+        'accept',
+      ),
     ).resolves.toEqual({
       failedIds: ['request-2'],
       unreadCount: 7,
@@ -476,9 +494,9 @@ describe('/friends route helpers', () => {
   it('optimistically removes requests and restores failures', async () => {
     const requests = [{ id: 'request-1' }, { id: 'request-2' }];
     const updates: Array<Array<{ id: string }>> = [];
-    const setRequests: React.Dispatch<React.SetStateAction<Array<{ id: string }>>> = (
-      updater,
-    ) => {
+    const setRequests: React.Dispatch<
+      React.SetStateAction<Array<{ id: string }>>
+    > = (updater) => {
       const next = applyStateUpdate(
         updater,
         updates.length === 0 ? requests : (updates.at(-1) ?? requests),
@@ -507,7 +525,9 @@ describe('/friends route helpers', () => {
     expect(updates[0]).toEqual([]);
     expect(updates[1]).toEqual([{ id: 'request-1' }]);
     expect(setUnreadCount).toHaveBeenCalledWith(4);
-    expect(toastError).toHaveBeenCalledWith('Some requests could not be accepted.');
+    expect(toastError).toHaveBeenCalledWith(
+      'Some requests could not be accepted.',
+    );
   });
 
   it('filters, toggles, maps, and transitions friend state', () => {
@@ -517,8 +537,12 @@ describe('/friends route helpers', () => {
     ];
     expect(filterFriends(friends, 'sa')).toEqual([friends[1]]);
     expect(filterFriends(friends, ' ')).toEqual(friends);
-    expect(toggleSelection(new Set(['a']), 'b', true)).toEqual(new Set(['a', 'b']));
-    expect(toggleSelection(new Set(['a', 'b']), 'b', false)).toEqual(new Set(['a']));
+    expect(toggleSelection(new Set(['a']), 'b', true)).toEqual(
+      new Set(['a', 'b']),
+    );
+    expect(toggleSelection(new Set(['a', 'b']), 'b', false)).toEqual(
+      new Set(['a']),
+    );
 
     const incoming = [createIncoming('request-1', 'sam', 'Sam')];
     const outgoing = [createOutgoing('request-2', 'jules', 'Jules')];
@@ -543,8 +567,12 @@ describe('/friends route helpers', () => {
       error: 'Some requests could not be accepted.',
       success: 'Accepted 2 requests.',
     });
-    expect(getRequestMutationMessages('reject', 1).success).toBe('Declined 1 request.');
-    expect(getRequestMutationMessages('cancel', 1).success).toBe('Cancelled 1 request.');
+    expect(getRequestMutationMessages('reject', 1).success).toBe(
+      'Declined 1 request.',
+    );
+    expect(getRequestMutationMessages('cancel', 1).success).toBe(
+      'Cancelled 1 request.',
+    );
 
     expect(
       toRelationshipSnapshot({
@@ -628,7 +656,9 @@ describe('/friends route helpers', () => {
       },
       addFriendEntry,
       (updater) => {
-        const next = applyStateUpdate(updater, [createIncoming('incoming-1', 'sam', 'Sam')]);
+        const next = applyStateUpdate(updater, [
+          createIncoming('incoming-1', 'sam', 'Sam'),
+        ]);
         incomingUpdates.push(next as unknown[]);
         return incomingUpdates.at(-1) ?? [];
       },
@@ -642,7 +672,9 @@ describe('/friends route helpers', () => {
       },
       addFriendEntry,
       (updater) => {
-        const next = applyStateUpdate(updater, [createOutgoing('outgoing-1', 'jules', 'Jules')]);
+        const next = applyStateUpdate(updater, [
+          createOutgoing('outgoing-1', 'jules', 'Jules'),
+        ]);
         outgoingUpdates.push(next as unknown[]);
         return outgoingUpdates.at(-1) ?? [];
       },
@@ -655,7 +687,9 @@ describe('/friends route helpers', () => {
       },
       (updater) => {
         friendUpdates.push(
-          applyStateUpdate(updater, [createFriend('friendship-1', 'alex', 'Alex')]),
+          applyStateUpdate(updater, [
+            createFriend('friendship-1', 'alex', 'Alex'),
+          ]),
         );
         return friendUpdates.at(-1) ?? [];
       },
@@ -708,7 +742,9 @@ describe('/friends route rendering', () => {
       await screen.findByRole('textbox', { name: 'Friend invite link' }),
     ).toBeInTheDocument();
 
-    await userEvent.click(screen.getByRole('button', { name: 'Copy invite link' }));
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Copy invite link' }),
+    );
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
       'https://giftpool.app/friends/accept/abc',
     );
@@ -721,7 +757,11 @@ describe('/friends route rendering', () => {
 
   it('filters friends and renders every match in the grid', async () => {
     const manyFriends = Array.from({ length: 45 }, (_, index) =>
-      createFriend(`friendship-${index + 1}`, `friend-${index + 1}`, `Friend ${index + 1}`),
+      createFriend(
+        `friendship-${index + 1}`,
+        `friend-${index + 1}`,
+        `Friend ${index + 1}`,
+      ),
     );
 
     renderFriendsRoute({
@@ -791,7 +831,11 @@ describe('/friends route rendering', () => {
     renderFriendsRoute({
       data: {
         friends: Array.from({ length: 9 }, (_, index) =>
-          createFriend(`friendship-${index}`, `friend${index}`, `Friend ${index}`),
+          createFriend(
+            `friendship-${index}`,
+            `friend${index}`,
+            `Friend ${index}`,
+          ),
         ),
         incoming: [createIncoming('incoming-1', 'sam', 'Sam')],
         outgoing: [],
@@ -855,9 +899,14 @@ describe('/friends route rendering', () => {
 
     const input = await screen.findByPlaceholderText('e.g. alice');
     await userEvent.type(input, 'zoe');
-    await waitFor(() => {
-      expect(screen.getByText('No users found for "zoe"')).toBeInTheDocument();
-    }, { timeout: 2000 });
+    await waitFor(
+      () => {
+        expect(
+          screen.getByText('No users found for "zoe"'),
+        ).toBeInTheDocument();
+      },
+      { timeout: 2000 },
+    );
   });
 
   it('shows the empty friends state when no friends exist', async () => {

--- a/app/routes/friends.test.tsx
+++ b/app/routes/friends.test.tsx
@@ -16,17 +16,11 @@ import FriendsRoute, {
   createOutgoingEntry,
   extractInviteUser,
   filterFriends,
-  getMutualGroupChips,
-  getRequestMutationMessages,
   mapSearchResults,
-  runBatchRequestMutation,
-  runOptimisticRequestBatch,
-  submitRequestMutation,
   syncFriendsForFriendshipEvent,
   syncIncomingForFriendshipEvent,
   syncOutgoingForFriendshipEvent,
   toRelationshipSnapshot,
-  toggleSelection,
 } from './friends.tsx';
 
 const toastSuccess = vi.fn();
@@ -421,120 +415,13 @@ describe('/friends route helpers', () => {
     ).toBe(true);
   });
 
-  it('submits request mutations and batches failures', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi
-        .fn()
-        .mockResolvedValueOnce(
-          new Response(JSON.stringify({ unreadCount: 5 }), {
-            status: 200,
-            headers: { 'Content-Type': 'application/json' },
-          }),
-        )
-        .mockResolvedValueOnce(new Response(null, { status: 500 }))
-        .mockResolvedValueOnce(new Response(null, { status: 200 })),
-    );
-
-    await expect(submitRequestMutation('request-1', 'accept')).resolves.toEqual(
-      {
-        ok: true,
-        unreadCount: 5,
-      },
-    );
-    await expect(submitRequestMutation('request-2', 'reject')).resolves.toEqual(
-      {
-        ok: false,
-        unreadCount: null,
-      },
-    );
-    await expect(submitRequestMutation('request-3', 'cancel')).resolves.toEqual(
-      {
-        ok: true,
-        unreadCount: null,
-      },
-    );
-  });
-
-  it('collects failed batch ids and last unread count', async () => {
-    vi.spyOn(globalThis, 'fetch')
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify({ unreadCount: 1 }), {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' },
-        }),
-      )
-      .mockResolvedValueOnce(new Response(null, { status: 500 }))
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify({ unreadCount: 7 }), {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' },
-        }),
-      );
-
-    await expect(
-      runBatchRequestMutation(
-        ['request-1', 'request-2', 'request-3'],
-        'accept',
-      ),
-    ).resolves.toEqual({
-      failedIds: ['request-2'],
-      unreadCount: 7,
-    });
-  });
-
-  it('optimistically removes requests and restores failures', async () => {
-    const requests = [{ id: 'request-1' }, { id: 'request-2' }];
-    const updates: Array<Array<{ id: string }>> = [];
-    const setRequests: React.Dispatch<
-      React.SetStateAction<Array<{ id: string }>>
-    > = (updater) => {
-      const next = applyStateUpdate(
-        updater,
-        updates.length === 0 ? requests : (updates.at(-1) ?? requests),
-      );
-      updates.push(next);
-      return next;
-    };
-
-    vi.spyOn(globalThis, 'fetch')
-      .mockResolvedValueOnce(new Response(null, { status: 500 }))
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify({ unreadCount: 4 }), {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' },
-        }),
-      );
-
-    await runOptimisticRequestBatch(
-      ['request-1', 'request-2'],
-      'accept',
-      requests,
-      setRequests,
-      setUnreadCount,
-    );
-
-    expect(updates[0]).toEqual([]);
-    expect(updates[1]).toEqual([{ id: 'request-1' }]);
-    expect(setUnreadCount).toHaveBeenCalledWith(4);
-    expect(toastError).toHaveBeenCalledWith(
-      'Some requests could not be accepted.',
-    );
-  });
-
-  it('filters, toggles, maps, and transitions friend state', () => {
+  it('filters, maps, and transitions friend state', () => {
     const friends = [
       createFriend('friendship-1', 'alex', 'Alex'),
       createFriend('friendship-2', 'sam', 'Sam'),
     ];
     expect(filterFriends(friends, 'sa')).toEqual([friends[1]]);
     expect(filterFriends(friends, ' ')).toEqual(friends);
-    expect(toggleSelection(new Set(['a']), 'b', true)).toEqual(
-      new Set(['a', 'b']),
-    );
-    expect(toggleSelection(new Set(['a', 'b']), 'b', false)).toEqual(
-      new Set(['a']),
-    );
 
     const incoming = [createIncoming('request-1', 'sam', 'Sam')];
     const outgoing = [createOutgoing('request-2', 'jules', 'Jules')];
@@ -555,17 +442,6 @@ describe('/friends route helpers', () => {
       }),
     ).toEqual([]);
 
-    expect(getRequestMutationMessages('accept', 2)).toEqual({
-      error: 'Some requests could not be accepted.',
-      success: 'Accepted 2 requests.',
-    });
-    expect(getRequestMutationMessages('reject', 1).success).toBe(
-      'Declined 1 request.',
-    );
-    expect(getRequestMutationMessages('cancel', 1).success).toBe(
-      'Cancelled 1 request.',
-    );
-
     expect(
       toRelationshipSnapshot({
         friendshipId: 'friendship-1',
@@ -578,28 +454,6 @@ describe('/friends route helpers', () => {
       incomingRequestId: 'incoming-1',
       outgoingRequestId: 'outgoing-1',
       state: 'FRIENDS',
-    });
-
-    expect(
-      getMutualGroupChips(
-        {
-          'user-1': {
-            groups: [
-              { id: 'group-1', name: 'Group 1' },
-              { id: 'group-2', name: 'Group 2' },
-              { id: 'group-3', name: 'Group 3' },
-            ],
-            more: 3,
-          },
-        },
-        'user-1',
-      ),
-    ).toEqual({
-      extraGroupCount: 3,
-      mutualGroups: [
-        { id: 'group-1', name: 'Group 1' },
-        { id: 'group-2', name: 'Group 2' },
-      ],
     });
 
     expect(

--- a/app/routes/friends.test.tsx
+++ b/app/routes/friends.test.tsx
@@ -719,7 +719,7 @@ describe('/friends route rendering', () => {
     });
   });
 
-  it('filters friends and uses virtualization for long lists', async () => {
+  it('filters friends and renders every match in the grid', async () => {
     const manyFriends = Array.from({ length: 45 }, (_, index) =>
       createFriend(`friendship-${index + 1}`, `friend-${index + 1}`, `Friend ${index + 1}`),
     );
@@ -741,8 +741,73 @@ describe('/friends route rendering', () => {
     expect(screen.queryByText('Friend 40')).not.toBeInTheDocument();
 
     await userEvent.clear(filterInput);
+    // The list is no longer virtualized — clearing the filter brings every
+    // friend back into the DOM rather than a scrolled window of them.
     const rows = screen.getAllByTestId('friend-row');
-    expect(rows.length).toBeLessThan(manyFriends.length);
+    expect(rows).toHaveLength(manyFriends.length);
+  });
+
+  it('reorders the list between birthday proximity and A–Z', async () => {
+    // Zoe has a birthday in 5 days, so proximity sort floats her above the
+    // alphabetically-earlier names.
+    const soon = new Date();
+    soon.setDate(soon.getDate() + 5);
+    const zoe = createFriend('friendship-z', 'zoe', 'Zoe');
+    zoe.user.birthday = new Date(1990, soon.getMonth(), soon.getDate());
+
+    renderFriendsRoute({
+      data: {
+        friends: [
+          zoe,
+          ...Array.from({ length: 9 }, (_, index) =>
+            createFriend(
+              `friendship-${index}`,
+              `anna${index}`,
+              `Anna ${index}`,
+            ),
+          ),
+        ],
+        incoming: [],
+        outgoing: [],
+      },
+    });
+
+    const namesInOrder = () =>
+      screen
+        .getAllByTestId('friend-row')
+        .map((row) => row.textContent ?? '')
+        .map((text) => text.trim());
+
+    await waitFor(() => expect(namesInOrder()[0]).toContain('Zoe'));
+
+    await userEvent.click(screen.getByRole('button', { name: 'A–Z' }));
+    await waitFor(() => expect(namesInOrder()[0]).toContain('Anna 0'));
+
+    await userEvent.click(screen.getByRole('button', { name: 'By birthday' }));
+    await waitFor(() => expect(namesInOrder()[0]).toContain('Zoe'));
+  });
+
+  it('hides the requests and Coming up sections while filtering', async () => {
+    renderFriendsRoute({
+      data: {
+        friends: Array.from({ length: 9 }, (_, index) =>
+          createFriend(`friendship-${index}`, `friend${index}`, `Friend ${index}`),
+        ),
+        incoming: [createIncoming('incoming-1', 'sam', 'Sam')],
+        outgoing: [],
+      },
+    });
+
+    expect(await screen.findByText('Friend requests')).toBeInTheDocument();
+
+    await userEvent.type(
+      screen.getByRole('textbox', { name: 'Search friends' }),
+      'Friend 3',
+    );
+
+    await waitFor(() =>
+      expect(screen.queryByText('Friend requests')).not.toBeInTheDocument(),
+    );
   });
 
   it('updates incoming/outgoing/friends state from interaction and friendship events', async () => {

--- a/app/routes/friends.test.tsx
+++ b/app/routes/friends.test.tsx
@@ -16,7 +16,6 @@ import FriendsRoute, {
   createOutgoingEntry,
   extractInviteUser,
   filterFriends,
-  getActiveTab,
   getMutualGroupChips,
   getRequestMutationMessages,
   mapSearchResults,
@@ -397,13 +396,6 @@ afterEach(() => {
 });
 
 describe('/friends route helpers', () => {
-  it('normalizes tabs and ignores unknown values', () => {
-    expect(getActiveTab(new URLSearchParams('tab=add'))).toBe('add');
-    expect(getActiveTab(new URLSearchParams('tab=requests'))).toBe('requests');
-    expect(getActiveTab(new URLSearchParams('tab=unknown'))).toBe('friends');
-    expect(getActiveTab(new URLSearchParams())).toBe('friends');
-  });
-
   it('builds and deduplicates friend entries', () => {
     const user = createUser('user-1', 'alex', 'Alex');
     const entry = buildFriendEntry('request-1', user);

--- a/app/routes/friends.test.tsx
+++ b/app/routes/friends.test.tsx
@@ -673,6 +673,42 @@ describe('/friends route rendering', () => {
     await waitFor(() => expect(namesInOrder()[0]).toContain('Zoe'));
   });
 
+  it('offers the sort toggle below the search threshold, but not for a single friend', async () => {
+    // The search input is gated at >8; sorting is useful well before that,
+    // so the two must not share a threshold.
+    const { unmount } = renderFriendsRoute({
+      data: {
+        friends: [
+          createFriend('friendship-1', 'alex', 'Alex'),
+          createFriend('friendship-2', 'sam', 'Sam'),
+          createFriend('friendship-3', 'zoe', 'Zoe'),
+        ],
+        incoming: [],
+        outgoing: [],
+      },
+    });
+
+    expect(await screen.findByRole('button', { name: 'A–Z' })).toBeVisible();
+    expect(
+      screen.queryByRole('textbox', { name: 'Search friends' }),
+    ).not.toBeInTheDocument();
+    unmount();
+
+    // A single friend cannot be reordered, so the control stays hidden.
+    renderFriendsRoute({
+      data: {
+        friends: [createFriend('friendship-1', 'alex', 'Alex')],
+        incoming: [],
+        outgoing: [],
+      },
+    });
+
+    await screen.findByText('Alex');
+    expect(
+      screen.queryByRole('button', { name: 'A–Z' }),
+    ).not.toBeInTheDocument();
+  });
+
   it('hides the requests and Coming up sections while filtering', async () => {
     renderFriendsRoute({
       data: {

--- a/app/routes/friends.tsx
+++ b/app/routes/friends.tsx
@@ -322,13 +322,19 @@ function FriendRequestRow({
 
   return (
     <li className="flex items-center gap-4 rounded-xl border border-border bg-card p-4 shadow-sm">
-      <Avatar size="s" image={user.image} user={user} />
-      <div className="flex-1 text-foreground">@{username}</div>
+      {/* The avatar and the actions must hold their size; the handle is the
+       * only thing allowed to give. Without this a long username shrinks the
+       * avatar to zero width on a narrow viewport. */}
+      <div className="shrink-0">
+        <Avatar size="s" image={user.image} user={user} />
+      </div>
+      <div className="min-w-0 flex-1 truncate text-foreground">@{username}</div>
       <FriendActionButton
         targetUserId={user.id}
         targetUserName={`@${username}`}
         relationship={relationship}
         variant="compact"
+        className="shrink-0"
         onStateChange={onStateChange}
       />
     </li>

--- a/app/routes/friends.tsx
+++ b/app/routes/friends.tsx
@@ -10,7 +10,6 @@ import {
 import {
   Outlet,
   useLoaderData,
-  useSearchParams,
   type ClientLoaderFunctionArgs,
   type LoaderFunctionArgs,
   type MetaFunction,
@@ -132,9 +131,7 @@ type InviteQrDialogProps = Readonly<{
   open: boolean;
   qrDataUrl: string | null;
 }>;
-type FriendsTab = 'add' | 'requests' | 'friends';
 type FriendsListSectionProps = Readonly<{
-  activeTab: FriendsTab;
   filteredFriends: FriendEntry[];
   friendsState: FriendEntry[];
   onRenderFriendRow: (friend: FriendEntry) => React.ReactNode;
@@ -145,13 +142,6 @@ type UseFriendsRouteStateOptions = Readonly<{
   setUnreadCount: (count: number) => void;
 }>;
 type FriendsRouteState = ReturnType<typeof useFriendsRouteState>;
-
-export function getActiveTab(searchParams: URLSearchParams): FriendsTab {
-  const activeTabParam = (searchParams.get('tab') ?? 'friends').toLowerCase();
-  return activeTabParam === 'add' || activeTabParam === 'requests'
-    ? activeTabParam
-    : 'friends';
-}
 
 export function addFriendIfMissing(friends: FriendEntry[], entry: FriendEntry) {
   if (friends.some((item) => item.user.id === entry.user.id)) {
@@ -781,50 +771,6 @@ export function syncFriendsForFriendshipEvent(
   );
 }
 
-function useFriendsSearchParams() {
-  const [searchParams, setSearchParams] = useSearchParams();
-  const activeTab = getActiveTab(searchParams);
-  const initialQ = searchParams.get('q') ?? '';
-  const [q, setQ] = useState(initialQ);
-
-  useEffect(() => {
-    setQ(initialQ);
-  }, [initialQ]);
-
-  useEffect(() => {
-    const timeoutId = setTimeout(() => {
-      const next = new URLSearchParams(searchParams);
-      if (q) next.set('q', q);
-      else next.delete('q');
-      next.set('tab', activeTab);
-      setSearchParams(next, {
-        preventScrollReset: true,
-      });
-    }, 300);
-    return () => clearTimeout(timeoutId);
-  }, [activeTab, q, searchParams, setSearchParams]);
-
-  const handleTabChange = useCallback(
-    (value: FriendsTab) => {
-      const next = new URLSearchParams(searchParams);
-      next.set('tab', value);
-      if (q) next.set('q', q);
-      setSearchParams(next, {
-        preventScrollReset: true,
-      });
-    },
-    [q, searchParams, setSearchParams],
-  );
-
-  return {
-    activeTab,
-    q,
-    setQ,
-    searchParams,
-    handleTabChange,
-  };
-}
-
 function useFriendsRouteState({
   data,
   setUnreadCount: _setUnreadCount,
@@ -908,7 +854,6 @@ function useFriendsRouteState({
 }
 
 function FriendsListSection({
-  activeTab,
   filteredFriends,
   friendsState,
   onRenderFriendRow,
@@ -935,9 +880,7 @@ function FriendsListSection({
   }
 
   return (
-    <section
-      className={cn(activeTab !== 'friends' ? 'hidden sm:block' : undefined)}
-    >
+    <section>
       <div className="mb-3 flex items-center justify-between gap-3">
         <h2 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
           {t('friends.friends')}
@@ -1305,7 +1248,13 @@ const FriendsRoute = () => {
   const { t } = useTranslation();
   const { setUnreadCount } = useNotificationsStore();
   useFriendWishlistPrefetch(data.friends.map((friend) => friend.user.username));
-  const { q, setQ } = useFriendsSearchParams();
+  // Query for the add-friend dialog's username search. Deliberately local:
+  // it used to be mirrored into `?q=` by a debounced effect that also
+  // re-wrote a `?tab=` param nobody read. Because that effect listed
+  // `searchParams` in its own deps, each write produced a fresh object and
+  // re-triggered itself — a navigation every 300ms that clobbered any
+  // navigation started in the same window.
+  const [q, setQ] = useState('');
   const [friendsFilter, setFriendsFilter] = useState('');
   const {
     friendsState,
@@ -1438,7 +1387,6 @@ const FriendsRoute = () => {
           ) : null}
 
           <FriendsListSection
-            activeTab="friends"
             filteredFriends={filteredFriends}
             friendsState={friendsState}
             onRenderFriendRow={renderFriendRow}

--- a/app/routes/friends.tsx
+++ b/app/routes/friends.tsx
@@ -1203,18 +1203,26 @@ const FriendsRoute = () => {
             </>
           )}
 
-          {friendsState.length > 8 ? (
+          {/* Two different thresholds on purpose. Searching a handful of
+           * friends is pointless, but ordering is not: the default
+           * birthday-proximity order reshuffles itself as dates approach, so
+           * A–Z stays useful at any size above one. */}
+          {friendsState.length > 1 ? (
             <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-              <Input
-                value={friendsFilter}
-                onChange={(event) =>
-                  setFriendsFilter(event.currentTarget.value)
-                }
-                placeholder="Search friends"
-                aria-label="Search friends"
-                className="sm:flex-1"
-              />
-              <FriendsSortToggle sort={sort} onSortChange={setSort} />
+              {friendsState.length > 8 ? (
+                <Input
+                  value={friendsFilter}
+                  onChange={(event) =>
+                    setFriendsFilter(event.currentTarget.value)
+                  }
+                  placeholder="Search friends"
+                  aria-label="Search friends"
+                  className="sm:flex-1"
+                />
+              ) : null}
+              <div className="sm:ml-auto">
+                <FriendsSortToggle sort={sort} onSortChange={setSort} />
+              </div>
             </div>
           ) : null}
 

--- a/app/routes/friends.tsx
+++ b/app/routes/friends.tsx
@@ -725,8 +725,8 @@ function FriendsListSection({
       </div>
       {filteredFriends.length === 0 ? (
         <EmptyState
-          title="No friends match your search"
-          description="Try a different name or @username."
+          title={t('friends.noMatchTitle')}
+          description={t('friends.noMatchDescription')}
         />
       ) : (
         /* Dense single column on mobile, card grid from the 768px

--- a/app/routes/friends.tsx
+++ b/app/routes/friends.tsx
@@ -40,6 +40,10 @@ import { Skeleton } from '#app/components/ui/skeleton.tsx';
 import { Stack } from '#app/components/ui-kit/stack.tsx';
 import { useFriendWishlistPrefetch } from '#app/hooks/use-background-route-prefetch.ts';
 import { requireUserId } from '#app/utils/auth.server.ts';
+import {
+  COMING_UP_WINDOW_DAYS,
+  getUpcomingBirthday,
+} from '#app/utils/birthday.ts';
 import { loadFriendsPageData } from '#app/utils/friends-page.server.ts';
 import {
   FRIENDSHIP_UPDATED_EVENT,
@@ -296,51 +300,49 @@ export function filterFriends(friends: FriendEntry[], term: string) {
   });
 }
 
-const MS_PER_DAY = 24 * 60 * 60 * 1000;
-const BIRTHDAY_SORT_WINDOW_DAYS = 60;
-
-// Days from `today` until this friend's next birthday (clamped to a year).
-// Returns Infinity for friends without a birthday — they sort to the bottom.
-function daysUntilNextBirthday(birthday: Date | string | null, today: Date) {
-  if (!birthday) return Number.POSITIVE_INFINITY;
-  const parsed = birthday instanceof Date ? birthday : new Date(birthday);
-  if (Number.isNaN(parsed.getTime())) return Number.POSITIVE_INFINITY;
-  const candidate = new Date(
-    today.getFullYear(),
-    parsed.getMonth(),
-    parsed.getDate(),
-  );
-  if (candidate.getTime() < today.getTime()) {
-    candidate.setFullYear(candidate.getFullYear() + 1);
-  }
-  return Math.round((candidate.getTime() - today.getTime()) / MS_PER_DAY);
-}
-
 // Sort friends so the people you most need to think about gifting come
-// first: anyone whose birthday is within the next 60 days, ordered by
+// first: anyone whose birthday is within COMING_UP_WINDOW_DAYS, ordered by
 // soonest first; everyone else falls back to alphabetical by display
 // name. Stable enough to look ordered, useful enough that the list
 // surfaces something actionable above the fold.
+//
+// Proximity comes from the shared `getUpcomingBirthday`, which reads the
+// stored date's UTC month/day. Birthdays are persisted at noon UTC so the
+// calendar date is timezone-invariant; a local-time reading here would let
+// this sort disagree by a day with the badge `friend-row.tsx` renders from
+// the same helper.
 export function sortFriendsByUpcomingBirthday(
   friends: FriendEntry[],
-  now: Date = new Date(),
 ): FriendEntry[] {
-  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-  const withMeta = friends.map((friend, index) => ({
+  const withMeta = friends.map((friend) => ({
     friend,
-    days: daysUntilNextBirthday(friend.user.birthday, today),
+    // Friends who hid their birthday sort as if they had none — the viewer
+    // must not be able to infer a hidden date from list position.
+    days:
+      friend.user.birthdayVisible === false
+        ? Number.POSITIVE_INFINITY
+        : (getUpcomingBirthday(friend.user.birthday)?.daysUntil ??
+          Number.POSITIVE_INFINITY),
     name: (friend.user.name ?? friend.user.username).toLowerCase(),
-    index,
   }));
   withMeta.sort((a, b) => {
-    const aSoon = a.days <= BIRTHDAY_SORT_WINDOW_DAYS;
-    const bSoon = b.days <= BIRTHDAY_SORT_WINDOW_DAYS;
+    const aSoon = a.days <= COMING_UP_WINDOW_DAYS;
+    const bSoon = b.days <= COMING_UP_WINDOW_DAYS;
     if (aSoon && bSoon) return a.days - b.days || a.name.localeCompare(b.name);
     if (aSoon) return -1;
     if (bSoon) return 1;
     return a.name.localeCompare(b.name);
   });
   return withMeta.map((entry) => entry.friend);
+}
+
+// Alphabetical by display name, for the "A–Z" sort toggle.
+export function sortFriendsByName(friends: FriendEntry[]): FriendEntry[] {
+  return [...friends].sort((a, b) =>
+    (a.user.name ?? a.user.username)
+      .toLowerCase()
+      .localeCompare((b.user.name ?? b.user.username).toLowerCase()),
+  );
 }
 
 export function toggleSelection(

--- a/app/routes/friends.tsx
+++ b/app/routes/friends.tsx
@@ -8,7 +8,6 @@ import {
   LuUsers,
 } from 'react-icons/lu';
 import {
-  Link,
   Outlet,
   useLoaderData,
   useSearchParams,
@@ -17,11 +16,11 @@ import {
   type MetaFunction,
 } from 'react-router';
 import { toast } from 'sonner';
+import { ComingUpSection } from '#app/components/friends/coming-up-section.tsx';
 import {
   FriendActionButton,
   type RelationshipSnapshot,
 } from '#app/components/friends/friend-action-button.tsx';
-import { ComingUpSection } from '#app/components/friends/coming-up-section.tsx';
 import { FriendRow as FriendRowCard } from '#app/components/friends/friend-row.tsx';
 import { useNotificationsStore } from '#app/components/notifications/notifications-context.tsx';
 import { PageHeader } from '#app/components/page-header.tsx';
@@ -426,6 +425,52 @@ export function getMutualGroupChips(
 }
 
 type TranslateFn = ReturnType<typeof useTranslation>['t'];
+
+export type FriendsSort = 'birthday' | 'az';
+
+// Segmented control for list order. Local state rather than a search param:
+// `useFriendsSearchParams` owns the `tab`/`q` contract that the add-friend
+// search shares with /api/users/search, and sort order isn't worth linking to.
+function FriendsSortToggle({
+  onSortChange,
+  sort,
+}: Readonly<{
+  onSortChange: (next: FriendsSort) => void;
+  sort: FriendsSort;
+}>) {
+  const options: Array<{ label: string; value: FriendsSort }> = [
+    { label: 'By birthday', value: 'birthday' },
+    { label: 'A–Z', value: 'az' },
+  ];
+
+  return (
+    <div
+      role="group"
+      aria-label="Sort friends"
+      className="inline-flex flex-none gap-0.5 rounded-full bg-muted p-1"
+    >
+      {options.map((option) => {
+        const active = sort === option.value;
+        return (
+          <button
+            key={option.value}
+            type="button"
+            aria-pressed={active}
+            onClick={() => onSortChange(option.value)}
+            className={cn(
+              'whitespace-nowrap rounded-full px-3 py-1.5 text-xs font-semibold transition-colors',
+              active
+                ? 'bg-card text-foreground shadow-sm'
+                : 'text-muted-foreground hover:text-foreground',
+            )}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
 
 function FriendRequestRow({
   onStateChange,
@@ -893,15 +938,23 @@ function FriendsListSection({
     <section
       className={cn(activeTab !== 'friends' ? 'hidden sm:block' : undefined)}
     >
-      <h2 className="text-lg font-semibold">{t('friends.friends')}</h2>
-      {filteredFriends.length > 40 ? (
-        <VirtualizedFriendsList
-          items={filteredFriends}
-          rowHeight={72}
-          renderRow={onRenderFriendRow}
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <h2 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          {t('friends.friends')}
+        </h2>
+        <span className="text-xs font-semibold text-muted-foreground">
+          {filteredFriends.length}
+        </span>
+      </div>
+      {filteredFriends.length === 0 ? (
+        <EmptyState
+          title="No friends match your search"
+          description="Try a different name or @username."
         />
       ) : (
-        <ul className="mt-3 space-y-3">
+        /* Dense single column on mobile, card grid from the 768px
+         * breakpoint up. */
+        <ul className="grid grid-cols-1 gap-3 md:grid-cols-2 md:gap-4 xl:grid-cols-3">
           {filteredFriends.map((friend) => onRenderFriendRow(friend))}
         </ul>
       )}
@@ -1266,11 +1319,17 @@ const FriendsRoute = () => {
     data,
     setUnreadCount,
   });
-  const filteredFriends = useMemo(
-    () =>
-      sortFriendsByUpcomingBirthday(filterFriends(friendsState, friendsFilter)),
-    [friendsFilter, friendsState],
-  );
+  const [sort, setSort] = useState<FriendsSort>('birthday');
+  const filteredFriends = useMemo(() => {
+    const matching = filterFriends(friendsState, friendsFilter);
+    return sort === 'az'
+      ? sortFriendsByName(matching)
+      : sortFriendsByUpcomingBirthday(matching);
+  }, [friendsFilter, friendsState, sort]);
+  // While the viewer is filtering, the pinned sections above the list are
+  // noise between them and their results — collapse the page down to the
+  // matches.
+  const isFiltering = friendsFilter.trim().length > 0;
   const handleRemoveFriend = useCallback(
     async (friend: FriendEntry) => {
       const displayName = friend.user.name ?? friend.user.username;
@@ -1350,22 +1409,30 @@ const FriendsRoute = () => {
 
       <PageShell className="min-h-0 flex-1 py-6 sm:py-8">
         <Stack gap={4}>
-          <PendingRequestsCard
-            incomingState={incomingState}
-            outgoingState={outgoingState}
-            onIncomingTransition={handleIncomingTransition}
-            onOutgoingTransition={handleOutgoingTransition}
-          />
+          {isFiltering ? null : (
+            <>
+              <PendingRequestsCard
+                incomingState={incomingState}
+                outgoingState={outgoingState}
+                onIncomingTransition={handleIncomingTransition}
+                onOutgoingTransition={handleOutgoingTransition}
+              />
 
-          <ComingUpSection friends={friendsState} />
+              <ComingUpSection friends={friendsState} />
+            </>
+          )}
 
           {friendsState.length > 8 ? (
-            <Input
-              value={friendsFilter}
-              onChange={(event) => setFriendsFilter(event.currentTarget.value)}
-              placeholder="Search friends"
-              aria-label="Search friends"
-            />
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+              <Input
+                value={friendsFilter}
+                onChange={(event) => setFriendsFilter(event.currentTarget.value)}
+                placeholder="Search friends"
+                aria-label="Search friends"
+                className="sm:flex-1"
+              />
+              <FriendsSortToggle sort={sort} onSortChange={setSort} />
+            </div>
           ) : null}
 
           <FriendsListSection
@@ -1383,100 +1450,6 @@ const FriendsRoute = () => {
   );
 };
 export default FriendsRoute;
-function VirtualizedFriendsList({
-  items,
-  rowHeight = 72,
-  renderRow,
-}: {
-  items: Array<{
-    friendshipId: string;
-    user: {
-      id: string;
-      username: string;
-      name: string | null;
-      image: {
-        id: string;
-        altText: string | null;
-      } | null;
-    };
-  }>;
-  rowHeight?: number;
-  renderRow: (item: any) => React.ReactNode;
-}) {
-  const containerRef = useRef<HTMLDivElement | null>(null);
-  const [viewport, setViewport] = useState({
-    height: 480,
-    scrollTop: 0,
-  });
-  useEffect(() => {
-    const el = containerRef.current;
-    if (!el) return;
-    const ro = new ResizeObserver(() => {
-      setViewport((v) => ({
-        ...v,
-        height: el.clientHeight,
-      }));
-    });
-    ro.observe(el);
-    const onScroll = () =>
-      setViewport((v) => ({
-        ...v,
-        scrollTop: el.scrollTop,
-      }));
-    el.addEventListener('scroll', onScroll, {
-      passive: true,
-    });
-    // initialize
-    setViewport({
-      height: el.clientHeight,
-      scrollTop: el.scrollTop,
-    });
-    return () => {
-      ro.disconnect();
-      el.removeEventListener('scroll', onScroll);
-    };
-  }, []);
-  const total = items.length * rowHeight;
-  const overscan = 8;
-  const start = Math.max(
-    0,
-    Math.floor(viewport.scrollTop / rowHeight) - overscan,
-  );
-  const end = Math.min(
-    items.length,
-    Math.ceil((viewport.scrollTop + viewport.height) / rowHeight) + overscan,
-  );
-  const slice = items.slice(start, end);
-  return (
-    <div ref={containerRef} className="mt-3 h-[60vh] overflow-auto sm:h-[70vh]">
-      <div
-        style={{
-          height: total,
-          position: 'relative',
-        }}
-      >
-        {slice.map((item, i) => {
-          const index = start + i;
-          const top = index * rowHeight;
-          return (
-            <div
-              key={item.friendshipId}
-              style={{
-                position: 'absolute',
-                top,
-                left: 0,
-                right: 0,
-                height: rowHeight,
-              }}
-            >
-              {renderRow(item)}
-            </div>
-          );
-        })}
-      </div>
-    </div>
-  );
-}
 function AddFriendsPanel({
   onOutgoingCreated,
   query: controlledQuery,

--- a/app/routes/friends.tsx
+++ b/app/routes/friends.tsx
@@ -1,5 +1,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { LuCopy, LuLink, LuPlus, LuQrCode, LuUsers } from 'react-icons/lu';
+import {
+  LuChevronDown,
+  LuCopy,
+  LuLink,
+  LuPlus,
+  LuQrCode,
+  LuUsers,
+} from 'react-icons/lu';
 import {
   Link,
   Outlet,
@@ -1084,55 +1091,107 @@ function PendingRequestsCard({
   ) => (snapshot: RelationshipSnapshot) => void;
 }>) {
   const total = incomingState.length + outgoingState.length;
+  const [open, setOpen] = useState(false);
+  const hasIncoming = incomingState.length > 0;
+
+  // Incoming requests are the actionable case, so their arrival opens the
+  // section — on mount and again whenever one shows up later via the
+  // optimistic FRIENDSHIP_UPDATED_EVENT wiring, which a `useState(...)`
+  // initialiser alone would miss.
+  //
+  // Deliberately one-way: never auto-collapse. Deriving `open` from
+  // `hasIncoming` instead would snap the section shut the moment you accept
+  // the last incoming request, yanking the "Sent" list you were reading out
+  // from under you. Collapsing stays a user action.
+  useEffect(() => {
+    if (hasIncoming) setOpen(true);
+  }, [hasIncoming]);
+
   if (total === 0) return null;
 
   return (
     <section
       id="pending-requests"
-      className="rounded-xl border border-border bg-card p-4 shadow-sm"
+      className="overflow-hidden rounded-xl border border-border bg-card shadow-sm"
     >
-      <div className="flex items-center justify-between gap-2">
-        <h2 className="text-base font-semibold">Pending requests</h2>
-        <span className="rounded-full bg-muted px-2 py-0.5 text-xs font-semibold text-muted-foreground">
+      <button
+        type="button"
+        aria-expanded={open}
+        aria-controls="pending-requests-body"
+        onClick={() => setOpen((prev) => !prev)}
+        className="flex w-full items-center gap-3 p-4 text-left transition-colors hover:bg-muted/40"
+      >
+        <span className="inline-flex h-6 min-w-[1.5rem] items-center justify-center rounded-full bg-primary px-1.5 text-xs font-bold text-primary-foreground">
           {total}
         </span>
-      </div>
-      <ul className="mt-3 space-y-2">
-        {incomingState.map((request) => (
-          <FriendRequestRow
-            key={request.id}
-            requestId={request.id}
-            user={request.fromUser}
-            relationship={{
-              state: 'PENDING_INCOMING',
-              friendshipId: null,
-              incomingRequestId: request.id,
-              outgoingRequestId: null,
-            }}
-            selected={false}
-            selectMode={false}
-            onToggleSelected={() => {}}
-            onStateChange={onIncomingTransition(request.id, request.fromUser)}
-          />
-        ))}
-        {outgoingState.map((request) => (
-          <FriendRequestRow
-            key={request.id}
-            requestId={request.id}
-            user={request.toUser}
-            relationship={{
-              state: 'PENDING_OUTGOING',
-              friendshipId: null,
-              incomingRequestId: null,
-              outgoingRequestId: request.id,
-            }}
-            selected={false}
-            selectMode={false}
-            onToggleSelected={() => {}}
-            onStateChange={onOutgoingTransition(request.id, request.toUser)}
-          />
-        ))}
-      </ul>
+        <h2 className="text-base font-semibold">Friend requests</h2>
+        <LuChevronDown
+          className={cn(
+            'ml-auto h-4 w-4 shrink-0 text-muted-foreground motion-safe:transition-transform',
+            open && 'rotate-180',
+          )}
+          aria-hidden
+        />
+      </button>
+
+      {open ? (
+        <div id="pending-requests-body" className="px-4 pb-4">
+          {incomingState.length > 0 ? (
+            <ul className="space-y-2">
+              {incomingState.map((request) => (
+                <FriendRequestRow
+                  key={request.id}
+                  requestId={request.id}
+                  user={request.fromUser}
+                  relationship={{
+                    state: 'PENDING_INCOMING',
+                    friendshipId: null,
+                    incomingRequestId: request.id,
+                    outgoingRequestId: null,
+                  }}
+                  selected={false}
+                  selectMode={false}
+                  onToggleSelected={() => {}}
+                  onStateChange={onIncomingTransition(
+                    request.id,
+                    request.fromUser,
+                  )}
+                />
+              ))}
+            </ul>
+          ) : null}
+
+          {outgoingState.length > 0 ? (
+            <>
+              <h3 className="mb-2 mt-4 text-xs font-semibold uppercase tracking-wide text-muted-foreground first:mt-0">
+                Sent
+              </h3>
+              <ul className="space-y-2">
+                {outgoingState.map((request) => (
+                  <FriendRequestRow
+                    key={request.id}
+                    requestId={request.id}
+                    user={request.toUser}
+                    relationship={{
+                      state: 'PENDING_OUTGOING',
+                      friendshipId: null,
+                      incomingRequestId: null,
+                      outgoingRequestId: request.id,
+                    }}
+                    selected={false}
+                    selectMode={false}
+                    onToggleSelected={() => {}}
+                    onStateChange={onOutgoingTransition(
+                      request.id,
+                      request.toUser,
+                    )}
+                  />
+                ))}
+              </ul>
+            </>
+          ) : null}
+        </div>
+      ) : null}
     </section>
   );
 }

--- a/app/routes/friends.tsx
+++ b/app/routes/friends.tsx
@@ -91,19 +91,10 @@ type SearchResult = {
   user: FriendEntry['user'];
   relationship: RelationshipSnapshot;
 };
-type RequestMutationAction = 'accept' | 'reject' | 'cancel';
-type RequestMutationResponse = {
-  ok: boolean;
-  unreadCount: number | null;
-};
 type RequestListEntryUser = IncomingEntry['fromUser'] | OutgoingEntry['toUser'];
 type FriendRequestRowProps = Readonly<{
   onStateChange: (snapshot: RelationshipSnapshot) => void;
-  onToggleSelected: (requestId: string, selected: boolean) => void;
   relationship: RelationshipSnapshot;
-  requestId: string;
-  selected: boolean;
-  selectMode: boolean;
   user: RequestListEntryUser;
 }>;
 type SearchResultRowProps = Readonly<{
@@ -175,115 +166,6 @@ export function buildFriendEntry(
   };
 }
 
-export async function submitRequestMutation(
-  id: string,
-  action: RequestMutationAction,
-): Promise<RequestMutationResponse> {
-  const response = await fetch(`/api/friends/requests/${id}/${action}`, {
-    method: 'POST',
-    credentials: 'same-origin',
-    ...(action === 'cancel'
-      ? {}
-      : {
-          headers: {
-            Accept: 'application/json',
-          },
-        }),
-  });
-
-  if (!response.ok) {
-    return { ok: false, unreadCount: null };
-  }
-
-  if (action === 'cancel') {
-    return { ok: true, unreadCount: null };
-  }
-
-  const payload = (await response.json()) as { unreadCount?: number };
-  return {
-    ok: true,
-    unreadCount:
-      typeof payload.unreadCount === 'number' ? payload.unreadCount : null,
-  };
-}
-
-export async function runBatchRequestMutation(
-  ids: string[],
-  action: RequestMutationAction,
-) {
-  const results = await Promise.allSettled(
-    ids.map((id) => submitRequestMutation(id, action)),
-  );
-  let unreadCount: number | null = null;
-  const failedIds: string[] = [];
-
-  results.forEach((result, index) => {
-    if (result.status === 'fulfilled' && result.value.ok) {
-      if (result.value.unreadCount != null) {
-        unreadCount = result.value.unreadCount;
-      }
-      return;
-    }
-
-    failedIds.push(ids[index] ?? '');
-  });
-
-  return { failedIds, unreadCount };
-}
-
-export async function runOptimisticRequestBatch<
-  TRequest extends { id: string },
->(
-  ids: string[],
-  action: RequestMutationAction,
-  requests: TRequest[],
-  setRequests: React.Dispatch<React.SetStateAction<TRequest[]>>,
-  setUnreadCount?: (count: number) => void,
-) {
-  const snapshot = requests.filter((request) => ids.includes(request.id));
-  setRequests((prev) => prev.filter((request) => !ids.includes(request.id)));
-
-  const { failedIds, unreadCount } = await runBatchRequestMutation(ids, action);
-  const messages = getRequestMutationMessages(action, ids.length);
-
-  if (unreadCount != null) {
-    setUnreadCount?.(unreadCount);
-  }
-
-  if (failedIds.length > 0) {
-    const failed = snapshot.filter((request) => failedIds.includes(request.id));
-    setRequests((prev) => [...failed, ...prev]);
-    toast.error(messages.error);
-    return;
-  }
-
-  toast.success(messages.success);
-}
-
-export function getRequestMutationMessages(
-  action: RequestMutationAction,
-  count: number,
-) {
-  if (action === 'accept') {
-    return {
-      error: 'Some requests could not be accepted.',
-      success: `Accepted ${count} request${count > 1 ? 's' : ''}.`,
-    };
-  }
-
-  if (action === 'reject') {
-    return {
-      error: 'Some requests could not be declined.',
-      success: `Declined ${count} request${count > 1 ? 's' : ''}.`,
-    };
-  }
-
-  return {
-    error: 'Some requests could not be cancelled.',
-    success: `Cancelled ${count} request${count > 1 ? 's' : ''}.`,
-  };
-}
-
 export function filterFriends(friends: FriendEntry[], term: string) {
   const normalizedTerm = term.trim().toLowerCase();
   if (!normalizedTerm) return friends;
@@ -342,17 +224,6 @@ export function sortFriendsByName(friends: FriendEntry[]): FriendEntry[] {
   );
 }
 
-export function toggleSelection(
-  set: Set<string>,
-  id: string,
-  selected: boolean,
-) {
-  const next = new Set(set);
-  if (selected) next.add(id);
-  else next.delete(id);
-  return next;
-}
-
 export function applyIncomingRelationshipTransition(
   incoming: IncomingEntry[],
   requestId: string,
@@ -391,26 +262,6 @@ export function toRelationshipSnapshot(
     friendshipId: detail.friendshipId ?? null,
     incomingRequestId: detail.incomingRequestId ?? null,
     outgoingRequestId: detail.outgoingRequestId ?? null,
-  };
-}
-
-export function getMutualGroupChips(
-  mutuals: Record<
-    string,
-    {
-      groups: Array<{
-        id: string;
-        name: string;
-      }>;
-      more: number;
-    }
-  >,
-  userId: string,
-) {
-  const mutualEntry = mutuals[userId];
-  return {
-    extraGroupCount: mutualEntry?.more ?? 0,
-    mutualGroups: mutualEntry ? mutualEntry.groups.slice(0, 2) : [],
   };
 }
 
@@ -464,39 +315,22 @@ function FriendsSortToggle({
 
 function FriendRequestRow({
   onStateChange,
-  onToggleSelected,
   relationship,
-  requestId,
-  selected,
-  selectMode,
   user,
 }: FriendRequestRowProps) {
   const username = user.username;
 
   return (
     <li className="flex items-center gap-4 rounded-xl border border-border bg-card p-4 shadow-sm">
-      {selectMode ? (
-        <input
-          type="checkbox"
-          aria-label={`Select @${username}`}
-          checked={selected}
-          onChange={(event) =>
-            onToggleSelected(requestId, event.currentTarget.checked)
-          }
-          className="h-4 w-4"
-        />
-      ) : null}
       <Avatar size="s" image={user.image} user={user} />
       <div className="flex-1 text-foreground">@{username}</div>
-      {selectMode ? null : (
-        <FriendActionButton
-          targetUserId={user.id}
-          targetUserName={`@${username}`}
-          relationship={relationship}
-          variant="compact"
-          onStateChange={onStateChange}
-        />
-      )}
+      <FriendActionButton
+        targetUserId={user.id}
+        targetUserName={`@${username}`}
+        relationship={relationship}
+        variant="compact"
+        onStateChange={onStateChange}
+      />
     </li>
   );
 }
@@ -1137,7 +971,6 @@ function PendingRequestsCard({
               {incomingState.map((request) => (
                 <FriendRequestRow
                   key={request.id}
-                  requestId={request.id}
                   user={request.fromUser}
                   relationship={{
                     state: 'PENDING_INCOMING',
@@ -1145,9 +978,6 @@ function PendingRequestsCard({
                     incomingRequestId: request.id,
                     outgoingRequestId: null,
                   }}
-                  selected={false}
-                  selectMode={false}
-                  onToggleSelected={() => {}}
                   onStateChange={onIncomingTransition(
                     request.id,
                     request.fromUser,
@@ -1166,7 +996,6 @@ function PendingRequestsCard({
                 {outgoingState.map((request) => (
                   <FriendRequestRow
                     key={request.id}
-                    requestId={request.id}
                     user={request.toUser}
                     relationship={{
                       state: 'PENDING_OUTGOING',
@@ -1174,9 +1003,6 @@ function PendingRequestsCard({
                       incomingRequestId: null,
                       outgoingRequestId: request.id,
                     }}
-                    selected={false}
-                    selectMode={false}
-                    onToggleSelected={() => {}}
                     onStateChange={onOutgoingTransition(
                       request.id,
                       request.toUser,

--- a/app/routes/friends.tsx
+++ b/app/routes/friends.tsx
@@ -14,6 +14,7 @@ import {
   FriendActionButton,
   type RelationshipSnapshot,
 } from '#app/components/friends/friend-action-button.tsx';
+import { ComingUpSection } from '#app/components/friends/coming-up-section.tsx';
 import { FriendRow as FriendRowCard } from '#app/components/friends/friend-row.tsx';
 import { useNotificationsStore } from '#app/components/notifications/notifications-context.tsx';
 import { PageHeader } from '#app/components/page-header.tsx';
@@ -1296,6 +1297,8 @@ const FriendsRoute = () => {
             onIncomingTransition={handleIncomingTransition}
             onOutgoingTransition={handleOutgoingTransition}
           />
+
+          <ComingUpSection friends={friendsState} />
 
           {friendsState.length > 8 ? (
             <Input

--- a/app/routes/friends.tsx
+++ b/app/routes/friends.tsx
@@ -1426,7 +1426,9 @@ const FriendsRoute = () => {
             <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
               <Input
                 value={friendsFilter}
-                onChange={(event) => setFriendsFilter(event.currentTarget.value)}
+                onChange={(event) =>
+                  setFriendsFilter(event.currentTarget.value)
+                }
                 placeholder="Search friends"
                 aria-label="Search friends"
                 className="sm:flex-1"

--- a/app/utils/birthday.ts
+++ b/app/utils/birthday.ts
@@ -5,6 +5,14 @@
 
 export const BIRTHDAY_VISIBILITY_DAYS = 60;
 
+// How far ahead the Friends page's "Coming up" rail looks, and the window
+// that pulls a friend to the top of the birthday-sorted list. Deliberately a
+// separate knob from BIRTHDAY_VISIBILITY_DAYS above (which governs whether a
+// date renders at all) even though both currently sit at 60: this one is a
+// product/attention decision tied to the occasion-reminder loop, that one is
+// a display rule. Change this to retune the rail without touching the badge.
+export const COMING_UP_WINDOW_DAYS = 60;
+
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 export type UpcomingBirthday = {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -37,7 +37,14 @@ export default defineConfig({
     env: {
       ...process.env,
       PORT,
-      NODE_ENV: 'test',
+      // Deliberately NOT setting NODE_ENV=test. `vite.config.ts` drops the
+      // reactRouter() plugin under NODE_ENV=test (so Vitest/Storybook can
+      // import the app), which leaves Vite in its default `appType: "spa"`
+      // with a terminal 404 middleware mounted ahead of the React Router
+      // handler — every route, including /login, 404s. CI never noticed
+      // because `start:mocks` re-sets NODE_ENV=production via cross-env, so
+      // this only ever broke local runs.
+      //
       // Ensure MSW mocks are enabled even when running locally (non-CI)
       MOCKS: 'true',
     },

--- a/tests/e2e/friends-list.test.ts
+++ b/tests/e2e/friends-list.test.ts
@@ -52,11 +52,6 @@ test('friend cards open the profile, and the actions menu opens the wishlist', a
       `/users/${friend.username}`,
     );
 
-    // `useFriendsSearchParams` writes `?tab=` on a 300ms debounce after mount.
-    // Wait for it to land first — a navigation started before it fires gets
-    // clobbered by that setSearchParams call.
-    await expect(page).toHaveURL(/\/friends\?tab=friends/);
-
     // The wishlist keeps a one-click path through the actions menu.
     await page
       .getByRole('button', { name: `Actions for ${friend.name}` })

--- a/tests/e2e/friends-list.test.ts
+++ b/tests/e2e/friends-list.test.ts
@@ -2,7 +2,7 @@ import { prisma } from '#app/utils/db.server.ts';
 import { createPassword, createUser } from '#tests/db-utils.ts';
 import { expect, test } from '#tests/playwright-utils.ts';
 
-test('friend summary links navigate to the wishlist', async ({
+test('friend cards open the profile, and the actions menu opens the wishlist', async ({
   page,
   login,
 }) => {
@@ -42,17 +42,31 @@ test('friend summary links navigate to the wishlist', async ({
     await login({ id: viewer.id });
     await page.goto('/friends');
 
-    const friendSummaryLink = page.getByRole('link', {
-      name: new RegExp(friend.name!, 'i'),
+    // The card itself goes to the profile.
+    const friendCardLink = page.getByRole('link', {
+      name: new RegExp(`View ${friend.name!}'s profile`, 'i'),
     });
-    await expect(friendSummaryLink).toBeVisible();
-    await expect(friendSummaryLink).toHaveAttribute(
+    await expect(friendCardLink).toBeVisible();
+    await expect(friendCardLink).toHaveAttribute(
       'href',
-      `/users/${friend.username}/wishlist`,
+      `/users/${friend.username}`,
     );
-    await friendSummaryLink.click();
 
+    // `useFriendsSearchParams` writes `?tab=` on a 300ms debounce after mount.
+    // Wait for it to land first — a navigation started before it fires gets
+    // clobbered by that setSearchParams call.
+    await expect(page).toHaveURL(/\/friends\?tab=friends/);
+
+    // The wishlist keeps a one-click path through the actions menu.
+    await page
+      .getByRole('button', { name: `Actions for ${friend.name}` })
+      .click();
+    await page.getByRole('menuitem', { name: /view wishlist/i }).click();
     await expect(page).toHaveURL(`/users/${friend.username}/wishlist`);
+
+    await page.goto('/friends');
+    await friendCardLink.click();
+    await expect(page).toHaveURL(`/users/${friend.username}`);
   } finally {
     await prisma.friendship.deleteMany({
       where: { userAId: pair.userAId, userBId: pair.userBId },

--- a/tests/e2e/nav-chrome.test.ts
+++ b/tests/e2e/nav-chrome.test.ts
@@ -101,10 +101,22 @@ test.describe('navigation chrome', () => {
       // boundingBox() calls get invalidated by hydration-driven layout
       // shifts like the PWA install banner) — and poll it, since the banner
       // can land mid-assertion.
+      //
+      // Scroll to the BOTTOM of the scroll area rather than calling
+      // `scrollIntoView({ block: 'end' })` on the row. The guarantee that
+      // matters is that a user who scrolls to the end can see their last
+      // friend — `block: 'end'` instead forces the row flush against the
+      // scrollport's bottom edge, which sits behind the fixed nav and is
+      // only reachable because the site footer adds scroll range below the
+      // list. That call used to be absorbed by the virtualized list's inner
+      // `h-[60vh] overflow-auto` container, so it never exercised this.
       await expect
         .poll(
           () =>
             page.evaluate(() => {
+              const area = document.querySelector(
+                '[data-testid="app-scroll-area"]',
+              ) as HTMLElement | null;
               const rows = Array.from(
                 document.querySelectorAll('[data-testid="friend-row"]'),
               );
@@ -112,14 +124,14 @@ test.describe('navigation chrome', () => {
               const nav = document.querySelector(
                 '[data-testid="bottom-nav"]',
               ) as HTMLElement | null;
-              if (!last || !nav) return Number.POSITIVE_INFINITY;
-              last.scrollIntoView({ block: 'end' });
+              if (!last || !nav || !area) return Number.POSITIVE_INFINITY;
+              area.scrollTop = area.scrollHeight;
               return (
                 last.getBoundingClientRect().bottom -
                 nav.getBoundingClientRect().top
               );
             }),
-          { message: 'bottom nav should sit below the last friend row' },
+          { message: 'bottom nav should not cover the last friend row' },
         )
         .toBeLessThanOrEqual(1);
 

--- a/tests/e2e/prefetch.test.ts
+++ b/tests/e2e/prefetch.test.ts
@@ -189,9 +189,13 @@ test('cached friend wishlist navigation avoids a fresh loader request and logs o
         response.request().method() === 'POST',
     );
 
+    // The friend card routes to the profile now, so the wishlist is reached
+    // through the actions menu — still a prefetched (`prefetch="intent"`)
+    // link, which is what this test is actually about.
     await page
-      .getByRole('link', { name: new RegExp(friend.name!, 'i') })
+      .getByRole('button', { name: `Actions for ${friend.name}` })
       .click();
+    await page.getByRole('menuitem', { name: /view wishlist/i }).click();
 
     await expect(page).toHaveURL(`/users/${friend.username}/wishlist`);
     await expect(page.getByText('Prefetched item')).toBeVisible();
@@ -293,9 +297,13 @@ test('cached friend wishlist navigation revalidates access before using prefetch
       },
     });
 
+    // The friend card routes to the profile now, so the wishlist is reached
+    // through the actions menu — still a prefetched (`prefetch="intent"`)
+    // link, which is what this test is actually about.
     await page
-      .getByRole('link', { name: new RegExp(friend.name!, 'i') })
+      .getByRole('button', { name: `Actions for ${friend.name}` })
       .click();
+    await page.getByRole('menuitem', { name: /view wishlist/i }).click();
 
     await expect(page).toHaveURL(`/users/${friend.username}/wishlist`);
     await expect(


### PR DESCRIPTION
Rebuilds the Friends page from a Claude Design export. First screen of a deliberate,
separate mobile-visual-language pass — no spacing or type changes propagate to other
screens here.

## What changed

- **"Coming up" rail** pinned above the list: friends with a birthday inside
  `COMING_UP_WINDOW_DAYS` (new named constant, not hardcoded), horizontal snap-scroll on
  mobile, each with a proximity label and **Plan gift** → `/pools/new?recipientId=<id>`
  (that route already accepts a standalone recipient — no new endpoint).
- **Pending requests** become a collapsible with a count badge, incoming first and a
  labelled "Sent" subgroup. Opening is one-way: incoming requests open it, nothing
  auto-collapses.
- **Friend card routes to the profile** (`/users/:username`) instead of jumping straight
  to the wishlist. The wishlist keeps a one-click path as the first kebab item.
- **Responsive grid** — dense single column on mobile, 2-up at `md:` (768px), 3-up at
  `xl:`. Adds a "By birthday / A–Z" toggle, default birthday proximity.
- Hand-rolled virtualizer removed; its fixed 72px row height cannot survive a grid.

## Theme note for reviewers

If the app renders pink-on-plum for you, that's `palette-fete` stuck in
`localStorage['gp-dev-palette']`, not production. Clear it. Production "Current" is
terracotta. This page uses **only** semantic tokens — no hex/HSL literals — verified by
cycling every palette candidate.

## Fixes found while verifying

- **Vestigial `?tab=` machinery removed.** Nothing in the repo produced `/friends?tab=`,
  but its debounced `setSearchParams` fired one spurious push ~300ms after mount that
  clobbered any navigation started in that window. Measured history writes on mount:
  `[replace, replace, push "", push "?tab=friends"]` → `[replace, replace]`.
- **Orphaned multi-select machinery removed** (~320 lines): a closed cycle of batch-request
  helpers with no entry point, plus `FriendRequestRow`'s unreachable checkbox branch, left
  behind when the incoming/outgoing sections were merged.
- **Request-row avatar collapsed to 0px** under a long username on a 390px viewport, with
  the buttons pushed past the card edge — every flex child defaulted to `shrink: 1`.
  Pre-dates this branch; found by actually looking at the rendered page.
- **`npm run test:e2e:run` now works locally.** `playwright.config.ts` forced
  `NODE_ENV=test`, which drops the `reactRouter()` Vite plugin, leaving Vite in SPA mode
  with a terminal 404 middleware ahead of the React Router handler — every route, including
  `/login`, 404'd. CI never noticed because `start:mocks` re-sets `NODE_ENV=production`.

## Deliberately not done

- **No "Add to a group" in the kebab** — no add-an-existing-friend-to-a-group flow exists
  (groups are join-by-invite/request only). Needs its own consent/permission design.
- **No message/nudge action** — separate, undecided. A test pins the menu at exactly three
  items so neither can appear by accident.
- **Birthday colour stays split** — the rail uses `text-gift`, the card an amber
  `bg-warning-muted` pill. Different roles: in the rail every item is a birthday so the
  date is content; in the grid it's an exception marker that must survive a scan.

## Test plan

- `npm run typecheck` — clean
- `npm run lint` — 0 errors
- `npm test -- --run` — 226 files / 1472 tests green
- `npm run test:e2e:run` — **117/117 passed**, confirmed via `test-results/.last-run.json`
  (`status: passed`), not just the exit code
- New `coming-up-section.test.tsx` covers the window rule and both visibility cases — a
  friend with `birthdayVisible: false` never appears; an optimistic entry with unknown
  visibility still does
- `nav-chrome`'s clearance assertion was rewritten: `scrollIntoView({block:'end'})` had
  been silently absorbed by the deleted virtualizer's inner `h-[60vh]` container. Now
  scrolls the scroll area to its end — measured clearance at max scroll is 139px

Screenshots (mobile 390, desktop 1280, dark, Botanical) captured via the e2e `login`
fixture; attaching separately.
