### PR TITLE
feat(wishlist): pool-backed claims — server module, privacy ladder, wishlist surfaces

### DIFF
--- a/app/components/users/person-surface.test.tsx
+++ b/app/components/users/person-surface.test.tsx
@@ -16,6 +16,7 @@ import React from 'react';
 import { MemoryRouter } from 'react-router';
 import type * as ReactRouter from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { HIDDEN_CLAIM_DISCLOSURE } from '#app/utils/wishlist-claim-disclosure.ts';
 import {
   PersonSurface,
   type PersonSurfaceViewData,
@@ -196,6 +197,7 @@ describe('PersonSurface form emission', () => {
             currency: null,
             claimed: false,
             claimedByViewer: false,
+            claimDisclosure: HIDDEN_CLAIM_DISCLOSURE,
           },
         ],
         openPools: [{ id: 'p1', title: 'Pool' }],
@@ -291,5 +293,74 @@ describe('PersonSurface pool continuation (§6.3)', () => {
       screen.getByRole('button', { name: /organize a gift/i }),
     ).toBeInTheDocument();
     expect(screen.queryByTestId('continue-planning')).not.toBeInTheDocument();
+  });
+});
+
+describe('PersonSurface wishlist claim attribution', () => {
+  it('renders the tiered ClaimDescriptor text in place of the old generic "Spoken for" badge', () => {
+    renderSurface(
+      baseData({
+        wishlistSource: [
+          {
+            id: 'w1',
+            title: 'Espresso machine',
+            url: null,
+            priceCents: null,
+            currency: null,
+            claimed: true,
+            claimedByViewer: false,
+            claimDisclosure: {
+              show: true,
+              tone: 'pool',
+              text: 'Kitchen Crew is getting this',
+              name: 'Kitchen Crew',
+              poolLink: '/pools/p1',
+              canJoinPool: true,
+            },
+          },
+        ],
+      }),
+    );
+
+    expect(
+      screen.getByText('Kitchen Crew is getting this'),
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Spoken for')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Someone's already covering this one."),
+    ).not.toBeInTheDocument();
+    // No claim/unclaim form for an item someone else already has.
+    expect(
+      screen.queryByRole('button', { name: /getting this/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders zero-attribution text when the viewer has no relationship to the holding pool', () => {
+    renderSurface(
+      baseData({
+        wishlistSource: [
+          {
+            id: 'w1',
+            title: 'Espresso machine',
+            url: null,
+            priceCents: null,
+            currency: null,
+            claimed: true,
+            claimedByViewer: false,
+            claimDisclosure: {
+              show: true,
+              tone: 'warning',
+              text: 'Already claimed',
+              name: null,
+              poolLink: null,
+              canJoinPool: false,
+            },
+          },
+        ],
+      }),
+    );
+
+    expect(screen.getByText('Already claimed')).toBeInTheDocument();
+    expect(screen.queryByText('Spoken for')).not.toBeInTheDocument();
   });
 });

--- a/app/components/users/person-surface.tsx
+++ b/app/components/users/person-surface.tsx
@@ -34,8 +34,10 @@ import {
   ResponsiveDialogTitle as DialogTitle,
 } from '#app/components/ui/responsive-dialog.tsx';
 import { Textarea } from '#app/components/ui/textarea.tsx';
+import { ClaimDescriptor } from '#app/components/wishlist/claim-descriptor.tsx';
 import { type RelationshipState } from '#app/utils/friends.ts';
 import { formatCents } from '#app/utils/pool-contributions.ts';
+import { type ClaimDisclosure } from '#app/utils/wishlist-claim-disclosure.ts';
 
 export type TemporalState =
   | 'occasion-near'
@@ -99,6 +101,7 @@ export type PersonSurfaceViewData = {
     currency: string | null;
     claimed: boolean;
     claimedByViewer: boolean;
+    claimDisclosure: ClaimDisclosure;
   }>;
   ideation: {
     giftHistory: Array<{
@@ -1109,13 +1112,7 @@ function WishlistSourceRow({
               </div>
             ) : null}
           </div>
-          <span className="inline-flex h-[22px] flex-none items-center gap-1 rounded-full bg-muted px-2.5 text-[11px] font-extrabold text-muted-foreground">
-            <LuCheck size={12} />
-            Spoken for
-          </span>
-        </div>
-        <div className="mt-2 text-[11.5px] font-semibold text-muted-foreground">
-          Someone's already covering this one.
+          <ClaimDescriptor disclosure={item.claimDisclosure} variant="label" />
         </div>
       </div>
     );

--- a/app/components/wishlist/claim-descriptor.test.tsx
+++ b/app/components/wishlist/claim-descriptor.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { type ClaimDisclosure } from '#app/utils/wishlist-claim-disclosure.ts';
+import { ClaimDescriptor } from './claim-descriptor.tsx';
+
+const base: ClaimDisclosure = {
+  show: true,
+  tone: 'warning',
+  text: 'Already claimed',
+  name: null,
+  poolLink: null,
+  canJoinPool: false,
+};
+
+describe('ClaimDescriptor', () => {
+  it('renders nothing when the disclosure is hidden', () => {
+    const { container } = render(
+      <ClaimDescriptor disclosure={{ ...base, show: false }} variant="label" />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('carries an icon and text, never colour alone', () => {
+    render(<ClaimDescriptor disclosure={base} variant="badge" />);
+    expect(screen.getByText('Already claimed')).toBeInTheDocument();
+    expect(screen.getByRole('status')).toHaveAccessibleName(/already claimed/i);
+  });
+
+  it('uses warning tone styling for conflicts and pool tone for reassurance', () => {
+    const { rerender } = render(<ClaimDescriptor disclosure={base} variant="badge" />);
+    expect(screen.getByRole('status').className).toContain('warning');
+
+    rerender(
+      <ClaimDescriptor
+        disclosure={{ ...base, tone: 'pool', text: 'Your pool Dave’s 40th is getting this' }}
+        variant="label"
+      />,
+    );
+    expect(screen.getByRole('status').className).toContain('pool');
+  });
+});

--- a/app/components/wishlist/claim-descriptor.test.tsx
+++ b/app/components/wishlist/claim-descriptor.test.tsx
@@ -2,6 +2,8 @@
  * @vitest-environment jsdom
  */
 import { render, screen } from '@testing-library/react';
+import { type ReactElement } from 'react';
+import { createRoutesStub } from 'react-router';
 import { describe, expect, it } from 'vitest';
 import { type ClaimDisclosure } from '#app/utils/wishlist-claim-disclosure.ts';
 import { ClaimDescriptor } from './claim-descriptor.tsx';
@@ -13,6 +15,20 @@ const base: ClaimDisclosure = {
   name: null,
   poolLink: null,
   canJoinPool: false,
+};
+
+const withPoolLink: ClaimDisclosure = {
+  show: true,
+  tone: 'pool',
+  text: 'Your pool Dave’s 40th is getting this',
+  name: 'Dave’s 40th',
+  poolLink: '/pools/pool-1',
+  canJoinPool: false,
+};
+
+const renderInRouter = (ui: ReactElement) => {
+  const App = createRoutesStub([{ path: '/', Component: () => ui }]);
+  return render(<App />);
 };
 
 describe('ClaimDescriptor', () => {
@@ -40,5 +56,55 @@ describe('ClaimDescriptor', () => {
       />,
     );
     expect(screen.getByRole('status').className).toContain('pool');
+  });
+
+  describe('variant="label" with a poolLink', () => {
+    it('wraps the badge content in a Link pointing at exactly disclosure.poolLink', () => {
+      renderInRouter(<ClaimDescriptor disclosure={withPoolLink} variant="label" />);
+
+      const link = screen.getByRole('link');
+      expect(link).toHaveAttribute('href', withPoolLink.poolLink);
+      expect(link).toContainElement(screen.getByRole('status'));
+      expect(link).toHaveTextContent(withPoolLink.text);
+    });
+
+    it('renders no link when poolLink is null', () => {
+      renderInRouter(<ClaimDescriptor disclosure={base} variant="label" />);
+      expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('non-navigable surfaces never render a Link, even with a poolLink', () => {
+    it('variant="badge" renders the badge but no link', () => {
+      renderInRouter(<ClaimDescriptor disclosure={withPoolLink} variant="badge" />);
+      expect(screen.queryByRole('link')).not.toBeInTheDocument();
+      expect(screen.getByRole('status')).toHaveTextContent(withPoolLink.text);
+    });
+
+    it('variant="row" renders the badge but no link', () => {
+      renderInRouter(<ClaimDescriptor disclosure={withPoolLink} variant="row" />);
+      expect(screen.queryByRole('link')).not.toBeInTheDocument();
+      expect(screen.getByRole('status')).toHaveTextContent(withPoolLink.text);
+    });
+  });
+
+  describe('variant="row"', () => {
+    it('applies the tight single-line row classes', () => {
+      render(<ClaimDescriptor disclosure={base} variant="row" />);
+      const status = screen.getByRole('status');
+      expect(status.className).toContain('px-2');
+      expect(status.className).toContain('py-0');
+      expect(status).not.toHaveTextContent(''); // sanity: still renders text
+      expect(status).toHaveTextContent(base.text);
+    });
+  });
+
+  describe('tone="none"', () => {
+    it('renders nothing, matching show: false behaviour', () => {
+      const { container } = render(
+        <ClaimDescriptor disclosure={{ ...base, tone: 'none' }} variant="badge" />,
+      );
+      expect(container).toBeEmptyDOMElement();
+    });
   });
 });

--- a/app/components/wishlist/claim-descriptor.tsx
+++ b/app/components/wishlist/claim-descriptor.tsx
@@ -1,12 +1,35 @@
 import { LuTriangleAlert, LuUsers } from 'react-icons/lu';
 import { Link } from 'react-router';
 import { cn } from '#app/utils/misc.tsx';
-import { type ClaimDisclosure } from '#app/utils/wishlist-claim-disclosure.ts';
+import {
+  type ClaimDisclosure,
+  type ClaimDisclosureTone,
+} from '#app/utils/wishlist-claim-disclosure.ts';
+
+type ToneStyle = { icon: typeof LuUsers; className: string };
+
+// Exhaustive over ClaimDisclosureTone: adding a tone without adding an entry
+// here is a compile error, not a silent fallback to pool styling.
+const TONE_STYLES: Record<ClaimDisclosureTone, ToneStyle | null> = {
+  none: null,
+  warning: {
+    icon: LuTriangleAlert,
+    className: 'border border-warning/30 bg-warning-muted text-warning',
+  },
+  pool: {
+    icon: LuUsers,
+    className: 'border border-pool/30 bg-pool/15 text-pool',
+  },
+};
 
 /**
  * One renderer for the claim privacy ladder, on all three surfaces. The
  * disclosure decision itself lives in resolveClaimDisclosure — this only
  * paints it, so a leak cannot hide on the surface nobody re-audited.
+ *
+ * `disclosure.canJoinPool` is deliberately never read here: the join
+ * affordance is a separate call-to-action owned by the calling surface, not
+ * part of this badge.
  */
 export const ClaimDescriptor = ({
   disclosure,
@@ -19,8 +42,10 @@ export const ClaimDescriptor = ({
 }) => {
   if (!disclosure.show) return null;
 
-  const isWarning = disclosure.tone === 'warning';
-  const Icon = isWarning ? LuTriangleAlert : LuUsers;
+  const style = TONE_STYLES[disclosure.tone];
+  if (style === null) return null;
+
+  const Icon = style.icon;
 
   const body = (
     <span
@@ -28,9 +53,7 @@ export const ClaimDescriptor = ({
       aria-label={disclosure.text}
       className={cn(
         'inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium',
-        isWarning
-          ? 'border border-warning/30 bg-warning-muted text-warning'
-          : 'border border-pool/30 bg-pool/15 text-pool',
+        style.className,
         variant === 'row' && 'px-2 py-0',
         className,
       )}

--- a/app/components/wishlist/claim-descriptor.tsx
+++ b/app/components/wishlist/claim-descriptor.tsx
@@ -1,0 +1,51 @@
+import { LuTriangleAlert, LuUsers } from 'react-icons/lu';
+import { Link } from 'react-router';
+import { cn } from '#app/utils/misc.tsx';
+import { type ClaimDisclosure } from '#app/utils/wishlist-claim-disclosure.ts';
+
+/**
+ * One renderer for the claim privacy ladder, on all three surfaces. The
+ * disclosure decision itself lives in resolveClaimDisclosure — this only
+ * paints it, so a leak cannot hide on the surface nobody re-audited.
+ */
+export const ClaimDescriptor = ({
+  disclosure,
+  variant,
+  className,
+}: {
+  disclosure: ClaimDisclosure;
+  variant: 'badge' | 'row' | 'label';
+  className?: string;
+}) => {
+  if (!disclosure.show) return null;
+
+  const isWarning = disclosure.tone === 'warning';
+  const Icon = isWarning ? LuTriangleAlert : LuUsers;
+
+  const body = (
+    <span
+      role="status"
+      aria-label={disclosure.text}
+      className={cn(
+        'inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium',
+        isWarning
+          ? 'border border-warning/30 bg-warning-muted text-warning'
+          : 'border border-pool/30 bg-pool/15 text-pool',
+        variant === 'row' && 'px-2 py-0',
+        className,
+      )}
+    >
+      <Icon className="h-3 w-3 shrink-0" aria-hidden />
+      {disclosure.text}
+    </span>
+  );
+
+  if (variant === 'label' && disclosure.poolLink) {
+    return (
+      <Link to={disclosure.poolLink} className="inline-flex">
+        {body}
+      </Link>
+    );
+  }
+  return body;
+};

--- a/app/components/wishlist/wishlist-item-state.ts
+++ b/app/components/wishlist/wishlist-item-state.ts
@@ -1,9 +1,10 @@
 import { arrayMove } from '@dnd-kit/sortable';
 
-import  { type WishlistItemImageSource } from '#app/utils/wishlist-images.server.ts';
-import  { type WishlistItemStatusValue } from '#app/utils/wishlist.ts';
+import { type ClaimDisclosure } from '#app/utils/wishlist-claim-disclosure.ts';
+import { type WishlistItemImageSource } from '#app/utils/wishlist-images.server.ts';
+import { type WishlistItemStatusValue } from '#app/utils/wishlist.ts';
 
-import  { type WishlistCategory } from './wishlist-category-state';
+import { type WishlistCategory } from './wishlist-category-state';
 
 export type WishlistItem = {
   id: string;
@@ -18,9 +19,13 @@ export type WishlistItem = {
   sortOrder: number;
   updatedAt: Date;
   status: WishlistItemStatusValue;
-  // Pool claims render through ClaimDescriptor (PR3); this surface is
-  // solo-only until then, so claimedByUserId may be null for a pool claim.
+  // A claim row can hold either a solo claimedByUserId or a pool — see
+  // ClaimDescriptor. claimDisclosure is the privacy-laddered read model for
+  // non-owner surfaces; owner loaders never populate it (see
+  // wishlist-claims.server.ts's loadClaimStates and the "owner never sees
+  // claims" rule).
   claim?: { claimedByUserId: string | null } | null;
+  claimDisclosure?: ClaimDisclosure;
   hasImage?: boolean;
   imageSource?: WishlistItemImageSource | null;
 };

--- a/app/components/wishlist/wishlist-item.behavior.test.tsx
+++ b/app/components/wishlist/wishlist-item.behavior.test.tsx
@@ -23,8 +23,15 @@ let useFetcherCallCount = 0;
 
 const purchaseFetcherState = {
   Form: (props: React.ComponentProps<'form'>) => <form {...props} />,
-  data: undefined,
-  state: 'idle' as const,
+  data: undefined as
+    | undefined
+    | {
+        claim: { claimedByUserId: string | null } | null;
+        ok: boolean;
+        wishlistItemId: string;
+        error?: string;
+      },
+  state: 'idle' as 'idle' | 'loading' | 'submitting',
   submit: vi.fn(),
 };
 
@@ -245,5 +252,76 @@ describe('wishlist item behavior', () => {
       'clientMutationId',
     ) as HTMLInputElement | null;
     expect(mutationIdInput?.value).toBeTruthy();
+  });
+
+  it('does not render an item as free after a release that transfers the claim to a pool', async () => {
+    // Reachable scenario this guards against: a friend claims an item, a
+    // pool later decides on the same item (conflict — the pool takes
+    // nothing yet), the friend releases. Settlement hands the claim
+    // straight to the waiting pool. The friend's screen must not show the
+    // item as free to grab — that's the duplicate-purchase bug this whole
+    // module exists to prevent.
+    mockUser = { id: 'viewer-id', roles: [] };
+    purchaseFetcherState.state = 'idle';
+    purchaseFetcherState.data = undefined;
+
+    const wishlistItem = {
+      categoryId: null,
+      claim: { claimedByUserId: 'viewer-id' },
+      id: 'item-1',
+      note: null,
+      ownerId: 'owner-id',
+      status: 'ACTIVE' as const,
+      title: 'Item one',
+      type: 'text',
+      updatedAt: new Date('2026-03-31T12:00:00.000Z'),
+      url: null,
+    };
+
+    const { rerender } = render(
+      <WishlistItem categories={[]} wishlistItem={wishlistItem} />,
+    );
+
+    expect(screen.getByTestId('wishlist-item-row')).not.toHaveAttribute(
+      'data-claimable',
+      'true',
+    );
+
+    const toggleButton = screen.getByRole('button', {
+      name: 'Let someone else pick up this gift',
+    });
+    await userEvent.click(toggleButton);
+
+    expect(purchaseFetcherState.submit).toHaveBeenCalledWith(
+      { intent: 'unpurchase', wishlistItemId: 'item-1' },
+      { method: 'post', action: '/wishlist/purchase' },
+    );
+
+    // Fetcher goes pending — matches real react-router behavior.
+    purchaseFetcherState.state = 'submitting';
+    rerender(<WishlistItem categories={[]} wishlistItem={wishlistItem} />);
+
+    // The server responds: the release transferred the claim to a pool, so
+    // the item is pool-held now — never `claim: null`.
+    purchaseFetcherState.state = 'idle';
+    purchaseFetcherState.data = {
+      claim: { claimedByUserId: null },
+      ok: true,
+      wishlistItemId: 'item-1',
+    };
+    rerender(<WishlistItem categories={[]} wishlistItem={wishlistItem} />);
+
+    expect(screen.getByTestId('wishlist-item-row')).not.toHaveAttribute(
+      'data-claimable',
+      'true',
+    );
+    // The "grab it" toggle must be gone — the item reads as claimed by
+    // someone else (the pool), not free.
+    expect(
+      screen.queryByRole('button', { name: "I'll grab this gift" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Let someone else pick up this gift' }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/app/components/wishlist/wishlist-item.behavior.test.tsx
+++ b/app/components/wishlist/wishlist-item.behavior.test.tsx
@@ -10,6 +10,7 @@ import { DeleteWishlistItem, WishlistItem } from './wishlist-item';
 const mockOpenView = vi.fn();
 const mockOpenEdit = vi.fn();
 const track = vi.fn();
+const toastError = vi.fn();
 
 let mockUser: { id: string; roles: string[] } | null = {
   id: 'owner-id',
@@ -76,6 +77,13 @@ vi.mock('#app/utils/analytics.client.ts', () => ({
   track: (...args: Array<unknown>) => track(...args),
 }));
 
+vi.mock('sonner', () => ({
+  toast: {
+    error: (...args: Array<unknown>) => toastError(...args),
+    success: vi.fn(),
+  },
+}));
+
 vi.mock('#app/utils/request-info.ts', () => ({
   useOptionalRequestInfo: () => requestInfoSnapshot,
 }));
@@ -102,21 +110,47 @@ vi.mock('#app/utils/misc.tsx', async () => {
 vi.mock('#app/routes/wishlist+/__wishlist-item-editor', () => {
   const React = require('react');
   const WishlistItemEditor = React.forwardRef(
-    ({ trigger }: { trigger?: React.ReactNode }, ref: React.ForwardedRef<unknown>) => {
+    (
+      {
+        trigger,
+        viewExtras,
+      }: { trigger?: React.ReactNode; viewExtras?: React.ReactNode },
+      ref: React.ForwardedRef<unknown>,
+    ) => {
+      // Real usage only mounts viewExtras once the modal is open (the real
+      // component is a Dialog that doesn't render its content until then).
+      // Gating on this local `isOpen` state — flipped by openView/openEdit,
+      // same as the real handle — keeps that behavior faithful: tests that
+      // never open the modal still see exactly one claim control (the row's),
+      // and a test that does open it (via the row's onOpen -> openView) can
+      // assert on the modal-only "claimed by someone else" surface
+      // (WishlistNonOwnerExtras) without duplicating controls across both.
+      const [isOpen, setIsOpen] = React.useState(false);
       React.useImperativeHandle(
         ref,
         () => ({
-          close: vi.fn(),
-          open: vi.fn(),
+          close: () => setIsOpen(false),
+          open: () => setIsOpen(true),
           openCreate: vi.fn(),
-          openEdit: mockOpenEdit,
-          openView: mockOpenView,
-          toggle: vi.fn(),
+          openEdit: () => {
+            mockOpenEdit();
+            setIsOpen(true);
+          },
+          openView: () => {
+            mockOpenView();
+            setIsOpen(true);
+          },
+          toggle: () => setIsOpen((value: boolean) => !value),
         }),
         [],
       );
 
-      return trigger ?? null;
+      return (
+        <>
+          {trigger ?? null}
+          {isOpen ? (viewExtras ?? null) : null}
+        </>
+      );
     },
   );
 
@@ -323,5 +357,89 @@ describe('wishlist item behavior', () => {
     expect(
       screen.queryByRole('button', { name: 'Let someone else pick up this gift' }),
     ).not.toBeInTheDocument();
+  });
+
+  it('shows an unattributed "Already claimed" state — never blank space — and toasts why when a concurrent claim race is lost', async () => {
+    // Reachable scenario this guards against: a viewer loads the item while
+    // it's unclaimed, so the loader hands them HIDDEN_CLAIM_DISCLOSURE. They
+    // tap "I'll grab this," but another user or a pool wins the race first.
+    // The optimistic state correctly reconciles to "claimed by someone
+    // else," but the disclosure computed at load time is still HIDDEN —
+    // without a fallback, the claim-detail surface (WishlistNonOwnerExtras
+    // -> ClaimDescriptor) used to render nothing at all, and the
+    // reconciliation effect returned early before ever showing the error
+    // toast.
+    mockUser = { id: 'viewer-id', roles: [] };
+    purchaseFetcherState.state = 'idle';
+    purchaseFetcherState.data = undefined;
+    toastError.mockClear();
+
+    const wishlistItem = {
+      categoryId: null,
+      claim: null,
+      id: 'item-1',
+      note: null,
+      ownerId: 'owner-id',
+      status: 'ACTIVE' as const,
+      title: 'Item one',
+      type: 'text',
+      updatedAt: new Date('2026-03-31T12:00:00.000Z'),
+      url: null,
+      // No claimDisclosure — the component falls back to
+      // HIDDEN_CLAIM_DISCLOSURE, matching the loader's response for an
+      // item that was unclaimed at load time.
+    };
+
+    const { rerender } = render(
+      <WishlistItem categories={[]} wishlistItem={wishlistItem} />,
+    );
+
+    const toggleButton = screen.getByRole('button', {
+      name: "I'll grab this gift",
+    });
+    await userEvent.click(toggleButton);
+
+    expect(purchaseFetcherState.submit).toHaveBeenCalledWith(
+      { intent: 'purchase', wishlistItemId: 'item-1' },
+      { method: 'post', action: '/wishlist/purchase' },
+    );
+
+    // Fetcher goes pending.
+    purchaseFetcherState.state = 'submitting';
+    rerender(<WishlistItem categories={[]} wishlistItem={wishlistItem} />);
+
+    // Someone else won the race: the server refuses the claim and reports
+    // the item now held by someone else, with its own distinct refusal
+    // copy.
+    purchaseFetcherState.state = 'idle';
+    purchaseFetcherState.data = {
+      claim: { claimedByUserId: 'someone-else' },
+      error: 'Someone already grabbed this one.',
+      ok: false,
+      wishlistItemId: 'item-1',
+    };
+    rerender(<WishlistItem categories={[]} wishlistItem={wishlistItem} />);
+
+    // The user learns WHY the claim button just disappeared.
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith(
+        'Someone already grabbed this one.',
+      );
+    });
+
+    // Open the item detail view — this is exactly the surface
+    // (WishlistNonOwnerExtras -> ClaimDescriptor) that used to render
+    // nothing, because the stale HIDDEN disclosure loaded before the race
+    // was passed straight through.
+    await userEvent.click(screen.getByTestId('wishlist-item-row'));
+    expect(mockOpenView).toHaveBeenCalledWith();
+
+    expect(screen.getByText('Already claimed')).toBeInTheDocument();
+
+    // No attribution: the client cannot know who won the race and must
+    // never invent a name, pool title, or link for it.
+    expect(screen.queryByText(/claimed by/i)).not.toBeInTheDocument();
+    expect(screen.queryByText('someone-else')).not.toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
   });
 });

--- a/app/components/wishlist/wishlist-item.test.tsx
+++ b/app/components/wishlist/wishlist-item.test.tsx
@@ -5,7 +5,11 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { WishlistItem, parseDisplayUrl } from './wishlist-item';
+import {
+  WishlistItem,
+  parseDisplayUrl,
+  toPurchaseBySentinel,
+} from './wishlist-item';
 
 const mockOpenView = vi.fn();
 const mockOpenEdit = vi.fn();
@@ -399,6 +403,57 @@ describe('WishlistItem', () => {
     // than on the row button specifically.
     expect(screen.getByText('Claimed')).toBeInTheDocument();
   });
+
+  it('renders a "Claimed" badge for a pool-held item too, not just a solo claim', () => {
+    // Regression test: a pool claim has `claimedByUserId: null` (the pool
+    // holds it, not a person). Deriving "is this claimed" from that field
+    // directly — as this component used to — collapsed a pool hold to the
+    // same shape as "unclaimed", so this exact item used to render as
+    // free-to-grab instead of claimed.
+    mockUser = { id: 'viewer-id', roles: [] };
+
+    render(
+      <WishlistItem
+        categories={[]}
+        disableClaims
+        wishlistItem={{
+          id: 'item-1',
+          title: 'Pool Claimed Item',
+          note: 'A note',
+          url: null,
+          type: 'text',
+          categoryId: null,
+          ownerId: 'owner-id',
+          updatedAt: new Date(),
+          status: 'ACTIVE',
+          claim: { claimedByUserId: null },
+        }}
+      />,
+    );
+
+    expect(screen.getByText('Claimed')).toBeInTheDocument();
+  });
+});
+
+describe('toPurchaseBySentinel', () => {
+  it('returns null for an unclaimed item', () => {
+    expect(toPurchaseBySentinel(null)).toBeNull();
+    expect(toPurchaseBySentinel(undefined)).toBeNull();
+  });
+
+  it('returns the real user id for a solo claim', () => {
+    expect(toPurchaseBySentinel({ claimedByUserId: 'user-1' })).toBe('user-1');
+  });
+
+  it('returns a non-null sentinel — never a real user id — for a pool-held claim', () => {
+    const sentinel = toPurchaseBySentinel({ claimedByUserId: null });
+    expect(sentinel).not.toBeNull();
+    expect(sentinel).not.toBe('user-1');
+    // Deterministic and distinct from an unclaimed item, so every
+    // `purchaseBy === userId` / `!== userId` comparison downstream treats a
+    // pool hold as "claimed by someone else" rather than "free to claim".
+    expect(sentinel).toBe(toPurchaseBySentinel({ claimedByUserId: null }));
+  });
 });
 
 describe('parseDisplayUrl', () => {
@@ -415,7 +470,9 @@ describe('parseDisplayUrl', () => {
   });
 
   it('returns null for a data: URL', () => {
-    expect(parseDisplayUrl('data:text/html,<script>alert(1)</script>')).toBeNull();
+    expect(
+      parseDisplayUrl('data:text/html,<script>alert(1)</script>'),
+    ).toBeNull();
   });
 
   it('returns null for a malformed string', () => {
@@ -521,7 +578,9 @@ describe('WishlistItem — list link type', () => {
       />,
     );
 
-    expect(screen.queryByRole('link', { name: /visit/i })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: /visit/i }),
+    ).not.toBeInTheDocument();
   });
 
   it('does not render a Visit link when the list link has no URL', () => {
@@ -543,7 +602,9 @@ describe('WishlistItem — list link type', () => {
       />,
     );
 
-    expect(screen.queryByRole('link', { name: /visit/i })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: /visit/i }),
+    ).not.toBeInTheDocument();
   });
 });
 

--- a/app/components/wishlist/wishlist-item.tsx
+++ b/app/components/wishlist/wishlist-item.tsx
@@ -45,6 +45,7 @@ import { useOptionalRequestInfo } from '#app/utils/request-info.ts';
 import { useOptionalUser, userHasPermission } from '#app/utils/user.ts';
 import {
   HIDDEN_CLAIM_DISCLOSURE,
+  UNATTRIBUTED_CLAIM_DISCLOSURE,
   type ClaimDisclosure,
 } from '#app/utils/wishlist-claim-disclosure.ts';
 import { type WishlistItemImageSource } from '#app/utils/wishlist-images.server.ts';
@@ -234,6 +235,15 @@ function useWishlistPurchaseController({
       if (reconciledPurchaseBy !== purchaseRollbackRef.current) {
         setPurchaseBy(reconciledPurchaseBy);
         purchaseRollbackRef.current = reconciledPurchaseBy;
+        // This is the lost-race case: the server refused the mutation
+        // (isFailedMutation) but reports the item now held by someone else,
+        // so the state above already reconciles to "claimed by someone
+        // else." The toast is what tells the user WHY their claim button
+        // just vanished — without it there's no feedback at all until a
+        // reload, which is exactly the silent-disappearance bug this fixes.
+        if (isFailedMutation) {
+          toast.error(actionData.error ?? 'Unable to update gift claim.');
+        }
         return;
       }
     }
@@ -1083,8 +1093,21 @@ export const WishlistItem = ({
   const purchaseStatusText = isPurchasedByMe
     ? 'You’re on gift duty for this one'
     : null;
-  const claimDisclosure =
+  const loadedClaimDisclosure =
     wishlistItem.claimDisclosure ?? HIDDEN_CLAIM_DISCLOSURE;
+  // The loader's disclosure is computed against the claim state AT LOAD
+  // TIME. If the viewer loaded the item while it was unclaimed (disclosure:
+  // HIDDEN) and then lost a concurrent claim race — another user or a pool
+  // won first — the optimistic reconciliation above flips
+  // isPurchasedBySomeoneElse to true, but this stale disclosure still says
+  // "show nothing." Left alone, that renders as blank space where the claim
+  // button used to be. Fall back to the same zero-attribution shape the
+  // resolver produces for a viewer who isn't allowed to know who holds the
+  // claim — never attribution the client invents itself.
+  const claimDisclosure =
+    isPurchasedBySomeoneElse && !loadedClaimDisclosure.show
+      ? UNATTRIBUTED_CLAIM_DISCLOSURE
+      : loadedClaimDisclosure;
   const purchaseActionLabel = isPurchasedByMe
     ? 'Change my mind'
     : "I'll grab this";

--- a/app/components/wishlist/wishlist-item.tsx
+++ b/app/components/wishlist/wishlist-item.tsx
@@ -43,18 +43,41 @@ import { cn, getWishlistItemImgSrc, useIsPending } from '#app/utils/misc.tsx';
 import { formatCents } from '#app/utils/pool-contributions.ts';
 import { useOptionalRequestInfo } from '#app/utils/request-info.ts';
 import { useOptionalUser, userHasPermission } from '#app/utils/user.ts';
+import {
+  HIDDEN_CLAIM_DISCLOSURE,
+  type ClaimDisclosure,
+} from '#app/utils/wishlist-claim-disclosure.ts';
 import { type WishlistItemImageSource } from '#app/utils/wishlist-images.server.ts';
 import {
   isWishlistItemActive,
   type WishlistItemStatusValue,
 } from '#app/utils/wishlist.ts';
-import { Text, Flex } from '../ui-kit';
+import { Text } from '../ui-kit';
+import { ClaimDescriptor } from './claim-descriptor.tsx';
 import { type usePressFeedback } from './hooks/use-press-feedback.ts';
 import { WishlistStatusBadge, getWishlistStatusMeta } from './status';
 import {
   WishlistRowActionsItem,
   WishlistRowActionsMenu,
 } from './wishlist-row-actions';
+
+// A claim row can exist with `claimedByUserId: null` when a pool holds it
+// instead of a person. Collapsing that straight to `null` (as the previous
+// `?? null` did) made pool-held items read as unclaimed — the exact
+// free-to-grab bug this feature exists to close. The sentinel is never a
+// real user id, so it flows through every `purchaseBy === userId` /
+// `purchaseBy !== userId` comparison below unchanged: a pool hold simply
+// reads as "claimed by someone else."
+export const POOL_HELD_SENTINEL = '__pool-claim__';
+
+// Exported for direct unit testing of the sentinel mapping in isolation from
+// the optimistic-UI hook that consumes it.
+export function toPurchaseBySentinel(
+  claim: { claimedByUserId: string | null } | null | undefined,
+): string | null {
+  if (!claim) return null;
+  return claim.claimedByUserId ?? POOL_HELD_SENTINEL;
+}
 
 export const DeleteFormSchema = z.object({
   intent: z.literal('delete-wishlist-item'),
@@ -93,7 +116,8 @@ type WishlistItemRecord = (Pick<
     priceCents: number | null;
     currency: string | null;
   }> &
-  Partial<{ claim: { claimedByUserId: string | null } | null }>;
+  Partial<{ claim: { claimedByUserId: string | null } | null }> &
+  Partial<{ claimDisclosure: ClaimDisclosure }>;
 type WishlistItemProps = Readonly<{
   wishlistItem: WishlistItemRecord;
   isOwner?: boolean;
@@ -114,6 +138,7 @@ type WishlistArchivedTriggerProps = Readonly<{
 }>;
 type WishlistNonOwnerExtrasProps = Readonly<{
   allowClaims: boolean;
+  disclosure: ClaimDisclosure;
   handlePurchaseToggle: (event: React.SyntheticEvent) => void;
   isClaimed: boolean;
   isPurchasePending: boolean;
@@ -170,7 +195,7 @@ function useWishlistPurchaseController({
 }) {
   const purchaseFetcher = useFetcher<WishlistPurchaseActionResponse>();
   const isPurchasePending = purchaseFetcher.state !== 'idle';
-  const serverPurchaseBy = wishlistItem.claim?.claimedByUserId ?? null;
+  const serverPurchaseBy = toPurchaseBySentinel(wishlistItem.claim);
   const [purchaseBy, setPurchaseBy] = React.useState<string | null>(
     serverPurchaseBy,
   );
@@ -384,6 +409,7 @@ function WishlistArchivedTrigger({
 
 function WishlistNonOwnerExtras({
   allowClaims,
+  disclosure,
   handlePurchaseToggle,
   isClaimed,
   isPurchasePending,
@@ -396,14 +422,7 @@ function WishlistNonOwnerExtras({
 }: WishlistNonOwnerExtrasProps) {
   if (allowClaims) {
     if (isPurchasedBySomeoneElse) {
-      return (
-        <Flex align="center" gap={2}>
-          <LuGift className="h-4 w-4 text-warning" aria-hidden />
-          <Text size="sm" className="text-warning">
-            Someone already grabbed this one.
-          </Text>
-        </Flex>
-      );
+      return <ClaimDescriptor disclosure={disclosure} variant="label" />;
     }
 
     return (
@@ -432,14 +451,7 @@ function WishlistNonOwnerExtras({
   }
 
   if (isClaimed) {
-    return (
-      <Flex align="center" gap={2}>
-        <LuGift className="h-4 w-4 text-warning" aria-hidden />
-        <Text size="sm" className="text-warning">
-          Someone already grabbed this one.
-        </Text>
-      </Flex>
-    );
+    return <ClaimDescriptor disclosure={disclosure} variant="label" />;
   }
 
   return (
@@ -641,7 +653,11 @@ function WishlistNonOwnerTrigger({
   wishlistItem,
 }: Omit<
   WishlistNonOwnerTriggerProps,
-  'imageBlock' | 'press' | 'purchaseButtonClassName' | 'purchaseButtonIconOnly' | 'purchaseStatusText'
+  | 'imageBlock'
+  | 'press'
+  | 'purchaseButtonClassName'
+  | 'purchaseButtonIconOnly'
+  | 'purchaseStatusText'
 > & {
   displayImageSrc: string | null;
   imageErrored: boolean;
@@ -1018,14 +1034,11 @@ export const WishlistItem = ({
     userId: user?.id,
     wishlistItem,
   });
-  const {
-    displayImageSrc,
-    handleImageError,
-    imageErrored,
-  } = useWishlistImageController({
-    isOwner,
-    wishlistItem,
-  });
+  const { displayImageSrc, handleImageError, imageErrored } =
+    useWishlistImageController({
+      isOwner,
+      wishlistItem,
+    });
   const [isClaimInfoOpen, setIsClaimInfoOpen] = React.useState(false);
   const [deleteOpen, setDeleteOpen] = React.useState(false);
   const typeChangeFetcher = useFetcher();
@@ -1039,7 +1052,8 @@ export const WishlistItem = ({
       formData.set('type', newType);
       if (wishlistItem.url) formData.set('url', wishlistItem.url);
       if (wishlistItem.note) formData.set('note', wishlistItem.note);
-      if (wishlistItem.categoryId) formData.set('categoryId', wishlistItem.categoryId);
+      if (wishlistItem.categoryId)
+        formData.set('categoryId', wishlistItem.categoryId);
       formData.set('imageAction', 'none');
       formData.set('clientMutationId', createClientMutationId());
       Promise.resolve(
@@ -1057,11 +1071,13 @@ export const WishlistItem = ({
   // renders INSIDE the item-editor modal (not on the row itself). The row
   // only needs handlePurchaseToggle + isPurchased* flags; the modal shows
   // the full "Claim this gift" button with the visible label + check state.
-  const purchaseStatusText = isPurchasedBySomeoneElse
-    ? 'Someone already grabbed this'
-    : isPurchasedByMe
-      ? 'You’re on gift duty for this one'
-      : null;
+  // The "claimed by someone else" case renders through ClaimDescriptor
+  // instead (tiered attribution) — this stays self-claim-only.
+  const purchaseStatusText = isPurchasedByMe
+    ? 'You’re on gift duty for this one'
+    : null;
+  const claimDisclosure =
+    wishlistItem.claimDisclosure ?? HIDDEN_CLAIM_DISCLOSURE;
   const purchaseActionLabel = isPurchasedByMe
     ? 'Change my mind'
     : "I'll grab this";
@@ -1135,6 +1151,7 @@ export const WishlistItem = ({
     const viewPurchaseExtras = (
       <WishlistNonOwnerExtras
         allowClaims={allowClaims}
+        disclosure={claimDisclosure}
         handlePurchaseToggle={handlePurchaseToggle}
         isClaimed={isClaimed}
         isPurchasePending={isPurchasePending}

--- a/app/components/wishlist/wishlist-item.tsx
+++ b/app/components/wishlist/wishlist-item.tsx
@@ -86,8 +86,9 @@ export const DeleteFormSchema = z.object({
 
 export type WishlistItemOwnerLayout = 'default' | 'reorder';
 type WishlistItemDragState = 'idle' | 'dragging-item' | 'dragging-category';
-// Pool claims render through ClaimDescriptor (PR3); this surface is
-// solo-only until then, so claimedByUserId may be null for a pool claim.
+// Pool claims render through ClaimDescriptor. claimedByUserId is null for a
+// pool-held claim — see `toPurchaseBySentinel` above for how that's told
+// apart from "unclaimed".
 type WishlistClaimPayload = { claimedByUserId: string | null } | null;
 type WishlistPurchaseActionResponse = {
   ok: boolean;
@@ -218,7 +219,13 @@ function useWishlistPurchaseController({
       actionData?.wishlistItemId === wishlistItem.id && actionData.ok === false;
 
     if (actionData?.wishlistItemId === wishlistItem.id) {
-      const reconciledPurchaseBy = actionData.claim?.claimedByUserId ?? null;
+      // Route the server's claim payload through the same sentinel mapping
+      // as the initial render (`serverPurchaseBy` above). Reading
+      // `claimedByUserId` directly here would collapse a pool-held claim
+      // (`{ claimedByUserId: null }`, meaning "a pool holds this now") down
+      // to the same value as "unclaimed" — the exact free-to-grab bug this
+      // module exists to close, reappearing through the fetcher path.
+      const reconciledPurchaseBy = toPurchaseBySentinel(actionData.claim);
       if (actionData.ok) {
         setPurchaseBy(reconciledPurchaseBy);
         purchaseRollbackRef.current = reconciledPurchaseBy;

--- a/app/routes/settings+/profile.index.action.test.ts
+++ b/app/routes/settings+/profile.index.action.test.ts
@@ -1,0 +1,138 @@
+/**
+ * @vitest-environment node
+ *
+ * Regression for the P1 finding: `WishlistClaim.claimedByUserId` has
+ * `onDelete: Cascade`, so a bare `prisma.user.delete` in `deleteDataAction`
+ * removed a claimant's solo claims at the database level with no
+ * `.wishlistClaim` call in sight — the write-guard test stayed green, but
+ * `settleItem` never ran, so a decided pool waiting behind that claim was
+ * left with nothing while the item sat free for anyone to take. The fix
+ * routes the deletion through `releaseSoloClaimsMatching` first, while the
+ * claim rows still exist, so a waiting pool inherits before the cascade
+ * would have quietly erased the evidence.
+ */
+import { type AppLoadContext } from 'react-router';
+import { expect, test } from 'vitest';
+import { getSessionExpirationDate } from '#app/utils/auth.server.ts';
+import { prisma } from '#app/utils/db.server.ts';
+import { createPassword, createUser } from '#tests/db-utils.ts';
+import {
+  getRouteResultStatus,
+  toActionArgs,
+} from '#tests/route-module-test-utils.ts';
+import { getSessionCookieHeader } from '#tests/utils.ts';
+
+import { action } from './profile.index.tsx';
+
+const context = {
+  cspNonce: undefined,
+  serverBuild: undefined,
+} as unknown as AppLoadContext;
+
+const ensureUserRole = () =>
+  prisma.role.upsert({
+    where: { name: 'user' },
+    update: {},
+    create: { name: 'user' },
+  });
+
+async function createUserWithSession() {
+  await ensureUserRole();
+
+  const user = await prisma.user.create({
+    data: {
+      ...createUser(),
+      password: { create: createPassword() },
+      roles: { connect: { name: 'user' } },
+    },
+  });
+
+  const session = await prisma.session.create({
+    select: { id: true },
+    data: { userId: user.id, expirationDate: getSessionExpirationDate() },
+  });
+
+  const cookie = await getSessionCookieHeader(session);
+  return { user, cookie };
+}
+
+function invokeDeleteData(cookie: string) {
+  return action(
+    toActionArgs({
+      context,
+      params: {},
+      request: new Request('https://www.giftpool.app/settings/profile', {
+        method: 'POST',
+        headers: {
+          cookie,
+          'content-type': 'application/x-www-form-urlencoded',
+        },
+        body: new URLSearchParams({ intent: 'delete-data' }),
+      }),
+    }),
+  );
+}
+
+test('hands a solo claim to a decided pool waiting behind it when the claimant deletes their account', async () => {
+  const owner = await prisma.user.create({ data: createUser() });
+  const organizer = await prisma.user.create({ data: createUser() });
+  const { user: claimant, cookie } = await createUserWithSession();
+
+  const item = await prisma.wishlistItem.create({
+    data: {
+      ownerId: owner.id,
+      title: 'Espresso machine',
+      type: 'text',
+      sortOrder: 0,
+    },
+  });
+  await prisma.wishlistClaim.create({
+    data: { wishlistItemId: item.id, claimedByUserId: claimant.id },
+  });
+
+  const pool = await prisma.pool.create({
+    data: {
+      title: 'Espresso machine pool',
+      organizerId: organizer.id,
+      recipientUserId: owner.id,
+    },
+  });
+  const idea = await prisma.giftIdea.create({
+    data: {
+      poolId: pool.id,
+      proposedById: organizer.id,
+      name: 'Espresso machine',
+      wishlistItemId: item.id,
+    },
+  });
+  await prisma.pool.update({
+    where: { id: pool.id },
+    data: { status: 'DECIDED', chosenIdeaId: idea.id, decidedAt: new Date() },
+  });
+
+  const response = await invokeDeleteData(cookie);
+  expect(getRouteResultStatus(response)).toBe(302);
+
+  const deletedUser = await prisma.user.findUnique({
+    where: { id: claimant.id },
+  });
+  expect(deletedUser).toBeNull();
+
+  // The account is gone, but the pool that had already decided on the item
+  // inherited the claim instead of the item being silently freed.
+  const claim = await prisma.wishlistClaim.findUniqueOrThrow({
+    where: { wishlistItemId: item.id },
+  });
+  expect(claim.poolId).toBe(pool.id);
+  expect(claim.claimedByUserId).toBeNull();
+});
+
+test('deletes the account with no error when the user holds no wishlist claims', async () => {
+  const { user, cookie } = await createUserWithSession();
+
+  const response = await invokeDeleteData(cookie);
+  expect(getRouteResultStatus(response)).toBe(302);
+
+  const deletedUser = await prisma.user.findUnique({ where: { id: user.id } });
+  expect(deletedUser).toBeNull();
+});

--- a/app/routes/settings+/profile.index.tsx
+++ b/app/routes/settings+/profile.index.tsx
@@ -45,6 +45,7 @@ import {
   type BirthdayVisibility,
   type WishlistVisibility,
 } from '#app/utils/user-validation.ts';
+import { releaseSoloClaimsMatching } from '#app/utils/wishlist-claims.server.ts';
 import { DangerZoneDeleteDialog } from './__danger-zone-delete-dialog.tsx';
 import { ProfilePhotoSheet } from './__profile-photo-sheet.tsx';
 import { twoFAVerificationType } from './profile.two-factor.tsx';
@@ -825,6 +826,18 @@ async function signOutOfSessionsAction({ request, userId }: ProfileActionArgs) {
 }
 
 async function deleteDataAction({ userId }: ProfileActionArgs) {
+  // `WishlistClaim.claimedByUserId` cascades on User deletion — a bare
+  // `prisma.user.delete` would remove this user's solo claims at the DB
+  // level with no `.wishlistClaim` call in sight, so the write-guard test
+  // stays green while a decided pool waiting behind that claim never
+  // settles onto the item (it's simply left free). Release-and-settle every
+  // solo claim through the module's batch entry point FIRST, while the user
+  // (and therefore the claim rows) still exist, so a waiting pool inherits
+  // before the account — and the cascade that would otherwise silently
+  // remove the evidence of that claim — goes away. `releaseSoloClaimsMatching`
+  // is a no-op (empty array, no throw) when the user holds no solo claims,
+  // so this never blocks deletion.
+  await releaseSoloClaimsMatching({ claimedByUserId: userId });
   await prisma.user.delete({ where: { id: userId } });
   return redirectWithToast('/', {
     type: 'success',

--- a/app/routes/w.public.$token.loader.test.ts
+++ b/app/routes/w.public.$token.loader.test.ts
@@ -1,0 +1,142 @@
+/**
+ * @vitest-environment node
+ *
+ * The highest-risk path for this feature: the public share link is reachable
+ * by anonymous visitors AND by signed-in users who followed someone else's
+ * link, and it must show claim state with ZERO attribution either way. This
+ * test constructs the strongest possible attribution case — a signed-in
+ * viewer who is a CONTRIBUTOR to the exact pool holding the claim, who would
+ * see "Your pool <title> is getting this" on every other non-owner surface —
+ * and asserts the public route still shows only the generic, unattributed
+ * "Already claimed" state to them, identically to an anonymous request.
+ */
+import { type AppLoadContext } from 'react-router';
+import { describe, expect, it, vi } from 'vitest';
+import { getSessionExpirationDate } from '#app/utils/auth.server.ts';
+import { prisma } from '#app/utils/db.server.ts';
+import { upsertWishlistPublicShare } from '#app/utils/wishlist.server.ts';
+import { createUser } from '#tests/db-utils.ts';
+import {
+  getRouteResultData,
+  toLoaderArgs,
+} from '#tests/route-module-test-utils.ts';
+import { getSessionCookieHeader } from '#tests/utils.ts';
+
+vi.mock('#app/utils/analytics.server.ts', () => ({
+  queueLogEvent: vi.fn(() => ({ eventId: 'evt-1' })),
+}));
+
+import { loader } from './w.public.$token.tsx';
+
+const context = {
+  cspNonce: undefined,
+  serverBuild: undefined,
+} as unknown as AppLoadContext;
+
+async function withSession(userId: string) {
+  const session = await prisma.session.create({
+    data: { userId, expirationDate: getSessionExpirationDate() },
+    select: { id: true },
+  });
+  return getSessionCookieHeader(session);
+}
+
+async function runLoader(token: string, cookie?: string) {
+  const request = new Request(`https://giftpool.app/w/public/${token}`, {
+    headers: cookie ? { cookie } : {},
+  });
+  return getRouteResultData<{
+    user: {
+      wishlistItems: Array<{
+        id: string;
+        claimDisclosure?: {
+          show: boolean;
+          tone: string;
+          text: string;
+          name: string | null;
+          poolLink: string | null;
+          canJoinPool: boolean;
+        };
+      }>;
+    };
+  }>(await loader(toLoaderArgs({ context, params: { token }, request })));
+}
+
+describe('w.public.$token loader — claim attribution', () => {
+  it('shows a pool-held claim with zero attribution to a signed-in contributor of the holding pool, and identically to an anonymous visitor', async () => {
+    const owner = await prisma.user.create({ data: createUser() });
+    const viewer = await prisma.user.create({ data: createUser() });
+    const item = await prisma.wishlistItem.create({
+      data: {
+        ownerId: owner.id,
+        title: 'Espresso machine',
+        type: 'item',
+        sortOrder: 0,
+      },
+    });
+    const group = await prisma.giftGroup.create({
+      data: { name: 'Secret Coffee Crew', createdById: viewer.id },
+    });
+    const pool = await prisma.pool.create({
+      data: {
+        title: 'Espresso pool',
+        organizerId: viewer.id,
+        recipientUserId: owner.id,
+        giftGroupId: group.id,
+      },
+    });
+    const idea = await prisma.giftIdea.create({
+      data: {
+        poolId: pool.id,
+        proposedById: viewer.id,
+        name: 'Espresso machine',
+        wishlistItemId: item.id,
+      },
+    });
+    await prisma.pool.update({
+      where: { id: pool.id },
+      data: { status: 'DECIDED', chosenIdeaId: idea.id, decidedAt: new Date() },
+    });
+    // The strongest attribution case: this viewer CONTRIBUTES to the pool
+    // that holds the claim — on any non-owner surface other than this one
+    // they'd see "Your pool Espresso pool is getting this".
+    await prisma.poolContributor.create({
+      data: { poolId: pool.id, userId: viewer.id },
+    });
+    await prisma.wishlistClaim.create({
+      data: { wishlistItemId: item.id, poolId: pool.id },
+    });
+
+    const { token } = await upsertWishlistPublicShare(owner.id);
+
+    const cookie = await withSession(viewer.id);
+    const asSignedInContributor = await runLoader(token, cookie);
+    const anonymous = await runLoader(token);
+
+    const expectedDisclosure = {
+      show: true,
+      tone: 'warning',
+      text: 'Already claimed',
+      name: null,
+      poolLink: null,
+      canJoinPool: false,
+    };
+
+    const signedInItem = asSignedInContributor.user.wishlistItems.find(
+      (i) => i.id === item.id,
+    );
+    const anonItem = anonymous.user.wishlistItems.find((i) => i.id === item.id);
+
+    expect(signedInItem?.claimDisclosure).toEqual(expectedDisclosure);
+    expect(anonItem?.claimDisclosure).toEqual(expectedDisclosure);
+
+    // Belt-and-braces: the pool title and group name must not leak anywhere
+    // in the payload, not just in the claimDisclosure field we asserted on.
+    expect(JSON.stringify(asSignedInContributor)).not.toContain(
+      'Espresso pool',
+    );
+    expect(JSON.stringify(asSignedInContributor)).not.toContain(
+      'Secret Coffee Crew',
+    );
+  });
+});

--- a/app/routes/w.public.$token.loader.test.ts
+++ b/app/routes/w.public.$token.loader.test.ts
@@ -132,11 +132,16 @@ describe('w.public.$token loader — claim attribution', () => {
 
     // Belt-and-braces: the pool title and group name must not leak anywhere
     // in the payload, not just in the claimDisclosure field we asserted on.
+    // Checked on both responses — the anonymous one is what an unauthenticated
+    // stranger actually hits, so it deserves the check at least as much as
+    // the signed-in-contributor response.
     expect(JSON.stringify(asSignedInContributor)).not.toContain(
       'Espresso pool',
     );
     expect(JSON.stringify(asSignedInContributor)).not.toContain(
       'Secret Coffee Crew',
     );
+    expect(JSON.stringify(anonymous)).not.toContain('Espresso pool');
+    expect(JSON.stringify(anonymous)).not.toContain('Secret Coffee Crew');
   });
 });

--- a/app/routes/w.public.$token.tsx
+++ b/app/routes/w.public.$token.tsx
@@ -8,7 +8,10 @@ import {
   data,
   useLoaderData,
 } from 'react-router';
-import { ErrorFallback, GeneralErrorBoundary } from '#app/components/error-boundary.tsx';
+import {
+  ErrorFallback,
+  GeneralErrorBoundary,
+} from '#app/components/error-boundary.tsx';
 import {
   ShareConversionBanner,
   ShareConversionCard,
@@ -18,6 +21,7 @@ import { queueLogEvent } from '#app/utils/analytics.server.ts';
 import { getUserId } from '#app/utils/auth.server.ts';
 import { prisma } from '#app/utils/db.server.ts';
 import { getRequestContext } from '#app/utils/request-context.server.ts';
+import { loadClaimStates } from '#app/utils/wishlist-claims.server.ts';
 import {
   cleanupWishlistClaimsForOwner,
   findWishlistPublicShareByToken,
@@ -179,6 +183,17 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
   invariantResponse(user, 'Wishlist not found', {
     status: 404,
   });
+  // This surface is reachable by anonymous visitors AND by a signed-in user
+  // who followed someone else's share link — either way it must show ZERO
+  // attribution. `isAnonymous` inside loadClaimStates is a surface-policy
+  // flag, not a "nobody is logged in" check (see ViewerRelationship's doc
+  // comment), so `userId` is hardcoded null here regardless of `viewerId`
+  // above (which exists only for analytics). Do not thread the real viewer
+  // id through — that would leak pool/group names to a signed-in visitor.
+  const claimDisclosures = await loadClaimStates(
+    user.wishlistItems.map((item) => item.id),
+    { userId: null, isOwner: false },
+  );
   const wishlistItems: WishlistUser['wishlistItems'] = user.wishlistItems.map(
     ({ image, imageSource, status, ...item }) => ({
       ...item,
@@ -189,6 +204,7 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
             claimedByUserId: item.claim.claimedByUserId,
           }
         : null,
+      claimDisclosure: claimDisclosures.get(item.id),
       updatedAt: item.updatedAt,
       hasImage: Boolean(image),
       imageSource:

--- a/app/routes/wishlist+/purchase.test.ts
+++ b/app/routes/wishlist+/purchase.test.ts
@@ -203,7 +203,7 @@ test('rejects a viewer without wishlist access (not a friend, no shared group)',
   });
 });
 
-test('rejects claiming an item already claimed by someone else', async () => {
+test('rejects claiming an item already claimed by another user', async () => {
   const { user: owner } = await createUserWithSession();
   const { user: firstClaimant } = await createUserWithSession();
   const { user: secondClaimant, cookie } = await createUserWithSession();
@@ -222,9 +222,36 @@ test('rejects claiming an item already claimed by someone else', async () => {
   expect(getRouteResultStatus(response)).toBe(400);
   await expect(getRouteResultData(response)).resolves.toMatchObject({
     ok: false,
-    error: 'This item has already been marked as purchased.',
+    error: 'Someone already grabbed this one.',
     claim: { claimedByUserId: firstClaimant.id },
   });
+});
+
+test('rejects claiming an item already held by a pool, without implying it was purchased', async () => {
+  const { user: owner } = await createUserWithSession();
+  const { user: organizer } = await createUserWithSession();
+  const { user: viewer, cookie } = await createUserWithSession();
+  await makeFriends(owner.id, viewer.id);
+  const item = await createWishlistItem({ ownerId: owner.id });
+  const pool = await prisma.pool.create({
+    data: { title: 'Pool', organizerId: organizer.id, recipientUserId: owner.id },
+  });
+  await prisma.wishlistClaim.create({
+    data: { wishlistItemId: item.id, poolId: pool.id },
+  });
+
+  const response = await invoke({
+    cookie,
+    form: { wishlistItemId: item.id, intent: 'purchase' },
+  });
+
+  expect(getRouteResultStatus(response)).toBe(400);
+  const payload = await getRouteResultData(response);
+  expect(payload).toMatchObject({
+    ok: false,
+    error: 'A group is already getting this one.',
+  });
+  expect((payload as { error: string }).error).not.toMatch(/purchased/i);
 });
 
 test('claims an item on the happy path and logs the purchase event', async () => {

--- a/app/routes/wishlist+/purchase.test.ts
+++ b/app/routes/wishlist+/purchase.test.ts
@@ -338,6 +338,70 @@ test('releases a claim held by the requester and returns claim: null', async () 
   ).resolves.toBeNull();
 });
 
+test('releasing a claim that transfers to a waiting pool reports the item as pool-held, not free', async () => {
+  const { user: owner } = await createUserWithSession();
+  const { user: organizer } = await createUserWithSession();
+  const { user: viewer, cookie } = await createUserWithSession();
+  await makeFriends(owner.id, viewer.id);
+  const item = await createWishlistItem({ ownerId: owner.id });
+
+  // The friend claims the item first.
+  await prisma.wishlistClaim.create({
+    data: { wishlistItemId: item.id, claimedByUserId: viewer.id },
+  });
+
+  // A pool decides on the same item afterward. It conflicts with the
+  // existing solo claim, so it takes nothing yet — but it now has intent
+  // and is waiting.
+  const pool = await prisma.pool.create({
+    data: { title: 'Pool', organizerId: organizer.id, recipientUserId: owner.id },
+  });
+  const idea = await prisma.giftIdea.create({
+    data: {
+      poolId: pool.id,
+      proposedById: organizer.id,
+      name: 'Espresso machine',
+      wishlistItemId: item.id,
+    },
+  });
+  await prisma.pool.update({
+    where: { id: pool.id },
+    data: { status: 'DECIDED', chosenIdeaId: idea.id, decidedAt: new Date() },
+  });
+
+  const response = await invoke({
+    cookie,
+    form: { wishlistItemId: item.id, intent: 'unpurchase' },
+  });
+
+  expect(getRouteResultStatus(response)).toBe(200);
+  const payload = await getRouteResultData(response);
+  expect(payload).toMatchObject({
+    ok: true,
+    wishlistItemId: item.id,
+    // Not `claim: null` — the pool immediately took the claim on release, so
+    // the item must not be reported as free to grab.
+    claim: { claimedByUserId: null },
+  });
+
+  const claim = await prisma.wishlistClaim.findUniqueOrThrow({
+    where: { wishlistItemId: item.id },
+  });
+  expect(claim.poolId).toBe(pool.id);
+  expect(claim.claimedByUserId).toBeNull();
+
+  expect(queueLogEvent).toHaveBeenCalledWith(
+    expect.objectContaining({
+      name: 'wishlist_claim_transferred',
+      userId: viewer.id,
+      properties: expect.objectContaining({
+        wishlistItemId: item.id,
+        toPoolId: pool.id,
+      }),
+    }),
+  );
+});
+
 test('rejects releasing a claim held by someone else', async () => {
   const { user: owner } = await createUserWithSession();
   const { user: holder } = await createUserWithSession();

--- a/app/routes/wishlist+/purchase.test.ts
+++ b/app/routes/wishlist+/purchase.test.ts
@@ -254,6 +254,43 @@ test('rejects claiming an item already held by a pool, without implying it was p
   expect((payload as { error: string }).error).not.toMatch(/purchased/i);
 });
 
+test('the loser of a concurrent claim race is told the winner, not a stale "unclaimed"', async () => {
+  // Regression for the P2 finding: the route used to return `currentClaim`,
+  // the claim state read *before* calling claimForUser — null for a free
+  // item. A loser of a genuine concurrent race would then have its UI
+  // reconciled back to "unclaimed" even though the winner's row already
+  // existed. The route must now report the actual post-race claim.
+  const { user: owner } = await createUserWithSession();
+  const { user: firstViewer, cookie: firstCookie } = await createUserWithSession();
+  const { user: secondViewer, cookie: secondCookie } = await createUserWithSession();
+  await makeFriends(owner.id, firstViewer.id);
+  await makeFriends(owner.id, secondViewer.id);
+  const item = await createWishlistItem({ ownerId: owner.id });
+
+  const [firstResponse, secondResponse] = await Promise.all([
+    invoke({ cookie: firstCookie, form: { wishlistItemId: item.id, intent: 'purchase' } }),
+    invoke({ cookie: secondCookie, form: { wishlistItemId: item.id, intent: 'purchase' } }),
+  ]);
+
+  type RaceResult = { ok: boolean; claim: { claimedByUserId: string | null } | null };
+  const [firstData, secondData] = await Promise.all([
+    getRouteResultData<RaceResult>(firstResponse),
+    getRouteResultData<RaceResult>(secondResponse),
+  ]);
+
+  const winner = firstData.ok ? firstData : secondData;
+  const loser = firstData.ok ? secondData : firstData;
+  expect(firstData.ok).not.toBe(secondData.ok);
+  expect(loser.claim).not.toBeNull();
+  expect(loser.claim?.claimedByUserId).not.toBeNull();
+  expect(loser.claim?.claimedByUserId).toBe(winner.claim?.claimedByUserId);
+
+  const claim = await prisma.wishlistClaim.findUniqueOrThrow({
+    where: { wishlistItemId: item.id },
+  });
+  expect(loser.claim?.claimedByUserId).toBe(claim.claimedByUserId);
+});
+
 test('claims an item on the happy path and logs the purchase event', async () => {
   const { user: owner } = await createUserWithSession();
   const { user: viewer, cookie } = await createUserWithSession();

--- a/app/routes/wishlist+/purchase.ts
+++ b/app/routes/wishlist+/purchase.ts
@@ -169,9 +169,17 @@ export async function action({ request }: ActionFunctionArgs) {
     source: 'server',
     properties: { wishlistItemId, toPoolId: release.transferredToPoolId },
   });
+  // A transfer means the item is NOT free — settlement handed the claim
+  // straight to the longest-waiting pool inside the same transaction as the
+  // release (see `releaseUserClaim`). Reporting `claim: null` here would be a
+  // lie the client believes: it renders the item as free to grab while a
+  // pool actively holds it. `{ claimedByUserId: null }` is the same shape
+  // the loaders use for a pool-held claim (see `mapWishlistItems` /
+  // `w.public.$token.tsx`), so the client's existing sentinel mapping
+  // (`toPurchaseBySentinel`) reconciles it correctly without special-casing.
   return {
     ok: true,
     wishlistItemId,
-    claim: null,
+    claim: release.transferredToPoolId ? { claimedByUserId: null } : null,
   };
 }

--- a/app/routes/wishlist+/purchase.ts
+++ b/app/routes/wishlist+/purchase.ts
@@ -161,6 +161,14 @@ export async function action({ request }: ActionFunctionArgs) {
       },
     );
   }
+  queueLogEvent({
+    name: release.transferredToPoolId
+      ? 'wishlist_claim_transferred'
+      : 'wishlist_claim_released',
+    userId,
+    source: 'server',
+    properties: { wishlistItemId, toPoolId: release.transferredToPoolId },
+  });
   return {
     ok: true,
     wishlistItemId,

--- a/app/routes/wishlist+/purchase.ts
+++ b/app/routes/wishlist+/purchase.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { queueLogEvent } from '#app/utils/analytics.server.ts';
 import { requireUserId } from '#app/utils/auth.server.ts';
 import { prisma } from '#app/utils/db.server.ts';
+import { claimForUser, releaseUserClaim } from '#app/utils/wishlist-claims.server.ts';
 import { usersShareWishlistAccess } from '#app/utils/wishlist.server.ts';
 const PurchaseFormSchema = z.object({
   wishlistItemId: z.string(),
@@ -109,31 +110,26 @@ export async function action({ request }: ActionFunctionArgs) {
     );
   }
   if (intent === 'purchase') {
-    if (wishlistItem.claim && wishlistItem.claim.claimedByUserId !== userId) {
+    const outcome = await claimForUser(wishlistItemId, userId);
+    if (!outcome.ok) {
       return data(
         {
           ok: false,
           wishlistItemId,
           claim: currentClaim,
-          error: 'This item has already been marked as purchased.',
+          // Today's message ("already marked as purchased") is false when a
+          // pool holds it — a DECIDED pool has explicitly not purchased
+          // anything. PURCHASED is a separate, later pool status.
+          error:
+            outcome.reason === 'held-by-pool'
+              ? 'A group is already getting this one.'
+              : 'Someone already grabbed this one.',
         },
         {
           status: 400,
         },
       );
     }
-    await prisma.wishlistClaim.upsert({
-      where: {
-        wishlistItemId,
-      },
-      create: {
-        wishlistItemId,
-        claimedByUserId: userId,
-      },
-      update: {
-        claimedByUserId: userId,
-      },
-    });
     queueLogEvent({
       name: 'wishlist_purchase_recorded',
       userId,
@@ -151,7 +147,8 @@ export async function action({ request }: ActionFunctionArgs) {
       },
     };
   }
-  if (wishlistItem.claim?.claimedByUserId !== userId) {
+  const release = await releaseUserClaim(wishlistItemId, userId);
+  if (!release.ok) {
     return data(
       {
         ok: false,
@@ -164,11 +161,6 @@ export async function action({ request }: ActionFunctionArgs) {
       },
     );
   }
-  await prisma.wishlistClaim.delete({
-    where: {
-      wishlistItemId,
-    },
-  });
   return {
     ok: true,
     wishlistItemId,

--- a/app/routes/wishlist+/purchase.ts
+++ b/app/routes/wishlist+/purchase.ts
@@ -116,7 +116,11 @@ export async function action({ request }: ActionFunctionArgs) {
         {
           ok: false,
           wishlistItemId,
-          claim: currentClaim,
+          // The actual current claim, not `currentClaim` (read before this
+          // attempt). A loser of a concurrent race must see the winner's
+          // claim, or the optimistic controller reconciles its UI back to
+          // "unclaimed" while the winner's row already exists in the DB.
+          claim: outcome.claim,
           // Today's message ("already marked as purchased") is false when a
           // pool holds it — a DECIDED pool has explicitly not purchased
           // anything. PURCHASED is a separate, later pool status.

--- a/app/routes/wishlist+/status.test.ts
+++ b/app/routes/wishlist+/status.test.ts
@@ -108,6 +108,50 @@ test('archiving an item releases a solo claim', async () => {
   ).resolves.toBeNull();
 });
 
+test('archiving a solo-claimed item a decided pool wants hands the pool the claim', async () => {
+  // Regression: archiving used to bare-delete the solo claim without
+  // settling it, so a pool that had already decided on the item was left
+  // with no claim at all — the exact opposite of "the pool inherits."
+  const { user: owner, cookie } = await createUserWithSession();
+  const { user: claimant } = await createUserWithSession();
+  const { user: organizer } = await createUserWithSession();
+  const item = await createWishlistItem({ ownerId: owner.id });
+  await prisma.wishlistClaim.create({
+    data: { wishlistItemId: item.id, claimedByUserId: claimant.id },
+  });
+  const pool = await prisma.pool.create({
+    data: { title: 'Pool', organizerId: organizer.id, recipientUserId: owner.id },
+  });
+  const idea = await prisma.giftIdea.create({
+    data: {
+      poolId: pool.id,
+      proposedById: organizer.id,
+      name: 'Espresso machine',
+      wishlistItemId: item.id,
+    },
+  });
+  await prisma.pool.update({
+    where: { id: pool.id },
+    data: { status: 'DECIDED', chosenIdeaId: idea.id, decidedAt: new Date() },
+  });
+
+  const response = await invoke({
+    cookie,
+    form: {
+      intent: 'update-wishlist-item-status',
+      wishlistItemId: item.id,
+      status: 'ARCHIVED',
+    },
+  });
+
+  expect(getRouteResultStatus(response)).toBe(200);
+  const claim = await prisma.wishlistClaim.findUniqueOrThrow({
+    where: { wishlistItemId: item.id },
+  });
+  expect(claim.poolId).toBe(pool.id);
+  expect(claim.claimedByUserId).toBeNull();
+});
+
 test('a pool-held claim survives an archive/restore cycle', async () => {
   const { user: owner, cookie } = await createUserWithSession();
   const { user: organizer } = await createUserWithSession();

--- a/app/routes/wishlist+/status.test.ts
+++ b/app/routes/wishlist+/status.test.ts
@@ -1,0 +1,167 @@
+/**
+ * @vitest-environment node
+ */
+import { type AppLoadContext } from 'react-router';
+import { expect, test } from 'vitest';
+import { getSessionExpirationDate } from '#app/utils/auth.server.ts';
+import { prisma } from '#app/utils/db.server.ts';
+import { createPassword, createUser } from '#tests/db-utils.ts';
+import {
+  getRouteResultData,
+  getRouteResultStatus,
+  toActionArgs,
+} from '#tests/route-module-test-utils.ts';
+import { getSessionCookieHeader } from '#tests/utils.ts';
+
+import { action } from './status.ts';
+
+const context = {
+  cspNonce: undefined,
+  serverBuild: undefined,
+} as unknown as AppLoadContext;
+
+const ensureUserRole = () =>
+  prisma.role.upsert({
+    where: { name: 'user' },
+    update: {},
+    create: { name: 'user' },
+  });
+
+async function createUserWithSession() {
+  await ensureUserRole();
+
+  const user = await prisma.user.create({
+    data: {
+      ...createUser(),
+      password: { create: createPassword() },
+      roles: { connect: { name: 'user' } },
+    },
+  });
+
+  const session = await prisma.session.create({
+    select: { id: true },
+    data: { userId: user.id, expirationDate: getSessionExpirationDate() },
+  });
+
+  const cookie = await getSessionCookieHeader(session);
+  return { user, cookie };
+}
+
+function createWishlistItem({ ownerId }: { ownerId: string }) {
+  return prisma.wishlistItem.create({
+    data: {
+      ownerId,
+      sortOrder: 0,
+      title: 'Espresso machine',
+      type: 'text',
+    },
+  });
+}
+
+function invoke({
+  cookie,
+  form,
+}: {
+  cookie: string;
+  form: Record<string, string>;
+}) {
+  return action(
+    toActionArgs({
+      context,
+      params: {},
+      request: new Request('https://www.giftpool.app/wishlist/status', {
+        method: 'POST',
+        headers: {
+          cookie,
+          'content-type': 'application/x-www-form-urlencoded',
+        },
+        body: new URLSearchParams(form),
+      }),
+    }),
+  );
+}
+
+test('archiving an item releases a solo claim', async () => {
+  const { user: owner, cookie } = await createUserWithSession();
+  const { user: claimant } = await createUserWithSession();
+  const item = await createWishlistItem({ ownerId: owner.id });
+  await prisma.wishlistClaim.create({
+    data: { wishlistItemId: item.id, claimedByUserId: claimant.id },
+  });
+
+  const response = await invoke({
+    cookie,
+    form: {
+      intent: 'update-wishlist-item-status',
+      wishlistItemId: item.id,
+      status: 'ARCHIVED',
+    },
+  });
+
+  expect(getRouteResultStatus(response)).toBe(200);
+  await expect(getRouteResultData(response)).resolves.toMatchObject({
+    ok: true,
+    status: 'ARCHIVED',
+  });
+  await expect(
+    prisma.wishlistClaim.findUnique({ where: { wishlistItemId: item.id } }),
+  ).resolves.toBeNull();
+});
+
+test('a pool-held claim survives an archive/restore cycle', async () => {
+  const { user: owner, cookie } = await createUserWithSession();
+  const { user: organizer } = await createUserWithSession();
+  const item = await createWishlistItem({ ownerId: owner.id });
+  const pool = await prisma.pool.create({
+    data: { title: 'Pool', organizerId: organizer.id, recipientUserId: owner.id },
+  });
+  const idea = await prisma.giftIdea.create({
+    data: {
+      poolId: pool.id,
+      proposedById: organizer.id,
+      name: 'Espresso machine',
+      wishlistItemId: item.id,
+    },
+  });
+  await prisma.pool.update({
+    where: { id: pool.id },
+    data: { status: 'DECIDED', chosenIdeaId: idea.id, decidedAt: new Date() },
+  });
+  await prisma.wishlistClaim.create({
+    data: { wishlistItemId: item.id, poolId: pool.id },
+  });
+
+  // Archive.
+  const archiveResponse = await invoke({
+    cookie,
+    form: {
+      intent: 'update-wishlist-item-status',
+      wishlistItemId: item.id,
+      status: 'ARCHIVED',
+    },
+  });
+  expect(getRouteResultStatus(archiveResponse)).toBe(200);
+
+  const claimAfterArchive = await prisma.wishlistClaim.findUniqueOrThrow({
+    where: { wishlistItemId: item.id },
+  });
+  expect(claimAfterArchive.poolId).toBe(pool.id);
+  expect(claimAfterArchive.claimedByUserId).toBeNull();
+
+  // Restore.
+  const restoreResponse = await invoke({
+    cookie,
+    form: {
+      intent: 'update-wishlist-item-status',
+      wishlistItemId: item.id,
+      status: 'ACTIVE',
+    },
+  });
+  expect(getRouteResultStatus(restoreResponse)).toBe(200);
+
+  const claimAfterRestore = await prisma.wishlistClaim.findUniqueOrThrow({
+    where: { wishlistItemId: item.id },
+  });
+  expect(claimAfterRestore.poolId).toBe(pool.id);
+  expect(claimAfterRestore.claimedByUserId).toBeNull();
+});

--- a/app/routes/wishlist+/status.ts
+++ b/app/routes/wishlist+/status.ts
@@ -4,6 +4,7 @@ import { data, type ActionFunctionArgs } from 'react-router';
 import { z } from 'zod';
 import { requireUserId } from '#app/utils/auth.server.ts';
 import { prisma } from '#app/utils/db.server.ts';
+import { releaseSoloClaimForItem } from '#app/utils/wishlist-claims.server.ts';
 import { wishlistItemStatusSchema } from '#app/utils/wishlist.ts';
 const WishlistStatusSchema = z.object({
   intent: z.literal('update-wishlist-item-status'),
@@ -83,20 +84,19 @@ export async function action({ request }: ActionFunctionArgs) {
       },
     });
   }
-  await prisma.wishlistClaim.deleteMany({
-    where: {
-      wishlistItemId,
-      // Solo claims only. A pool-held claim has claimedByUserId: null (see
-      // the DB CHECK in the WishlistClaim migration — exactly one of
-      // claimedByUserId/poolId is set), so omitting this predicate would
-      // delete a pool's claim every time the owner archives or restores the
-      // item, with nothing to bring it back (syncPoolClaim only reruns on
-      // pool decide/cancel). Pool claims are released only by pool lifecycle
-      // events. Same predicate as cleanupWishlistClaimsForOwner in
-      // wishlist.server.ts — do not remove it here either.
-      claimedByUserId: { not: null },
-    },
-  });
+  // Solo claims only — `releaseSoloClaimForItem` no-ops on a pool-held claim
+  // (claimedByUserId: null; see the DB CHECK in the WishlistClaim migration —
+  // exactly one of claimedByUserId/poolId is set). Pool claims are released
+  // only by pool lifecycle events. Same predicate as
+  // cleanupWishlistClaimsForOwner in wishlist.server.ts.
+  //
+  // Routed through the module's transactional release-and-settle path
+  // (rather than a bare deleteMany) so a pool that has already decided on
+  // this item inherits the claim in the same commit as the release — a bare
+  // delete would leave the item unclaimed even though the pool still has
+  // intent, letting someone else claim it out from under the pool on the
+  // next request.
+  await releaseSoloClaimForItem(wishlistItemId);
   const statusTextMap: Record<
     string,
     {

--- a/app/routes/wishlist+/status.ts
+++ b/app/routes/wishlist+/status.ts
@@ -86,6 +86,15 @@ export async function action({ request }: ActionFunctionArgs) {
   await prisma.wishlistClaim.deleteMany({
     where: {
       wishlistItemId,
+      // Solo claims only. A pool-held claim has claimedByUserId: null (see
+      // the DB CHECK in the WishlistClaim migration — exactly one of
+      // claimedByUserId/poolId is set), so omitting this predicate would
+      // delete a pool's claim every time the owner archives or restores the
+      // item, with nothing to bring it back (syncPoolClaim only reruns on
+      // pool decide/cancel). Pool claims are released only by pool lifecycle
+      // events. Same predicate as cleanupWishlistClaimsForOwner in
+      // wishlist.server.ts — do not remove it here either.
+      claimedByUserId: { not: null },
     },
   });
   const statusTextMap: Record<

--- a/app/utils/analytics.ts
+++ b/app/utils/analytics.ts
@@ -32,6 +32,13 @@ export const ANALYTIC_EVENT_NAMES = [
   // Automatic pool activity fanout. Fires per recipient only when at least one
   // channel newly delivers; properties contain type, pool id, and channels.
   'pool_activity_notification_sent',
+  // Pool-backed wishlist claims. The conflict/transfer pair is the measurement
+  // of whether this actually prevents duplicate gifts:
+  //   wishlist_claim_conflict_shown → wishlist_claim_released → wishlist_claim_transferred
+  'wishlist_claim_granted',
+  'wishlist_claim_conflict_shown',
+  'wishlist_claim_released',
+  'wishlist_claim_transferred',
   // Preset task-bound organizer reminders. Fires per recipient only after at
   // least one channel delivers; repeated requests remain queryable from the
   // OrganizerNudge audit rows without putting recipient lists in analytics.
@@ -208,6 +215,12 @@ export const USER_REQUIRED_EVENTS: Set<AnalyticEventName> = new Set([
   'pool_purchaser_assigned',
   'pool_deliverer_assigned',
   'pool_activity_notification_sent',
+  // Pool-backed wishlist claims: the actor is always the authenticated
+  // decider (grant/conflict) or claim holder (release/transfer).
+  'wishlist_claim_granted',
+  'wishlist_claim_conflict_shown',
+  'wishlist_claim_released',
+  'wishlist_claim_transferred',
   'organizer_reminder_sent',
   'organizer_reminder_skipped',
   'friend_request_sent',

--- a/app/utils/person-surface.server.ts
+++ b/app/utils/person-surface.server.ts
@@ -16,7 +16,7 @@ import {
   HIDDEN_CLAIM_DISCLOSURE,
   type ClaimDisclosure,
 } from '#app/utils/wishlist-claim-disclosure.ts';
-import { loadClaimStates } from '#app/utils/wishlist-claims.server.ts';
+import { loadClaimStates, setClaimOutcomeFeedback } from '#app/utils/wishlist-claims.server.ts';
 
 // Post-occasion detection window (spec §4): 14 days after the occasion.
 export const POST_OCCASION_WINDOW_DAYS = 14;
@@ -330,17 +330,13 @@ export async function recordWishlistClaimOutcome(input: {
   requestId?: string | null;
 }) {
   const { userId, wishlistItemId, feedback } = input;
-  const claim = await prisma.wishlistClaim.findUnique({
-    where: { wishlistItemId },
-    select: { claimedByUserId: true },
-  });
-  if (!claim || claim.claimedByUserId !== userId) {
+  // The actual write to WishlistClaim goes through wishlist-claims.server.ts
+  // — it is the only code in the app permitted to write that table. This
+  // function still owns authorization framing (the 404 shape below).
+  const result = await setClaimOutcomeFeedback(wishlistItemId, userId, feedback);
+  if (!result.ok) {
     throw data({ error: 'Claim not found.' }, { status: 404 });
   }
-  await prisma.wishlistClaim.update({
-    where: { wishlistItemId },
-    data: { outcomeFeedback: feedback },
-  });
 
   queueLogEvent({
     name: 'gift_outcome_recorded',

--- a/app/utils/person-surface.server.ts
+++ b/app/utils/person-surface.server.ts
@@ -12,6 +12,11 @@ import {
   POOL_STATUS,
 } from '#app/utils/pool-constants.ts';
 import { createPool, proposeIdea } from '#app/utils/pool.server.ts';
+import {
+  HIDDEN_CLAIM_DISCLOSURE,
+  type ClaimDisclosure,
+} from '#app/utils/wishlist-claim-disclosure.ts';
+import { loadClaimStates } from '#app/utils/wishlist-claims.server.ts';
 
 // Post-occasion detection window (spec §4): 14 days after the occasion.
 export const POST_OCCASION_WINDOW_DAYS = 14;
@@ -450,11 +455,16 @@ export type PersonWishlistItem = {
   currency: string | null;
   claimed: boolean;
   claimedByViewer: boolean;
+  // Tiered disclosure for the "claimed by someone else" case (pool or
+  // another user). Never consulted for the viewer's own claim — that stays
+  // on `claimed`/`claimedByViewer`, which this ladder doesn't special-case.
+  claimDisclosure: ClaimDisclosure;
 };
 
 // The target's active wishlist as a gift source. Claim identity is never
 // exposed — only whether the item is claimed, and whether the VIEWER is the
-// claimer (for the self "I'm getting this" toggle).
+// claimer (for the self "I'm getting this" toggle). This is always a
+// non-owner surface (the target is never the viewer on this route).
 export async function loadPersonWishlistSource(
   viewerId: string,
   targetUserId: string,
@@ -471,6 +481,10 @@ export async function loadPersonWishlistSource(
     },
     orderBy: [{ sortOrder: 'asc' }, { updatedAt: 'desc' }],
   });
+  const claimDisclosures = await loadClaimStates(
+    items.map((i) => i.id),
+    { userId: viewerId, isOwner: false },
+  );
   return items.map((i) => ({
     id: i.id,
     title: i.title,
@@ -479,6 +493,7 @@ export async function loadPersonWishlistSource(
     currency: i.currency,
     claimed: i.claim != null,
     claimedByViewer: i.claim?.claimedByUserId === viewerId,
+    claimDisclosure: claimDisclosures.get(i.id) ?? HIDDEN_CLAIM_DISCLOSURE,
   }));
 }
 

--- a/app/utils/pool.server.test.ts
+++ b/app/utils/pool.server.test.ts
@@ -25,7 +25,6 @@ const poolUpdate = vi.fn();
 const poolUpdateMany = vi.fn();
 const queueLogEvent = vi.fn();
 const queuePoolActivityNotifications = vi.fn();
-const syncPoolClaim = vi.fn();
 const syncPoolClaimInTx = vi.fn();
 
 vi.mock('nanoid', () => ({
@@ -85,7 +84,6 @@ vi.mock('#app/utils/pool-notifications.server.ts', () => ({
 }));
 
 vi.mock('#app/utils/wishlist-claims.server.ts', () => ({
-  syncPoolClaim: (...args: Array<unknown>) => syncPoolClaim(...args),
   syncPoolClaimInTx: (...args: Array<unknown>) => syncPoolClaimInTx(...args),
 }));
 
@@ -142,9 +140,6 @@ beforeEach(() => {
   poolUpdateMany.mockReset().mockResolvedValue({ count: 1 });
   queueLogEvent.mockReset().mockReturnValue({ eventId: 'event-123' });
   queuePoolActivityNotifications.mockReset();
-  syncPoolClaim
-    .mockReset()
-    .mockResolvedValue({ claimedItemId: null, conflictedItemId: null, released: [] });
   syncPoolClaimInTx
     .mockReset()
     .mockResolvedValue({ claimedItemId: null, conflictedItemId: null, released: [] });
@@ -866,7 +861,29 @@ describe('pool server utilities', () => {
     });
     expect(poolDelete).not.toHaveBeenCalled();
     expect(giftIdeaDelete).not.toHaveBeenCalled();
-    expect(syncPoolClaim).toHaveBeenCalledWith('pool-1');
+    expect(syncPoolClaimInTx).toHaveBeenCalledWith(expect.anything(), 'pool-1');
+  });
+
+  it('rolls back the CANCELLED transition when the claim sync fails mid-transaction', async () => {
+    // Regression for the P1 finding: cancelPool used to call syncPoolClaim
+    // (opening its own separate transaction) *after* the status update had
+    // already committed, and swallowed sync failures to Sentry — so a failed
+    // sync left a cancelled pool still holding its claim, permanently (the
+    // early return above makes a retry a no-op once status already reads
+    // CANCELLED). Status update and claim sync now commit in the same
+    // `$transaction`, so a rejection from the sync must abort the whole
+    // thing — nothing downstream (activity log, analytics, notification
+    // fanout) fires for a cancellation that didn't land. The real-DB
+    // rollback of the pool row itself is covered in
+    // wishlist-claims.server.test.ts, which exercises the actual Prisma
+    // transaction rather than this mocked client.
+    syncPoolClaimInTx.mockRejectedValueOnce(new Error('claim sync boom'));
+
+    await expect(cancelPool('pool-1', 'user-1')).rejects.toThrow('claim sync boom');
+
+    expect(logPoolActivity).not.toHaveBeenCalled();
+    expect(queueLogEvent).not.toHaveBeenCalled();
+    expect(queuePoolActivityNotifications).not.toHaveBeenCalled();
   });
 
   it('getContributionBreakdown returns null without a confirmed final price', async () => {

--- a/app/utils/pool.server.test.ts
+++ b/app/utils/pool.server.test.ts
@@ -25,6 +25,7 @@ const poolUpdate = vi.fn();
 const poolUpdateMany = vi.fn();
 const queueLogEvent = vi.fn();
 const queuePoolActivityNotifications = vi.fn();
+const syncPoolClaim = vi.fn();
 
 vi.mock('nanoid', () => ({
   nanoid: () => nanoid(),
@@ -74,6 +75,10 @@ vi.mock('#app/utils/analytics.server.ts', () => ({
 vi.mock('#app/utils/pool-notifications.server.ts', () => ({
   queuePoolActivityNotifications: (...args: Array<unknown>) =>
     queuePoolActivityNotifications(...args),
+}));
+
+vi.mock('#app/utils/wishlist-claims.server.ts', () => ({
+  syncPoolClaim: (...args: Array<unknown>) => syncPoolClaim(...args),
 }));
 
 import {
@@ -129,6 +134,9 @@ beforeEach(() => {
   poolUpdateMany.mockReset().mockResolvedValue({ count: 1 });
   queueLogEvent.mockReset().mockReturnValue({ eventId: 'event-123' });
   queuePoolActivityNotifications.mockReset();
+  syncPoolClaim
+    .mockReset()
+    .mockResolvedValue({ claimedItemId: null, conflictedItemId: null, releasedItemIds: [] });
 });
 
 describe('pool server utilities', () => {
@@ -572,6 +580,7 @@ describe('pool server utilities', () => {
         chosenIdeaId: 'idea-1',
         finalPriceCents: 8000,
         status: 'DECIDED',
+        decidedAt: expect.any(Date),
       },
       where: {
         id: 'pool-1',
@@ -587,6 +596,7 @@ describe('pool server utilities', () => {
       actorId: 'user-1',
       payload: { finalPriceCents: 8000, ideaId: 'idea-1', name: 'Speaker' },
     });
+    expect(syncPoolClaim).toHaveBeenCalledWith('pool-1');
     expect(queuePoolActivityNotifications).toHaveBeenCalledWith({
       type: NOTIFICATION_TYPES.POOL_GIFT_CHOSEN,
       poolId: 'pool-1',
@@ -822,6 +832,7 @@ describe('pool server utilities', () => {
     });
     expect(poolDelete).not.toHaveBeenCalled();
     expect(giftIdeaDelete).not.toHaveBeenCalled();
+    expect(syncPoolClaim).toHaveBeenCalledWith('pool-1');
   });
 
   it('getContributionBreakdown returns null without a confirmed final price', async () => {

--- a/app/utils/pool.server.test.ts
+++ b/app/utils/pool.server.test.ts
@@ -26,6 +26,7 @@ const poolUpdateMany = vi.fn();
 const queueLogEvent = vi.fn();
 const queuePoolActivityNotifications = vi.fn();
 const syncPoolClaim = vi.fn();
+const syncPoolClaimInTx = vi.fn();
 
 vi.mock('nanoid', () => ({
   nanoid: () => nanoid(),
@@ -36,8 +37,12 @@ vi.mock('@sentry/react-router', () => ({
   captureMessage: (...args: Array<unknown>) => captureMessage(...args),
 }));
 
-vi.mock('#app/utils/db.server.ts', () => ({
-  prisma: {
+vi.mock('#app/utils/db.server.ts', () => {
+  // `$transaction` runs the callback against this same mocked client, so a
+  // transaction body's `tx.pool.updateMany(...)` etc. hit the very mocks
+  // (`poolUpdateMany` and friends) that non-transactional callers already
+  // exercise — no separate tx-mock surface to keep in sync.
+  const prismaMock: any = {
     giftIdea: {
       create: (...args: Array<unknown>) => giftIdeaCreate(...args),
       delete: (...args: Array<unknown>) => giftIdeaDelete(...args),
@@ -61,8 +66,10 @@ vi.mock('#app/utils/db.server.ts', () => ({
         poolContributorFindUnique(...args),
       update: (...args: Array<unknown>) => poolContributorUpdate(...args),
     },
-  },
-}));
+    $transaction: (fn: (tx: unknown) => unknown) => fn(prismaMock),
+  };
+  return { prisma: prismaMock };
+});
 
 vi.mock('#app/utils/pool-activity.server.ts', () => ({
   logPoolActivity: (...args: Array<unknown>) => logPoolActivity(...args),
@@ -79,6 +86,7 @@ vi.mock('#app/utils/pool-notifications.server.ts', () => ({
 
 vi.mock('#app/utils/wishlist-claims.server.ts', () => ({
   syncPoolClaim: (...args: Array<unknown>) => syncPoolClaim(...args),
+  syncPoolClaimInTx: (...args: Array<unknown>) => syncPoolClaimInTx(...args),
 }));
 
 import {
@@ -135,6 +143,9 @@ beforeEach(() => {
   queueLogEvent.mockReset().mockReturnValue({ eventId: 'event-123' });
   queuePoolActivityNotifications.mockReset();
   syncPoolClaim
+    .mockReset()
+    .mockResolvedValue({ claimedItemId: null, conflictedItemId: null, released: [] });
+  syncPoolClaimInTx
     .mockReset()
     .mockResolvedValue({ claimedItemId: null, conflictedItemId: null, released: [] });
 });
@@ -596,13 +607,36 @@ describe('pool server utilities', () => {
       actorId: 'user-1',
       payload: { finalPriceCents: 8000, ideaId: 'idea-1', name: 'Speaker' },
     });
-    expect(syncPoolClaim).toHaveBeenCalledWith('pool-1');
+    expect(syncPoolClaimInTx).toHaveBeenCalledWith(expect.anything(), 'pool-1');
     expect(queuePoolActivityNotifications).toHaveBeenCalledWith({
       type: NOTIFICATION_TYPES.POOL_GIFT_CHOSEN,
       poolId: 'pool-1',
       actorUserId: 'user-1',
       occurrenceId: 'event-123',
     });
+  });
+
+  it('propagates a claim-sync failure and skips every post-decision side effect', async () => {
+    // The decision (`updateMany`) and the claim sync now commit in the same
+    // `$transaction` — a rejection from the sync must abort the whole thing,
+    // so nothing downstream of the transaction (activity log, analytics,
+    // notification fanout) ever fires for a decision that didn't land. The
+    // real-DB rollback of the pool row itself is covered in
+    // wishlist-claims.server.test.ts, which exercises the actual Prisma
+    // transaction rather than this mocked client.
+    giftIdeaFindFirst.mockResolvedValue({
+      estimatedPriceCents: 8000,
+      name: 'Speaker',
+    });
+    syncPoolClaimInTx.mockRejectedValueOnce(new Error('claim sync boom'));
+
+    await expect(chooseIdea('pool-1', 'idea-1', 'user-1')).rejects.toThrow(
+      'claim sync boom',
+    );
+
+    expect(logPoolActivity).not.toHaveBeenCalled();
+    expect(queueLogEvent).not.toHaveBeenCalled();
+    expect(queuePoolActivityNotifications).not.toHaveBeenCalled();
   });
 
   it('does not repeat decision side effects when the gift is already chosen', async () => {

--- a/app/utils/pool.server.test.ts
+++ b/app/utils/pool.server.test.ts
@@ -136,7 +136,7 @@ beforeEach(() => {
   queuePoolActivityNotifications.mockReset();
   syncPoolClaim
     .mockReset()
-    .mockResolvedValue({ claimedItemId: null, conflictedItemId: null, releasedItemIds: [] });
+    .mockResolvedValue({ claimedItemId: null, conflictedItemId: null, released: [] });
 });
 
 describe('pool server utilities', () => {

--- a/app/utils/pool.server.ts
+++ b/app/utils/pool.server.ts
@@ -635,6 +635,18 @@ export async function chooseIdea(
 			properties: { poolId, wishlistItemId: claimSync.conflictedItemId },
 		})
 	}
+	for (const release of claimSync.released) {
+		if (!release.transferredToPoolId) continue
+		queueLogEvent({
+			name: 'wishlist_claim_transferred',
+			userId: actorId,
+			source: 'server',
+			properties: {
+				wishlistItemId: release.wishlistItemId,
+				toPoolId: release.transferredToPoolId,
+			},
+		})
+	}
 
 	const { eventId } = queueLogEvent({
 		name: 'pool_decided',
@@ -803,7 +815,19 @@ export async function cancelPool(poolId: string, actorId: string) {
 	await logPoolActivity(poolId, POOL_ACTIVITY_TYPE.POOL_CANCELLED, { actorId })
 
 	// Cancelling frees the wishlist item — and hands it to any other pool waiting.
-	await syncPoolClaim(poolId)
+	const claimSync = await syncPoolClaim(poolId)
+	for (const release of claimSync.released) {
+		if (!release.transferredToPoolId) continue
+		queueLogEvent({
+			name: 'wishlist_claim_transferred',
+			userId: actorId,
+			source: 'server',
+			properties: {
+				wishlistItemId: release.wishlistItemId,
+				toPoolId: release.transferredToPoolId,
+			},
+		})
+	}
 
 	const { eventId } = queueLogEvent({
 		name: 'pool_cancelled',

--- a/app/utils/pool.server.ts
+++ b/app/utils/pool.server.ts
@@ -1,4 +1,4 @@
-import { captureMessage } from '@sentry/react-router'
+import { captureException, captureMessage } from '@sentry/react-router'
 import { data } from 'react-router'
 import { nanoid } from 'nanoid'
 import { queueLogEvent } from '#app/utils/analytics.server.ts'
@@ -13,7 +13,7 @@ import {
 import { calculateContributions } from '#app/utils/pool-contributions.ts'
 import { queuePoolActivityNotifications } from '#app/utils/pool-notifications.server.ts'
 import { assertPoolStatus } from '#app/utils/pool-permissions.server.ts'
-import { syncPoolClaim } from '#app/utils/wishlist-claims.server.ts'
+import { syncPoolClaim, type SyncPoolClaimResult } from '#app/utils/wishlist-claims.server.ts'
 import type { DecisionMode, OccasionType } from '#app/utils/pool-constants.ts'
 
 // ─── Selects ──────────────────────────────────────────────────────────────────
@@ -567,6 +567,22 @@ export async function closeVote(poolId: string, actorId: string) {
 
 // ─── Decision ─────────────────────────────────────────────────────────────────
 
+// By the time this runs, the pool's status change is already committed —
+// chooseIdea's DECIDED, cancelPool's CANCELLED. A sync failure (SQLITE_BUSY
+// under LiteFS, or the P2002 its internal `create` can hit racing a solo
+// claimer onto the same item) must not turn that committed decision into a
+// 500, and must not skip the notification fanout that follows. Capture to
+// Sentry and degrade to firing no claim events, matching how queueLogEvent /
+// queueNotification tail fanout failures instead of throwing them.
+async function syncPoolClaimSafely(poolId: string): Promise<SyncPoolClaimResult> {
+	try {
+		return await syncPoolClaim(poolId)
+	} catch (error) {
+		captureException(error)
+		return { claimedItemId: null, conflictedItemId: null, released: [] }
+	}
+}
+
 // Choose an idea as the winner and move the pool to DECIDED.
 // finalPriceCents defaults to the idea's estimatedPriceCents if not provided.
 export async function chooseIdea(
@@ -617,7 +633,7 @@ export async function chooseIdea(
 
 	// Claim the recipient's wishlist item, if the chosen idea links one. Runs
 	// after the decision commits; a conflict is reported, never blocking.
-	const claimSync = await syncPoolClaim(poolId)
+	const claimSync = await syncPoolClaimSafely(poolId)
 
 	if (claimSync.claimedItemId) {
 		queueLogEvent({
@@ -815,7 +831,7 @@ export async function cancelPool(poolId: string, actorId: string) {
 	await logPoolActivity(poolId, POOL_ACTIVITY_TYPE.POOL_CANCELLED, { actorId })
 
 	// Cancelling frees the wishlist item — and hands it to any other pool waiting.
-	const claimSync = await syncPoolClaim(poolId)
+	const claimSync = await syncPoolClaimSafely(poolId)
 	for (const release of claimSync.released) {
 		if (!release.transferredToPoolId) continue
 		queueLogEvent({

--- a/app/utils/pool.server.ts
+++ b/app/utils/pool.server.ts
@@ -617,7 +617,24 @@ export async function chooseIdea(
 
 	// Claim the recipient's wishlist item, if the chosen idea links one. Runs
 	// after the decision commits; a conflict is reported, never blocking.
-	await syncPoolClaim(poolId)
+	const claimSync = await syncPoolClaim(poolId)
+
+	if (claimSync.claimedItemId) {
+		queueLogEvent({
+			name: 'wishlist_claim_granted',
+			userId: actorId,
+			source: 'server',
+			properties: { poolId, claimantType: 'pool', wishlistItemId: claimSync.claimedItemId },
+		})
+	}
+	if (claimSync.conflictedItemId) {
+		queueLogEvent({
+			name: 'wishlist_claim_conflict_shown',
+			userId: actorId,
+			source: 'server',
+			properties: { poolId, wishlistItemId: claimSync.conflictedItemId },
+		})
+	}
 
 	const { eventId } = queueLogEvent({
 		name: 'pool_decided',

--- a/app/utils/pool.server.ts
+++ b/app/utils/pool.server.ts
@@ -13,7 +13,11 @@ import {
 import { calculateContributions } from '#app/utils/pool-contributions.ts'
 import { queuePoolActivityNotifications } from '#app/utils/pool-notifications.server.ts'
 import { assertPoolStatus } from '#app/utils/pool-permissions.server.ts'
-import { syncPoolClaim, type SyncPoolClaimResult } from '#app/utils/wishlist-claims.server.ts'
+import {
+	syncPoolClaim,
+	syncPoolClaimInTx,
+	type SyncPoolClaimResult,
+} from '#app/utils/wishlist-claims.server.ts'
 import type { DecisionMode, OccasionType } from '#app/utils/pool-constants.ts'
 
 // ─── Selects ──────────────────────────────────────────────────────────────────
@@ -568,12 +572,15 @@ export async function closeVote(poolId: string, actorId: string) {
 // ─── Decision ─────────────────────────────────────────────────────────────────
 
 // By the time this runs, the pool's status change is already committed —
-// chooseIdea's DECIDED, cancelPool's CANCELLED. A sync failure (SQLITE_BUSY
-// under LiteFS, or the P2002 its internal `create` can hit racing a solo
-// claimer onto the same item) must not turn that committed decision into a
-// 500, and must not skip the notification fanout that follows. Capture to
-// Sentry and degrade to firing no claim events, matching how queueLogEvent /
-// queueNotification tail fanout failures instead of throwing them.
+// cancelPool's CANCELLED. (chooseIdea's DECIDED transition instead commits
+// the claim sync in the *same* transaction as the status change — see
+// `chooseIdea` — so a sync failure there rolls back the decision rather than
+// landing here.) A sync failure (SQLITE_BUSY under LiteFS, or the P2002 its
+// internal `create` can hit racing a solo claimer onto the same item) must
+// not turn that committed decision into a 500, and must not skip the
+// notification fanout that follows. Capture to Sentry and degrade to firing
+// no claim events, matching how queueLogEvent / queueNotification tail
+// fanout failures instead of throwing them.
 async function syncPoolClaimSafely(poolId: string): Promise<SyncPoolClaimResult> {
 	try {
 		return await syncPoolClaim(poolId)
@@ -602,38 +609,51 @@ export async function chooseIdea(
 
 	const resolvedPrice = finalPriceCents ?? idea.estimatedPriceCents ?? null
 
-	const decision = await prisma.pool.updateMany({
-		where: {
-			id: poolId,
-			// Forward-only: a gift can be (re)chosen while OPEN/VOTING/DECIDED, but
-			// never from a terminal/purchased state — that would resurrect a
-			// CANCELLED pool or roll a DELIVERED one back to DECIDED.
-			status: {
-				in: [POOL_STATUS.OPEN, POOL_STATUS.VOTING, POOL_STATUS.DECIDED],
+	// The status transition and the claim it triggers must commit as one
+	// unit. If they were separate writes, a concurrent `POST
+	// /wishlist/purchase` could land a solo claim on the item in the window
+	// between them — the pool decided first, but the solo claimer would win
+	// the item, exactly the bug this feature exists to prevent. Wrapping both
+	// in one transaction also means a sync failure (SQLITE_BUSY, a P2002 race)
+	// rolls back the decision instead of leaving it DECIDED with no claim and
+	// no retry path.
+	const claimSync = await prisma.$transaction(async (tx) => {
+		const decision = await tx.pool.updateMany({
+			where: {
+				id: poolId,
+				// Forward-only: a gift can be (re)chosen while OPEN/VOTING/DECIDED,
+				// but never from a terminal/purchased state — that would resurrect
+				// a CANCELLED pool or roll a DELIVERED one back to DECIDED.
+				status: {
+					in: [POOL_STATUS.OPEN, POOL_STATUS.VOTING, POOL_STATUS.DECIDED],
+				},
+				OR: [
+					{ status: { not: POOL_STATUS.DECIDED } },
+					{ chosenIdeaId: null },
+					{ chosenIdeaId: { not: ideaId } },
+				],
 			},
-			OR: [
-				{ status: { not: POOL_STATUS.DECIDED } },
-				{ chosenIdeaId: null },
-				{ chosenIdeaId: { not: ideaId } },
-			],
-		},
-		data: {
-			status: POOL_STATUS.DECIDED,
-			chosenIdeaId: ideaId,
-			finalPriceCents: resolvedPrice,
-			decidedAt: new Date(),
-		},
-	})
-	if (decision.count === 0) return
+			data: {
+				status: POOL_STATUS.DECIDED,
+				chosenIdeaId: ideaId,
+				finalPriceCents: resolvedPrice,
+				decidedAt: new Date(),
+			},
+		})
+		if (decision.count === 0) return null
 
+		return syncPoolClaimInTx(tx, poolId)
+	})
+	if (claimSync === null) return
+
+	// logPoolActivity, queueLogEvent, and queuePoolActivityNotifications all
+	// run after the transaction closes: queueLogEvent inside a transaction
+	// produces spurious SQLITE_BUSY under LiteFS, and a fanout failure here
+	// must never turn the now-committed decision into a 500.
 	await logPoolActivity(poolId, POOL_ACTIVITY_TYPE.IDEA_CHOSEN, {
 		actorId,
 		payload: { ideaId, name: idea.name, finalPriceCents: resolvedPrice },
 	})
-
-	// Claim the recipient's wishlist item, if the chosen idea links one. Runs
-	// after the decision commits; a conflict is reported, never blocking.
-	const claimSync = await syncPoolClaimSafely(poolId)
 
 	if (claimSync.claimedItemId) {
 		queueLogEvent({

--- a/app/utils/pool.server.ts
+++ b/app/utils/pool.server.ts
@@ -1,4 +1,4 @@
-import { captureException, captureMessage } from '@sentry/react-router'
+import { captureMessage } from '@sentry/react-router'
 import { data } from 'react-router'
 import { nanoid } from 'nanoid'
 import { queueLogEvent } from '#app/utils/analytics.server.ts'
@@ -13,11 +13,7 @@ import {
 import { calculateContributions } from '#app/utils/pool-contributions.ts'
 import { queuePoolActivityNotifications } from '#app/utils/pool-notifications.server.ts'
 import { assertPoolStatus } from '#app/utils/pool-permissions.server.ts'
-import {
-	syncPoolClaim,
-	syncPoolClaimInTx,
-	type SyncPoolClaimResult,
-} from '#app/utils/wishlist-claims.server.ts'
+import { syncPoolClaimInTx } from '#app/utils/wishlist-claims.server.ts'
 import type { DecisionMode, OccasionType } from '#app/utils/pool-constants.ts'
 
 // ─── Selects ──────────────────────────────────────────────────────────────────
@@ -571,25 +567,6 @@ export async function closeVote(poolId: string, actorId: string) {
 
 // ─── Decision ─────────────────────────────────────────────────────────────────
 
-// By the time this runs, the pool's status change is already committed —
-// cancelPool's CANCELLED. (chooseIdea's DECIDED transition instead commits
-// the claim sync in the *same* transaction as the status change — see
-// `chooseIdea` — so a sync failure there rolls back the decision rather than
-// landing here.) A sync failure (SQLITE_BUSY under LiteFS, or the P2002 its
-// internal `create` can hit racing a solo claimer onto the same item) must
-// not turn that committed decision into a 500, and must not skip the
-// notification fanout that follows. Capture to Sentry and degrade to firing
-// no claim events, matching how queueLogEvent / queueNotification tail
-// fanout failures instead of throwing them.
-async function syncPoolClaimSafely(poolId: string): Promise<SyncPoolClaimResult> {
-	try {
-		return await syncPoolClaim(poolId)
-	} catch (error) {
-		captureException(error)
-		return { claimedItemId: null, conflictedItemId: null, released: [] }
-	}
-}
-
 // Choose an idea as the winner and move the pool to DECIDED.
 // finalPriceCents defaults to the idea's estimatedPriceCents if not provided.
 export async function chooseIdea(
@@ -842,16 +819,31 @@ export async function markDelivered(poolId: string, actorId: string) {
 }
 
 export async function cancelPool(poolId: string, actorId: string) {
-	const cancellation = await prisma.pool.updateMany({
-		where: { id: poolId, status: { not: POOL_STATUS.CANCELLED } },
-		data: { status: POOL_STATUS.CANCELLED },
-	})
-	if (cancellation.count === 0) return
+	// The status transition and its claim sync must commit as one unit — same
+	// reasoning as chooseIdea. Split them and a sync failure (SQLITE_BUSY under
+	// LiteFS) leaves the pool CANCELLED with its claim never released — and
+	// unrecoverably so, because the early return below makes a retry a no-op
+	// once the pool already reads CANCELLED. Wrapping both in one transaction
+	// means a sync failure rolls back the cancellation instead, so the caller
+	// sees the failure and can retry from a pool that still isn't cancelled.
+	const claimSync = await prisma.$transaction(async (tx) => {
+		const cancellation = await tx.pool.updateMany({
+			where: { id: poolId, status: { not: POOL_STATUS.CANCELLED } },
+			data: { status: POOL_STATUS.CANCELLED },
+		})
+		if (cancellation.count === 0) return null
 
+		return syncPoolClaimInTx(tx, poolId)
+	})
+	if (claimSync === null) return
+
+	// logPoolActivity, queueLogEvent, and queuePoolActivityNotifications all
+	// run after the transaction closes — see chooseIdea's comment on the same
+	// pattern: queueLogEvent inside a transaction produces spurious
+	// SQLITE_BUSY under LiteFS, and a fanout failure here must never turn the
+	// now-committed cancellation into a 500.
 	await logPoolActivity(poolId, POOL_ACTIVITY_TYPE.POOL_CANCELLED, { actorId })
 
-	// Cancelling frees the wishlist item — and hands it to any other pool waiting.
-	const claimSync = await syncPoolClaimSafely(poolId)
 	for (const release of claimSync.released) {
 		if (!release.transferredToPoolId) continue
 		queueLogEvent({

--- a/app/utils/pool.server.ts
+++ b/app/utils/pool.server.ts
@@ -13,6 +13,7 @@ import {
 import { calculateContributions } from '#app/utils/pool-contributions.ts'
 import { queuePoolActivityNotifications } from '#app/utils/pool-notifications.server.ts'
 import { assertPoolStatus } from '#app/utils/pool-permissions.server.ts'
+import { syncPoolClaim } from '#app/utils/wishlist-claims.server.ts'
 import type { DecisionMode, OccasionType } from '#app/utils/pool-constants.ts'
 
 // ─── Selects ──────────────────────────────────────────────────────────────────
@@ -604,6 +605,7 @@ export async function chooseIdea(
 			status: POOL_STATUS.DECIDED,
 			chosenIdeaId: ideaId,
 			finalPriceCents: resolvedPrice,
+			decidedAt: new Date(),
 		},
 	})
 	if (decision.count === 0) return
@@ -612,6 +614,10 @@ export async function chooseIdea(
 		actorId,
 		payload: { ideaId, name: idea.name, finalPriceCents: resolvedPrice },
 	})
+
+	// Claim the recipient's wishlist item, if the chosen idea links one. Runs
+	// after the decision commits; a conflict is reported, never blocking.
+	await syncPoolClaim(poolId)
 
 	const { eventId } = queueLogEvent({
 		name: 'pool_decided',
@@ -778,6 +784,9 @@ export async function cancelPool(poolId: string, actorId: string) {
 	if (cancellation.count === 0) return
 
 	await logPoolActivity(poolId, POOL_ACTIVITY_TYPE.POOL_CANCELLED, { actorId })
+
+	// Cancelling frees the wishlist item — and hands it to any other pool waiting.
+	await syncPoolClaim(poolId)
 
 	const { eventId } = queueLogEvent({
 		name: 'pool_cancelled',

--- a/app/utils/wishlist-claim-disclosure.test.ts
+++ b/app/utils/wishlist-claim-disclosure.test.ts
@@ -1,0 +1,121 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  resolveClaimDisclosure,
+  type ClaimHolder,
+  type ViewerRelationship,
+} from './wishlist-claim-disclosure.ts';
+
+const VIEWER: ViewerRelationship = {
+  isOwner: false,
+  isAnonymous: false,
+  viewerUserId: 'viewer-1',
+  contributesToHolderPool: false,
+  memberOfHolderGroup: false,
+  sharesPoolWithHolderUser: false,
+};
+const viewer = (o: Partial<ViewerRelationship> = {}): ViewerRelationship => ({ ...VIEWER, ...o });
+
+const POOL_HOLDER: ClaimHolder = {
+  kind: 'pool',
+  poolId: 'pool-1',
+  poolTitle: "Dave's 40th",
+  giftGroupId: 'group-1',
+  giftGroupName: 'Sunday Roasters',
+};
+const USER_HOLDER: ClaimHolder = { kind: 'user', userId: 'sarah', displayName: 'Sarah' };
+
+describe('resolveClaimDisclosure — the owner boundary', () => {
+  it('shows nothing to the wishlist owner, whoever holds the claim', () => {
+    for (const holder of [POOL_HOLDER, USER_HOLDER, null]) {
+      const d = resolveClaimDisclosure(holder, viewer({ isOwner: true }), 'label');
+      expect(d.show).toBe(false);
+      expect(d.text).toBe('');
+      expect(d.name).toBeNull();
+    }
+  });
+
+  it('shows nothing when the item is unclaimed', () => {
+    expect(resolveClaimDisclosure(null, viewer(), 'label').show).toBe(false);
+  });
+});
+
+describe('resolveClaimDisclosure — pool-held claims, five tiers', () => {
+  it('tier 2: a contributor of the holding pool sees the pool named, toned pool not warning', () => {
+    const d = resolveClaimDisclosure(POOL_HOLDER, viewer({ contributesToHolderPool: true }), 'label');
+    expect(d.show).toBe(true);
+    expect(d.name).toBe("Dave's 40th");
+    expect(d.text).toBe("Your pool Dave's 40th is getting this");
+    expect(d.tone).toBe('pool');
+    expect(d.poolLink).toBe('/pools/pool-1');
+    expect(d.canJoinPool).toBe(false);
+  });
+
+  it('tier 3: a group member outside the pool sees the group named and can join', () => {
+    const d = resolveClaimDisclosure(POOL_HOLDER, viewer({ memberOfHolderGroup: true }), 'label');
+    expect(d.name).toBe('Sunday Roasters');
+    expect(d.text).toBe('Sunday Roasters is getting this');
+    expect(d.canJoinPool).toBe(true);
+  });
+
+  it('tier 4: any other signed-in viewer gets no attribution', () => {
+    const d = resolveClaimDisclosure(POOL_HOLDER, viewer(), 'label');
+    expect(d.show).toBe(true);
+    expect(d.text).toBe('Already claimed');
+    expect(d.name).toBeNull();
+    expect(d.poolLink).toBeNull();
+    expect(d.canJoinPool).toBe(false);
+  });
+
+  it('tier 5: an anonymous public-share visitor gets no attribution, even as a group member', () => {
+    const d = resolveClaimDisclosure(
+      POOL_HOLDER,
+      viewer({ isAnonymous: true, viewerUserId: null, memberOfHolderGroup: true }),
+      'label',
+    );
+    expect(d.text).toBe('Already claimed');
+    expect(d.name).toBeNull();
+  });
+
+  it('never leaks the pool or group name into any tier-4 or tier-5 field', () => {
+    for (const v of [viewer(), viewer({ isAnonymous: true, viewerUserId: null })]) {
+      const d = resolveClaimDisclosure(POOL_HOLDER, v, 'label');
+      const serialized = JSON.stringify(d);
+      expect(serialized).not.toContain("Dave's 40th");
+      expect(serialized).not.toContain('Sunday Roasters');
+      expect(serialized).not.toContain('pool-1');
+      expect(serialized).not.toContain('group-1');
+    }
+  });
+});
+
+describe('resolveClaimDisclosure — the badge surface', () => {
+  it('names a solo claimer who shares this pool, and warns', () => {
+    const d = resolveClaimDisclosure(USER_HOLDER, viewer({ sharesPoolWithHolderUser: true }), 'badge');
+    expect(d.text).toBe('Claimed by Sarah');
+    expect(d.tone).toBe('warning');
+  });
+
+  it('does not name a solo claimer outside this pool', () => {
+    const d = resolveClaimDisclosure(USER_HOLDER, viewer(), 'badge');
+    expect(d.text).toBe('Already claimed');
+    expect(d.name).toBeNull();
+    expect(d.tone).toBe('warning');
+  });
+
+  it('says another group without naming it', () => {
+    const d = resolveClaimDisclosure(POOL_HOLDER, viewer(), 'badge');
+    expect(d.text).toBe('Another group is getting this');
+    expect(JSON.stringify(d)).not.toContain('Sunday Roasters');
+  });
+});
+
+describe('resolveClaimDisclosure — the picker row surface', () => {
+  it('withholds identity entirely, even from someone who could be told', () => {
+    const d = resolveClaimDisclosure(USER_HOLDER, viewer({ sharesPoolWithHolderUser: true }), 'row');
+    expect(d.text).toBe('Already claimed');
+    expect(d.name).toBeNull();
+  });
+});

--- a/app/utils/wishlist-claim-disclosure.test.ts
+++ b/app/utils/wishlist-claim-disclosure.test.ts
@@ -73,11 +73,15 @@ describe('resolveClaimDisclosure — pool-held claims, five tiers', () => {
     expect(d.canJoinPool).toBe(false);
   });
 
-  it('tier 3: a group member outside the pool sees the group named and can join', () => {
+  it('tier 3: a group member outside the pool sees the group named and can join, but gets no pool link', () => {
+    // canJoinPool is true, but the join affordance for this tier is
+    // deliberately unbuilt and the pool route 404s every non-contributor —
+    // so this tier must not get a poolLink (see __route.server.ts).
     const d = resolveClaimDisclosure(POOL_HOLDER, viewer({ memberOfHolderGroup: true }), 'label');
     expect(d.name).toBe('Sunday Roasters');
     expect(d.text).toBe('Sunday Roasters is getting this');
     expect(d.canJoinPool).toBe(true);
+    expect(d.poolLink).toBeNull();
   });
 
   it('tier 4: any other signed-in viewer gets no attribution', () => {
@@ -171,12 +175,13 @@ describe('resolveClaimDisclosure — the badge surface', () => {
     expect(d.canJoinPool).toBe(false);
   });
 
-  it('names the group for a group member on the badge surface too', () => {
+  it('names the group for a group member on the badge surface too, with no pool link', () => {
     const d = resolveClaimDisclosure(POOL_HOLDER, viewer({ memberOfHolderGroup: true }), 'badge');
     expect(d.show).toBe(true);
     expect(d.name).toBe('Sunday Roasters');
     expect(d.text).toBe('Sunday Roasters is getting this');
     expect(d.canJoinPool).toBe(true);
+    expect(d.poolLink).toBeNull();
   });
 });
 

--- a/app/utils/wishlist-claim-disclosure.test.ts
+++ b/app/utils/wishlist-claim-disclosure.test.ts
@@ -11,7 +11,6 @@ import {
 const VIEWER: ViewerRelationship = {
   isOwner: false,
   isAnonymous: false,
-  viewerUserId: 'viewer-1',
   contributesToHolderPool: false,
   memberOfHolderGroup: false,
   sharesPoolWithHolderUser: false,
@@ -22,7 +21,6 @@ const POOL_HOLDER: ClaimHolder = {
   kind: 'pool',
   poolId: 'pool-1',
   poolTitle: "Dave's 40th",
-  giftGroupId: 'group-1',
   giftGroupName: 'Sunday Roasters',
 };
 const USER_HOLDER: ClaimHolder = { kind: 'user', userId: 'sarah', displayName: 'Sarah' };
@@ -39,6 +37,28 @@ describe('resolveClaimDisclosure — the owner boundary', () => {
 
   it('shows nothing when the item is unclaimed', () => {
     expect(resolveClaimDisclosure(null, viewer(), 'label').show).toBe(false);
+  });
+
+  it('the owner boundary wins even when every other viewer flag is also true', () => {
+    const owningEverything = viewer({
+      isOwner: true,
+      isAnonymous: true,
+      contributesToHolderPool: true,
+      memberOfHolderGroup: true,
+      sharesPoolWithHolderUser: true,
+    });
+    for (const holder of [POOL_HOLDER, USER_HOLDER]) {
+      const d = resolveClaimDisclosure(holder, owningEverything, 'label');
+      const serialized = JSON.stringify(d);
+      expect(d.show).toBe(false);
+      expect(d.text).toBe('');
+      expect(d.name).toBeNull();
+      expect(serialized).not.toContain("Dave's 40th");
+      expect(serialized).not.toContain('Sunday Roasters');
+      expect(serialized).not.toContain('pool-1');
+      expect(serialized).not.toContain('Sarah');
+      expect(serialized).not.toContain('sarah');
+    }
   });
 });
 
@@ -72,7 +92,7 @@ describe('resolveClaimDisclosure — pool-held claims, five tiers', () => {
   it('tier 5: an anonymous public-share visitor gets no attribution, even as a group member', () => {
     const d = resolveClaimDisclosure(
       POOL_HOLDER,
-      viewer({ isAnonymous: true, viewerUserId: null, memberOfHolderGroup: true }),
+      viewer({ isAnonymous: true, memberOfHolderGroup: true }),
       'label',
     );
     expect(d.text).toBe('Already claimed');
@@ -80,14 +100,44 @@ describe('resolveClaimDisclosure — pool-held claims, five tiers', () => {
   });
 
   it('never leaks the pool or group name into any tier-4 or tier-5 field', () => {
-    for (const v of [viewer(), viewer({ isAnonymous: true, viewerUserId: null })]) {
+    for (const v of [viewer(), viewer({ isAnonymous: true })]) {
       const d = resolveClaimDisclosure(POOL_HOLDER, v, 'label');
       const serialized = JSON.stringify(d);
       expect(serialized).not.toContain("Dave's 40th");
       expect(serialized).not.toContain('Sunday Roasters');
       expect(serialized).not.toContain('pool-1');
-      expect(serialized).not.toContain('group-1');
     }
+  });
+
+  it('a group member sees the fallback, unattributed text when the holding pool has no group name', () => {
+    // Under-discloses on purpose: a legitimate group member loses the join
+    // affordance here because giftGroupName is null. That's the safe
+    // direction to fail — it never leaks a name it can't confirm.
+    const d = resolveClaimDisclosure(
+      { ...POOL_HOLDER, giftGroupName: null },
+      viewer({ memberOfHolderGroup: true }),
+      'label',
+    );
+    expect(d.text).toBe('Already claimed');
+    expect(d.name).toBeNull();
+    expect(d.canJoinPool).toBe(false);
+    expect(d.poolLink).toBeNull();
+  });
+
+  it('an anonymous public-share visitor gets no attribution even when genuinely a pool contributor and group member', () => {
+    const d = resolveClaimDisclosure(
+      POOL_HOLDER,
+      viewer({ isAnonymous: true, contributesToHolderPool: true, memberOfHolderGroup: true }),
+      'label',
+    );
+    const serialized = JSON.stringify(d);
+    expect(d.text).toBe('Already claimed');
+    expect(d.name).toBeNull();
+    expect(d.poolLink).toBeNull();
+    expect(d.canJoinPool).toBe(false);
+    expect(serialized).not.toContain("Dave's 40th");
+    expect(serialized).not.toContain('Sunday Roasters');
+    expect(serialized).not.toContain('pool-1');
   });
 });
 
@@ -109,6 +159,24 @@ describe('resolveClaimDisclosure — the badge surface', () => {
     const d = resolveClaimDisclosure(POOL_HOLDER, viewer(), 'badge');
     expect(d.text).toBe('Another group is getting this');
     expect(JSON.stringify(d)).not.toContain('Sunday Roasters');
+  });
+
+  it('names the pool for a contributor on the badge surface too', () => {
+    const d = resolveClaimDisclosure(POOL_HOLDER, viewer({ contributesToHolderPool: true }), 'badge');
+    expect(d.show).toBe(true);
+    expect(d.name).toBe("Dave's 40th");
+    expect(d.text).toBe("Your pool Dave's 40th is getting this");
+    expect(d.tone).toBe('pool');
+    expect(d.poolLink).toBe('/pools/pool-1');
+    expect(d.canJoinPool).toBe(false);
+  });
+
+  it('names the group for a group member on the badge surface too', () => {
+    const d = resolveClaimDisclosure(POOL_HOLDER, viewer({ memberOfHolderGroup: true }), 'badge');
+    expect(d.show).toBe(true);
+    expect(d.name).toBe('Sunday Roasters');
+    expect(d.text).toBe('Sunday Roasters is getting this');
+    expect(d.canJoinPool).toBe(true);
   });
 });
 

--- a/app/utils/wishlist-claim-disclosure.ts
+++ b/app/utils/wishlist-claim-disclosure.ts
@@ -50,7 +50,11 @@ export type ClaimDisclosure = {
 
 export type ClaimSurface = 'label' | 'badge' | 'row';
 
-const HIDDEN: ClaimDisclosure = {
+// Exported so callers merging `loadClaimStates`'s Map back onto a wider item
+// list have a safe, typed default for items the map has no entry for (an
+// unclaimed item never gets a row) instead of hand-rolling an equivalent
+// literal at each call site.
+export const HIDDEN_CLAIM_DISCLOSURE: ClaimDisclosure = {
   show: false,
   tone: 'none',
   text: '',
@@ -58,8 +62,12 @@ const HIDDEN: ClaimDisclosure = {
   poolLink: null,
   canJoinPool: false,
 };
+const HIDDEN = HIDDEN_CLAIM_DISCLOSURE;
 
-const anonymous = (tone: ClaimDisclosureTone, text: string): ClaimDisclosure => ({
+const anonymous = (
+  tone: ClaimDisclosureTone,
+  text: string,
+): ClaimDisclosure => ({
   show: true,
   tone,
   text,
@@ -82,7 +90,9 @@ export function resolveClaimDisclosure(
 
   if (holder.kind === 'user') {
     const canName =
-      !viewer.isAnonymous && viewer.sharesPoolWithHolderUser && holder.displayName !== null;
+      !viewer.isAnonymous &&
+      viewer.sharesPoolWithHolderUser &&
+      holder.displayName !== null;
     return canName
       ? {
           show: true,

--- a/app/utils/wishlist-claim-disclosure.ts
+++ b/app/utils/wishlist-claim-disclosure.ts
@@ -76,6 +76,24 @@ const anonymous = (
   canJoinPool: false,
 });
 
+// A generic "someone else has this" disclosure, carrying the same
+// zero-attribution shape `anonymous()` produces for every tier of the
+// ladder above (no name, no pool link, no group name, canJoinPool: false).
+//
+// For clients that already know — via optimistic reconciliation of a claim
+// mutation's response — that an item is claimed by someone else, but whose
+// `claimDisclosure` is stale (e.g. still `HIDDEN_CLAIM_DISCLOSURE` from a
+// load-time render where the item was unclaimed, because another user or
+// pool won a concurrent claim race). The client cannot know who won that
+// race, so it must never invent attribution the server never sent it — this
+// constant is exactly the same shape the resolver itself would have produced
+// for an unattributed viewer, just reached without a fresh server round
+// trip. Reuse this instead of hand-rolling an equivalent literal.
+export const UNATTRIBUTED_CLAIM_DISCLOSURE: ClaimDisclosure = anonymous(
+  'warning',
+  'Already claimed',
+);
+
 export function resolveClaimDisclosure(
   holder: ClaimHolder | null,
   viewer: ViewerRelationship,

--- a/app/utils/wishlist-claim-disclosure.ts
+++ b/app/utils/wishlist-claim-disclosure.ts
@@ -14,14 +14,21 @@ export type ClaimHolder =
       kind: 'pool';
       poolId: string;
       poolTitle: string;
-      giftGroupId: string | null;
       giftGroupName: string | null;
     };
 
 export type ViewerRelationship = {
   isOwner: boolean;
+  /**
+   * The surface this viewer sees must not attribute the claim to any name,
+   * pool, or group — regardless of whether the viewer is signed in. This is
+   * NOT "there is no logged-in user": a signed-in user can open someone's
+   * public wishlist share link, and that surface must show zero attribution
+   * even though a session exists. Set this from the surface's disclosure
+   * policy (e.g. "is this the public share view?"), never from viewer
+   * identity.
+   */
   isAnonymous: boolean;
-  viewerUserId: string | null;
   /** Viewer contributes to the pool that holds the claim. */
   contributesToHolderPool: boolean;
   /** Viewer is in the group owning the holding pool, but not the pool itself. */

--- a/app/utils/wishlist-claim-disclosure.ts
+++ b/app/utils/wishlist-claim-disclosure.ts
@@ -1,0 +1,126 @@
+/**
+ * The privacy ladder for wishlist claims, as a pure function.
+ *
+ * Governing rule: never disclose anything the viewer could not already
+ * discover through an existing surface. Kept pure and DB-free (like
+ * canViewBirthday in birthday-visibility.server.ts) so the ladder can be
+ * exhaustively tested — including the negative cases, where a leak would
+ * otherwise be a silent pass.
+ */
+
+export type ClaimHolder =
+  | { kind: 'user'; userId: string; displayName: string | null }
+  | {
+      kind: 'pool';
+      poolId: string;
+      poolTitle: string;
+      giftGroupId: string | null;
+      giftGroupName: string | null;
+    };
+
+export type ViewerRelationship = {
+  isOwner: boolean;
+  isAnonymous: boolean;
+  viewerUserId: string | null;
+  /** Viewer contributes to the pool that holds the claim. */
+  contributesToHolderPool: boolean;
+  /** Viewer is in the group owning the holding pool, but not the pool itself. */
+  memberOfHolderGroup: boolean;
+  /** Badge surface: the solo claimer contributes to the pool being viewed. */
+  sharesPoolWithHolderUser: boolean;
+};
+
+export type ClaimDisclosureTone = 'none' | 'pool' | 'warning';
+
+export type ClaimDisclosure = {
+  show: boolean;
+  tone: ClaimDisclosureTone;
+  text: string;
+  name: string | null;
+  poolLink: string | null;
+  canJoinPool: boolean;
+};
+
+export type ClaimSurface = 'label' | 'badge' | 'row';
+
+const HIDDEN: ClaimDisclosure = {
+  show: false,
+  tone: 'none',
+  text: '',
+  name: null,
+  poolLink: null,
+  canJoinPool: false,
+};
+
+const anonymous = (tone: ClaimDisclosureTone, text: string): ClaimDisclosure => ({
+  show: true,
+  tone,
+  text,
+  name: null,
+  poolLink: null,
+  canJoinPool: false,
+});
+
+export function resolveClaimDisclosure(
+  holder: ClaimHolder | null,
+  viewer: ViewerRelationship,
+  surface: ClaimSurface,
+): ClaimDisclosure {
+  // The surprise boundary. Nothing below this line can reach the owner.
+  if (holder === null || viewer.isOwner) return HIDDEN;
+
+  // The picker is a compose-time list; attribution there is noise, and the
+  // idea card resolves the who once the idea is proposed.
+  if (surface === 'row') return anonymous('warning', 'Already claimed');
+
+  if (holder.kind === 'user') {
+    const canName =
+      !viewer.isAnonymous && viewer.sharesPoolWithHolderUser && holder.displayName !== null;
+    return canName
+      ? {
+          show: true,
+          tone: 'warning',
+          text: `Claimed by ${holder.displayName}`,
+          name: holder.displayName,
+          poolLink: null,
+          canJoinPool: false,
+        }
+      : anonymous('warning', 'Already claimed');
+  }
+
+  // Anonymous viewers never get attribution, regardless of any other fact.
+  if (viewer.isAnonymous) return anonymous('warning', 'Already claimed');
+
+  if (viewer.contributesToHolderPool) {
+    // Reassurance, not a conflict — so pool tone, never warning. --warning is
+    // reserved for states that advise against an action.
+    return {
+      show: true,
+      tone: 'pool',
+      text: `Your pool ${holder.poolTitle} is getting this`,
+      name: holder.poolTitle,
+      poolLink: `/pools/${holder.poolId}`,
+      canJoinPool: false,
+    };
+  }
+
+  if (viewer.memberOfHolderGroup && holder.giftGroupName !== null) {
+    // Safe: group members already see every active pool in their group via
+    // queryActivePools, so naming it discloses nothing new.
+    return {
+      show: true,
+      tone: 'pool',
+      text: `${holder.giftGroupName} is getting this`,
+      name: holder.giftGroupName,
+      poolLink: `/pools/${holder.poolId}`,
+      canJoinPool: true,
+    };
+  }
+
+  // A pool the viewer has no relationship to: reveal that a group exists —
+  // discoverable from the item anyway — but never which one.
+  return anonymous(
+    'warning',
+    surface === 'badge' ? 'Another group is getting this' : 'Already claimed',
+  );
+}

--- a/app/utils/wishlist-claim-disclosure.ts
+++ b/app/utils/wishlist-claim-disclosure.ts
@@ -123,13 +123,16 @@ export function resolveClaimDisclosure(
 
   if (viewer.memberOfHolderGroup && holder.giftGroupName !== null) {
     // Safe: group members already see every active pool in their group via
-    // queryActivePools, so naming it discloses nothing new.
+    // queryActivePools, so naming it discloses nothing new. No poolLink,
+    // though: this tier can't open the pool page (contributors-only, see
+    // __route.server.ts) — a join affordance for this tier is deliberately
+    // unbuilt, so a link here would 404 every time it's tapped.
     return {
       show: true,
       tone: 'pool',
       text: `${holder.giftGroupName} is getting this`,
       name: holder.giftGroupName,
-      poolLink: `/pools/${holder.poolId}`,
+      poolLink: null,
       canJoinPool: true,
     };
   }

--- a/app/utils/wishlist-claim-write-guard.test.ts
+++ b/app/utils/wishlist-claim-write-guard.test.ts
@@ -1,0 +1,95 @@
+/**
+ * @vitest-environment node
+ *
+ * Architectural guard for the invariant `wishlist-claims.server.ts` declares
+ * in its own docstring: it is "the only code in the app permitted to write
+ * WishlistClaim." That invariant has been violated three times so far, each
+ * discovered one at a time as a real bug — `cancelPool` losing a cancelled
+ * pool's claim on a failed sync, `cleanupWishlistClaimsForOwner` bare-deleting
+ * a solo claim without settling it to a waiting pool, and
+ * `recordWishlistClaimOutcome` writing `outcomeFeedback` directly. Every
+ * write outside the module skips `settleItem`, so a claim can vanish (or be
+ * created) without the longest-waiting pool ever inheriting the item — the
+ * exact bug this feature exists to prevent.
+ *
+ * This test reads every non-test source file under app/ from disk and fails
+ * if any file other than wishlist-claims.server.ts itself calls a write
+ * method on `.wishlistClaim` (create/createMany/update/updateMany/upsert/
+ * delete/deleteMany), on either a `prisma` or an in-transaction `tx` client.
+ * Reads (findUnique, findMany, findFirst, findUniqueOrThrow, count) are not
+ * flagged and never need to be.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const APP_DIR = path.resolve(__dirname, '..');
+const MODULE_FILE = path.join(__dirname, 'wishlist-claims.server.ts');
+
+const WRITE_METHODS = ['create', 'createMany', 'update', 'updateMany', 'upsert', 'delete', 'deleteMany'];
+// Matches `<anything>.wishlistClaim.<writeMethod>` regardless of what the
+// Prisma client variable is called (`prisma`, `tx`, ...) — the invariant is
+// about the table, not the variable name.
+const WRITE_CALL_PATTERN = new RegExp(`\\.wishlistClaim\\.(${WRITE_METHODS.join('|')})\\b`);
+
+const SOURCE_EXTENSIONS = new Set(['.ts', '.tsx']);
+const TEST_FILE_PATTERN = /\.test\.(ts|tsx)$/;
+
+function collectSourceFiles(dir: string): Array<string> {
+  const files: Array<string> = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      // Skip vendored/build output if it ever shows up under app/.
+      if (entry.name === 'node_modules' || entry.name === '.cache') continue;
+      files.push(...collectSourceFiles(fullPath));
+      continue;
+    }
+    if (!SOURCE_EXTENSIONS.has(path.extname(entry.name))) continue;
+    files.push(fullPath);
+  }
+  return files;
+}
+
+describe('WishlistClaim write invariant', () => {
+  it('is never written outside wishlist-claims.server.ts', () => {
+    const offenders: Array<{ file: string; line: number; snippet: string }> = [];
+
+    for (const file of collectSourceFiles(APP_DIR)) {
+      if (file === MODULE_FILE) continue;
+      // Test files legitimately set up WishlistClaim fixtures directly.
+      if (TEST_FILE_PATTERN.test(file)) continue;
+
+      const content = fs.readFileSync(file, 'utf8');
+      const lines = content.split('\n');
+      lines.forEach((lineText, index) => {
+        if (WRITE_CALL_PATTERN.test(lineText)) {
+          offenders.push({
+            file: path.relative(APP_DIR, file),
+            line: index + 1,
+            snippet: lineText.trim(),
+          });
+        }
+      });
+    }
+
+    if (offenders.length > 0) {
+      const report = offenders
+        .map((o) => `  app/${o.file}:${o.line}  ${o.snippet}`)
+        .join('\n');
+      throw new Error(
+        `Found ${offenders.length} write(s) to WishlistClaim outside wishlist-claims.server.ts:\n${report}\n\n` +
+          'wishlist-claims.server.ts documents itself as "the only code in the app ' +
+          'permitted to write WishlistClaim." That single-writer rule exists because ' +
+          'every release/creation must run through settleItem() in the same transaction ' +
+          '— a claim that disappears (or appears) any other way skips settlement, so the ' +
+          'longest-waiting pool never inherits an item it has already decided on. This has ' +
+          'been a real, shipped bug three separate times. Route this write through an ' +
+          'existing or new export of wishlist-claims.server.ts instead of writing ' +
+          '`.wishlistClaim` directly.',
+      );
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/app/utils/wishlist-claim-write-guard.test.ts
+++ b/app/utils/wishlist-claim-write-guard.test.ts
@@ -18,6 +18,19 @@
  * delete/deleteMany), on either a `prisma` or an in-transaction `tx` client.
  * Reads (findUnique, findMany, findFirst, findUniqueOrThrow, count) are not
  * flagged and never need to be.
+ *
+ * LIMITATION — this guard is a source-text grep. It cannot see, and does not
+ * catch, rows removed by a database-level `onDelete: Cascade` (e.g.
+ * `WishlistClaim.claimedByUserId` cascading when its `User` is deleted). No
+ * `.wishlistClaim` call appears in that code path, so the claim vanishes
+ * without ever running `settleItem`, and this test stays green while the
+ * settlement invariant is silently violated (see the account-deletion P1
+ * fix in profile.index.tsx, which routes the cascade-adjacent delete through
+ * `releaseSoloClaimsMatching` first for exactly this reason). Any new
+ * cascade path that can remove a `WishlistClaim` row — a new `onDelete:
+ * Cascade` relation reaching `User`, `WishlistItem`, or `Pool` — needs its
+ * own explicit settlement call before the cascading delete runs; this test
+ * will not tell you it's missing.
  */
 import fs from 'node:fs';
 import path from 'node:path';
@@ -86,7 +99,12 @@ describe('WishlistClaim write invariant', () => {
           'longest-waiting pool never inherits an item it has already decided on. This has ' +
           'been a real, shipped bug three separate times. Route this write through an ' +
           'existing or new export of wishlist-claims.server.ts instead of writing ' +
-          '`.wishlistClaim` directly.',
+          '`.wishlistClaim` directly.\n\n' +
+          'NOTE: this test greps source text, so it cannot see a WishlistClaim row removed ' +
+          'by a database-level onDelete: Cascade (e.g. via User deletion) — that path has no ' +
+          '`.wishlistClaim` call to flag and stays green even though settlement never runs. ' +
+          'If you are adding a new cascade that can reach WishlistClaim, settle it explicitly ' +
+          'before the cascading delete; this test will not catch a missing one.',
       );
     }
 

--- a/app/utils/wishlist-claims.server.test.ts
+++ b/app/utils/wishlist-claims.server.test.ts
@@ -4,7 +4,8 @@
 import { describe, expect, it } from 'vitest';
 import { prisma } from '#app/utils/db.server.ts';
 import { createUser } from '#tests/db-utils.ts';
-import { claimForUser, releaseUserClaim } from './wishlist-claims.server.ts';
+import { claimForUser, releaseUserClaim, syncPoolClaim } from './wishlist-claims.server.ts';
+import { cancelPool, chooseIdea } from './pool.server.ts';
 
 async function fixture() {
   const [owner, friend, organizer] = await Promise.all([
@@ -159,5 +160,56 @@ describe('settlement on release', () => {
     expect(result.ok).toBe(false);
     const claim = await prisma.wishlistClaim.findUnique({ where: { wishlistItemId: item.id } });
     expect(claim?.claimedByUserId).toBe(friend.id);
+  });
+});
+
+describe('syncPoolClaim', () => {
+  it('claims a free wishlist item when the pool decides', async () => {
+    const { owner, organizer, item } = await fixture();
+    const pool = await decidedPoolFor(item.id, owner.id, organizer.id, new Date());
+    const result = await syncPoolClaim(pool.id);
+    expect(result.claimedItemId).toBe(item.id);
+    expect(result.conflictedItemId).toBeNull();
+    const claim = await prisma.wishlistClaim.findUnique({ where: { wishlistItemId: item.id } });
+    expect(claim?.poolId).toBe(pool.id);
+  });
+
+  it('reports a conflict and takes nothing when a person already holds it', async () => {
+    const { owner, friend, organizer, item } = await fixture();
+    await claimForUser(item.id, friend.id);
+    const pool = await decidedPoolFor(item.id, owner.id, organizer.id, new Date());
+
+    const result = await syncPoolClaim(pool.id);
+
+    expect(result.claimedItemId).toBeNull();
+    expect(result.conflictedItemId).toBe(item.id);
+    const claim = await prisma.wishlistClaim.findUnique({ where: { wishlistItemId: item.id } });
+    expect(claim?.claimedByUserId).toBe(friend.id);
+  });
+
+  it('releases the old item and settles it when the pool re-decides', async () => {
+    const { owner, organizer, item } = await fixture();
+    const other = await prisma.wishlistItem.create({
+      data: { ownerId: owner.id, title: 'Headphones', type: 'item', sortOrder: 1 },
+    });
+    const pool = await decidedPoolFor(item.id, owner.id, organizer.id, new Date());
+    await syncPoolClaim(pool.id);
+
+    const newIdea = await prisma.giftIdea.create({
+      data: { poolId: pool.id, proposedById: organizer.id, name: 'Headphones', wishlistItemId: other.id },
+    });
+    await chooseIdea(pool.id, newIdea.id, organizer.id);
+
+    expect(await prisma.wishlistClaim.findUnique({ where: { wishlistItemId: item.id } })).toBeNull();
+    const moved = await prisma.wishlistClaim.findUnique({ where: { wishlistItemId: other.id } });
+    expect(moved?.poolId).toBe(pool.id);
+  });
+
+  it('releases the claim when the pool is cancelled', async () => {
+    const { owner, organizer, item } = await fixture();
+    const pool = await decidedPoolFor(item.id, owner.id, organizer.id, new Date());
+    await syncPoolClaim(pool.id);
+    await cancelPool(pool.id, organizer.id);
+    expect(await prisma.wishlistClaim.findUnique({ where: { wishlistItemId: item.id } })).toBeNull();
   });
 });

--- a/app/utils/wishlist-claims.server.test.ts
+++ b/app/utils/wishlist-claims.server.test.ts
@@ -1,0 +1,112 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, expect, it } from 'vitest';
+import { prisma } from '#app/utils/db.server.ts';
+import { createUser } from '#tests/db-utils.ts';
+import { claimForUser, releaseUserClaim } from './wishlist-claims.server.ts';
+
+async function fixture() {
+  const [owner, friend, organizer] = await Promise.all([
+    prisma.user.create({ data: createUser() }),
+    prisma.user.create({ data: createUser() }),
+    prisma.user.create({ data: createUser() }),
+  ]);
+  const item = await prisma.wishlistItem.create({
+    data: { ownerId: owner.id, title: 'Spa voucher', type: 'item', sortOrder: 0 },
+  });
+  return { owner, friend, organizer, item };
+}
+
+async function decidedPoolFor(
+  itemId: string,
+  recipientId: string,
+  organizerId: string,
+  decidedAt: Date,
+) {
+  const pool = await prisma.pool.create({
+    data: { title: 'Birthday pool', organizerId, recipientUserId: recipientId },
+  });
+  const idea = await prisma.giftIdea.create({
+    data: { poolId: pool.id, proposedById: organizerId, name: 'Spa voucher', wishlistItemId: itemId },
+  });
+  await prisma.pool.update({
+    where: { id: pool.id },
+    data: { status: 'DECIDED', chosenIdeaId: idea.id, decidedAt },
+  });
+  return pool;
+}
+
+describe('claimForUser', () => {
+  it('grants a claim on a free item', async () => {
+    const { friend, item } = await fixture();
+    await expect(claimForUser(item.id, friend.id)).resolves.toEqual({ ok: true });
+    const claim = await prisma.wishlistClaim.findUnique({ where: { wishlistItemId: item.id } });
+    expect(claim?.claimedByUserId).toBe(friend.id);
+    expect(claim?.poolId).toBeNull();
+  });
+
+  it('refuses when a pool holds the claim, and says so distinctly', async () => {
+    const { owner, friend, organizer, item } = await fixture();
+    const pool = await decidedPoolFor(item.id, owner.id, organizer.id, new Date());
+    await prisma.wishlistClaim.create({ data: { wishlistItemId: item.id, poolId: pool.id } });
+    await expect(claimForUser(item.id, friend.id)).resolves.toEqual({
+      ok: false,
+      reason: 'held-by-pool',
+    });
+  });
+});
+
+describe('settlement on release', () => {
+  it('hands a released claim to a pool that has intent — the orphaned-claim fix', async () => {
+    const { owner, friend, organizer, item } = await fixture();
+    await claimForUser(item.id, friend.id);
+    const pool = await decidedPoolFor(item.id, owner.id, organizer.id, new Date());
+
+    const result = await releaseUserClaim(item.id, friend.id);
+
+    expect(result.transferredToPoolId).toBe(pool.id);
+    const claim = await prisma.wishlistClaim.findUnique({ where: { wishlistItemId: item.id } });
+    expect(claim?.poolId).toBe(pool.id);
+    expect(claim?.claimedByUserId).toBeNull();
+  });
+
+  it('frees the item when no pool has intent', async () => {
+    const { friend, item } = await fixture();
+    await claimForUser(item.id, friend.id);
+    const result = await releaseUserClaim(item.id, friend.id);
+    expect(result.transferredToPoolId).toBeNull();
+    expect(await prisma.wishlistClaim.findUnique({ where: { wishlistItemId: item.id } })).toBeNull();
+  });
+
+  it('gives the claim to the earliest decision when two pools have intent', async () => {
+    const { owner, friend, organizer, item } = await fixture();
+    await claimForUser(item.id, friend.id);
+    const later = await decidedPoolFor(item.id, owner.id, organizer.id, new Date('2026-07-20'));
+    const earlier = await decidedPoolFor(item.id, owner.id, organizer.id, new Date('2026-07-10'));
+
+    const result = await releaseUserClaim(item.id, friend.id);
+
+    expect(result.transferredToPoolId).toBe(earlier.id);
+    expect(result.transferredToPoolId).not.toBe(later.id);
+  });
+
+  it('ignores a cancelled pool when settling', async () => {
+    const { owner, friend, organizer, item } = await fixture();
+    await claimForUser(item.id, friend.id);
+    const pool = await decidedPoolFor(item.id, owner.id, organizer.id, new Date());
+    await prisma.pool.update({ where: { id: pool.id }, data: { status: 'CANCELLED' } });
+
+    const result = await releaseUserClaim(item.id, friend.id);
+    expect(result.transferredToPoolId).toBeNull();
+  });
+
+  it('refuses to release a claim the caller does not hold', async () => {
+    const { friend, organizer, item } = await fixture();
+    await claimForUser(item.id, friend.id);
+    const result = await releaseUserClaim(item.id, organizer.id);
+    expect(result.ok).toBe(false);
+    const claim = await prisma.wishlistClaim.findUnique({ where: { wishlistItemId: item.id } });
+    expect(claim?.claimedByUserId).toBe(friend.id);
+  });
+});

--- a/app/utils/wishlist-claims.server.test.ts
+++ b/app/utils/wishlist-claims.server.test.ts
@@ -4,7 +4,7 @@
 import { describe, expect, it } from 'vitest';
 import { prisma } from '#app/utils/db.server.ts';
 import { createUser } from '#tests/db-utils.ts';
-import { claimForUser, releaseUserClaim, syncPoolClaim } from './wishlist-claims.server.ts';
+import { claimForUser, loadClaimStates, releaseUserClaim, syncPoolClaim } from './wishlist-claims.server.ts';
 import { cancelPool, chooseIdea } from './pool.server.ts';
 
 async function fixture() {
@@ -245,5 +245,63 @@ describe('syncPoolClaim', () => {
     await syncPoolClaim(pool.id);
     await cancelPool(pool.id, organizer.id);
     expect(await prisma.wishlistClaim.findUnique({ where: { wishlistItemId: item.id } })).toBeNull();
+  });
+});
+
+describe('loadClaimStates', () => {
+  it('returns nothing at all for the wishlist owner', async () => {
+    const { owner, friend, item } = await fixture();
+    await claimForUser(item.id, friend.id);
+    const states = await loadClaimStates([item.id], { userId: owner.id, isOwner: true });
+    expect(states.get(item.id)?.show).toBe(false);
+  });
+
+  it('names the pool to one of its contributors and not to an outsider', async () => {
+    const { owner, friend, organizer, item } = await fixture();
+    const pool = await decidedPoolFor(item.id, owner.id, organizer.id, new Date());
+    await prisma.poolContributor.create({ data: { poolId: pool.id, userId: organizer.id } });
+    await syncPoolClaim(pool.id);
+
+    const inside = await loadClaimStates([item.id], { userId: organizer.id, isOwner: false });
+    expect(inside.get(item.id)?.name).toBe('Birthday pool');
+
+    const outside = await loadClaimStates([item.id], { userId: friend.id, isOwner: false });
+    expect(outside.get(item.id)?.text).toBe('Already claimed');
+    expect(JSON.stringify(outside.get(item.id))).not.toContain('Birthday pool');
+  });
+
+  it('gives an anonymous viewer claim state with zero attribution', async () => {
+    const { owner, organizer, item } = await fixture();
+    const pool = await decidedPoolFor(item.id, owner.id, organizer.id, new Date());
+    await syncPoolClaim(pool.id);
+    const states = await loadClaimStates([item.id], { userId: null, isOwner: false });
+    expect(states.get(item.id)?.show).toBe(true);
+    expect(states.get(item.id)?.name).toBeNull();
+  });
+
+  it('stops naming the group to a member who has been removed from it', async () => {
+    const { owner, friend, organizer, item } = await fixture();
+    const group = await prisma.giftGroup.create({
+      data: { name: 'Sunday Roasters', createdById: organizer.id },
+    });
+    const pool = await decidedPoolFor(item.id, owner.id, organizer.id, new Date());
+    await prisma.pool.update({ where: { id: pool.id }, data: { giftGroupId: group.id } });
+    await syncPoolClaim(pool.id);
+    const membership = await prisma.usersInGiftGroups.create({
+      data: { userId: friend.id, giftGroupId: group.id },
+    });
+
+    const asMember = await loadClaimStates([item.id], { userId: friend.id, isOwner: false });
+    expect(asMember.get(item.id)?.name).toBe('Sunday Roasters');
+
+    // The membership row survives removal — only removedAt makes it non-current.
+    await prisma.usersInGiftGroups.update({
+      where: { userId_giftGroupId: { userId: membership.userId, giftGroupId: group.id } },
+      data: { removedAt: new Date() },
+    });
+
+    const afterRemoval = await loadClaimStates([item.id], { userId: friend.id, isOwner: false });
+    expect(afterRemoval.get(item.id)?.name).toBeNull();
+    expect(JSON.stringify(afterRemoval.get(item.id))).not.toContain('Sunday Roasters');
   });
 });

--- a/app/utils/wishlist-claims.server.test.ts
+++ b/app/utils/wishlist-claims.server.test.ts
@@ -284,6 +284,36 @@ describe('chooseIdea + claim sync atomicity', () => {
   });
 });
 
+describe('cancelPool + claim sync atomicity', () => {
+  it('rolls back the CANCELLED transition when the claim sync fails mid-transaction', async () => {
+    // Regression for the P1 finding: cancelPool used to set the pool
+    // CANCELLED, then call a separately-transacted sync whose failures were
+    // swallowed to Sentry — leaving a cancelled pool that still owned its
+    // wishlist claim, with no retry path (cancelPool early-returns once the
+    // pool already reads CANCELLED). The status transition and the claim
+    // sync now commit inside one `prisma.$transaction`, so a rejection from
+    // the sync must roll back the cancellation too.
+    const { owner, organizer, item } = await fixture();
+    const pool = await decidedPoolFor(item.id, owner.id, organizer.id, new Date());
+    await syncPoolClaim(pool.id);
+
+    const spy = vi
+      .spyOn(wishlistClaims, 'syncPoolClaimInTx')
+      .mockRejectedValueOnce(new Error('claim sync boom'));
+
+    await expect(cancelPool(pool.id, organizer.id)).rejects.toThrow('claim sync boom');
+
+    const reloaded = await prisma.pool.findUniqueOrThrow({ where: { id: pool.id } });
+    expect(reloaded.status).not.toBe('CANCELLED');
+    // The pool must still hold its claim — the bug this regression closes is
+    // a cancelled pool that lost its claim with no way to get it back.
+    const claim = await prisma.wishlistClaim.findUnique({ where: { wishlistItemId: item.id } });
+    expect(claim?.poolId).toBe(pool.id);
+
+    spy.mockRestore();
+  });
+});
+
 describe('releaseSoloClaimForItem', () => {
   it('hands the item to a waiting pool instead of leaving it unclaimed', async () => {
     // Regression for the P1 finding: the owner-archive route used to

--- a/app/utils/wishlist-claims.server.test.ts
+++ b/app/utils/wishlist-claims.server.test.ts
@@ -1,9 +1,10 @@
 /**
  * @vitest-environment node
  */
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { prisma } from '#app/utils/db.server.ts';
 import { createUser } from '#tests/db-utils.ts';
+import * as wishlistClaims from './wishlist-claims.server.ts';
 import { claimForUser, loadClaimStates, releaseUserClaim, syncPoolClaim } from './wishlist-claims.server.ts';
 import { cancelPool, chooseIdea } from './pool.server.ts';
 
@@ -54,6 +55,7 @@ describe('claimForUser', () => {
     await expect(claimForUser(item.id, friend.id)).resolves.toEqual({
       ok: false,
       reason: 'held-by-pool',
+      claim: { claimedByUserId: null },
     });
   });
 
@@ -245,6 +247,135 @@ describe('syncPoolClaim', () => {
     await syncPoolClaim(pool.id);
     await cancelPool(pool.id, organizer.id);
     expect(await prisma.wishlistClaim.findUnique({ where: { wishlistItemId: item.id } })).toBeNull();
+  });
+});
+
+describe('chooseIdea + claim sync atomicity', () => {
+  it('rolls back the DECIDED transition when the claim sync fails mid-transaction', async () => {
+    // Regression for the P1 finding: chooseIdea's status transition and its
+    // claim sync used to be two separate writes, leaving a window where a
+    // concurrent solo claim could steal the item a pool just decided on —
+    // and a sync failure left the pool stuck DECIDED with no claim and no
+    // retry path. They now commit inside one `prisma.$transaction`, so a
+    // rejection from the sync must roll back the pool's status change too.
+    // Spying on the real `syncPoolClaimInTx` export (rather than mocking the
+    // whole module) keeps this a real Prisma transaction end to end — only
+    // the sync's outcome is forced to fail.
+    const { owner, organizer, item } = await fixture();
+    const pool = await prisma.pool.create({
+      data: { title: 'Birthday pool', organizerId: organizer.id, recipientUserId: owner.id },
+    });
+    const idea = await prisma.giftIdea.create({
+      data: { poolId: pool.id, proposedById: organizer.id, name: 'Spa voucher', wishlistItemId: item.id },
+    });
+
+    const spy = vi
+      .spyOn(wishlistClaims, 'syncPoolClaimInTx')
+      .mockRejectedValueOnce(new Error('claim sync boom'));
+
+    await expect(chooseIdea(pool.id, idea.id, organizer.id)).rejects.toThrow('claim sync boom');
+
+    const reloaded = await prisma.pool.findUniqueOrThrow({ where: { id: pool.id } });
+    expect(reloaded.status).not.toBe('DECIDED');
+    expect(reloaded.chosenIdeaId).toBeNull();
+    expect(await prisma.wishlistClaim.findUnique({ where: { wishlistItemId: item.id } })).toBeNull();
+
+    spy.mockRestore();
+  });
+});
+
+describe('releaseSoloClaimForItem', () => {
+  it('hands the item to a waiting pool instead of leaving it unclaimed', async () => {
+    // Regression for the P1 finding: the owner-archive route used to
+    // bare-delete a solo claim without settling it, so a pool that had
+    // already decided on the item was left with no claim after the owner
+    // archived (or restored) it.
+    const { owner, friend, organizer, item } = await fixture();
+    await claimForUser(item.id, friend.id);
+    const pool = await decidedPoolFor(item.id, owner.id, organizer.id, new Date());
+
+    const result = await wishlistClaims.releaseSoloClaimForItem(item.id);
+
+    expect(result).toEqual({ ok: true, transferredToPoolId: pool.id });
+    const claim = await prisma.wishlistClaim.findUnique({ where: { wishlistItemId: item.id } });
+    expect(claim?.poolId).toBe(pool.id);
+    expect(claim?.claimedByUserId).toBeNull();
+  });
+
+  it('leaves a pool-held claim untouched', async () => {
+    const { owner, organizer, item } = await fixture();
+    const pool = await decidedPoolFor(item.id, owner.id, organizer.id, new Date());
+    await syncPoolClaim(pool.id);
+
+    const result = await wishlistClaims.releaseSoloClaimForItem(item.id);
+
+    expect(result).toEqual({ ok: false, transferredToPoolId: null });
+    const claim = await prisma.wishlistClaim.findUnique({ where: { wishlistItemId: item.id } });
+    expect(claim?.poolId).toBe(pool.id);
+  });
+
+  it('is a no-op when the item has no claim', async () => {
+    const { item } = await fixture();
+    const result = await wishlistClaims.releaseSoloClaimForItem(item.id);
+    expect(result).toEqual({ ok: false, transferredToPoolId: null });
+  });
+});
+
+describe('claimForUser losing a race', () => {
+  it('tells the loser of a concurrent race the winning claim, not a pre-race null', async () => {
+    // Regression for the P2 finding: the caller (purchase.ts) used to send
+    // back the claim state it read *before* calling claimForUser — null, for
+    // a free item — so a loser of a genuine concurrent race had its UI
+    // reconciled back to "unclaimed" even though the winner's row already
+    // existed. claimForUser must report the actual post-race state.
+    const { friend, organizer, item } = await fixture();
+
+    const results = await Promise.all([
+      claimForUser(item.id, friend.id),
+      claimForUser(item.id, organizer.id),
+    ]);
+
+    const loser = results.find((r) => !r.ok);
+    expect(loser).toBeDefined();
+    if (!loser || loser.ok) throw new Error('expected a losing outcome');
+    expect(loser.reason).toBe('held-by-user');
+    // The loser must be told the actual winner, not null.
+    expect(loser.claim.claimedByUserId).not.toBeNull();
+    expect([friend.id, organizer.id]).toContain(loser.claim.claimedByUserId);
+
+    const claim = await prisma.wishlistClaim.findUniqueOrThrow({
+      where: { wishlistItemId: item.id },
+    });
+    expect(loser.claim.claimedByUserId).toBe(claim.claimedByUserId);
+  });
+
+  it('reports a pre-existing user claim without needing a race', async () => {
+    const { friend, organizer, item } = await fixture();
+    await prisma.wishlistClaim.create({
+      data: { wishlistItemId: item.id, claimedByUserId: organizer.id },
+    });
+
+    const result = await claimForUser(item.id, friend.id);
+
+    expect(result).toEqual({
+      ok: false,
+      reason: 'held-by-user',
+      claim: { claimedByUserId: organizer.id },
+    });
+  });
+
+  it('reports a pool-held claim with the null-claimedByUserId sentinel', async () => {
+    const { owner, friend, organizer, item } = await fixture();
+    const pool = await decidedPoolFor(item.id, owner.id, organizer.id, new Date());
+    await syncPoolClaim(pool.id);
+
+    const result = await claimForUser(item.id, friend.id);
+
+    expect(result).toEqual({
+      ok: false,
+      reason: 'held-by-pool',
+      claim: { claimedByUserId: null },
+    });
   });
 });
 

--- a/app/utils/wishlist-claims.server.test.ts
+++ b/app/utils/wishlist-claims.server.test.ts
@@ -55,6 +55,24 @@ describe('claimForUser', () => {
       reason: 'held-by-pool',
     });
   });
+
+  it('resolves a concurrent race on the same free item without throwing', async () => {
+    const { friend, organizer, item } = await fixture();
+
+    const results = await Promise.all([
+      claimForUser(item.id, friend.id),
+      claimForUser(item.id, organizer.id),
+    ]);
+
+    const oks = results.filter((r) => r.ok);
+    const failures = results.filter((r) => !r.ok);
+    expect(oks).toHaveLength(1);
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toMatchObject({ ok: false, reason: 'held-by-user' });
+
+    const claims = await prisma.wishlistClaim.findMany({ where: { wishlistItemId: item.id } });
+    expect(claims).toHaveLength(1);
+  });
 });
 
 describe('settlement on release', () => {
@@ -89,6 +107,39 @@ describe('settlement on release', () => {
 
     expect(result.transferredToPoolId).toBe(earlier.id);
     expect(result.transferredToPoolId).not.toBe(later.id);
+  });
+
+  it('prefers a pool with a real decidedAt over one with a null decidedAt, even when the null one is older', async () => {
+    // SQLite sorts NULL before every value in `ORDER BY ... ASC`, so a naive
+    // `orderBy: [{ decidedAt: 'asc' }, { createdAt: 'asc' }]` would let this
+    // null-dated (legacy, not-yet-backfilled) pool permanently outrank a
+    // correctly-dated one, regardless of createdAt. This must fail against
+    // that orderBy and pass once settlement sorts nulls-last in JS.
+    const { owner, friend, organizer, item } = await fixture();
+    await claimForUser(item.id, friend.id);
+
+    const nullDatedPool = await prisma.pool.create({
+      data: { title: 'Legacy pool', organizerId: organizer.id, recipientUserId: owner.id },
+    });
+    const nullIdea = await prisma.giftIdea.create({
+      data: {
+        poolId: nullDatedPool.id,
+        proposedById: organizer.id,
+        name: 'Spa voucher',
+        wishlistItemId: item.id,
+      },
+    });
+    await prisma.pool.update({
+      where: { id: nullDatedPool.id },
+      data: { status: 'DECIDED', chosenIdeaId: nullIdea.id },
+    });
+
+    const datedPool = await decidedPoolFor(item.id, owner.id, organizer.id, new Date('2026-07-20'));
+
+    const result = await releaseUserClaim(item.id, friend.id);
+
+    expect(result.transferredToPoolId).toBe(datedPool.id);
+    expect(result.transferredToPoolId).not.toBe(nullDatedPool.id);
   });
 
   it('ignores a cancelled pool when settling', async () => {

--- a/app/utils/wishlist-claims.server.test.ts
+++ b/app/utils/wishlist-claims.server.test.ts
@@ -205,6 +205,40 @@ describe('syncPoolClaim', () => {
     expect(moved?.poolId).toBe(pool.id);
   });
 
+  it('reports a released item as transferred when settlement hands it to a waiting pool', async () => {
+    const { owner, organizer, item } = await fixture();
+    const other = await prisma.wishlistItem.create({
+      data: { ownerId: owner.id, title: 'Headphones', type: 'item', sortOrder: 1 },
+    });
+    const holder = await decidedPoolFor(item.id, owner.id, organizer.id, new Date('2026-07-01'));
+    await syncPoolClaim(holder.id);
+
+    // A second pool has intent on the same item and is left waiting behind the holder.
+    const waiter = await decidedPoolFor(item.id, owner.id, organizer.id, new Date('2026-07-10'));
+
+    // The holder re-decides onto a different item, freeing `item` for the waiter.
+    const newIdea = await prisma.giftIdea.create({
+      data: {
+        poolId: holder.id,
+        proposedById: organizer.id,
+        name: 'Headphones',
+        wishlistItemId: other.id,
+      },
+    });
+    await prisma.pool.update({
+      where: { id: holder.id },
+      data: { chosenIdeaId: newIdea.id, decidedAt: new Date('2026-07-15') },
+    });
+
+    const result = await syncPoolClaim(holder.id);
+
+    expect(result.released).toEqual([
+      { wishlistItemId: item.id, transferredToPoolId: waiter.id },
+    ]);
+    const claim = await prisma.wishlistClaim.findUnique({ where: { wishlistItemId: item.id } });
+    expect(claim?.poolId).toBe(waiter.id);
+  });
+
   it('releases the claim when the pool is cancelled', async () => {
     const { owner, organizer, item } = await fixture();
     const pool = await decidedPoolFor(item.id, owner.id, organizer.id, new Date());

--- a/app/utils/wishlist-claims.server.ts
+++ b/app/utils/wishlist-claims.server.ts
@@ -11,6 +11,11 @@
 import { Prisma } from '@prisma/client';
 import { prisma } from './db.server.ts';
 import { POOL_STATUS } from './pool-constants.ts';
+import {
+  resolveClaimDisclosure,
+  type ClaimDisclosure,
+  type ClaimHolder,
+} from './wishlist-claim-disclosure.ts';
 
 export const POOL_INTENT_STATUSES = [
   POOL_STATUS.DECIDED,
@@ -185,4 +190,108 @@ export async function syncPoolClaim(poolId: string): Promise<{
     await tx.wishlistClaim.create({ data: { wishlistItemId: intendedItemId, poolId } });
     return { claimedItemId: intendedItemId, conflictedItemId: null, released };
   });
+}
+
+/**
+ * The read model for wishlist claims: gathers the facts (who holds the
+ * claim, whether the viewer contributes to or is a current member of the
+ * holding pool's group) and hands them to the pure privacy ladder in
+ * wishlist-claim-disclosure.ts, which is the only place that decides what
+ * gets shown. This function never re-derives or second-guesses that
+ * decision — it only assembles the inputs.
+ */
+export async function loadClaimStates(
+  wishlistItemIds: string[],
+  viewer: { userId: string | null; isOwner: boolean },
+): Promise<Map<string, ClaimDisclosure>> {
+  const states = new Map<string, ClaimDisclosure>();
+  if (wishlistItemIds.length === 0) return states;
+
+  const claims = await prisma.wishlistClaim.findMany({
+    where: { wishlistItemId: { in: wishlistItemIds } },
+    select: {
+      wishlistItemId: true,
+      claimedByUserId: true,
+      claimedByUser: { select: { name: true, username: true } },
+      pool: {
+        select: {
+          id: true,
+          title: true,
+          giftGroupId: true,
+          giftGroup: { select: { name: true } },
+          contributors: viewer.userId
+            ? { where: { userId: viewer.userId }, select: { id: true } }
+            : false,
+        },
+      },
+    },
+  });
+
+  const groupIds = claims
+    .map((claim) => claim.pool?.giftGroupId)
+    .filter((id): id is string => Boolean(id));
+  const memberGroupIds = new Set(
+    viewer.userId && groupIds.length
+      ? (
+          await prisma.usersInGiftGroups.findMany({
+            where: {
+              userId: viewer.userId,
+              giftGroupId: { in: groupIds },
+              // A membership row survives removal — `removedAt` is what makes
+              // it current. Without this filter a removed member would keep
+              // being told the group's name, which is exactly the leak the
+              // ladder exists to prevent. Same predicate the repo uses in
+              // group-overview.server.ts and occasion-reminders.server.ts.
+              removedAt: null,
+            },
+            select: { giftGroupId: true },
+          })
+        ).map((membership) => membership.giftGroupId)
+      : [],
+  );
+
+  for (const claim of claims) {
+    const holder: ClaimHolder = claim.pool
+      ? {
+          kind: 'pool',
+          poolId: claim.pool.id,
+          poolTitle: claim.pool.title,
+          giftGroupName: claim.pool.giftGroup?.name ?? null,
+        }
+      : {
+          kind: 'user',
+          userId: claim.claimedByUserId ?? '',
+          displayName: claim.claimedByUser?.name ?? claim.claimedByUser?.username ?? null,
+        };
+
+    const contributesToHolderPool = Boolean(
+      claim.pool && Array.isArray(claim.pool.contributors) && claim.pool.contributors.length > 0,
+    );
+
+    states.set(
+      claim.wishlistItemId,
+      resolveClaimDisclosure(
+        holder,
+        {
+          isOwner: viewer.isOwner,
+          // `loadClaimStates`'s caller is the only source of `viewer` here,
+          // and a null userId always means an unattributed surface for this
+          // caller — but that equivalence is local to this function, not a
+          // general rule. `isAnonymous` is a surface-policy flag on
+          // ViewerRelationship, not a viewer-identity one; do not copy this
+          // line to a caller (e.g. the public share page) where a signed-in
+          // viewer can still be on an unattributed surface.
+          isAnonymous: viewer.userId === null,
+          contributesToHolderPool,
+          memberOfHolderGroup:
+            !contributesToHolderPool &&
+            Boolean(claim.pool?.giftGroupId && memberGroupIds.has(claim.pool.giftGroupId)),
+          sharesPoolWithHolderUser: false,
+        },
+        'label',
+      ),
+    );
+  }
+
+  return states;
 }

--- a/app/utils/wishlist-claims.server.ts
+++ b/app/utils/wishlist-claims.server.ts
@@ -8,7 +8,7 @@
  * whose chosen idea links the item. Cancellation, re-decision, and idea deletion
  * therefore invalidate intent automatically — there is nothing to keep in sync.
  */
-import { type Prisma } from '@prisma/client';
+import { Prisma } from '@prisma/client';
 import { prisma } from './db.server.ts';
 import { POOL_STATUS } from './pool-constants.ts';
 
@@ -19,6 +19,22 @@ export const POOL_INTENT_STATUSES = [
 ] as const;
 
 type Tx = Prisma.TransactionClient;
+
+type IntentCandidate = { id: string; decidedAt: Date | null; createdAt: Date };
+
+// SQLite sorts NULL before every value in `ORDER BY ... ASC` — Prisma's
+// `nulls: 'last'` support on SQLite isn't something to rely on either — so a
+// pool that hasn't had `decidedAt` backfilled yet would permanently outrank
+// every correctly-dated pool if we sorted this in the query. The candidate
+// set is tiny (pools with intent on one wishlist item — normally zero or
+// one), so sort in JS instead: a real `decidedAt` always beats a null one,
+// and null-dated pools fall back to `createdAt` among themselves.
+function waitedLonger(a: IntentCandidate, b: IntentCandidate): boolean {
+  if (a.decidedAt && b.decidedAt) return a.decidedAt.getTime() <= b.decidedAt.getTime();
+  if (a.decidedAt && !b.decidedAt) return true;
+  if (!a.decidedAt && b.decidedAt) return false;
+  return a.createdAt.getTime() <= b.createdAt.getTime();
+}
 
 /**
  * The settlement hook. Runs whenever a claim disappears — and MUST run inside
@@ -33,15 +49,18 @@ async function settleItem(tx: Tx, wishlistItemId: string): Promise<string | null
   });
   if (existing) return null;
 
-  const heir = await tx.pool.findFirst({
+  const candidates = await tx.pool.findMany({
     where: {
       status: { in: [...POOL_INTENT_STATUSES] },
       chosenIdea: { wishlistItemId },
     },
-    orderBy: [{ decidedAt: 'asc' }, { createdAt: 'asc' }],
-    select: { id: true },
+    select: { id: true, decidedAt: true, createdAt: true },
   });
-  if (!heir) return null;
+  if (candidates.length === 0) return null;
+
+  const heir = candidates.reduce((longestWaiting, candidate) =>
+    waitedLonger(candidate, longestWaiting) ? candidate : longestWaiting,
+  );
 
   await tx.wishlistClaim.create({ data: { wishlistItemId, poolId: heir.id } });
   return heir.id;
@@ -61,8 +80,26 @@ export async function claimForUser(
     return { ok: false, reason: existing.poolId ? 'held-by-pool' : 'held-by-user' };
   }
 
-  await prisma.wishlistClaim.create({ data: { wishlistItemId, claimedByUserId: userId } });
-  return { ok: true };
+  try {
+    await prisma.wishlistClaim.create({ data: { wishlistItemId, claimedByUserId: userId } });
+    return { ok: true };
+  } catch (error) {
+    // Two callers can both pass the existence check above and race to
+    // `create`; the loser hits the DB's unique constraint on
+    // `wishlistItemId`. Translate that into the documented result instead of
+    // letting P2002 escape as an unhandled exception. Re-read rather than
+    // assume the winner: it could be a user (a genuine duplicate claim
+    // attempt) or a pool that settled onto the item in the same instant.
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
+      const winner = await prisma.wishlistClaim.findUnique({
+        where: { wishlistItemId },
+        select: { claimedByUserId: true, poolId: true },
+      });
+      if (winner?.claimedByUserId === userId) return { ok: true };
+      return { ok: false, reason: winner?.poolId ? 'held-by-pool' : 'held-by-user' };
+    }
+    throw error;
+  }
 }
 
 export async function releaseUserClaim(
@@ -81,9 +118,13 @@ export async function releaseUserClaim(
     }
 
     await tx.wishlistClaim.delete({ where: { id: claim.id } });
+    // Do not pull this call out of the transaction, and do not await/queue it
+    // after `$transaction` resolves. Delete-then-settle must commit as one
+    // unit: if the delete were visible to other connections before settlement
+    // runs, a concurrent `claimForUser` could win the free item in that gap,
+    // and a pool actively buying it would silently lose out with no error —
+    // the exact bug this module exists to close. See `settleItem`'s docstring.
     const transferredToPoolId = await settleItem(tx, wishlistItemId);
     return { ok: true, transferredToPoolId };
   });
 }
-
-export { settleItem as settleItemForTesting };

--- a/app/utils/wishlist-claims.server.ts
+++ b/app/utils/wishlist-claims.server.ts
@@ -139,11 +139,13 @@ export async function releaseUserClaim(
  * decides, re-decides, or is cancelled. Releasing an old item settles it, so a
  * pool switching from A to B frees A for whoever was waiting on it.
  */
-export async function syncPoolClaim(poolId: string): Promise<{
+export type SyncPoolClaimResult = {
   claimedItemId: string | null;
   conflictedItemId: string | null;
   released: Array<{ wishlistItemId: string; transferredToPoolId: string | null }>;
-}> {
+};
+
+export async function syncPoolClaim(poolId: string): Promise<SyncPoolClaimResult> {
   return prisma.$transaction(async (tx) => {
     const pool = await tx.pool.findUnique({
       where: { id: poolId },

--- a/app/utils/wishlist-claims.server.ts
+++ b/app/utils/wishlist-claims.server.ts
@@ -128,3 +128,57 @@ export async function releaseUserClaim(
     return { ok: true, transferredToPoolId };
   });
 }
+
+/**
+ * Reconcile a pool's claims with its current decision. Called after the pool
+ * decides, re-decides, or is cancelled. Releasing an old item settles it, so a
+ * pool switching from A to B frees A for whoever was waiting on it.
+ */
+export async function syncPoolClaim(poolId: string): Promise<{
+  claimedItemId: string | null;
+  conflictedItemId: string | null;
+  releasedItemIds: string[];
+}> {
+  return prisma.$transaction(async (tx) => {
+    const pool = await tx.pool.findUnique({
+      where: { id: poolId },
+      select: { status: true, chosenIdea: { select: { wishlistItemId: true } } },
+    });
+
+    const intendedItemId =
+      pool && (POOL_INTENT_STATUSES as readonly string[]).includes(pool.status)
+        ? (pool.chosenIdea?.wishlistItemId ?? null)
+        : null;
+
+    // Drop any claim this pool holds that is no longer what it intends.
+    const stale = await tx.wishlistClaim.findMany({
+      where: { poolId, ...(intendedItemId ? { NOT: { wishlistItemId: intendedItemId } } : {}) },
+      select: { id: true, wishlistItemId: true },
+    });
+    const releasedItemIds: string[] = [];
+    for (const claim of stale) {
+      await tx.wishlistClaim.delete({ where: { id: claim.id } });
+      releasedItemIds.push(claim.wishlistItemId);
+    }
+    // Settle only after every release, so an heir can't take an item this pool
+    // is about to release and then re-take.
+    for (const itemId of releasedItemIds) await settleItem(tx, itemId);
+
+    if (!intendedItemId) {
+      return { claimedItemId: null, conflictedItemId: null, releasedItemIds };
+    }
+
+    const holder = await tx.wishlistClaim.findUnique({
+      where: { wishlistItemId: intendedItemId },
+      select: { poolId: true },
+    });
+    if (holder) {
+      return holder.poolId === poolId
+        ? { claimedItemId: intendedItemId, conflictedItemId: null, releasedItemIds }
+        : { claimedItemId: null, conflictedItemId: intendedItemId, releasedItemIds };
+    }
+
+    await tx.wishlistClaim.create({ data: { wishlistItemId: intendedItemId, poolId } });
+    return { claimedItemId: intendedItemId, conflictedItemId: null, releasedItemIds };
+  });
+}

--- a/app/utils/wishlist-claims.server.ts
+++ b/app/utils/wishlist-claims.server.ts
@@ -268,9 +268,18 @@ export async function syncPoolClaim(poolId: string): Promise<SyncPoolClaimResult
  * are intentionally NOT all released in one shared transaction — there is no
  * cross-item invariant to protect, and holding one giant transaction open
  * across an unbounded number of rows is worse for LiteFS contention than many
- * small ones. The inner re-check guards against a claim that was released by
- * someone else (e.g. the claimer themselves) between the initial `findMany`
- * and this item's turn.
+ * small ones. The inner re-check re-applies the caller's full `where` (not
+ * just the claim id) inside the transaction, so it atomically re-evaluates
+ * the same predicate the outer `findMany` used, at delete time — exactly
+ * what the bare `deleteMany` this replaced did. This matters because `where`
+ * is not just "does this row still exist": it typically encodes an access
+ * predicate (e.g. "no longer shares a group/friendship with the owner"), and
+ * that predicate can flip back to false between the initial `findMany` and
+ * this item's turn — e.g. a friendship accepted concurrently with an owner's
+ * page-view cleanup. An id-only recheck would still delete (and possibly
+ * transfer to a waiting pool) a claim that has become valid again; the
+ * id-plus-`where` recheck skips it instead, matching what the atomic
+ * `deleteMany` guaranteed.
  */
 export async function releaseSoloClaimsMatching(
   where: Prisma.WishlistClaimWhereInput,
@@ -283,8 +292,8 @@ export async function releaseSoloClaimsMatching(
   const released: Array<{ wishlistItemId: string; transferredToPoolId: string | null }> = [];
   for (const claim of claims) {
     const outcome = await prisma.$transaction(async (tx) => {
-      const current = await tx.wishlistClaim.findUnique({
-        where: { id: claim.id },
+      const current = await tx.wishlistClaim.findFirst({
+        where: { AND: [{ id: claim.id }, where] },
         select: { id: true },
       });
       if (!current) return { released: false as const };

--- a/app/utils/wishlist-claims.server.ts
+++ b/app/utils/wishlist-claims.server.ts
@@ -74,10 +74,21 @@ async function settleItem(tx: Tx, wishlistItemId: string): Promise<string | null
   return heir.id;
 }
 
+export type ClaimForUserFailure = {
+  ok: false;
+  reason: 'held-by-user' | 'held-by-pool';
+  // The claim as it actually stands after the attempt — never the
+  // pre-attempt read. A loser of a concurrent race must be told the winner's
+  // claim exists, or its UI reconciles back to "unclaimed" while the winner's
+  // row sits in the DB. `claimedByUserId: null` here means a pool holds it
+  // (same sentinel shape used across the module for a pool-held claim).
+  claim: { claimedByUserId: string | null };
+};
+
 export async function claimForUser(
   wishlistItemId: string,
   userId: string,
-): Promise<{ ok: true } | { ok: false; reason: 'held-by-user' | 'held-by-pool' }> {
+): Promise<{ ok: true } | ClaimForUserFailure> {
   const existing = await prisma.wishlistClaim.findUnique({
     where: { wishlistItemId },
     select: { claimedByUserId: true, poolId: true },
@@ -85,7 +96,11 @@ export async function claimForUser(
 
   if (existing) {
     if (existing.claimedByUserId === userId) return { ok: true };
-    return { ok: false, reason: existing.poolId ? 'held-by-pool' : 'held-by-user' };
+    return {
+      ok: false,
+      reason: existing.poolId ? 'held-by-pool' : 'held-by-user',
+      claim: { claimedByUserId: existing.claimedByUserId },
+    };
   }
 
   try {
@@ -104,7 +119,11 @@ export async function claimForUser(
         select: { claimedByUserId: true, poolId: true },
       });
       if (winner?.claimedByUserId === userId) return { ok: true };
-      return { ok: false, reason: winner?.poolId ? 'held-by-pool' : 'held-by-user' };
+      return {
+        ok: false,
+        reason: winner?.poolId ? 'held-by-pool' : 'held-by-user',
+        claim: { claimedByUserId: winner?.claimedByUserId ?? null },
+      };
     }
     throw error;
   }
@@ -138,6 +157,35 @@ export async function releaseUserClaim(
 }
 
 /**
+ * Owner-facing release: drops a *solo* claim on an item regardless of which
+ * user holds it (unlike `releaseUserClaim`, this is not gated to the caller's
+ * own claim — the owner archiving/restoring their item is not "the claimer").
+ * A pool-held claim (`claimedByUserId: null`) is left untouched; pool claims
+ * are released only by pool lifecycle events (decide/re-decide/cancel).
+ *
+ * Same atomicity requirement as `releaseUserClaim`: delete-then-settle must
+ * commit as one transaction, or a waiting pool can lose the race for the item
+ * it just watched become free.
+ */
+export async function releaseSoloClaimForItem(
+  wishlistItemId: string,
+): Promise<{ ok: boolean; transferredToPoolId: string | null }> {
+  return prisma.$transaction(async (tx) => {
+    const claim = await tx.wishlistClaim.findUnique({
+      where: { wishlistItemId },
+      select: { id: true, claimedByUserId: true },
+    });
+    if (!claim || claim.claimedByUserId === null) {
+      return { ok: false, transferredToPoolId: null };
+    }
+
+    await tx.wishlistClaim.delete({ where: { id: claim.id } });
+    const transferredToPoolId = await settleItem(tx, wishlistItemId);
+    return { ok: true, transferredToPoolId };
+  });
+}
+
+/**
  * Reconcile a pool's claims with its current decision. Called after the pool
  * decides, re-decides, or is cancelled. Releasing an old item settles it, so a
  * pool switching from A to B frees A for whoever was waiting on it.
@@ -148,53 +196,61 @@ export type SyncPoolClaimResult = {
   released: Array<{ wishlistItemId: string; transferredToPoolId: string | null }>;
 };
 
-export async function syncPoolClaim(poolId: string): Promise<SyncPoolClaimResult> {
-  return prisma.$transaction(async (tx) => {
-    const pool = await tx.pool.findUnique({
-      where: { id: poolId },
-      select: { status: true, chosenIdea: { select: { wishlistItemId: true } } },
-    });
-
-    const intendedItemId =
-      pool && (POOL_INTENT_STATUSES as readonly string[]).includes(pool.status)
-        ? (pool.chosenIdea?.wishlistItemId ?? null)
-        : null;
-
-    // Drop any claim this pool holds that is no longer what it intends.
-    const stale = await tx.wishlistClaim.findMany({
-      where: { poolId, ...(intendedItemId ? { NOT: { wishlistItemId: intendedItemId } } : {}) },
-      select: { id: true, wishlistItemId: true },
-    });
-    const releasedItemIds: string[] = [];
-    for (const claim of stale) {
-      await tx.wishlistClaim.delete({ where: { id: claim.id } });
-      releasedItemIds.push(claim.wishlistItemId);
-    }
-    // Settle only after every release, so an heir can't take an item this pool
-    // is about to release and then re-take.
-    const released: Array<{ wishlistItemId: string; transferredToPoolId: string | null }> = [];
-    for (const itemId of releasedItemIds) {
-      const transferredToPoolId = await settleItem(tx, itemId);
-      released.push({ wishlistItemId: itemId, transferredToPoolId });
-    }
-
-    if (!intendedItemId) {
-      return { claimedItemId: null, conflictedItemId: null, released };
-    }
-
-    const holder = await tx.wishlistClaim.findUnique({
-      where: { wishlistItemId: intendedItemId },
-      select: { poolId: true },
-    });
-    if (holder) {
-      return holder.poolId === poolId
-        ? { claimedItemId: intendedItemId, conflictedItemId: null, released }
-        : { claimedItemId: null, conflictedItemId: intendedItemId, released };
-    }
-
-    await tx.wishlistClaim.create({ data: { wishlistItemId: intendedItemId, poolId } });
-    return { claimedItemId: intendedItemId, conflictedItemId: null, released };
+/**
+ * Transaction-accepting core of `syncPoolClaim`. Callers that must commit the
+ * sync together with another write (e.g. `chooseIdea`'s status transition)
+ * pass their own transaction client in here instead of going through the
+ * thin `syncPoolClaim` wrapper, which opens its own transaction.
+ */
+export async function syncPoolClaimInTx(tx: Tx, poolId: string): Promise<SyncPoolClaimResult> {
+  const pool = await tx.pool.findUnique({
+    where: { id: poolId },
+    select: { status: true, chosenIdea: { select: { wishlistItemId: true } } },
   });
+
+  const intendedItemId =
+    pool && (POOL_INTENT_STATUSES as readonly string[]).includes(pool.status)
+      ? (pool.chosenIdea?.wishlistItemId ?? null)
+      : null;
+
+  // Drop any claim this pool holds that is no longer what it intends.
+  const stale = await tx.wishlistClaim.findMany({
+    where: { poolId, ...(intendedItemId ? { NOT: { wishlistItemId: intendedItemId } } : {}) },
+    select: { id: true, wishlistItemId: true },
+  });
+  const releasedItemIds: string[] = [];
+  for (const claim of stale) {
+    await tx.wishlistClaim.delete({ where: { id: claim.id } });
+    releasedItemIds.push(claim.wishlistItemId);
+  }
+  // Settle only after every release, so an heir can't take an item this pool
+  // is about to release and then re-take.
+  const released: Array<{ wishlistItemId: string; transferredToPoolId: string | null }> = [];
+  for (const itemId of releasedItemIds) {
+    const transferredToPoolId = await settleItem(tx, itemId);
+    released.push({ wishlistItemId: itemId, transferredToPoolId });
+  }
+
+  if (!intendedItemId) {
+    return { claimedItemId: null, conflictedItemId: null, released };
+  }
+
+  const holder = await tx.wishlistClaim.findUnique({
+    where: { wishlistItemId: intendedItemId },
+    select: { poolId: true },
+  });
+  if (holder) {
+    return holder.poolId === poolId
+      ? { claimedItemId: intendedItemId, conflictedItemId: null, released }
+      : { claimedItemId: null, conflictedItemId: intendedItemId, released };
+  }
+
+  await tx.wishlistClaim.create({ data: { wishlistItemId: intendedItemId, poolId } });
+  return { claimedItemId: intendedItemId, conflictedItemId: null, released };
+}
+
+export async function syncPoolClaim(poolId: string): Promise<SyncPoolClaimResult> {
+  return prisma.$transaction((tx) => syncPoolClaimInTx(tx, poolId));
 }
 
 /**

--- a/app/utils/wishlist-claims.server.ts
+++ b/app/utils/wishlist-claims.server.ts
@@ -1,0 +1,89 @@
+/**
+ * Wishlist claims — the only code in the app permitted to write WishlistClaim.
+ *
+ * Owns one invariant: exactly one claim per item, and an item that becomes free
+ * goes immediately to the longest-waiting pool that has intent on it.
+ *
+ * Claim intent is never stored. It is derived: a pool in a live decided status
+ * whose chosen idea links the item. Cancellation, re-decision, and idea deletion
+ * therefore invalidate intent automatically — there is nothing to keep in sync.
+ */
+import { type Prisma } from '@prisma/client';
+import { prisma } from './db.server.ts';
+import { POOL_STATUS } from './pool-constants.ts';
+
+export const POOL_INTENT_STATUSES = [
+  POOL_STATUS.DECIDED,
+  POOL_STATUS.PURCHASED,
+  POOL_STATUS.DELIVERED,
+] as const;
+
+type Tx = Prisma.TransactionClient;
+
+/**
+ * The settlement hook. Runs whenever a claim disappears — and MUST run inside
+ * the same transaction as the release. Split them and there is a window where
+ * the item reads as unclaimed, letting a third party take an item a pool is
+ * actively buying: exactly the bug this feature exists to close.
+ */
+async function settleItem(tx: Tx, wishlistItemId: string): Promise<string | null> {
+  const existing = await tx.wishlistClaim.findUnique({
+    where: { wishlistItemId },
+    select: { id: true },
+  });
+  if (existing) return null;
+
+  const heir = await tx.pool.findFirst({
+    where: {
+      status: { in: [...POOL_INTENT_STATUSES] },
+      chosenIdea: { wishlistItemId },
+    },
+    orderBy: [{ decidedAt: 'asc' }, { createdAt: 'asc' }],
+    select: { id: true },
+  });
+  if (!heir) return null;
+
+  await tx.wishlistClaim.create({ data: { wishlistItemId, poolId: heir.id } });
+  return heir.id;
+}
+
+export async function claimForUser(
+  wishlistItemId: string,
+  userId: string,
+): Promise<{ ok: true } | { ok: false; reason: 'held-by-user' | 'held-by-pool' }> {
+  const existing = await prisma.wishlistClaim.findUnique({
+    where: { wishlistItemId },
+    select: { claimedByUserId: true, poolId: true },
+  });
+
+  if (existing) {
+    if (existing.claimedByUserId === userId) return { ok: true };
+    return { ok: false, reason: existing.poolId ? 'held-by-pool' : 'held-by-user' };
+  }
+
+  await prisma.wishlistClaim.create({ data: { wishlistItemId, claimedByUserId: userId } });
+  return { ok: true };
+}
+
+export async function releaseUserClaim(
+  wishlistItemId: string,
+  userId: string,
+): Promise<{ ok: boolean; transferredToPoolId: string | null }> {
+  return prisma.$transaction(async (tx) => {
+    const claim = await tx.wishlistClaim.findUnique({
+      where: { wishlistItemId },
+      select: { id: true, claimedByUserId: true },
+    });
+    // Only a claimer releases their own claim. No override exists, by design:
+    // an override could erase evidence of a purchase that physically happened.
+    if (!claim || claim.claimedByUserId !== userId) {
+      return { ok: false, transferredToPoolId: null };
+    }
+
+    await tx.wishlistClaim.delete({ where: { id: claim.id } });
+    const transferredToPoolId = await settleItem(tx, wishlistItemId);
+    return { ok: true, transferredToPoolId };
+  });
+}
+
+export { settleItem as settleItemForTesting };

--- a/app/utils/wishlist-claims.server.ts
+++ b/app/utils/wishlist-claims.server.ts
@@ -61,10 +61,13 @@ async function settleItem(tx: Tx, wishlistItemId: string): Promise<string | null
     },
     select: { id: true, decidedAt: true, createdAt: true },
   });
-  if (candidates.length === 0) return null;
+  const [first, ...rest] = candidates;
+  if (!first) return null;
 
-  const heir = candidates.reduce((longestWaiting, candidate) =>
-    waitedLonger(candidate, longestWaiting) ? candidate : longestWaiting,
+  const heir = rest.reduce(
+    (longestWaiting, candidate) =>
+      waitedLonger(candidate, longestWaiting) ? candidate : longestWaiting,
+    first,
   );
 
   await tx.wishlistClaim.create({ data: { wishlistItemId, poolId: heir.id } });

--- a/app/utils/wishlist-claims.server.ts
+++ b/app/utils/wishlist-claims.server.ts
@@ -137,7 +137,7 @@ export async function releaseUserClaim(
 export async function syncPoolClaim(poolId: string): Promise<{
   claimedItemId: string | null;
   conflictedItemId: string | null;
-  releasedItemIds: string[];
+  released: Array<{ wishlistItemId: string; transferredToPoolId: string | null }>;
 }> {
   return prisma.$transaction(async (tx) => {
     const pool = await tx.pool.findUnique({
@@ -162,10 +162,14 @@ export async function syncPoolClaim(poolId: string): Promise<{
     }
     // Settle only after every release, so an heir can't take an item this pool
     // is about to release and then re-take.
-    for (const itemId of releasedItemIds) await settleItem(tx, itemId);
+    const released: Array<{ wishlistItemId: string; transferredToPoolId: string | null }> = [];
+    for (const itemId of releasedItemIds) {
+      const transferredToPoolId = await settleItem(tx, itemId);
+      released.push({ wishlistItemId: itemId, transferredToPoolId });
+    }
 
     if (!intendedItemId) {
-      return { claimedItemId: null, conflictedItemId: null, releasedItemIds };
+      return { claimedItemId: null, conflictedItemId: null, released };
     }
 
     const holder = await tx.wishlistClaim.findUnique({
@@ -174,11 +178,11 @@ export async function syncPoolClaim(poolId: string): Promise<{
     });
     if (holder) {
       return holder.poolId === poolId
-        ? { claimedItemId: intendedItemId, conflictedItemId: null, releasedItemIds }
-        : { claimedItemId: null, conflictedItemId: intendedItemId, releasedItemIds };
+        ? { claimedItemId: intendedItemId, conflictedItemId: null, released }
+        : { claimedItemId: null, conflictedItemId: intendedItemId, released };
     }
 
     await tx.wishlistClaim.create({ data: { wishlistItemId: intendedItemId, poolId } });
-    return { claimedItemId: intendedItemId, conflictedItemId: null, releasedItemIds };
+    return { claimedItemId: intendedItemId, conflictedItemId: null, released };
   });
 }

--- a/app/utils/wishlist-claims.server.ts
+++ b/app/utils/wishlist-claims.server.ts
@@ -301,6 +301,36 @@ export async function releaseSoloClaimsMatching(
   return released;
 }
 
+export type ClaimOutcomeFeedback = 'LOVED' | 'OKAY' | 'SKIPPED';
+
+/**
+ * Records post-occasion "did it land" feedback on a *solo* claim. Callers
+ * (currently `recordWishlistClaimOutcome` in person-surface.server.ts) still
+ * own authorization framing (throwing the caller-appropriate error shape);
+ * this just keeps the actual write to WishlistClaim inside the module. Does
+ * not touch a pool-held claim's outcome — that lives on `Pool.outcomeFeedback`
+ * and is a separate write outside this module's remit.
+ */
+export async function setClaimOutcomeFeedback(
+  wishlistItemId: string,
+  userId: string,
+  feedback: ClaimOutcomeFeedback,
+): Promise<{ ok: boolean }> {
+  const claim = await prisma.wishlistClaim.findUnique({
+    where: { wishlistItemId },
+    select: { claimedByUserId: true },
+  });
+  if (!claim || claim.claimedByUserId !== userId) {
+    return { ok: false };
+  }
+
+  await prisma.wishlistClaim.update({
+    where: { wishlistItemId },
+    data: { outcomeFeedback: feedback },
+  });
+  return { ok: true };
+}
+
 /**
  * The read model for wishlist claims: gathers the facts (who holds the
  * claim, whether the viewer contributes to or is a current member of the

--- a/app/utils/wishlist-claims.server.ts
+++ b/app/utils/wishlist-claims.server.ts
@@ -254,6 +254,54 @@ export async function syncPoolClaim(poolId: string): Promise<SyncPoolClaimResult
 }
 
 /**
+ * Batch-capable release for callers that must drop many solo claims in one
+ * pass — currently only `cleanupWishlistClaimsForOwner`, which is scoped by
+ * owner rather than by item and so can match any number of claims at once.
+ * `where` is a caller-supplied predicate over WishlistClaim (e.g. "solo
+ * claims by users who no longer share access with this owner"); this
+ * function owns none of that domain logic, only the release-and-settle
+ * mechanics, so the invariant (never bare-delete a claim without settling
+ * it) holds no matter how many rows match.
+ *
+ * Each matched claim is released in its own transaction: a per-item
+ * find-then-delete-then-settle, exactly like `releaseSoloClaimForItem`. Items
+ * are intentionally NOT all released in one shared transaction — there is no
+ * cross-item invariant to protect, and holding one giant transaction open
+ * across an unbounded number of rows is worse for LiteFS contention than many
+ * small ones. The inner re-check guards against a claim that was released by
+ * someone else (e.g. the claimer themselves) between the initial `findMany`
+ * and this item's turn.
+ */
+export async function releaseSoloClaimsMatching(
+  where: Prisma.WishlistClaimWhereInput,
+): Promise<Array<{ wishlistItemId: string; transferredToPoolId: string | null }>> {
+  const claims = await prisma.wishlistClaim.findMany({
+    where,
+    select: { id: true, wishlistItemId: true },
+  });
+
+  const released: Array<{ wishlistItemId: string; transferredToPoolId: string | null }> = [];
+  for (const claim of claims) {
+    const outcome = await prisma.$transaction(async (tx) => {
+      const current = await tx.wishlistClaim.findUnique({
+        where: { id: claim.id },
+        select: { id: true },
+      });
+      if (!current) return { released: false as const };
+
+      await tx.wishlistClaim.delete({ where: { id: claim.id } });
+      const transferredToPoolId = await settleItem(tx, claim.wishlistItemId);
+      return { released: true as const, transferredToPoolId };
+    });
+
+    if (outcome.released) {
+      released.push({ wishlistItemId: claim.wishlistItemId, transferredToPoolId: outcome.transferredToPoolId });
+    }
+  }
+  return released;
+}
+
+/**
  * The read model for wishlist claims: gathers the facts (who holds the
  * claim, whether the viewer contributes to or is a current member of the
  * holding pool's group) and hands them to the pure privacy ladder in

--- a/app/utils/wishlist-page.server.test.ts
+++ b/app/utils/wishlist-page.server.test.ts
@@ -38,18 +38,31 @@ vi.mock('./wishlist.server.ts', () => ({
     cleanupWishlistClaimsForOwner(...args),
 }));
 
+// Claim resolution has its own dedicated coverage in
+// wishlist-claims.server.test.ts; this suite only needs to prove
+// loadFriendWishlistPageData calls it with the right viewer and item ids and
+// merges the result — so it's mocked rather than routed through a fuller
+// prisma.wishlistClaim stub.
+const loadClaimStates = vi.fn();
+
+vi.mock('./wishlist-claims.server.ts', () => ({
+  loadClaimStates: (...args: Array<unknown>) => loadClaimStates(...args),
+}));
+
 import {
   loadFriendWishlistPageData,
   loadOwnWishlistPageData,
 } from './wishlist-page.server.ts';
 
-function createOwnerSummary(overrides?: Partial<{
-  id: string;
-  image: { id: string } | null;
-  name: string | null;
-  username: string;
-  wishlistVisibility: string;
-}>) {
+function createOwnerSummary(
+  overrides?: Partial<{
+    id: string;
+    image: { id: string } | null;
+    name: string | null;
+    username: string;
+    wishlistVisibility: string;
+  }>,
+) {
   return {
     id: 'owner-1',
     image: { id: 'image-1' },
@@ -61,12 +74,14 @@ function createOwnerSummary(overrides?: Partial<{
 
 // Creates the subset of the owner summary that the loader echoes back in
 // the `user` field (wishlistVisibility is stripped out before returning).
-function createExpectedUser(overrides?: Partial<{
-  id: string;
-  image: { id: string } | null;
-  name: string | null;
-  username: string;
-}>) {
+function createExpectedUser(
+  overrides?: Partial<{
+    id: string;
+    image: { id: string } | null;
+    name: string | null;
+    username: string;
+  }>,
+) {
   return {
     id: 'owner-1',
     image: { id: 'image-1' },
@@ -125,6 +140,8 @@ beforeEach(() => {
   isFriendOfFriend.mockReset();
   queueLogEvent.mockReset();
   cleanupWishlistClaimsForOwner.mockReset();
+  loadClaimStates.mockReset();
+  loadClaimStates.mockResolvedValue(new Map());
 });
 
 describe('loadFriendWishlistPageData', () => {
@@ -276,6 +293,13 @@ describe('loadFriendWishlistPageData', () => {
     });
     expect(cleanupWishlistClaimsForOwner).toHaveBeenCalledWith('owner-1');
     expect(queueLogEvent).not.toHaveBeenCalled();
+    // This is always a non-owner surface (the self-view redirects above), so
+    // the viewer gets their own relationship-scoped disclosure, never the
+    // owner's suppressed one.
+    expect(loadClaimStates).toHaveBeenCalledWith(['item-1', 'item-2'], {
+      userId: 'viewer-1',
+      isOwner: false,
+    });
   });
 
   it('grants access for wishlistVisibility EVERYONE and loads wishlist details', async () => {
@@ -404,9 +428,7 @@ describe('loadOwnWishlistPageData', () => {
       image: { id: 'image-1' },
       name: 'Alex',
       username: 'alex',
-      wishlistCategories: [
-        { id: 'category-1', name: 'Books', order: 0 },
-      ],
+      wishlistCategories: [{ id: 'category-1', name: 'Books', order: 0 }],
       wishlistItems: [
         {
           categoryId: 'category-1',

--- a/app/utils/wishlist-page.server.ts
+++ b/app/utils/wishlist-page.server.ts
@@ -117,8 +117,8 @@ function mapWishlistItems(
     status: string;
     hasImage: boolean;
     imageSource: string | null;
-    // Pool claims render through ClaimDescriptor (PR3); this surface is
-    // solo-only until then, so claimedByUserId may be null for a pool claim.
+    // A claim row can hold either a solo claimedByUserId or a pool — see
+    // ClaimDescriptor. claimedByUserId is null for a pool-held claim.
     claim?: {
       claimedByUserId: string | null;
     } | null;

--- a/app/utils/wishlist-page.server.ts
+++ b/app/utils/wishlist-page.server.ts
@@ -3,6 +3,7 @@ import { type WishlistUser } from '#app/components/wishlist';
 import { queueLogEvent } from './analytics.server.ts';
 import { prisma } from './db.server.ts';
 import { getRelationshipDetails, isFriendOfFriend } from './friends.server.ts';
+import { loadClaimStates } from './wishlist-claims.server.ts';
 import { cleanupWishlistClaimsForOwner } from './wishlist.server.ts';
 
 type Relationship = {
@@ -368,6 +369,17 @@ export async function loadFriendWishlistPageData({
   void cleanupWishlistClaimsForOwner(wishlistOwner.id);
 
   const wishlistItems = mapWishlistItems(wishlistDetails.wishlistItems);
+  // Non-owner surface (this is the friend/groupmate view, never the wishlist
+  // owner — `wishlistOwner.id === viewerId` redirects to /wishlist above),
+  // so the viewer gets the full privacy-laddered disclosure keyed to their
+  // own relationship to whichever pool/user holds each claim.
+  const claimDisclosures = await loadClaimStates(
+    wishlistItems.map((item) => item.id),
+    { userId: viewerId, isOwner: false },
+  );
+  for (const item of wishlistItems) {
+    item.claimDisclosure = claimDisclosures.get(item.id);
+  }
   const viewEvent = includeAnalytics
     ? queueLogEvent({
         name: 'wishlist_viewed',

--- a/app/utils/wishlist.server.test.ts
+++ b/app/utils/wishlist.server.test.ts
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment node
  */
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { prisma } from '#app/utils/db.server.ts';
 import { createUser } from '#tests/db-utils.ts';
 import { cleanupWishlistClaimsForOwner } from './wishlist.server.ts';
@@ -114,5 +114,52 @@ describe('cleanupWishlistClaimsForOwner', () => {
     });
     expect(claim.poolId).toBe(pool.id);
     expect(claim.claimedByUserId).toBeNull();
+  });
+
+  it('skips a claim whose claimant regains access between the find and its transaction — TOCTOU', async () => {
+    // Regression for the P2 finding: releaseSoloClaimsMatching's outer
+    // findMany matched this claim (stranger, no shared access with owner),
+    // but only rechecked the claim's *id* inside the per-item transaction —
+    // not the access predicate itself. If the stranger and owner became
+    // friends in the gap between the find and this claim's turn, the old
+    // code deleted (and could transfer to a waiting pool) a claim that had
+    // already become valid again. The bare `deleteMany` this replaced
+    // evaluated the whole predicate atomically at deletion time; the fix
+    // re-applies the full caller `where` (not just the id) inside the
+    // transaction to match that.
+    const owner = await prisma.user.create({ data: createUser() });
+    const stranger = await prisma.user.create({ data: createUser() });
+    const item = await prisma.wishlistItem.create({
+      data: {
+        ownerId: owner.id,
+        title: 'Espresso machine',
+        sortOrder: 0,
+        type: 'text',
+      },
+    });
+    const claim = await prisma.wishlistClaim.create({
+      data: { wishlistItemId: item.id, claimedByUserId: stranger.id },
+    });
+
+    // Simulate a friendship being accepted concurrently with the owner's
+    // wishlist-page cleanup: it lands after the outer `findMany` matched
+    // this claim, but before this claim's own release transaction runs.
+    const originalTransaction = prisma.$transaction.bind(prisma);
+    const transactionSpy = vi
+      .spyOn(prisma, '$transaction')
+      .mockImplementationOnce(async (callback: any) => {
+        await prisma.friendship.create({
+          data: { userAId: stranger.id, userBId: owner.id },
+        });
+        return originalTransaction(callback);
+      });
+
+    await cleanupWishlistClaimsForOwner(owner.id);
+    transactionSpy.mockRestore();
+
+    const stillExists = await prisma.wishlistClaim.findUnique({
+      where: { id: claim.id },
+    });
+    expect(stillExists).not.toBeNull();
   });
 });

--- a/app/utils/wishlist.server.test.ts
+++ b/app/utils/wishlist.server.test.ts
@@ -61,4 +61,58 @@ describe('cleanupWishlistClaimsForOwner', () => {
     });
     expect(stillExists).toBeNull();
   });
+
+  it('settles a released solo claim onto a decided pool waiting behind it, instead of bare-deleting it', async () => {
+    // Regression for the P1 finding: cleanupWishlistClaimsForOwner used to
+    // call a bare wishlistClaim.deleteMany. If a decided pool was waiting
+    // behind a solo claimant who had since lost wishlist access, the next
+    // cleanup (which runs from wishlist loaders, i.e. on page views) deleted
+    // that solo claim without settlement — freeing the item for anyone,
+    // instead of transferring it to the pool that had already decided on it.
+    const owner = await prisma.user.create({ data: createUser() });
+    const stranger = await prisma.user.create({ data: createUser() });
+    const organizer = await prisma.user.create({ data: createUser() });
+    const item = await prisma.wishlistItem.create({
+      data: {
+        ownerId: owner.id,
+        title: 'Espresso machine',
+        sortOrder: 0,
+        type: 'text',
+      },
+    });
+    // The stranger holds a solo claim but shares no friendship or group with
+    // the owner, so this claim is exactly what the next cleanup releases.
+    await prisma.wishlistClaim.create({
+      data: { wishlistItemId: item.id, claimedByUserId: stranger.id },
+    });
+    // A pool has already decided on the same item and is waiting behind the
+    // solo claimant.
+    const pool = await prisma.pool.create({
+      data: {
+        title: 'Espresso machine pool',
+        organizerId: organizer.id,
+        recipientUserId: owner.id,
+      },
+    });
+    const idea = await prisma.giftIdea.create({
+      data: {
+        poolId: pool.id,
+        proposedById: organizer.id,
+        name: 'Espresso machine',
+        wishlistItemId: item.id,
+      },
+    });
+    await prisma.pool.update({
+      where: { id: pool.id },
+      data: { status: 'DECIDED', chosenIdeaId: idea.id, decidedAt: new Date() },
+    });
+
+    await cleanupWishlistClaimsForOwner(owner.id);
+
+    const claim = await prisma.wishlistClaim.findUniqueOrThrow({
+      where: { wishlistItemId: item.id },
+    });
+    expect(claim.poolId).toBe(pool.id);
+    expect(claim.claimedByUserId).toBeNull();
+  });
 });

--- a/app/utils/wishlist.server.ts
+++ b/app/utils/wishlist.server.ts
@@ -1,37 +1,43 @@
 import { createHash, randomBytes } from 'node:crypto';
 import { prisma } from './db.server.ts';
 import { usersShareAGroupOrAreFriendsByIds } from './groups.server.ts';
+import { releaseSoloClaimsMatching } from './wishlist-claims.server.ts';
 
 const PUBLIC_SHARE_TOKEN_BYTES = 24;
 
 export async function cleanupWishlistClaimsForOwner(ownerId: string) {
-  await prisma.wishlistClaim.deleteMany({
-    where: {
-      wishlistItem: { ownerId },
-      // Solo claims only. A pool-held claim has claimedByUserId: null (see
-      // the DB CHECK in the WishlistClaim migration — exactly one of
-      // claimedByUserId/poolId is set), so every claimedByUser predicate
-      // below fails to match it and NOT(...) would otherwise evaluate true,
-      // silently deleting the pool's claim on every wishlist page view.
-      // Pool claims are released only by pool lifecycle events (decide,
-      // re-decide, cancel) — never by this viewer-access cleanup. Do not
-      // remove this predicate.
-      claimedByUserId: { not: null },
-      NOT: {
-        OR: [
-          { claimedByUser: { friendshipsA: { some: { userBId: ownerId } } } },
-          { claimedByUser: { friendshipsB: { some: { userAId: ownerId } } } },
-          {
-            claimedByUser: {
-              giftGroups: {
-                some: {
-                  giftGroup: { groupMembers: { some: { userId: ownerId } } },
-                },
+  // Routed through the module's transactional release-and-settle path
+  // (rather than a bare deleteMany) so a decided pool waiting behind a solo
+  // claimant who lost access inherits the item in the same commit as the
+  // release. This runs from wishlist loaders — i.e. on page views — and can
+  // match many claims at once (scoped by owner, not by item), which is why
+  // it goes through the batch-capable `releaseSoloClaimsMatching` rather than
+  // one-at-a-time `releaseSoloClaimForItem`.
+  await releaseSoloClaimsMatching({
+    wishlistItem: { ownerId },
+    // Solo claims only. A pool-held claim has claimedByUserId: null (see
+    // the DB CHECK in the WishlistClaim migration — exactly one of
+    // claimedByUserId/poolId is set), so every claimedByUser predicate
+    // below fails to match it and NOT(...) would otherwise evaluate true,
+    // silently deleting the pool's claim on every wishlist page view.
+    // Pool claims are released only by pool lifecycle events (decide,
+    // re-decide, cancel) — never by this viewer-access cleanup. Do not
+    // remove this predicate.
+    claimedByUserId: { not: null },
+    NOT: {
+      OR: [
+        { claimedByUser: { friendshipsA: { some: { userBId: ownerId } } } },
+        { claimedByUser: { friendshipsB: { some: { userAId: ownerId } } } },
+        {
+          claimedByUser: {
+            giftGroups: {
+              some: {
+                giftGroup: { groupMembers: { some: { userId: ownerId } } },
               },
             },
           },
-        ],
-      },
+        },
+      ],
     },
   });
 }


### PR DESCRIPTION
## Summary

Lets a **pool** hold a claim on someone's wishlist item, not just an individual. When a pool decides on a gift that came off the recipient's wishlist, that item is marked claimed so nobody else buys the same thing.

Builds on #527 (schema). This is the server module plus the wishlist-facing UI. Pool surfaces (idea-card conflict badges, the picker, the decision confirmation) are a follow-up PR.

## What lands

- **`wishlist-claims.server.ts`** — the only code permitted to write `WishlistClaim`. Owns grant, release, and settlement.
- **`wishlist-claim-disclosure.ts`** — the privacy ladder as a pure function: given a claim and a viewer, what may the viewer be told?
- **`<ClaimDescriptor />`** — one renderer for that ladder across all surfaces, so the rule can't drift between them.
- Wiring into the friend-wishlist and public-share surfaces, plus analytics.

## Design decisions worth knowing

**Claim intent is derived, never stored.** A pool "intends" an item when its status is `DECIDED`/`PURCHASED`/`DELIVERED` and its chosen idea links that item. So cancelling, re-deciding, or deleting the idea invalidates intent automatically — there's no intent table to drift.

**Release and settlement share one transaction.** Splitting them opens a window where the item reads as unclaimed and a third party can grab something a pool is actively buying. There's a prominent comment at the call site saying so; see "not covered by tests" below.

**Conflicts advise, never block.** A pool can always decide on a claimed item; the claim just doesn't transfer. The organizer may know something the app doesn't.

**Only a claimer releases their own claim.** No override exists, deliberately — an override could erase evidence of a purchase that physically happened.

## The privacy ladder

| Viewer | Sees |
|---|---|
| Wishlist owner | **Nothing.** The owner's loader selects no claim data; that absence is the product promise |
| Contributor of the holding pool | Pool named + link |
| Current group member, not in the pool | Group named (no link — see below) |
| Any other signed-in viewer | "Already claimed", no attribution |
| Public-share visitor | "Already claimed", no attribution — **even when signed in** |

That last row is the subtle one. `isAnonymous` is a *surface policy* flag, not a "nobody is logged in" check: a signed-in user can follow someone's public share link, and attribution must still be suppressed. There's a test asserting a viewer who contributes to the very pool holding the claim still gets zero attribution on that page.

## Test plan

Run individually — `npm run validate` as a single command is flaky on this repo, independent of this branch (an `input-otp` post-teardown exception in `verify.dom.test.tsx` trips `run-p` and kills the concurrent e2e before it reports).

- `npm test -- --run` — **234 files / 1545 tests, exit 0**
- `npm run test:e2e:run` — **117 passed, exit 0**, `[WebServer]` lines confirm Playwright started its own server; `.last-run.json` `status: "passed"`
- `npm run typecheck` / `npm run lint` — clean

## Three bugs found by review, worth a look

- `syncPoolClaim` ran unguarded between the committed pool mutation and its notification fanout. A `SQLITE_BUSY` under LiteFS would have 500'd the action with the pool **already `DECIDED`** and no contributor ever notified.
- The group-member tier emitted a `poolLink` that 404s — that route returns 404 to every non-contributor. Link removed; the join affordance arrives with the pool surfaces.
- `wishlist+/status.ts` archive/restore did an **unconditional** `wishlistClaim.deleteMany` — a sibling writer bypassing the module that would destroy a pool's claim on an archive/restore cycle, with no settlement to recover it. Same class as the fix in `cleanupWishlistClaimsForOwner`; this one was missed.

## Not covered by tests

Nothing asserts that settlement stays **inside** the release transaction. A concurrency test was written and validated against a deliberately broken variant (settlement moved out, plus an artificial delay) and detected nothing in 20 attempts — this app's Prisma client uses `connection_limit=1`, which serialises the reads so the window never opens. Rather than ship a test that passes either way, the invariant is documented at the call site. **A future refactor that splits that transaction reopens the race with green CI.**

https://claude.ai/code/session_01TGwCvTjxaDbeuZo8DrX2Qx