### PR TITLE
feat(pools): surface wishlist claim conflicts on the pool page

### DIFF
--- a/app/routes/pools+/$poolId+/__route.server.test.ts
+++ b/app/routes/pools+/$poolId+/__route.server.test.ts
@@ -45,6 +45,8 @@ const queueLogEvent = vi.fn();
 const redirectWithToast = vi.fn();
 const getContextNotificationAwareness = vi.fn();
 const getOrganizerNudgeAvailability = vi.fn();
+const loadClaimStates = vi.fn();
+const loadIdeaClaimConflicts = vi.fn();
 
 vi.mock('#app/utils/auth.server.ts', () => ({
   requireUserId: (...args: Array<unknown>) => requireUserId(...args),
@@ -85,6 +87,17 @@ vi.mock('#app/utils/db.server.ts', () => ({
       findFirst: (...args: Array<unknown>) => wishlistItemFindFirst(...args),
     },
   },
+}));
+
+// The loader resolves wishlist-claim state through these two. They hit Prisma
+// models this file's client mock does not define, so leaving them real makes
+// every loader test throw. Their real behaviour is covered against a live
+// database in app/utils/wishlist-claims.server.test.ts — the same split
+// pool.server.test.ts uses for syncPoolClaim.
+vi.mock('#app/utils/wishlist-claims.server.ts', () => ({
+  loadClaimStates: (...args: Array<unknown>) => loadClaimStates(...args),
+  loadIdeaClaimConflicts: (...args: Array<unknown>) =>
+    loadIdeaClaimConflicts(...args),
 }));
 
 vi.mock('#app/utils/pool.server.ts', () => ({
@@ -250,6 +263,8 @@ beforeEach(() => {
       status: 'AVAILABLE',
     }),
   );
+  loadClaimStates.mockReset().mockResolvedValue(new Map());
+  loadIdeaClaimConflicts.mockReset().mockResolvedValue(new Map());
 });
 
 describe('pool detail route loader', () => {

--- a/app/routes/pools+/$poolId+/__route.server.test.ts
+++ b/app/routes/pools+/$poolId+/__route.server.test.ts
@@ -223,7 +223,9 @@ beforeEach(() => {
   callVote.mockReset().mockResolvedValue(undefined);
   cancelPool.mockReset().mockResolvedValue(undefined);
   castVote.mockReset().mockResolvedValue(undefined);
-  chooseIdea.mockReset().mockResolvedValue({ claimedItemId: null });
+  chooseIdea
+    .mockReset()
+    .mockResolvedValue({ claimedItemId: null, conflictedItemId: null });
   closeVote.mockReset().mockResolvedValue(undefined);
   deleteIdea.mockReset().mockResolvedValue(undefined);
   deletePool.mockReset().mockResolvedValue(undefined);
@@ -1027,7 +1029,10 @@ describe('pool detail route action', () => {
   });
 
   it('threads claimedItemId back through the response so the client can toast', async () => {
-    chooseIdea.mockResolvedValueOnce({ claimedItemId: 'wish-1' });
+    chooseIdea.mockResolvedValueOnce({
+      claimedItemId: 'wish-1',
+      conflictedItemId: null,
+    });
 
     const result = await action(
       toActionArgs({
@@ -1044,6 +1049,34 @@ describe('pool detail route action', () => {
     expect(getRouteResultStatus(result)).toBe(200);
     await expect(getRouteResultData(result)).resolves.toMatchObject({
       claimedItemId: 'wish-1',
+    });
+  });
+
+  it('threads conflictedItemId back through the response so a decision-time conflict is never silent', async () => {
+    // The loader may have rendered this idea as unconflicted — the item can
+    // still be claimed by someone else in the gap before this POST commits.
+    // Without this, the pool moves to DECIDED (unmounting the idea list)
+    // with zero indication anything went wrong.
+    chooseIdea.mockResolvedValueOnce({
+      claimedItemId: null,
+      conflictedItemId: 'wish-1',
+    });
+
+    const result = await action(
+      toActionArgs({
+        context: {} as never,
+        params: { poolId: 'pool-1' },
+        request: createFormRequest({
+          ideaId: 'idea-1',
+          intent: 'choose-idea',
+          poolId: 'pool-1',
+        }),
+      }),
+    );
+
+    expect(getRouteResultStatus(result)).toBe(200);
+    await expect(getRouteResultData(result)).resolves.toMatchObject({
+      conflictedItemId: 'wish-1',
     });
   });
 

--- a/app/routes/pools+/$poolId+/__route.server.test.ts
+++ b/app/routes/pools+/$poolId+/__route.server.test.ts
@@ -210,7 +210,7 @@ beforeEach(() => {
   callVote.mockReset().mockResolvedValue(undefined);
   cancelPool.mockReset().mockResolvedValue(undefined);
   castVote.mockReset().mockResolvedValue(undefined);
-  chooseIdea.mockReset().mockResolvedValue(undefined);
+  chooseIdea.mockReset().mockResolvedValue({ claimedItemId: null });
   closeVote.mockReset().mockResolvedValue(undefined);
   deleteIdea.mockReset().mockResolvedValue(undefined);
   deletePool.mockReset().mockResolvedValue(undefined);
@@ -1009,6 +1009,27 @@ describe('pool detail route action', () => {
       'viewer-1',
       2500,
     );
+  });
+
+  it('threads claimedItemId back through the response so the client can toast', async () => {
+    chooseIdea.mockResolvedValueOnce({ claimedItemId: 'wish-1' });
+
+    const result = await action(
+      toActionArgs({
+        context: {} as never,
+        params: { poolId: 'pool-1' },
+        request: createFormRequest({
+          ideaId: 'idea-1',
+          intent: 'choose-idea',
+          poolId: 'pool-1',
+        }),
+      }),
+    );
+
+    expect(getRouteResultStatus(result)).toBe(200);
+    await expect(getRouteResultData(result)).resolves.toMatchObject({
+      claimedItemId: 'wish-1',
+    });
   });
 
   it('updates the current user contribution in cents', async () => {

--- a/app/routes/pools+/$poolId+/__route.server.ts
+++ b/app/routes/pools+/$poolId+/__route.server.ts
@@ -63,7 +63,11 @@ import {
 import { dollarsToCents } from '#app/utils/price.ts';
 import { getRequestContext } from '#app/utils/request-context.server.ts';
 import { redirectWithToast } from '#app/utils/toast.server.ts';
-import { loadIdeaClaimConflicts } from '#app/utils/wishlist-claims.server.ts';
+import { type ClaimDisclosure } from '#app/utils/wishlist-claim-disclosure.ts';
+import {
+  loadClaimStates,
+  loadIdeaClaimConflicts,
+} from '#app/utils/wishlist-claims.server.ts';
 
 // ─── Loader ───────────────────────────────────────────────────────────────────
 
@@ -149,7 +153,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   // (e.g. via invite code) must not bypass the recipient's privacy setting.
   const ideasOpen =
     pool.status === POOL_STATUS.OPEN || pool.status === POOL_STATUS.VOTING;
-  const recipientWishlistItems =
+  const recipientWishlistItemsBase =
     pool.recipientUserId &&
     ideasOpen &&
     (await canViewWishlistOf(userId, pool.recipientUserId))
@@ -170,6 +174,27 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
           orderBy: [{ categoryId: 'asc' }, { sortOrder: 'asc' }],
         })
       : [];
+
+  // Picker chip (Task 13 part 2): resolved at the 'row' surface, which
+  // resolveClaimDisclosure forces to a fully anonymous "Already claimed"
+  // regardless of viewer relationship — the picker is a compose-time list
+  // and must never name a person, pool, or group. `isOwner: false` is safe
+  // unconditionally here: the recipient is already 404'd out of this loader
+  // above, so every viewer reaching this line is a contributor, never the
+  // owner.
+  const pickerClaimStates: Map<string, ClaimDisclosure> =
+    recipientWishlistItemsBase.length > 0
+      ? await loadClaimStates(
+          recipientWishlistItemsBase.map((item) => item.id),
+          { userId, isOwner: false },
+          'row',
+        )
+      : new Map();
+
+  const recipientWishlistItems = recipientWishlistItemsBase.map((item) => ({
+    ...item,
+    claimDisclosure: pickerClaimStates.get(item.id) ?? null,
+  }));
 
   const organizerReminderKinds: OrganizerNudgeKind[] = [];
   if (canManage && ideasOpen) {

--- a/app/routes/pools+/$poolId+/__route.server.ts
+++ b/app/routes/pools+/$poolId+/__route.server.ts
@@ -63,6 +63,7 @@ import {
 import { dollarsToCents } from '#app/utils/price.ts';
 import { getRequestContext } from '#app/utils/request-context.server.ts';
 import { redirectWithToast } from '#app/utils/toast.server.ts';
+import { loadIdeaClaimConflicts } from '#app/utils/wishlist-claims.server.ts';
 
 // ─── Loader ───────────────────────────────────────────────────────────────────
 
@@ -110,11 +111,20 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     canManage,
   });
 
-  // My vote (if any)
-  const myVote = await prisma.ideaVote.findUnique({
-    where: { poolId_voterId: { poolId, voterId: userId } },
-    select: { ideaId: true },
-  });
+  // My vote (if any). Runs alongside the idea claim-conflict lookup below —
+  // neither depends on the other's result.
+  const [myVote, ideaClaimConflicts] = await Promise.all([
+    prisma.ideaVote.findUnique({
+      where: { poolId_voterId: { poolId, voterId: userId } },
+      select: { ideaId: true },
+    }),
+    // Per-idea claim conflicts (badge surface): flags any proposed idea whose
+    // linked wishlist item is already claimed by someone other than this
+    // pool. Shipped as an array of [ideaId, disclosure] pairs — loader data
+    // round-trips through the client as JSON, and a Map doesn't survive that.
+    loadIdeaClaimConflicts(poolId, userId),
+  ]);
+  const ideaClaimConflictEntries = Array.from(ideaClaimConflicts.entries());
 
   // Contribution breakdown (only meaningful when DECIDED+). Projected per
   // viewer: full rows for the purchaser, own-share-only for everyone else.
@@ -206,6 +216,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     contributionBreakdown,
     inviteUrl,
     recipientWishlistItems,
+    ideaClaimConflicts: ideaClaimConflictEntries,
     organizerReminderStates,
     notificationAwareness: await getContextNotificationAwareness({
       userId,

--- a/app/routes/pools+/$poolId+/__route.server.ts
+++ b/app/routes/pools+/$poolId+/__route.server.ts
@@ -586,16 +586,19 @@ export async function action({ request, params }: ActionFunctionArgs) {
       if (!(await canManagePool(userId, poolForPerms))) {
         throw data({ error: 'Not allowed.' }, { status: 403 });
       }
-      const { claimedItemId } = await chooseIdea(
+      const { claimedItemId, conflictedItemId } = await chooseIdea(
         poolId,
         v.ideaId,
         userId,
         v.finalPriceCents ?? null,
       );
       // Threaded through so the idea card can toast when this decision
-      // silently claimed a previously-free wishlist item — otherwise the
-      // feature is invisible to the person who caused it.
-      return data({ ...submission.reply(), claimedItemId });
+      // silently claimed a previously-free wishlist item, or warn when the
+      // item turned out to already be claimed by someone else at commit
+      // time (e.g. discovered after the loader rendered this idea as
+      // unconflicted) — otherwise either outcome is invisible to the person
+      // who caused it, and the organizer may go buy a duplicate.
+      return data({ ...submission.reply(), claimedItemId, conflictedItemId });
     }
 
     case Intent.UpdateContribution: {

--- a/app/routes/pools+/$poolId+/__route.server.ts
+++ b/app/routes/pools+/$poolId+/__route.server.ts
@@ -586,8 +586,16 @@ export async function action({ request, params }: ActionFunctionArgs) {
       if (!(await canManagePool(userId, poolForPerms))) {
         throw data({ error: 'Not allowed.' }, { status: 403 });
       }
-      await chooseIdea(poolId, v.ideaId, userId, v.finalPriceCents ?? null);
-      return data(submission.reply());
+      const { claimedItemId } = await chooseIdea(
+        poolId,
+        v.ideaId,
+        userId,
+        v.finalPriceCents ?? null,
+      );
+      // Threaded through so the idea card can toast when this decision
+      // silently claimed a previously-free wishlist item — otherwise the
+      // feature is invisible to the person who caused it.
+      return data({ ...submission.reply(), claimedItemId });
     }
 
     case Intent.UpdateContribution: {

--- a/app/routes/pools+/$poolId+/index.test.tsx
+++ b/app/routes/pools+/$poolId+/index.test.tsx
@@ -6,6 +6,7 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { type ClaimDisclosure } from '#app/utils/wishlist-claim-disclosure.ts';
 
 const clipboardWriteText = vi.fn();
 const fetcherState = {
@@ -43,6 +44,7 @@ const loaderDataSnapshot = {
         shortfallCents: number;
         allReceived: boolean;
       },
+  ideaClaimConflicts: [] as Array<[string, ClaimDisclosure]>,
   inviteUrl: 'https://giftpool.app/pools/join/invite-1' as string | null,
   isOrganizer: true,
   myVoteIdeaId: 'idea-1' as string | null,
@@ -151,6 +153,7 @@ const loaderDataSnapshot = {
     url: string | null;
     priceCents: number | null;
     currency: string | null;
+    claimDisclosure: ClaimDisclosure | null;
   }>,
   viewer: {
     contributionCents: 3000,
@@ -219,6 +222,7 @@ describe('app/routes/pools+/$poolId+/index.tsx', () => {
       url: null,
     };
     loaderDataSnapshot.recipientWishlistItems = [];
+    loaderDataSnapshot.ideaClaimConflicts = [];
     loaderDataSnapshot.viewer.userId = 'viewer-1';
 
     vi.stubGlobal('navigator', {
@@ -324,6 +328,7 @@ describe('app/routes/pools+/$poolId+/index.tsx', () => {
         url: 'https://shop.example.com/espresso',
         priceCents: 24999,
         currency: 'USD',
+        claimDisclosure: null,
       },
     ];
 
@@ -570,5 +575,85 @@ describe('app/routes/pools+/$poolId+/index.tsx', () => {
     expect(
       screen.queryByRole('button', { name: 'Mark as delivered' }),
     ).not.toBeInTheDocument();
+  });
+
+  it('renders the conflict badge instead of the "From wishlist" pill when a conflict exists', () => {
+    loaderDataSnapshot.ideaClaimConflicts = [
+      [
+        'idea-1',
+        {
+          show: true,
+          tone: 'warning',
+          text: 'Another group is getting this',
+          name: null,
+          poolLink: null,
+          canJoinPool: false,
+        },
+      ],
+    ];
+
+    renderRoute();
+
+    expect(
+      screen.getByText('Another group is getting this'),
+    ).toBeInTheDocument();
+    expect(screen.queryByText('From wishlist')).not.toBeInTheDocument();
+  });
+
+  it('renders the unmodified "From wishlist" pill when there is no conflict', () => {
+    loaderDataSnapshot.ideaClaimConflicts = [];
+
+    renderRoute();
+
+    expect(screen.getByText('From wishlist')).toBeInTheDocument();
+    expect(
+      screen.queryByText('Another group is getting this'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('marks a claimed picker item as such, keeps it selectable, and discloses no name/pool/link', async () => {
+    loaderDataSnapshot.recipientWishlistItems = [
+      {
+        id: 'wish-9',
+        title: 'Espresso machine',
+        url: 'https://shop.example.com/espresso',
+        priceCents: 24999,
+        currency: 'USD',
+        claimDisclosure: {
+          show: true,
+          tone: 'warning',
+          text: 'Already claimed',
+          name: null,
+          poolLink: null,
+          canJoinPool: false,
+        },
+      },
+    ];
+
+    renderRoute();
+
+    const picker = screen.getByTestId('wishlist-item-picker');
+    await userEvent.click(picker);
+    await screen.findAllByRole('option');
+    const option = screen
+      .getAllByRole('option')
+      .find((el) => el.textContent?.includes('Espresso machine'));
+    expect(option).toBeDefined();
+    expect(option).toHaveTextContent('Already claimed');
+    if (!option) throw new Error('option not found');
+    // Selectable, not disabled — conflicts advise, never block.
+    expect(option).not.toHaveAttribute('aria-disabled', 'true');
+    expect(option).not.toHaveAttribute('data-disabled');
+
+    await userEvent.click(option);
+    expect(
+      document.querySelector<HTMLInputElement>('input[name="wishlistItemId"]')
+        ?.value,
+    ).toBe('wish-9');
+
+    // Negative containment: the picker must never name a person, pool, or
+    // group, and must never carry a link — it's a compose-time list.
+    expect(option).not.toHaveTextContent(/pool/i);
+    expect(option.querySelector('a')).not.toBeInTheDocument();
   });
 });

--- a/app/routes/pools+/$poolId+/index.test.tsx
+++ b/app/routes/pools+/$poolId+/index.test.tsx
@@ -957,7 +957,7 @@ describe('app/routes/pools+/$poolId+/index.tsx', () => {
       renderRoute();
 
       expect(toastSuccess).toHaveBeenCalledWith(
-        'Marked as claimed on their wishlist, so nobody else buys it.',
+        'Marked as claimed on their wishlist.',
       );
     });
 

--- a/app/routes/pools+/$poolId+/index.test.tsx
+++ b/app/routes/pools+/$poolId+/index.test.tsx
@@ -662,6 +662,44 @@ describe('app/routes/pools+/$poolId+/index.tsx', () => {
     // be contacted — there is no notification or keep/release flow yet.
     expect(conflict.textContent?.toLowerCase()).not.toContain('contact');
     expect(conflict.textContent?.toLowerCase()).not.toContain('notif');
+    // Pre-purchase, "check before buying" is still actionable advice.
+    expect(conflict.textContent?.toLowerCase()).toContain('before buying');
+  });
+
+  it('keeps the chosen-gift conflict visible once PURCHASED, without instructing to check before buying', () => {
+    // A returning contributor (or a different assigned deliverer) still
+    // needs to know this pool never held the claim — but by PURCHASED the
+    // purchase has already happened, so "check before buying" would be
+    // stale, already-too-late advice.
+    loaderDataSnapshot.pool.status = 'PURCHASED';
+    loaderDataSnapshot.pool.chosenIdeaId = 'idea-1';
+    loaderDataSnapshot.pool.purchaserId = 'buyer-1';
+    loaderDataSnapshot.viewer.userId = 'deliverer-1';
+    loaderDataSnapshot.ideaClaimConflicts = [
+      [
+        'idea-1',
+        {
+          show: true,
+          tone: 'warning',
+          text: 'Already claimed',
+          name: null,
+          poolLink: null,
+          canJoinPool: false,
+        },
+      ],
+    ];
+
+    renderRoute();
+
+    const conflict = screen.getByTestId('chosen-gift-conflict');
+    expect(conflict).toHaveTextContent('Already claimed');
+    expect(conflict.textContent?.toLowerCase()).not.toContain(
+      'before buying',
+    );
+    // Still communicates the actual risk, just without the stale action.
+    expect(conflict.textContent?.toLowerCase()).toContain(
+      'duplicate purchase',
+    );
   });
 
   it('shows no conflict on the chosen gift when the pool holds its own claim', () => {
@@ -840,7 +878,7 @@ describe('app/routes/pools+/$poolId+/index.tsx', () => {
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     });
 
-    it('carries no attribution when the disclosure withheld a name', async () => {
+    it('carries no attribution when the disclosure withheld a name, and never describes a pool holder as a person', async () => {
       loaderDataSnapshot.ideaClaimConflicts = [
         [
           'idea-1',
@@ -863,11 +901,53 @@ describe('app/routes/pools+/$poolId+/index.tsx', () => {
       await userEvent.click(chooseButton!);
 
       const dialog = await screen.findByRole('dialog', {
-        name: 'Someone else is already getting this one',
+        name: "This one's already claimed",
       });
       expect(dialog).toBeVisible();
+      // Leads with the ladder's own wording for this tier — a pool holder,
+      // not a person.
+      expect(dialog).toHaveTextContent('Another group is getting this');
       // Never reconstruct attribution the disclosure withheld.
       expect(dialog).not.toHaveTextContent(/sarah/i);
+      const dialogText = dialog.textContent?.toLowerCase() ?? '';
+      // Never rewrite a pool holder into a person, and never misattribute
+      // the wishlist — it belongs to the pool's recipient, not the holder.
+      expect(dialogText).not.toContain('someone');
+      expect(dialogText).not.toContain('on their wishlist');
+    });
+
+    it('names the claimer for a solo conflict without misattributing whose wishlist it is', async () => {
+      loaderDataSnapshot.ideaClaimConflicts = [
+        [
+          'idea-1',
+          {
+            show: true,
+            tone: 'warning',
+            text: 'Claimed by Sarah',
+            name: 'Sarah',
+            poolLink: null,
+            canJoinPool: false,
+          },
+        ],
+      ];
+
+      renderRoute();
+
+      const [chooseButton] = screen.getAllByRole('button', {
+        name: 'Choose',
+      });
+      await userEvent.click(chooseButton!);
+
+      const dialog = await screen.findByRole('dialog', {
+        name: "Sarah's already getting this one",
+      });
+      expect(dialog).toBeVisible();
+      expect(dialog).toHaveTextContent('Claimed by Sarah');
+      // The wishlist belongs to the pool's recipient, not to Sarah — never
+      // imply otherwise.
+      expect(dialog.textContent?.toLowerCase()).not.toContain(
+        'on their wishlist',
+      );
     });
 
     it('toasts once a decision actually claims a previously-free wishlist item', () => {

--- a/app/routes/pools+/$poolId+/index.test.tsx
+++ b/app/routes/pools+/$poolId+/index.test.tsx
@@ -11,10 +11,15 @@ import { type ClaimDisclosure } from '#app/utils/wishlist-claim-disclosure.ts';
 const clipboardWriteText = vi.fn();
 const fetcherSubmit = vi.fn();
 const toastSuccess = vi.fn();
+const toastWarning = vi.fn();
 const fetcherState = {
   data: undefined as
     | undefined
-    | { inviteUrl?: string; claimedItemId?: string | null },
+    | {
+        inviteUrl?: string;
+        claimedItemId?: string | null;
+        conflictedItemId?: string | null;
+      },
   formData: undefined as FormData | undefined,
   state: 'idle' as 'idle' | 'loading' | 'submitting',
 };
@@ -22,6 +27,7 @@ const fetcherState = {
 vi.mock('sonner', () => ({
   toast: {
     success: (...args: Array<unknown>) => toastSuccess(...args),
+    warning: (...args: Array<unknown>) => toastWarning(...args),
   },
 }));
 
@@ -200,6 +206,7 @@ describe('app/routes/pools+/$poolId+/index.tsx', () => {
     clipboardWriteText.mockReset().mockResolvedValue(undefined);
     fetcherSubmit.mockReset();
     toastSuccess.mockReset();
+    toastWarning.mockReset();
     fetcherState.data = undefined;
     fetcherState.formData = undefined;
     fetcherState.state = 'idle';
@@ -821,6 +828,60 @@ describe('app/routes/pools+/$poolId+/index.tsx', () => {
 
       expect(toastSuccess).toHaveBeenCalledWith(
         'Marked as claimed on their wishlist, so nobody else buys it.',
+      );
+    });
+
+    it('warns when a conflict is discovered at decision time even though the loader rendered the idea as unconflicted', () => {
+      // The loader saw no conflict, so the idea card submitted with no
+      // confirmation dialog — the pool still lost the claim underneath it,
+      // and the organizer must not be left with silence.
+      loaderDataSnapshot.ideaClaimConflicts = [];
+      fetcherState.data = { claimedItemId: null, conflictedItemId: 'wish-1' };
+
+      renderRoute();
+
+      expect(toastWarning).toHaveBeenCalledTimes(1);
+      const [message] = toastWarning.mock.calls[0] as [string];
+      // Generic on purpose — the action response carries no disclosure
+      // object, so the client must never guess a claimant's identity.
+      expect(message).not.toMatch(/sarah/i);
+      expect(message.toLowerCase()).toContain("didn't get it");
+      expect(toastSuccess).not.toHaveBeenCalled();
+    });
+
+    it('does not claim the claimant will be contacted or notified', async () => {
+      loaderDataSnapshot.ideaClaimConflicts = [
+        [
+          'idea-1',
+          {
+            show: true,
+            tone: 'warning',
+            text: 'Claimed by Sarah',
+            name: 'Sarah',
+            poolLink: null,
+            canJoinPool: false,
+          },
+        ],
+      ];
+
+      renderRoute();
+
+      const [chooseButton] = screen.getAllByRole('button', {
+        name: 'Choose',
+      });
+      await userEvent.click(chooseButton!);
+
+      const dialog = await screen.findByRole('dialog', {
+        name: "Sarah's already getting this one",
+      });
+      const dialogText = dialog.textContent ?? '';
+      // No promise of a Keep/Release follow-up to the claimant — that
+      // feature does not exist yet.
+      expect(dialogText).not.toMatch(/ask (them|if)/i);
+      expect(dialogText).not.toMatch(/let them know/i);
+      expect(dialogText).not.toMatch(/we'll/i);
+      expect(dialogText).toContain(
+        "your pool won't hold the claim — so there's a real risk you both end up buying it.",
       );
     });
   });

--- a/app/routes/pools+/$poolId+/index.test.tsx
+++ b/app/routes/pools+/$poolId+/index.test.tsx
@@ -9,11 +9,21 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { type ClaimDisclosure } from '#app/utils/wishlist-claim-disclosure.ts';
 
 const clipboardWriteText = vi.fn();
+const fetcherSubmit = vi.fn();
+const toastSuccess = vi.fn();
 const fetcherState = {
-  data: undefined as undefined | { inviteUrl?: string },
+  data: undefined as
+    | undefined
+    | { inviteUrl?: string; claimedItemId?: string | null },
   formData: undefined as FormData | undefined,
   state: 'idle' as 'idle' | 'loading' | 'submitting',
 };
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: (...args: Array<unknown>) => toastSuccess(...args),
+  },
+}));
 
 type UserImageFixture = { id: string; altText: string | null } | null;
 
@@ -176,7 +186,7 @@ vi.mock('react-router', async () => {
       data: fetcherState.data,
       formData: fetcherState.formData,
       state: fetcherState.state,
-      submit: vi.fn(),
+      submit: fetcherSubmit,
     }),
     useNavigation: () => ({ state: 'idle' }),
     useRouteLoaderData: () => loaderDataSnapshot,
@@ -188,6 +198,8 @@ import PoolIndex from './index.tsx';
 describe('app/routes/pools+/$poolId+/index.tsx', () => {
   beforeEach(() => {
     clipboardWriteText.mockReset().mockResolvedValue(undefined);
+    fetcherSubmit.mockReset();
+    toastSuccess.mockReset();
     fetcherState.data = undefined;
     fetcherState.formData = undefined;
     fetcherState.state = 'idle';
@@ -655,5 +667,161 @@ describe('app/routes/pools+/$poolId+/index.tsx', () => {
     // group, and must never carry a link — it's a compose-time list.
     expect(option).not.toHaveTextContent(/pool/i);
     expect(option.querySelector('a')).not.toBeInTheDocument();
+  });
+
+  describe('conflicted-decision confirmation', () => {
+    it('opens a confirmation dialog instead of submitting when the idea has a claim conflict', async () => {
+      loaderDataSnapshot.ideaClaimConflicts = [
+        [
+          'idea-1',
+          {
+            show: true,
+            tone: 'warning',
+            text: 'Claimed by Sarah',
+            name: 'Sarah',
+            poolLink: null,
+            canJoinPool: false,
+          },
+        ],
+      ];
+
+      renderRoute();
+
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      const [chooseButton] = screen.getAllByRole('button', {
+        name: 'Choose',
+      });
+      await userEvent.click(chooseButton!);
+
+      expect(
+        await screen.findByRole('dialog', {
+          name: "Sarah's already getting this one",
+        }),
+      ).toBeVisible();
+      // A single click never submits when the idea is conflicted.
+      expect(fetcherSubmit).not.toHaveBeenCalled();
+    });
+
+    it('submits immediately with no dialog for an unconflicted idea', async () => {
+      loaderDataSnapshot.ideaClaimConflicts = [];
+
+      renderRoute();
+
+      const [chooseButton] = screen.getAllByRole('button', {
+        name: 'Choose',
+      });
+      // Unconflicted ideas render as a plain submit button inside a form —
+      // a single click submits natively, with no JS gate and no dialog
+      // anywhere in the tree. (jsdom doesn't implement real form
+      // submission, so this is asserted structurally rather than by
+      // clicking — clicking would just hit jsdom's unimplemented
+      // requestSubmit, not exercise anything this feature owns.)
+      expect(chooseButton).toHaveAttribute('type', 'submit');
+      expect(chooseButton!.closest('form')).not.toBeNull();
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
+    it('confirming proceeds with the decision', async () => {
+      loaderDataSnapshot.ideaClaimConflicts = [
+        [
+          'idea-1',
+          {
+            show: true,
+            tone: 'warning',
+            text: 'Claimed by Sarah',
+            name: 'Sarah',
+            poolLink: null,
+            canJoinPool: false,
+          },
+        ],
+      ];
+
+      renderRoute();
+
+      const [chooseButton] = screen.getAllByRole('button', {
+        name: 'Choose',
+      });
+      await userEvent.click(chooseButton!);
+      await userEvent.click(
+        await screen.findByRole('button', { name: 'Choose it anyway' }),
+      );
+
+      expect(fetcherSubmit).toHaveBeenCalledTimes(1);
+      const [submittedFormData] = fetcherSubmit.mock.calls[0] as [FormData];
+      expect(submittedFormData.get('intent')).toBe('choose-idea');
+      expect(submittedFormData.get('poolId')).toBe('pool-1');
+      expect(submittedFormData.get('ideaId')).toBe('idea-1');
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
+    it('dismissing does not submit', async () => {
+      loaderDataSnapshot.ideaClaimConflicts = [
+        [
+          'idea-1',
+          {
+            show: true,
+            tone: 'warning',
+            text: 'Claimed by Sarah',
+            name: 'Sarah',
+            poolLink: null,
+            canJoinPool: false,
+          },
+        ],
+      ];
+
+      renderRoute();
+
+      const [chooseButton] = screen.getAllByRole('button', {
+        name: 'Choose',
+      });
+      await userEvent.click(chooseButton!);
+      await userEvent.click(
+        await screen.findByRole('button', { name: 'Keep looking' }),
+      );
+
+      expect(fetcherSubmit).not.toHaveBeenCalled();
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
+    it('carries no attribution when the disclosure withheld a name', async () => {
+      loaderDataSnapshot.ideaClaimConflicts = [
+        [
+          'idea-1',
+          {
+            show: true,
+            tone: 'warning',
+            text: 'Another group is getting this',
+            name: null,
+            poolLink: null,
+            canJoinPool: false,
+          },
+        ],
+      ];
+
+      renderRoute();
+
+      const [chooseButton] = screen.getAllByRole('button', {
+        name: 'Choose',
+      });
+      await userEvent.click(chooseButton!);
+
+      const dialog = await screen.findByRole('dialog', {
+        name: 'Someone else is already getting this one',
+      });
+      expect(dialog).toBeVisible();
+      // Never reconstruct attribution the disclosure withheld.
+      expect(dialog).not.toHaveTextContent(/sarah/i);
+    });
+
+    it('toasts once a decision actually claims a previously-free wishlist item', () => {
+      loaderDataSnapshot.ideaClaimConflicts = [];
+      fetcherState.data = { claimedItemId: 'wish-1' };
+
+      renderRoute();
+
+      expect(toastSuccess).toHaveBeenCalledWith(
+        'Marked as claimed on their wishlist, so nobody else buys it.',
+      );
+    });
   });
 });

--- a/app/routes/pools+/$poolId+/index.test.tsx
+++ b/app/routes/pools+/$poolId+/index.test.tsx
@@ -630,6 +630,56 @@ describe('app/routes/pools+/$poolId+/index.tsx', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('shows the conflict on the chosen gift for a decided pool that does not hold the claim — from loader data, not a toast', () => {
+    // No fetcher submission happened in this render at all (fetcherState.data
+    // stays undefined) — the viewer is someone who reloaded the page or never
+    // submitted the decision themselves, so the toast effect never fires.
+    // The only way this warning can reach them is loader-driven.
+    loaderDataSnapshot.pool.status = 'DECIDED';
+    loaderDataSnapshot.pool.chosenIdeaId = 'idea-1';
+    loaderDataSnapshot.pool.purchaserId = 'buyer-1';
+    loaderDataSnapshot.viewer.userId = 'deliverer-1';
+    loaderDataSnapshot.ideaClaimConflicts = [
+      [
+        'idea-1',
+        {
+          show: true,
+          tone: 'warning',
+          text: 'Already claimed',
+          name: null,
+          poolLink: null,
+          canJoinPool: false,
+        },
+      ],
+    ];
+
+    renderRoute();
+
+    expect(toastWarning).not.toHaveBeenCalled();
+    const conflict = screen.getByTestId('chosen-gift-conflict');
+    expect(conflict).toHaveTextContent('Already claimed');
+    // Honest about today's behavior: it must never promise the claimant will
+    // be contacted — there is no notification or keep/release flow yet.
+    expect(conflict.textContent?.toLowerCase()).not.toContain('contact');
+    expect(conflict.textContent?.toLowerCase()).not.toContain('notif');
+  });
+
+  it('shows no conflict on the chosen gift when the pool holds its own claim', () => {
+    loaderDataSnapshot.pool.status = 'DECIDED';
+    loaderDataSnapshot.pool.chosenIdeaId = 'idea-1';
+    loaderDataSnapshot.pool.purchaserId = 'buyer-1';
+    // A chosen idea absent from ideaClaimConflicts means this pool holds the
+    // claim (loadIdeaClaimConflicts excludes exactly that case) — the normal,
+    // non-conflicted state, which must render nothing.
+    loaderDataSnapshot.ideaClaimConflicts = [];
+
+    renderRoute();
+
+    expect(
+      screen.queryByTestId('chosen-gift-conflict'),
+    ).not.toBeInTheDocument();
+  });
+
   it('marks a claimed picker item as such, keeps it selectable, and discloses no name/pool/link', async () => {
     loaderDataSnapshot.recipientWishlistItems = [
       {

--- a/app/routes/pools+/$poolId+/index.tsx
+++ b/app/routes/pools+/$poolId+/index.tsx
@@ -1132,19 +1132,23 @@ const PoolIndex = () => {
   const chooseFetcher = useFetcher({ key: CHOOSE_IDEA_FETCHER_KEY });
   useEffect(() => {
     if (chooseFetcher.data?.claimedItemId) {
-      toast.success(
-        'Marked as claimed on their wishlist, so nobody else buys it.',
-      );
+      // States the claim, does not guarantee an outcome: another pool that
+      // already intends this item can still proceed via "Choose it anyway",
+      // so promising nobody else buys it would be false by construction.
+      toast.success('Marked as claimed on their wishlist.');
     } else if (chooseFetcher.data?.conflictedItemId) {
       // Covers both the case where the idea card already warned about a
       // conflict, and the case where the item was claimed by someone else
       // in the gap between the loader render and this POST — the loader
       // showed it as free, so a silent success here would send the
       // organizer off to buy a duplicate with no indication anything went
-      // wrong. Generic on purpose: the action has no disclosure object here,
-      // so the client must never guess who holds the claim.
+      // wrong. Entity-neutral on purpose: the action has no disclosure object
+      // here, so the client knows neither who holds the claim nor whether the
+      // holder is a person or another pool. "Someone else"/"you both" would
+      // assert a person, reintroducing the holder-type error fixed in the
+      // dialog above.
       toast.warning(
-        "Someone else already claimed this — your pool didn't get it, so there's a real risk you both buy it.",
+        "This item is already claimed — your pool didn't get it, so there's a real risk of a duplicate purchase.",
       );
     }
   }, [chooseFetcher.data]);

--- a/app/routes/pools+/$poolId+/index.tsx
+++ b/app/routes/pools+/$poolId+/index.tsx
@@ -567,7 +567,7 @@ const ChosenGiftBanner = ({
   poolId,
   canManage,
   conflict,
-  purchaseCompleted,
+  buyingAdviceStale,
 }: {
   idea: Idea;
   finalPriceCents: number | null;
@@ -578,7 +578,7 @@ const ChosenGiftBanner = ({
   // still actionable (PURCHASED or DELIVERED) — the banner stays mounted at
   // every stage (see comment below), so the instruction has to match what's
   // actually still ahead of the viewer.
-  purchaseCompleted: boolean;
+  buyingAdviceStale: boolean;
 }) => {
   const fetcher = useFetcher();
 
@@ -622,10 +622,13 @@ const ChosenGiftBanner = ({
           >
             <ClaimDescriptor disclosure={conflict} variant="badge" />
             <Text size="xs" className="text-warning">
-              {purchaseCompleted
-                ? // Purchase has already happened by this stage — "check
-                  // before buying" would be stale advice. State the risk
-                  // without pointing at an action that's already past.
+              {buyingAdviceStale
+                ? // Buying is either already done (PURCHASED/DELIVERED) or can
+                  // no longer happen through this pool (CANCELLED), so "check
+                  // before buying" points at an action that isn't available.
+                  // The duplicate risk is still worth stating: a cancelled
+                  // pool's released claim may have transferred elsewhere, and
+                  // contributors may already have bought.
                   'This pool didn’t hold the claim on this item, so there’s a real risk of a duplicate purchase. Worth checking with the group if it hasn’t come up already.'
                 : 'This pool doesn’t hold the claim on this item, so there’s a real risk of a duplicate purchase. Check with the group before buying.'}
             </Text>
@@ -1163,7 +1166,9 @@ const PoolIndex = () => {
       poolId={pool.id}
       canManage={canManage}
       conflict={ideaConflicts.get(chosenIdea.id) ?? null}
-      purchaseCompleted={isPurchased || isDelivered}
+      buyingAdviceStale={
+        isPurchased || isDelivered || status === POOL_STATUS.CANCELLED
+      }
     />
   ) : null;
 

--- a/app/routes/pools+/$poolId+/index.tsx
+++ b/app/routes/pools+/$poolId+/index.tsx
@@ -338,12 +338,15 @@ const IdeaCard = ({
                       <DialogTitle>
                         {conflict.name
                           ? `${conflict.name}'s already getting this one`
-                          : 'Someone else is already getting this one'}
+                          : "This one's already claimed"}
                       </DialogTitle>
+                      {/* Lead with disclosure.text verbatim — it's already
+                          worded correctly for this viewer's tier (person,
+                          withheld person, or another pool) — then append the
+                          honest consequence instead of rewriting who holds
+                          the claim or whose wishlist it's on. */}
                       <DialogDescription>
-                        {conflict.name
-                          ? `${conflict.name} already claimed ${idea.name} on their wishlist. If you choose it anyway, your pool won't hold the claim — so there's a real risk you both end up buying it.`
-                          : `Someone already claimed ${idea.name} on their wishlist. If you choose it anyway, your pool won't hold the claim — so there's a real risk you both end up buying it.`}
+                        {`${conflict.text}. If you choose it anyway, your pool won't hold the claim — so there's a real risk you both end up buying it.`}
                       </DialogDescription>
                     </DialogHeader>
                     <DialogFooter>
@@ -564,12 +567,18 @@ const ChosenGiftBanner = ({
   poolId,
   canManage,
   conflict,
+  purchaseCompleted,
 }: {
   idea: Idea;
   finalPriceCents: number | null;
   poolId: string;
   canManage: boolean;
   conflict: ClaimDisclosure | null;
+  // True once this pool has passed the point where "check before buying" is
+  // still actionable (PURCHASED or DELIVERED) — the banner stays mounted at
+  // every stage (see comment below), so the instruction has to match what's
+  // actually still ahead of the viewer.
+  purchaseCompleted: boolean;
 }) => {
   const fetcher = useFetcher();
 
@@ -613,9 +622,12 @@ const ChosenGiftBanner = ({
           >
             <ClaimDescriptor disclosure={conflict} variant="badge" />
             <Text size="xs" className="text-warning">
-              This pool doesn&rsquo;t hold the claim on this item, so
-              there&rsquo;s a real risk of a duplicate purchase. Check with the
-              group before buying.
+              {purchaseCompleted
+                ? // Purchase has already happened by this stage — "check
+                  // before buying" would be stale advice. State the risk
+                  // without pointing at an action that's already past.
+                  'This pool didn’t hold the claim on this item, so there’s a real risk of a duplicate purchase. Worth checking with the group if it hasn’t come up already.'
+                : 'This pool doesn’t hold the claim on this item, so there’s a real risk of a duplicate purchase. Check with the group before buying.'}
             </Text>
           </div>
         )}
@@ -1147,6 +1159,7 @@ const PoolIndex = () => {
       poolId={pool.id}
       canManage={canManage}
       conflict={ideaConflicts.get(chosenIdea.id) ?? null}
+      purchaseCompleted={isPurchased || isDelivered}
     />
   ) : null;
 

--- a/app/routes/pools+/$poolId+/index.tsx
+++ b/app/routes/pools+/$poolId+/index.tsx
@@ -3,7 +3,7 @@
 // in a child route submit to that child's action, not the parent's.
 export { action } from './__route.server';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { getFormProps, getInputProps, useForm } from '@conform-to/react';
 import { parseWithZod } from '@conform-to/zod';
 import {
@@ -38,12 +38,14 @@ import {
 import { SystemLabel } from '#app/components/ui/system-label.tsx';
 import { Textarea } from '#app/components/ui/textarea.tsx';
 import { Flex, Stack, Text } from '#app/components/ui-kit';
+import { ClaimDescriptor } from '#app/components/wishlist/claim-descriptor.tsx';
 import { formatCents } from '#app/utils/pool-contributions.ts';
 import {
   DECISION_MODE,
   POOL_STATUS,
   type PoolStatus,
 } from '#app/utils/pool-constants.ts';
+import { type ClaimDisclosure } from '#app/utils/wishlist-claim-disclosure.ts';
 import { type loader as routeLoader } from './__route.server';
 
 type LoaderData = Awaited<ReturnType<typeof routeLoader>>;
@@ -144,6 +146,7 @@ const IdeaCard = ({
   canManage,
   canDelete,
   canChoose,
+  conflict,
 }: {
   idea: Idea;
   poolId: string;
@@ -152,6 +155,7 @@ const IdeaCard = ({
   canManage: boolean;
   canDelete: boolean;
   canChoose: boolean;
+  conflict: ClaimDisclosure | null;
 }) => {
   const voteFetcher = useFetcher();
   const chooseFetcher = useFetcher();
@@ -224,11 +228,14 @@ const IdeaCard = ({
                 <LuLink size={11} /> View link
               </a>
             )}
-            {idea.wishlistItem && (
-              <span className="inline-flex items-center rounded-full border border-pool/30 bg-pool/15 px-2.5 py-0.5 text-xs font-medium text-pool">
-                From wishlist
-              </span>
-            )}
+            {idea.wishlistItem &&
+              (conflict ? (
+                <ClaimDescriptor disclosure={conflict} variant="badge" />
+              ) : (
+                <span className="inline-flex items-center rounded-full border border-pool/30 bg-pool/15 px-2.5 py-0.5 text-xs font-medium text-pool">
+                  From wishlist
+                </span>
+              ))}
           </div>
         </div>
       </div>
@@ -410,6 +417,13 @@ const ProposeIdeaForm = ({
                     {item.priceCents == null
                       ? ''
                       : ` — ${formatCents(item.priceCents, item.currency ?? 'USD')}`}
+                    {item.claimDisclosure?.show ? (
+                      <ClaimDescriptor
+                        disclosure={item.claimDisclosure}
+                        variant="row"
+                        className="ml-2"
+                      />
+                    ) : null}
                   </SelectItem>
                 ))}
               </SelectContent>
@@ -971,7 +985,15 @@ const PoolIndex = () => {
     contributionBreakdown,
     recipientWishlistItems,
     organizerReminderStates,
+    ideaClaimConflicts,
   } = useRouteLoaderData<typeof routeLoader>('routes/pools+/$poolId+/_layout')!;
+
+  // Loader data round-trips through JSON, so the Map is shipped as entry
+  // pairs — rebuild it once per render rather than re-deriving per card.
+  const ideaConflicts = useMemo(
+    () => new Map(ideaClaimConflicts),
+    [ideaClaimConflicts],
+  );
 
   const status = pool.status as PoolStatus;
   const isOpen = status === POOL_STATUS.OPEN;
@@ -1254,6 +1276,7 @@ const PoolIndex = () => {
                   canChoose={
                     canManage && (isOpen || isVoting) && !pool.chosenIdeaId
                   }
+                  conflict={ideaConflicts.get(idea.id) ?? null}
                 />
               ))}
             </Stack>

--- a/app/routes/pools+/$poolId+/index.tsx
+++ b/app/routes/pools+/$poolId+/index.tsx
@@ -21,6 +21,7 @@ import {
   useNavigation,
   useRouteLoaderData,
 } from 'react-router';
+import { toast } from 'sonner';
 import { z } from 'zod';
 import { OrganizerReminderAction } from '#app/components/pools/organizer-reminder-action.tsx';
 import { Avatar } from '#app/components/ui/avatar.tsx';
@@ -28,6 +29,14 @@ import { Badge } from '#app/components/ui/badge.tsx';
 import { Button } from '#app/components/ui/button.tsx';
 import { Card } from '#app/components/ui/card.tsx';
 import { Input } from '#app/components/ui/input.tsx';
+import {
+  ResponsiveDialog as Dialog,
+  ResponsiveDialogContent as DialogContent,
+  ResponsiveDialogDescription as DialogDescription,
+  ResponsiveDialogFooter as DialogFooter,
+  ResponsiveDialogHeader as DialogHeader,
+  ResponsiveDialogTitle as DialogTitle,
+} from '#app/components/ui/responsive-dialog.tsx';
 import {
   Select,
   SelectContent,
@@ -52,6 +61,15 @@ type LoaderData = Awaited<ReturnType<typeof routeLoader>>;
 type Pool = LoaderData['pool'];
 type Idea = Pool['ideas'][number];
 type Contributor = Pool['contributors'][number];
+
+// Shared fetcher key for "choose this idea" across every IdeaCard AND the
+// page-level toast effect. Choosing an idea moves the pool out of the
+// active (OPEN/VOTING) status, which unmounts the whole ideas section —
+// including whichever IdeaCard submitted — in the same render the action
+// response lands. A component-local useEffect on that submission would
+// never fire. Keying the fetcher lets the always-mounted PoolIndex read the
+// same fetcher's `.data` to fire the "claimed on their wishlist" toast.
+const CHOOSE_IDEA_FETCHER_KEY = 'pool-choose-idea';
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -158,13 +176,26 @@ const IdeaCard = ({
   conflict: ClaimDisclosure | null;
 }) => {
   const voteFetcher = useFetcher();
-  const chooseFetcher = useFetcher();
+  const chooseFetcher = useFetcher({ key: CHOOSE_IDEA_FETCHER_KEY });
   const deleteFetcher = useFetcher();
+  const [confirmOpen, setConfirmOpen] = useState(false);
 
   const hasMyVote = myVoteIdeaId === idea.id;
   const isChoosingThis =
     chooseFetcher.state !== 'idle' &&
     (chooseFetcher.formData?.get('ideaId') as string) === idea.id;
+
+  // Every unconflicted idea stays a single instant click (D12) — only a
+  // conflicted idea interrupts with a confirmation, since the organizer may
+  // legitimately know something the app doesn't.
+  const submitChoose = () => {
+    const formData = new FormData();
+    formData.set('intent', 'choose-idea');
+    formData.set('poolId', poolId);
+    formData.set('ideaId', idea.id);
+    void chooseFetcher.submit(formData, { method: 'post' });
+    setConfirmOpen(false);
+  };
 
   const wishlistItem = idea.wishlistItem;
   // Routed through the pool-scoped image resource, not
@@ -284,24 +315,73 @@ const IdeaCard = ({
             </voteFetcher.Form>
           )}
 
-          {/* Choose this — outline so it doesn't shout on every card */}
-          {canChoose && (
-            <chooseFetcher.Form method="post">
-              <input type="hidden" name="intent" value="choose-idea" />
-              <input type="hidden" name="poolId" value={poolId} />
-              <input type="hidden" name="ideaId" value={idea.id} />
-              <Button
-                type="submit"
-                size="sm"
-                variant="outline"
-                className="h-7 gap-1.5 text-xs"
-                disabled={isChoosingThis}
-              >
-                <LuCheck size={12} />
-                {isChoosingThis ? 'Choosing…' : 'Choose'}
-              </Button>
-            </chooseFetcher.Form>
-          )}
+          {/* Choose this — outline so it doesn't shout on every card.
+              Unconflicted ideas stay a single instant click (D12); a
+              conflicted idea opens a confirmation instead of submitting. */}
+          {canChoose &&
+            (conflict ? (
+              <>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  className="h-7 gap-1.5 text-xs"
+                  disabled={isChoosingThis}
+                  onClick={() => setConfirmOpen(true)}
+                >
+                  <LuCheck size={12} />
+                  {isChoosingThis ? 'Choosing…' : 'Choose'}
+                </Button>
+                <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+                  <DialogContent>
+                    <DialogHeader>
+                      <DialogTitle>
+                        {conflict.name
+                          ? `${conflict.name}'s already getting this one`
+                          : 'Someone else is already getting this one'}
+                      </DialogTitle>
+                      <DialogDescription>
+                        {conflict.name
+                          ? `${conflict.name} claimed ${idea.name} on their wishlist. Decide on it anyway and we'll ask if they're still getting it themselves — so you won't both buy it.`
+                          : `Someone has already claimed ${idea.name}. Decide on it anyway and we'll ask if they're still getting it themselves — so you won't both buy it.`}
+                      </DialogDescription>
+                    </DialogHeader>
+                    <DialogFooter>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        onClick={() => setConfirmOpen(false)}
+                      >
+                        Keep looking
+                      </Button>
+                      <Button
+                        type="button"
+                        className="bg-warning text-warning-foreground hover:bg-warning/90"
+                        onClick={submitChoose}
+                      >
+                        Choose it anyway
+                      </Button>
+                    </DialogFooter>
+                  </DialogContent>
+                </Dialog>
+              </>
+            ) : (
+              <chooseFetcher.Form method="post">
+                <input type="hidden" name="intent" value="choose-idea" />
+                <input type="hidden" name="poolId" value={poolId} />
+                <input type="hidden" name="ideaId" value={idea.id} />
+                <Button
+                  type="submit"
+                  size="sm"
+                  variant="outline"
+                  className="h-7 gap-1.5 text-xs"
+                  disabled={isChoosingThis}
+                >
+                  <LuCheck size={12} />
+                  {isChoosingThis ? 'Choosing…' : 'Choose'}
+                </Button>
+              </chooseFetcher.Form>
+            ))}
 
           {/* Remove — in the footer, separated from title */}
           {deleteFetcher.state === 'idle' && canDelete && (
@@ -1010,6 +1090,20 @@ const PoolIndex = () => {
     viewer?.user.name ?? viewer?.user.username ?? 'A pool manager';
 
   const navigation = useNavigation();
+
+  // Hoisted here (not in IdeaCard) because choosing an idea moves the pool
+  // out of the active status, unmounting the whole ideas section in the
+  // same render the action response lands — a component-local effect on
+  // the submitting IdeaCard would never fire. PoolIndex never unmounts, and
+  // the shared CHOOSE_IDEA_FETCHER_KEY lets it observe the same submission.
+  const chooseFetcher = useFetcher({ key: CHOOSE_IDEA_FETCHER_KEY });
+  useEffect(() => {
+    if (chooseFetcher.data?.claimedItemId) {
+      toast.success(
+        'Marked as claimed on their wishlist, so nobody else buys it.',
+      );
+    }
+  }, [chooseFetcher.data]);
 
   // ── Stage-adaptive composition (§6.5): the shell is stable, the main
   // column changes by stage. In Complete, factual memory dominates and the

--- a/app/routes/pools+/$poolId+/index.tsx
+++ b/app/routes/pools+/$poolId+/index.tsx
@@ -563,11 +563,13 @@ const ChosenGiftBanner = ({
   finalPriceCents,
   poolId,
   canManage,
+  conflict,
 }: {
   idea: Idea;
   finalPriceCents: number | null;
   poolId: string;
   canManage: boolean;
+  conflict: ClaimDisclosure | null;
 }) => {
   const fetcher = useFetcher();
 
@@ -598,6 +600,25 @@ const ChosenGiftBanner = ({
             </a>
           )}
         </Stack>
+        {/* Conflict disclosure: stays mounted for as long as the pool has
+            decided on an item it doesn't hold the claim on — unlike the
+            idea-card badge, which unmounts the instant the pool leaves
+            OPEN/VOTING. This is the only surface a returning viewer or a
+            different assigned purchaser ever sees the warning on, since the
+            choose-idea toast only reaches the browser that submitted it. */}
+        {conflict && (
+          <div
+            className="flex flex-col gap-1.5 rounded-lg border border-warning/30 bg-warning-muted p-3"
+            data-testid="chosen-gift-conflict"
+          >
+            <ClaimDescriptor disclosure={conflict} variant="badge" />
+            <Text size="xs" className="text-warning">
+              This pool doesn&rsquo;t hold the claim on this item, so
+              there&rsquo;s a real risk of a duplicate purchase. Check with the
+              group before buying.
+            </Text>
+          </div>
+        )}
         {/* Final price: display + optional inline editor for managers */}
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div>
@@ -1125,6 +1146,7 @@ const PoolIndex = () => {
       finalPriceCents={pool.finalPriceCents}
       poolId={pool.id}
       canManage={canManage}
+      conflict={ideaConflicts.get(chosenIdea.id) ?? null}
     />
   ) : null;
 

--- a/app/routes/pools+/$poolId+/index.tsx
+++ b/app/routes/pools+/$poolId+/index.tsx
@@ -342,8 +342,8 @@ const IdeaCard = ({
                       </DialogTitle>
                       <DialogDescription>
                         {conflict.name
-                          ? `${conflict.name} claimed ${idea.name} on their wishlist. Decide on it anyway and we'll ask if they're still getting it themselves — so you won't both buy it.`
-                          : `Someone has already claimed ${idea.name}. Decide on it anyway and we'll ask if they're still getting it themselves — so you won't both buy it.`}
+                          ? `${conflict.name} already claimed ${idea.name} on their wishlist. If you choose it anyway, your pool won't hold the claim — so there's a real risk you both end up buying it.`
+                          : `Someone already claimed ${idea.name} on their wishlist. If you choose it anyway, your pool won't hold the claim — so there's a real risk you both end up buying it.`}
                       </DialogDescription>
                     </DialogHeader>
                     <DialogFooter>
@@ -1101,6 +1101,17 @@ const PoolIndex = () => {
     if (chooseFetcher.data?.claimedItemId) {
       toast.success(
         'Marked as claimed on their wishlist, so nobody else buys it.',
+      );
+    } else if (chooseFetcher.data?.conflictedItemId) {
+      // Covers both the case where the idea card already warned about a
+      // conflict, and the case where the item was claimed by someone else
+      // in the gap between the loader render and this POST — the loader
+      // showed it as free, so a silent success here would send the
+      // organizer off to buy a duplicate with no indication anything went
+      // wrong. Generic on purpose: the action has no disclosure object here,
+      // so the client must never guess who holds the claim.
+      toast.warning(
+        "Someone else already claimed this — your pool didn't get it, so there's a real risk you both buy it.",
       );
     }
   }, [chooseFetcher.data]);

--- a/app/routes/pools+/$poolId+/settings.test.tsx
+++ b/app/routes/pools+/$poolId+/settings.test.tsx
@@ -151,6 +151,22 @@ describe('app/routes/pools+/$poolId+/settings.tsx', () => {
     ).toBeInTheDocument();
   });
 
+  it('describes cancellation as releasing this pool\'s claim, never promising the item ends up unclaimed', async () => {
+    // syncPoolClaimInTx settles a released claim onto the longest-waiting
+    // pool immediately when one exists, so "will be unclaimed" is false in
+    // exactly the case where it matters most. The confirmation must describe
+    // releasing our claim, not the item's resulting state, and must hold for
+    // OPEN/VOTING pools that hold no claim at all too.
+    renderRoute();
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel pool' }));
+
+    const description = await screen.findByText(/release/i);
+    expect(description.textContent).not.toMatch(/will be unclaimed/i);
+    expect(description.textContent?.toLowerCase()).toContain(
+      'may transfer',
+    );
+  });
+
   it('selects and sends eligible people from the responsive picker', async () => {
     const candidate = invitationPerson('naomi', 'Naomi');
     loaderDataSnapshot.invitationState.candidates = [

--- a/app/routes/pools+/$poolId+/settings.tsx
+++ b/app/routes/pools+/$poolId+/settings.tsx
@@ -705,7 +705,7 @@ const DangerZone = ({
 					{canCancel && (
 						<ConfirmDialog
 							title="Cancel this pool?"
-							description="Contributors will no longer be able to act on it. This can't be undone."
+							description="Contributors will no longer be able to act on it, and the wishlist item will be unclaimed. This can't be undone."
 							confirmText="Cancel pool"
 							onConfirm={() => submitIntent(cancelFetcher, 'cancel-pool')}
 						>

--- a/app/routes/pools+/$poolId+/settings.tsx
+++ b/app/routes/pools+/$poolId+/settings.tsx
@@ -705,7 +705,7 @@ const DangerZone = ({
 					{canCancel && (
 						<ConfirmDialog
 							title="Cancel this pool?"
-							description="Contributors will no longer be able to act on it, and the wishlist item will be unclaimed. This can't be undone."
+							description="Contributors will no longer be able to act on it. Any claim this pool holds on the wishlist item is released, and may transfer immediately to another pool waiting on the same item. This can't be undone."
 							confirmText="Cancel pool"
 							onConfirm={() => submitIntent(cancelFetcher, 'cancel-pool')}
 						>

--- a/app/utils/pool.server.test.ts
+++ b/app/utils/pool.server.test.ts
@@ -611,6 +611,23 @@ describe('pool server utilities', () => {
     });
   });
 
+  it('threads conflictedItemId back so a decision-time conflict is not silent', async () => {
+    giftIdeaFindFirst.mockResolvedValue({
+      estimatedPriceCents: 8000,
+      name: 'Speaker',
+    });
+    syncPoolClaimInTx.mockResolvedValueOnce({
+      claimedItemId: null,
+      conflictedItemId: 'wish-9',
+      released: [],
+    });
+
+    await expect(chooseIdea('pool-1', 'idea-1', 'user-1')).resolves.toEqual({
+      claimedItemId: null,
+      conflictedItemId: 'wish-9',
+    });
+  });
+
   it('propagates a claim-sync failure and skips every post-decision side effect', async () => {
     // The decision (`updateMany`) and the claim sync now commit in the same
     // `$transaction` — a rejection from the sync must abort the whole thing,

--- a/app/utils/pool.server.ts
+++ b/app/utils/pool.server.ts
@@ -574,7 +574,7 @@ export async function chooseIdea(
 	ideaId: string,
 	actorId: string,
 	finalPriceCents?: number | null,
-): Promise<{ claimedItemId: string | null }> {
+): Promise<{ claimedItemId: string | null; conflictedItemId: string | null }> {
 	const idea = await prisma.giftIdea.findFirst({
 		where: { id: ideaId, poolId },
 		select: { estimatedPriceCents: true, name: true },
@@ -621,7 +621,7 @@ export async function chooseIdea(
 
 		return syncPoolClaimInTx(tx, poolId)
 	})
-	if (claimSync === null) return { claimedItemId: null }
+	if (claimSync === null) return { claimedItemId: null, conflictedItemId: null }
 
 	// logPoolActivity, queueLogEvent, and queuePoolActivityNotifications all
 	// run after the transaction closes: queueLogEvent inside a transaction
@@ -675,9 +675,15 @@ export async function chooseIdea(
 	})
 
 	// Threaded back through the action response so the client can surface a
-	// toast when this decision silently claimed a previously-free wishlist
-	// item — otherwise the feature is invisible to the person who caused it.
-	return { claimedItemId: claimSync.claimedItemId }
+	// toast either when this decision silently claimed a previously-free
+	// wishlist item, or when the item turned out to be claimed by someone
+	// else at commit time (e.g. a race lost between the loader render and
+	// this POST) — otherwise both outcomes are invisible to the person who
+	// caused them.
+	return {
+		claimedItemId: claimSync.claimedItemId,
+		conflictedItemId: claimSync.conflictedItemId,
+	}
 }
 
 // Update the confirmed final price after the gift has been decided.

--- a/app/utils/pool.server.ts
+++ b/app/utils/pool.server.ts
@@ -574,7 +574,7 @@ export async function chooseIdea(
 	ideaId: string,
 	actorId: string,
 	finalPriceCents?: number | null,
-) {
+): Promise<{ claimedItemId: string | null }> {
 	const idea = await prisma.giftIdea.findFirst({
 		where: { id: ideaId, poolId },
 		select: { estimatedPriceCents: true, name: true },
@@ -621,7 +621,7 @@ export async function chooseIdea(
 
 		return syncPoolClaimInTx(tx, poolId)
 	})
-	if (claimSync === null) return
+	if (claimSync === null) return { claimedItemId: null }
 
 	// logPoolActivity, queueLogEvent, and queuePoolActivityNotifications all
 	// run after the transaction closes: queueLogEvent inside a transaction
@@ -673,6 +673,11 @@ export async function chooseIdea(
 		actorUserId: actorId,
 		occurrenceId: eventId,
 	})
+
+	// Threaded back through the action response so the client can surface a
+	// toast when this decision silently claimed a previously-free wishlist
+	// item — otherwise the feature is invisible to the person who caused it.
+	return { claimedItemId: claimSync.claimedItemId }
 }
 
 // Update the confirmed final price after the gift has been decided.

--- a/app/utils/wishlist-claims.server.test.ts
+++ b/app/utils/wishlist-claims.server.test.ts
@@ -471,6 +471,40 @@ describe('loadClaimStates', () => {
     expect(afterRemoval.get(item.id)?.name).toBeNull();
     expect(JSON.stringify(afterRemoval.get(item.id))).not.toContain('Sunday Roasters');
   });
+
+  it('defaults to the label surface when no surface argument is given', async () => {
+    const { owner, organizer, item } = await fixture();
+    const pool = await decidedPoolFor(item.id, owner.id, organizer.id, new Date());
+    await prisma.poolContributor.create({ data: { poolId: pool.id, userId: organizer.id } });
+    await syncPoolClaim(pool.id);
+
+    const defaulted = await loadClaimStates([item.id], { userId: organizer.id, isOwner: false });
+    const explicitLabel = await loadClaimStates(
+      [item.id],
+      { userId: organizer.id, isOwner: false },
+      'label',
+    );
+    expect(defaulted.get(item.id)).toEqual(explicitLabel.get(item.id));
+    expect(defaulted.get(item.id)?.name).toBe('Birthday pool');
+  });
+
+  it("the 'row' surface names nobody, even to a viewer the label surface would name", async () => {
+    const { owner, organizer, item } = await fixture();
+    const pool = await decidedPoolFor(item.id, owner.id, organizer.id, new Date());
+    await prisma.poolContributor.create({ data: { poolId: pool.id, userId: organizer.id } });
+    await syncPoolClaim(pool.id);
+
+    // Sanity: the label surface *would* name this pool to its own contributor.
+    const label = await loadClaimStates([item.id], { userId: organizer.id, isOwner: false }, 'label');
+    expect(label.get(item.id)?.name).toBe('Birthday pool');
+
+    const row = await loadClaimStates([item.id], { userId: organizer.id, isOwner: false }, 'row');
+    expect(row.get(item.id)?.show).toBe(true);
+    expect(row.get(item.id)?.name).toBeNull();
+    expect(row.get(item.id)?.poolLink).toBeNull();
+    expect(row.get(item.id)?.text).toBe('Already claimed');
+    expect(JSON.stringify(row.get(item.id))).not.toContain('Birthday pool');
+  });
 });
 
 describe('loadIdeaClaimConflicts', () => {

--- a/app/utils/wishlist-claims.server.test.ts
+++ b/app/utils/wishlist-claims.server.test.ts
@@ -4,9 +4,15 @@
 import { describe, expect, it, vi } from 'vitest';
 import { prisma } from '#app/utils/db.server.ts';
 import { createUser } from '#tests/db-utils.ts';
-import * as wishlistClaims from './wishlist-claims.server.ts';
-import { claimForUser, loadClaimStates, releaseUserClaim, syncPoolClaim } from './wishlist-claims.server.ts';
 import { cancelPool, chooseIdea } from './pool.server.ts';
+import * as wishlistClaims from './wishlist-claims.server.ts';
+import {
+  claimForUser,
+  loadClaimStates,
+  loadIdeaClaimConflicts,
+  releaseUserClaim,
+  syncPoolClaim,
+} from './wishlist-claims.server.ts';
 
 async function fixture() {
   const [owner, friend, organizer] = await Promise.all([
@@ -464,5 +470,83 @@ describe('loadClaimStates', () => {
     const afterRemoval = await loadClaimStates([item.id], { userId: friend.id, isOwner: false });
     expect(afterRemoval.get(item.id)?.name).toBeNull();
     expect(JSON.stringify(afterRemoval.get(item.id))).not.toContain('Sunday Roasters');
+  });
+});
+
+describe('loadIdeaClaimConflicts', () => {
+  it('names a claimer who contributes to this pool, and not one who does not', async () => {
+    const { owner, friend, organizer, item } = await fixture();
+    await claimForUser(item.id, friend.id);
+    const pool = await prisma.pool.create({
+      data: { title: 'Pool', organizerId: organizer.id, recipientUserId: owner.id },
+    });
+    const idea = await prisma.giftIdea.create({
+      data: { poolId: pool.id, proposedById: organizer.id, name: 'Spa', wishlistItemId: item.id },
+    });
+    await prisma.poolContributor.create({ data: { poolId: pool.id, userId: organizer.id } });
+
+    const outside = await loadIdeaClaimConflicts(pool.id, organizer.id);
+    expect(outside.get(idea.id)?.name).toBeNull();
+    expect(outside.get(idea.id)?.text).toBe('Already claimed');
+    // Negative containment: the claimer's identity must not leak into the
+    // serialised disclosure even indirectly (e.g. via an unused field).
+    expect(JSON.stringify(outside.get(idea.id))).not.toContain(friend.id);
+
+    await prisma.poolContributor.create({ data: { poolId: pool.id, userId: friend.id } });
+    const inside = await loadIdeaClaimConflicts(pool.id, organizer.id);
+    expect(inside.get(idea.id)?.name).not.toBeNull();
+    expect(inside.get(idea.id)?.tone).toBe('warning');
+  });
+
+  it('is absent for an idea whose item this same pool already holds the claim on', async () => {
+    const { owner, organizer, item } = await fixture();
+    const pool = await decidedPoolFor(item.id, owner.id, organizer.id, new Date());
+    const idea = await prisma.giftIdea.findFirstOrThrow({ where: { poolId: pool.id } });
+    await syncPoolClaim(pool.id);
+
+    const conflicts = await loadIdeaClaimConflicts(pool.id, organizer.id);
+
+    expect(conflicts.has(idea.id)).toBe(false);
+  });
+
+  it('never names a rival pool, even to a viewer who also contributes there', async () => {
+    const { owner, organizer, item } = await fixture();
+    const holder = await decidedPoolFor(item.id, owner.id, organizer.id, new Date());
+    await syncPoolClaim(holder.id);
+
+    // A second pool proposes the same (now pool-claimed) item as an idea.
+    const viewerPool = await prisma.pool.create({
+      data: { title: 'Rival viewing pool', organizerId: organizer.id, recipientUserId: owner.id },
+    });
+    const idea = await prisma.giftIdea.create({
+      data: {
+        poolId: viewerPool.id,
+        proposedById: organizer.id,
+        name: 'Spa voucher',
+        wishlistItemId: item.id,
+      },
+    });
+    // The viewer contributes to both pools — must still learn nothing about
+    // the holder pool's identity from this surface.
+    await prisma.poolContributor.create({ data: { poolId: holder.id, userId: organizer.id } });
+    await prisma.poolContributor.create({ data: { poolId: viewerPool.id, userId: organizer.id } });
+
+    const conflicts = await loadIdeaClaimConflicts(viewerPool.id, organizer.id);
+
+    expect(conflicts.get(idea.id)?.text).toBe('Another group is getting this');
+    expect(conflicts.get(idea.id)?.name).toBeNull();
+    expect(conflicts.get(idea.id)?.poolLink).toBeNull();
+    const serialised = JSON.stringify(conflicts.get(idea.id));
+    expect(serialised).not.toContain('Birthday pool');
+    expect(serialised).not.toContain(holder.id);
+  });
+
+  it('returns an empty map when the pool has no ideas linked to wishlist items', async () => {
+    const { owner, organizer } = await fixture();
+    const pool = await prisma.pool.create({
+      data: { title: 'Empty pool', organizerId: organizer.id, recipientUserId: owner.id },
+    });
+    const conflicts = await loadIdeaClaimConflicts(pool.id, organizer.id);
+    expect(conflicts.size).toBe(0);
   });
 });

--- a/app/utils/wishlist-claims.server.ts
+++ b/app/utils/wishlist-claims.server.ts
@@ -443,3 +443,102 @@ export async function loadClaimStates(
 
   return states;
 }
+
+/**
+ * The read model for a pool's gift-idea list: for each idea whose linked
+ * wishlist item is claimed by someone *other than this pool*, resolves what
+ * this pool's viewer may be told about the conflict. A pool holding its own
+ * claim on the item is the expected steady state, not a conflict — those
+ * ideas are absent from the returned map.
+ *
+ * Sibling of `loadClaimStates` (same gather-facts-then-defer-to-the-ladder
+ * shape) but for the `'badge'` surface: keyed by gift idea id rather than
+ * wishlist item id, and the pool-vs-pool tiers collapse to "another group is
+ * getting this" — the viewer here is always an authenticated contributor to
+ * *this* pool, so `isAnonymous` is always false, and a rival pool's identity
+ * is never disclosed regardless of any relationship the viewer might have to
+ * it (hence `contributesToHolderPool`/`memberOfHolderGroup` are hardcoded
+ * false rather than derived — this surface's whole point is "don't name the
+ * other group").
+ */
+export async function loadIdeaClaimConflicts(
+  poolId: string,
+  viewerUserId: string,
+): Promise<Map<string, ClaimDisclosure>> {
+  const conflicts = new Map<string, ClaimDisclosure>();
+
+  const ideas = await prisma.giftIdea.findMany({
+    where: { poolId, wishlistItemId: { not: null } },
+    select: { id: true, wishlistItemId: true },
+  });
+  if (ideas.length === 0) return conflicts;
+
+  const itemIds = ideas
+    .map((idea) => idea.wishlistItemId)
+    .filter((id): id is string => id !== null);
+
+  const [pool, claims] = await Promise.all([
+    prisma.pool.findUnique({
+      where: { id: poolId },
+      select: {
+        recipientUserId: true,
+        contributors: { select: { userId: true } },
+      },
+    }),
+    prisma.wishlistClaim.findMany({
+      where: { wishlistItemId: { in: itemIds } },
+      select: {
+        wishlistItemId: true,
+        poolId: true,
+        claimedByUserId: true,
+        claimedByUser: { select: { name: true, username: true } },
+        pool: { select: { id: true, title: true } },
+      },
+    }),
+  ]);
+
+  const contributorIds = new Set(pool?.contributors.map((c) => c.userId) ?? []);
+  const claimsByItem = new Map(claims.map((claim) => [claim.wishlistItemId, claim]));
+
+  for (const idea of ideas) {
+    if (!idea.wishlistItemId) continue;
+    const claim = claimsByItem.get(idea.wishlistItemId);
+    // Unclaimed, or this pool holding its own claim — not a conflict.
+    if (!claim || claim.poolId === poolId) continue;
+
+    const holder: ClaimHolder = claim.pool
+      ? {
+          kind: 'pool',
+          poolId: claim.pool.id,
+          poolTitle: claim.pool.title,
+          giftGroupName: null,
+        }
+      : {
+          kind: 'user',
+          userId: claim.claimedByUserId ?? '',
+          displayName: claim.claimedByUser?.name ?? claim.claimedByUser?.username ?? null,
+        };
+
+    conflicts.set(
+      idea.id,
+      resolveClaimDisclosure(
+        holder,
+        {
+          // Defensive, not load-bearing: the pool page loader already blocks
+          // the recipient from reaching this code (see __route.server.ts), so
+          // this is always false in practice. Derived rather than hardcoded
+          // so the module doesn't silently rely on that upstream gate.
+          isOwner: pool !== null && viewerUserId === pool.recipientUserId,
+          isAnonymous: false,
+          contributesToHolderPool: false,
+          memberOfHolderGroup: false,
+          sharesPoolWithHolderUser:
+            claim.claimedByUserId !== null && contributorIds.has(claim.claimedByUserId),
+        },
+        'badge',
+      ),
+    );
+  }
+
+  return conflicts;
+}

--- a/app/utils/wishlist-claims.server.ts
+++ b/app/utils/wishlist-claims.server.ts
@@ -15,6 +15,7 @@ import {
   resolveClaimDisclosure,
   type ClaimDisclosure,
   type ClaimHolder,
+  type ClaimSurface,
 } from './wishlist-claim-disclosure.ts';
 
 export const POOL_INTENT_STATUSES = [
@@ -351,6 +352,7 @@ export async function setClaimOutcomeFeedback(
 export async function loadClaimStates(
   wishlistItemIds: string[],
   viewer: { userId: string | null; isOwner: boolean },
+  surface: ClaimSurface = 'label',
 ): Promise<Map<string, ClaimDisclosure>> {
   const states = new Map<string, ClaimDisclosure>();
   if (wishlistItemIds.length === 0) return states;
@@ -436,7 +438,7 @@ export async function loadClaimStates(
             Boolean(claim.pool?.giftGroupId && memberGroupIds.has(claim.pool.giftGroupId)),
           sharesPoolWithHolderUser: false,
         },
-        'label',
+        surface,
       ),
     );
   }


### PR DESCRIPTION
## Summary

Makes claim conflicts **visible**. Until now the server prevented a pool from taking an item someone else held, but nobody was told — contributors could still go buy a duplicate.

Builds on #532 (server module, privacy ladder, wishlist surfaces).

- **Idea-card badge** — the existing pool-coloured "From wishlist" pill *changes state* when the linked item is claimed by someone else. One slot, one meaning; it never gains a second pill, because the card footer is already dense.
- **Picker chips** — already-claimed items in the propose-idea dropdown are marked but **still selectable**. Conflicts advise, never block: the organizer may know something the app doesn't.
- **Confirmation before deciding on a claimed item** — a `ResponsiveDialog` (bottom sheet under 640px, centred dialog above). Unconflicted decisions stay a single instant click with no dialog.
- **The happy path finally speaks** — deciding on a *free* wishlist item now toasts "marked as claimed", so the feature isn't invisible to the person who caused it. Cancel confirmation states the item will be unclaimed.

## Privacy

The badge follows the same ladder as everything else in this feature:

| Holder | Shown as |
|---|---|
| A user who contributes to this pool | Named — "Claimed by Sarah" |
| A user outside this pool | "Already claimed", no name |
| Another pool | "Another group is getting this", never named |

The **picker names nobody, ever** — `resolveClaimDisclosure` short-circuits the `row` surface to anonymous before any holder branch. Tested differentially: the same claim that *would* be named at `label` for that same viewer comes back anonymous at `row`.

## Test plan

- `npm test -- --run` — **236 files / 1579 tests, exit 0**
- `npm run typecheck` clean, `npm run lint` 0 errors

**Local e2e was not usable and I'm flagging that rather than claiming it passed.** Playwright's `reuseExistingServer: true` adopted a dev server already on :3000, producing ~96 phantom failures over 41.8 minutes with zero `[WebServer]` lines — the foreign-server scenario `AGENTS.md` documents. CI runs e2e in a clean container, so **please treat CI's Playwright result as the authoritative one for this PR.**

## Also in here

`2f24f88` fixes 12 tests in `__route.server.test.ts` that the first commit of this branch broke. Adding `loadIdeaClaimConflicts` to the pool loader made it query Prisma models that file's client mock doesn't define. It mocks the two read-model functions instead of growing the Prisma mock — the same split `pool.server.test.ts` already uses for `syncPoolClaim`, with real behaviour covered against a live database in `wishlist-claims.server.test.ts`. No existing assertion was changed.

## Not in here

The Keep/Release notification loop is the next and final PR. Until it lands, a claimant is never asked whether they're still getting the item — so a conflicted decision warns the organizer but doesn't yet resolve the conflict.

https://claude.ai/code/session_01TGwCvTjxaDbeuZo8DrX2Qx