### PR TITLE
feat(notifications): close the wishlist claim conflict loop

### DIFF
--- a/app/components/notifications/notification-bell.test.tsx
+++ b/app/components/notifications/notification-bell.test.tsx
@@ -77,6 +77,8 @@ vi.mock('#app/utils/i18n.tsx', () => ({
           "Kept — you're still on gift duty for this one.",
         'notifications.wishlistClaimConflict.releaseSuccess':
           "Released — the group's got it from here. Thanks!",
+        'notifications.wishlistClaimConflict.releaseStale':
+          "That's out of date — your current claim on this item wasn't touched.",
         'toasts.genericError': 'Something went wrong',
       })[key] ?? key,
   }),
@@ -424,7 +426,7 @@ describe('NotificationBell', () => {
           id: 'notification-1',
           messageKey: 'wishlist.claim.conflict',
           messageParams: null,
-          metadata: { wishlistItemId: 'wish-9' },
+          metadata: { wishlistItemId: 'wish-9', claimId: 'claim-9' },
           status: 'UNREAD',
           targetUrl: '/users/taylor/wishlist',
           type: 'WISHLIST_CLAIM_CONFLICT',
@@ -459,6 +461,13 @@ describe('NotificationBell', () => {
       '/wishlist/purchase',
       expect.objectContaining({ method: 'POST', credentials: 'same-origin' }),
     );
+    // The release binds to the specific claim occurrence the notification
+    // was raised about, not just the item id.
+    const [, releaseInit] = fetchMock.mock.calls.find(
+      ([url]) => url === '/wishlist/purchase',
+    )!;
+    const releaseBody = releaseInit?.body as FormData;
+    expect(releaseBody.get('claimId')).toBe('claim-9');
     expect(fetchMock).toHaveBeenCalledWith(
       '/api/notifications/notification-1/delete',
       expect.objectContaining({ method: 'POST' }),
@@ -470,6 +479,46 @@ describe('NotificationBell', () => {
     expect(toastSuccess).toHaveBeenCalledWith(
       "Released — the group's got it from here. Thanks!",
     );
+  });
+
+  it('shows a distinct message and rolls back when the release targets a stale claim occurrence', async () => {
+    // The notification's claimId no longer matches the item's current
+    // claim (e.g. the user released elsewhere and re-claimed the same item)
+    // — the server rejects with reason: 'stale', and the bell must say so
+    // rather than showing the generic error.
+    testConsole.error.mockImplementation(() => {});
+    fetchMock
+      .mockResolvedValueOnce(wishlistClaimConflictListResponse())
+      .mockResolvedValueOnce(
+        jsonResponse(
+          { ok: false, reason: 'stale', claim: { claimedByUserId: 'someone-else' } },
+          { status: 400 },
+        ),
+      );
+
+    renderBell(1);
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Notifications' }),
+    );
+    await screen.findByText('wishlist.claim.conflict');
+    await userEvent.click(screen.getByRole('button', { name: 'Release it' }));
+
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith(
+        "That's out of date — your current claim on this item wasn't touched.",
+      );
+    });
+    // Rolled back: nothing committed, so the notification (and its Release
+    // action) is still there for the user to reconsider.
+    expect(await screen.findByText('wishlist.claim.conflict')).toBeInTheDocument();
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      '/api/notifications/notification-1/delete',
+      expect.anything(),
+    );
+    expect(track).toHaveBeenCalledWith('notification_action_completed', {
+      kind: 'WISHLIST_CLAIM_RELEASE',
+      success: false,
+    });
   });
 
   it('keeps a wishlist claim by dismissing only — never calls the purchase route', async () => {
@@ -505,6 +554,39 @@ describe('NotificationBell', () => {
     expect(toastSuccess).toHaveBeenCalledWith(
       "Kept — you're still on gift duty for this one.",
     );
+  });
+
+  it('surfaces an error and rolls back — never reports success — when Keep fails to dismiss', async () => {
+    // Regression: Keep has no irreversible side effect — dismissal IS the
+    // whole action. The swallow-dismiss-failures behavior only exists to
+    // protect an already-committed Release; applied to Keep it let a failed
+    // dismissal report success while the notification lived on server-side.
+    testConsole.error.mockImplementation(() => {});
+    fetchMock
+      .mockResolvedValueOnce(wishlistClaimConflictListResponse())
+      .mockRejectedValueOnce(new Error('network down'));
+
+    renderBell(1);
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Notifications' }),
+    );
+    await screen.findByText('wishlist.claim.conflict');
+    await userEvent.click(screen.getByRole('button', { name: 'Keep it' }));
+
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith('Something went wrong');
+    });
+    // Rolled back: the notification (with its Keep/Release actions) is back
+    // rather than falsely reported as dismissed.
+    expect(await screen.findByText('wishlist.claim.conflict')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Keep it' }),
+    ).toBeInTheDocument();
+    expect(track).toHaveBeenCalledWith('notification_action_completed', {
+      kind: 'WISHLIST_CLAIM_KEEP',
+      success: false,
+    });
+    expect(toastSuccess).not.toHaveBeenCalled();
   });
 
   it('does not roll back a committed release when the dismissal request fails', async () => {

--- a/app/components/notifications/notification-bell.test.tsx
+++ b/app/components/notifications/notification-bell.test.tsx
@@ -72,6 +72,10 @@ vi.mock('#app/utils/i18n.tsx', () => ({
         'notifications.poolInvitation.declineSuccess': 'Invitation declined',
         'notifications.title': 'Notifications',
         'notifications.viewMore': 'View more',
+        'notifications.wishlistClaimConflict.keepSuccess':
+          "Kept — you're still on gift duty for this one.",
+        'notifications.wishlistClaimConflict.releaseSuccess':
+          "Released — the group's got it from here. Thanks!",
         'toasts.genericError': 'Something went wrong',
       })[key] ?? key,
   }),
@@ -401,5 +405,104 @@ describe('NotificationBell', () => {
     );
     expect(navigate).toHaveBeenCalledWith('/pools/pool-1');
     expect(toastSuccess).toHaveBeenCalledWith('Pool joined');
+  });
+
+  function wishlistClaimConflictListResponse() {
+    return jsonResponse({
+      hasMore: false,
+      nextCursor: null,
+      notifications: [
+        {
+          actions: [
+            { kind: 'WISHLIST_CLAIM_KEEP', label: 'Keep it' },
+            { kind: 'WISHLIST_CLAIM_RELEASE', label: 'Release it' },
+          ],
+          createdAt: '2026-03-31T12:00:00.000Z',
+          friendRequestId: null,
+          poolInvitationId: null,
+          id: 'notification-1',
+          messageKey: 'wishlist.claim.conflict',
+          messageParams: null,
+          metadata: { wishlistItemId: 'wish-9' },
+          status: 'UNREAD',
+          targetUrl: '/users/taylor/wishlist',
+          type: 'WISHLIST_CLAIM_CONFLICT',
+        },
+      ],
+      unreadCount: 1,
+    });
+  }
+
+  it('releases a wishlist claim inline through the same unpurchase path as the wishlist page, then dismisses the notification', async () => {
+    fetchMock
+      .mockResolvedValueOnce(wishlistClaimConflictListResponse())
+      .mockResolvedValueOnce(
+        jsonResponse({ ok: true, wishlistItemId: 'wish-9', claim: null }),
+      )
+      .mockResolvedValueOnce(jsonResponse({ success: true, unreadCount: 0 }));
+
+    renderBell(1);
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Notifications' }),
+    );
+    await screen.findByText('wishlist.claim.conflict');
+    await userEvent.click(screen.getByRole('button', { name: 'Release it' }));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText('wishlist.claim.conflict'),
+      ).not.toBeInTheDocument();
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/wishlist/purchase',
+      expect.objectContaining({ method: 'POST', credentials: 'same-origin' }),
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/notifications/notification-1/delete',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(track).toHaveBeenCalledWith('notification_action_completed', {
+      kind: 'WISHLIST_CLAIM_RELEASE',
+      success: true,
+    });
+    expect(toastSuccess).toHaveBeenCalledWith(
+      "Released — the group's got it from here. Thanks!",
+    );
+  });
+
+  it('keeps a wishlist claim by dismissing only — never calls the purchase route', async () => {
+    fetchMock
+      .mockResolvedValueOnce(wishlistClaimConflictListResponse())
+      .mockResolvedValueOnce(jsonResponse({ success: true, unreadCount: 0 }));
+
+    renderBell(1);
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Notifications' }),
+    );
+    await screen.findByText('wishlist.claim.conflict');
+    await userEvent.click(screen.getByRole('button', { name: 'Keep it' }));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText('wishlist.claim.conflict'),
+      ).not.toBeInTheDocument();
+    });
+
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      '/wishlist/purchase',
+      expect.anything(),
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/notifications/notification-1/delete',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(track).toHaveBeenCalledWith('notification_action_completed', {
+      kind: 'WISHLIST_CLAIM_KEEP',
+      success: true,
+    });
+    expect(toastSuccess).toHaveBeenCalledWith(
+      "Kept — you're still on gift duty for this one.",
+    );
   });
 });

--- a/app/components/notifications/notification-bell.test.tsx
+++ b/app/components/notifications/notification-bell.test.tsx
@@ -5,6 +5,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type * as ReactModule from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { testConsole } from '#tests/setup/setup-test-env.ts';
 import { NotificationBell } from './notification-bell.tsx';
 import { NotificationsProvider } from './notifications-context.tsx';
 
@@ -504,5 +505,91 @@ describe('NotificationBell', () => {
     expect(toastSuccess).toHaveBeenCalledWith(
       "Kept — you're still on gift duty for this one.",
     );
+  });
+
+  it('does not roll back a committed release when the dismissal request fails', async () => {
+    // Regression: a release that succeeds server-side (the claim is gone,
+    // possibly transferred to the pool) must not be undone in the UI just
+    // because the follow-up dismiss call fails. Rolling back would restore
+    // the "Release it" button for a claim the user no longer holds — a
+    // button that can only fail forever if pressed again.
+    testConsole.error.mockImplementation(() => {});
+    fetchMock
+      .mockResolvedValueOnce(wishlistClaimConflictListResponse())
+      .mockResolvedValueOnce(
+        jsonResponse({ ok: true, wishlistItemId: 'wish-9', claim: null }),
+      )
+      .mockRejectedValueOnce(new Error('network down'));
+
+    renderBell(1);
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Notifications' }),
+    );
+    await screen.findByText('wishlist.claim.conflict');
+    await userEvent.click(screen.getByRole('button', { name: 'Release it' }));
+
+    // The release call landed...
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/wishlist/purchase',
+        expect.objectContaining({ method: 'POST', credentials: 'same-origin' }),
+      );
+    });
+    // ...and even though the dismiss call rejected, the notification (and
+    // its "Release it" button) must stay gone rather than reappear.
+    await waitFor(() => {
+      expect(
+        screen.queryByText('wishlist.claim.conflict'),
+      ).not.toBeInTheDocument();
+    });
+    expect(
+      screen.queryByRole('button', { name: 'Release it' }),
+    ).not.toBeInTheDocument();
+
+    // The already-committed release is still reported as a success, not
+    // rolled back and surfaced as a generic failure.
+    expect(track).toHaveBeenCalledWith('notification_action_completed', {
+      kind: 'WISHLIST_CLAIM_RELEASE',
+      success: true,
+    });
+    expect(toastSuccess).toHaveBeenCalledWith(
+      "Released — the group's got it from here. Thanks!",
+    );
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it('rolls back the optimistic dismissal when the release call itself fails', async () => {
+    // Contrast case for the regression above: when the release never
+    // committed, the existing rollback-on-failure behavior must still hold
+    // — the notification (with its Keep/Release actions) reappears so the
+    // user can retry.
+    testConsole.error.mockImplementation(() => {});
+    fetchMock
+      .mockResolvedValueOnce(wishlistClaimConflictListResponse())
+      .mockResolvedValueOnce(jsonResponse({ ok: false }, { status: 409 }));
+
+    renderBell(1);
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Notifications' }),
+    );
+    await screen.findByText('wishlist.claim.conflict');
+    await userEvent.click(screen.getByRole('button', { name: 'Release it' }));
+
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith('Something went wrong');
+    });
+    // Rolled back: the notification — and its Release action — is back.
+    expect(await screen.findByText('wishlist.claim.conflict')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Release it' }),
+    ).toBeInTheDocument();
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      '/api/notifications/notification-1/delete',
+      expect.anything(),
+    );
+    expect(track).toHaveBeenCalledWith('notification_action_completed', {
+      kind: 'WISHLIST_CLAIM_RELEASE',
+      success: false,
+    });
   });
 });

--- a/app/components/notifications/notification-bell.tsx
+++ b/app/components/notifications/notification-bell.tsx
@@ -702,6 +702,15 @@ export const NotificationBell = () => {
       const previousUnreadCount = unreadCountRef.current;
       const wasUnread = notification.status === 'UNREAD';
 
+      // Tracks whether the release itself — the one irreversible side
+      // effect here, since it can hand the claim off to the pool — has
+      // already committed server-side. Once true, nothing below may roll
+      // the optimistic UI back to a state that offers Release again: the
+      // claim is gone, and a second Release attempt could only fail
+      // forever. Only a failure of the release call itself (still false at
+      // that point) triggers the rollback.
+      let releaseCompleted = false;
+
       setPendingActionKeys((prev) => new Set(prev).add(actionKey));
       try {
         if (isRelease && wishlistItemId) {
@@ -720,6 +729,7 @@ export const NotificationBell = () => {
           if (!releaseResponse.ok || !releasePayload?.ok) {
             throw new Error('Unable to release wishlist claim');
           }
+          releaseCompleted = true;
         }
 
         // Both actions dismiss the notification once they've done their work.
@@ -729,21 +739,29 @@ export const NotificationBell = () => {
         if (wasUnread) {
           setUnreadCount(Math.max(0, previousUnreadCount - 1));
         }
-        const dismissResponse = await fetch(
-          `${NOTIFICATIONS_ENDPOINT}/${notification.id}/delete`,
-          {
-            method: 'POST',
-            credentials: 'same-origin',
-            headers: { Accept: 'application/json' },
-          },
-        );
-        if (dismissResponse.ok) {
-          const dismissPayload = (await dismissResponse.json()) as {
-            unreadCount?: number;
-          };
-          if (typeof dismissPayload.unreadCount === 'number') {
-            setUnreadCount(dismissPayload.unreadCount);
+        try {
+          const dismissResponse = await fetch(
+            `${NOTIFICATIONS_ENDPOINT}/${notification.id}/delete`,
+            {
+              method: 'POST',
+              credentials: 'same-origin',
+              headers: { Accept: 'application/json' },
+            },
+          );
+          if (dismissResponse.ok) {
+            const dismissPayload = (await dismissResponse.json()) as {
+              unreadCount?: number;
+            };
+            if (typeof dismissPayload.unreadCount === 'number') {
+              setUnreadCount(dismissPayload.unreadCount);
+            }
           }
+        } catch (dismissErr) {
+          // The release (if any) already committed server-side by this
+          // point — only log the dismissal failure, never roll back past
+          // it. The notification row will simply resurface as read on the
+          // next list load instead of staying dismissed.
+          console.error(dismissErr);
         }
 
         track('notification_action_completed', {
@@ -757,8 +775,10 @@ export const NotificationBell = () => {
         );
       } catch (err) {
         console.error(err);
-        setNotifications(previousNotifications);
-        setUnreadCount(previousUnreadCount);
+        if (!releaseCompleted) {
+          setNotifications(previousNotifications);
+          setUnreadCount(previousUnreadCount);
+        }
         track('notification_action_completed', {
           kind: action.kind,
           success: false,

--- a/app/components/notifications/notification-bell.tsx
+++ b/app/components/notifications/notification-bell.tsx
@@ -695,6 +695,12 @@ export const NotificationBell = () => {
         unknown
       >;
       const wishlistItemId = metadata.wishlistItemId as string | undefined;
+      // Present on WISHLIST_CLAIM_CONFLICT notifications — binds Release to
+      // the exact claim occurrence this notification was raised about, so a
+      // stale notification (the user released elsewhere and re-claimed the
+      // same item) can't drop their new claim. See the payload comment in
+      // notification-catalog.ts and releaseUserClaim's expectedClaimId.
+      const claimId = metadata.claimId as string | undefined;
       const isRelease = action.kind === WISHLIST_CLAIM_RELEASE_EVENT;
       if (isRelease && !wishlistItemId) return;
 
@@ -710,6 +716,12 @@ export const NotificationBell = () => {
       // forever. Only a failure of the release call itself (still false at
       // that point) triggers the rollback.
       let releaseCompleted = false;
+      // Set when the server rejected the release because `claimId` no
+      // longer matches the claim actually live on the item — i.e. this
+      // notification is stale. Surfaced as a distinct, legible toast rather
+      // than the generic failure message, per the fix for a stale Release
+      // silently no-op'ing on the wrong claim.
+      let releaseStale = false;
 
       setPendingActionKeys((prev) => new Set(prev).add(actionKey));
       try {
@@ -717,6 +729,7 @@ export const NotificationBell = () => {
           const releaseFormData = new FormData();
           releaseFormData.set('wishlistItemId', wishlistItemId);
           releaseFormData.set('intent', 'unpurchase');
+          if (claimId) releaseFormData.set('claimId', claimId);
           const releaseResponse = await fetch(WISHLIST_PURCHASE_ENDPOINT, {
             method: 'POST',
             credentials: 'same-origin',
@@ -725,8 +738,9 @@ export const NotificationBell = () => {
           });
           const releasePayload = (await releaseResponse
             .json()
-            .catch(() => null)) as { ok?: boolean } | null;
+            .catch(() => null)) as { ok?: boolean; reason?: string } | null;
           if (!releaseResponse.ok || !releasePayload?.ok) {
+            releaseStale = releasePayload?.reason === 'stale';
             throw new Error('Unable to release wishlist claim');
           }
           releaseCompleted = true;
@@ -748,20 +762,28 @@ export const NotificationBell = () => {
               headers: { Accept: 'application/json' },
             },
           );
-          if (dismissResponse.ok) {
-            const dismissPayload = (await dismissResponse.json()) as {
-              unreadCount?: number;
-            };
-            if (typeof dismissPayload.unreadCount === 'number') {
-              setUnreadCount(dismissPayload.unreadCount);
-            }
+          if (!dismissResponse.ok) {
+            throw new Error('Unable to dismiss notification');
+          }
+          const dismissPayload = (await dismissResponse.json()) as {
+            unreadCount?: number;
+          };
+          if (typeof dismissPayload.unreadCount === 'number') {
+            setUnreadCount(dismissPayload.unreadCount);
           }
         } catch (dismissErr) {
-          // The release (if any) already committed server-side by this
-          // point — only log the dismissal failure, never roll back past
-          // it. The notification row will simply resurface as read on the
-          // next list load instead of staying dismissed.
-          console.error(dismissErr);
+          if (releaseCompleted) {
+            // The release already committed server-side by this point —
+            // only log the dismissal failure, never roll back past it. The
+            // notification row will simply resurface as read on the next
+            // list load instead of staying dismissed.
+            console.error(dismissErr);
+          } else {
+            // Keep has no irreversible side effect: dismissal IS the whole
+            // action. Let the failure reach the outer catch so the rollback
+            // below runs and the UI doesn't lie about Keep having worked.
+            throw dismissErr;
+          }
         }
 
         track('notification_action_completed', {
@@ -783,7 +805,11 @@ export const NotificationBell = () => {
           kind: action.kind,
           success: false,
         });
-        toast.error(t('toasts.genericError'));
+        toast.error(
+          releaseStale
+            ? t('notifications.wishlistClaimConflict.releaseStale')
+            : t('toasts.genericError'),
+        );
       } finally {
         setPendingActionKeys((prev) => {
           const next = new Set(prev);

--- a/app/components/notifications/notification-bell.tsx
+++ b/app/components/notifications/notification-bell.tsx
@@ -83,6 +83,9 @@ const MARK_ALL_ENDPOINT = '/api/notifications/read-all';
 const FRIEND_ACCEPT_EVENT = 'FRIEND_ACCEPT';
 const POOL_INVITATION_ACCEPT_EVENT = 'POOL_INVITATION_ACCEPT';
 const POOL_INVITATION_DECLINE_EVENT = 'POOL_INVITATION_DECLINE';
+const WISHLIST_CLAIM_KEEP_EVENT = 'WISHLIST_CLAIM_KEEP';
+const WISHLIST_CLAIM_RELEASE_EVENT = 'WISHLIST_CLAIM_RELEASE';
+const WISHLIST_PURCHASE_ENDPOINT = '/wishlist/purchase';
 
 type PendingActionKey = `${string}:${string}`;
 type NotificationTranslator = ReturnType<typeof useTranslation>['t'];
@@ -118,7 +121,8 @@ function NotificationRowActions({
             size="sm"
             variant={
               action.kind === FRIEND_ACCEPT_EVENT ||
-              action.kind === POOL_INVITATION_ACCEPT_EVENT
+              action.kind === POOL_INVITATION_ACCEPT_EVENT ||
+              action.kind === WISHLIST_CLAIM_RELEASE_EVENT
                 ? 'default'
                 : 'secondary'
             }
@@ -675,6 +679,102 @@ export const NotificationBell = () => {
     [navigate, pendingActionKeys, setUnreadCount, t],
   );
 
+  // Keep and Release both resolve the notification inline — neither
+  // navigates away. Release actually mutates the claim (via the same
+  // `/wishlist/purchase` unpurchase path the wishlist page uses); Keep only
+  // dismisses, since overriding someone's claim is an explicit non-goal.
+  const handleWishlistClaimAction = useCallback(
+    async (
+      notification: ApiNotification,
+      action: NotificationActionPayload,
+    ) => {
+      const actionKey: PendingActionKey = `${notification.id}:${action.kind}`;
+      if (pendingActionKeys.has(actionKey)) return;
+      const metadata = (notification.metadata ?? {}) as Record<
+        string,
+        unknown
+      >;
+      const wishlistItemId = metadata.wishlistItemId as string | undefined;
+      const isRelease = action.kind === WISHLIST_CLAIM_RELEASE_EVENT;
+      if (isRelease && !wishlistItemId) return;
+
+      const previousNotifications = notificationsRef.current;
+      const previousUnreadCount = unreadCountRef.current;
+      const wasUnread = notification.status === 'UNREAD';
+
+      setPendingActionKeys((prev) => new Set(prev).add(actionKey));
+      try {
+        if (isRelease && wishlistItemId) {
+          const releaseFormData = new FormData();
+          releaseFormData.set('wishlistItemId', wishlistItemId);
+          releaseFormData.set('intent', 'unpurchase');
+          const releaseResponse = await fetch(WISHLIST_PURCHASE_ENDPOINT, {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: { Accept: 'application/json' },
+            body: releaseFormData,
+          });
+          const releasePayload = (await releaseResponse
+            .json()
+            .catch(() => null)) as { ok?: boolean } | null;
+          if (!releaseResponse.ok || !releasePayload?.ok) {
+            throw new Error('Unable to release wishlist claim');
+          }
+        }
+
+        // Both actions dismiss the notification once they've done their work.
+        setNotifications((prev) =>
+          prev.filter((item) => item.id !== notification.id),
+        );
+        if (wasUnread) {
+          setUnreadCount(Math.max(0, previousUnreadCount - 1));
+        }
+        const dismissResponse = await fetch(
+          `${NOTIFICATIONS_ENDPOINT}/${notification.id}/delete`,
+          {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: { Accept: 'application/json' },
+          },
+        );
+        if (dismissResponse.ok) {
+          const dismissPayload = (await dismissResponse.json()) as {
+            unreadCount?: number;
+          };
+          if (typeof dismissPayload.unreadCount === 'number') {
+            setUnreadCount(dismissPayload.unreadCount);
+          }
+        }
+
+        track('notification_action_completed', {
+          kind: action.kind,
+          success: true,
+        });
+        toast.success(
+          isRelease
+            ? t('notifications.wishlistClaimConflict.releaseSuccess')
+            : t('notifications.wishlistClaimConflict.keepSuccess'),
+        );
+      } catch (err) {
+        console.error(err);
+        setNotifications(previousNotifications);
+        setUnreadCount(previousUnreadCount);
+        track('notification_action_completed', {
+          kind: action.kind,
+          success: false,
+        });
+        toast.error(t('toasts.genericError'));
+      } finally {
+        setPendingActionKeys((prev) => {
+          const next = new Set(prev);
+          next.delete(actionKey);
+          return next;
+        });
+      }
+    },
+    [pendingActionKeys, setUnreadCount, t],
+  );
+
   const displayCount = unreadCount > 9 ? '9+' : unreadCount.toString();
 
   const handleDeleteNotificationClick = useCallback(
@@ -699,9 +799,16 @@ export const NotificationBell = () => {
         handlePoolInvitationAction(notification, action).catch(() => {});
         return;
       }
+      if (
+        action.kind === WISHLIST_CLAIM_KEEP_EVENT ||
+        action.kind === WISHLIST_CLAIM_RELEASE_EVENT
+      ) {
+        handleWishlistClaimAction(notification, action).catch(() => {});
+        return;
+      }
       handleFriendAction(notification, action).catch(() => {});
     },
-    [handleFriendAction, handlePoolInvitationAction],
+    [handleFriendAction, handlePoolInvitationAction, handleWishlistClaimAction],
   );
   const handleLoadMore = useCallback(() => {
     loadNotifications({

--- a/app/components/notifications/notification-bell.tsx
+++ b/app/components/notifications/notification-bell.tsx
@@ -775,8 +775,12 @@ export const NotificationBell = () => {
           if (releaseCompleted) {
             // The release already committed server-side by this point —
             // only log the dismissal failure, never roll back past it. The
-            // notification row will simply resurface as read on the next
-            // list load instead of staying dismissed.
+            // notification row itself is already resolved: the release path
+            // deletes any WISHLIST_CLAIM_CONFLICT notification bound to the
+            // claim it just released (see
+            // resolveWishlistClaimConflictNotifications in pool.server.ts),
+            // so a failure of this separate dismiss request can't resurface
+            // a Release action for a claim that's already gone.
             console.error(dismissErr);
           } else {
             // Keep has no irreversible side effect: dismissal IS the whole

--- a/app/emails/wishlist-claim-conflict.tsx
+++ b/app/emails/wishlist-claim-conflict.tsx
@@ -1,0 +1,62 @@
+import * as E from '@react-email/components';
+
+type WishlistClaimConflictEmailProps = {
+  appName: string;
+  itemTitle: string;
+  recipientName: string;
+  wishlistUrl: string;
+  managePreferencesUrl: string;
+};
+
+// Deliberately does not name the pool or group that made the decision — the
+// recipient of this email may have no relationship to either. See the
+// privacy ladder in wishlist-claim-disclosure.ts and the payload comment in
+// notification-catalog.ts.
+export function WishlistClaimConflictEmail({
+  appName,
+  itemTitle,
+  recipientName,
+  wishlistUrl,
+  managePreferencesUrl,
+}: Readonly<WishlistClaimConflictEmailProps>) {
+  return (
+    <E.Html lang="en" dir="ltr">
+      <E.Container>
+        <E.Heading as="h1">
+          A group has also decided to get {itemTitle} for {recipientName}
+        </E.Heading>
+        <E.Text>
+          Are you still getting it yourself? If not, release your claim so
+          the group can get it without a duplicate purchase.
+        </E.Text>
+        <E.Button
+          href={wishlistUrl}
+          style={{
+            backgroundColor: '#0f172a',
+            color: '#ffffff',
+            padding: '12px 24px',
+            borderRadius: '9999px',
+            display: 'inline-block',
+            textDecoration: 'none',
+            fontWeight: 600,
+          }}
+        >
+          Open wishlist
+        </E.Button>
+        <E.Text
+          style={{ marginTop: '32px', fontSize: '12px', color: '#64748b' }}
+        >
+          You are receiving this email because you have enabled pool
+          coordination email notifications on {appName}. You can update your
+          preferences at any time.
+        </E.Text>
+        <E.Link
+          href={managePreferencesUrl}
+          style={{ fontSize: '12px', color: '#0f172a' }}
+        >
+          Manage notification preferences
+        </E.Link>
+      </E.Container>
+    </E.Html>
+  );
+}

--- a/app/i18n/dictionaries/en.ts
+++ b/app/i18n/dictionaries/en.ts
@@ -94,6 +94,11 @@ export const en = {
       keepSuccess: "Kept — you're still on gift duty for this one.",
       releaseSuccess: "Released — the group's got it from here. Thanks!",
     },
+    wishlistClaimTransferred: {
+      message:
+        'The other claim on {{item}} for {{recipient}} was released — {{pool}} now holds it, so there’s no more duplicate risk from that claim.',
+      pushTitle: 'Duplicate risk cleared',
+    },
     markAllReadSuccess: 'All notifications marked as read.',
   },
   friends: {

--- a/app/i18n/dictionaries/en.ts
+++ b/app/i18n/dictionaries/en.ts
@@ -93,6 +93,8 @@ export const en = {
       release: 'Release it',
       keepSuccess: "Kept — you're still on gift duty for this one.",
       releaseSuccess: "Released — the group's got it from here. Thanks!",
+      releaseStale:
+        "That's out of date — your current claim on this item wasn't touched.",
     },
     wishlistClaimTransferred: {
       message:

--- a/app/i18n/dictionaries/en.ts
+++ b/app/i18n/dictionaries/en.ts
@@ -85,6 +85,15 @@ export const en = {
       message: '{{sender}} reminded you to deliver the gift for {{pool}}',
       pushTitle: 'Delivery reminder',
     },
+    wishlistClaimConflict: {
+      message:
+        'A group has also decided to get {{item}} for {{recipient}}. Are you still getting it yourself?',
+      pushTitle: 'Still getting this?',
+      keep: 'Keep it',
+      release: 'Release it',
+      keepSuccess: "Kept — you're still on gift duty for this one.",
+      releaseSuccess: "Released — the group's got it from here. Thanks!",
+    },
     markAllReadSuccess: 'All notifications marked as read.',
   },
   friends: {

--- a/app/routes/pools+/$poolId+/index.test.tsx
+++ b/app/routes/pools+/$poolId+/index.test.tsx
@@ -979,7 +979,7 @@ describe('app/routes/pools+/$poolId+/index.tsx', () => {
       expect(toastSuccess).not.toHaveBeenCalled();
     });
 
-    it('does not claim the claimant will be contacted or notified', async () => {
+    it('mentions the automatic keep/release ask without promising the conflict resolves', async () => {
       loaderDataSnapshot.ideaClaimConflicts = [
         [
           'idea-1',
@@ -1005,13 +1005,13 @@ describe('app/routes/pools+/$poolId+/index.tsx', () => {
         name: "Sarah's already getting this one",
       });
       const dialogText = dialog.textContent ?? '';
-      // No promise of a Keep/Release follow-up to the claimant — that
-      // feature does not exist yet.
-      expect(dialogText).not.toMatch(/ask (them|if)/i);
-      expect(dialogText).not.toMatch(/let them know/i);
-      expect(dialogText).not.toMatch(/we'll/i);
+      // Task 16 wired the ask, so the dialog should now say so — but Keep is
+      // a legitimate outcome for the claimant, so this must never promise
+      // the conflict resolves or that nobody else ends up buying it.
+      expect(dialogText).toMatch(/we'll ask/i);
+      expect(dialogText).not.toMatch(/nobody else (will )?buys?/i);
       expect(dialogText).toContain(
-        "your pool won't hold the claim — so there's a real risk you both end up buying it.",
+        "there's still a real risk you both end up buying it.",
       );
     });
   });

--- a/app/routes/pools+/$poolId+/index.tsx
+++ b/app/routes/pools+/$poolId+/index.tsx
@@ -344,9 +344,12 @@ const IdeaCard = ({
                           worded correctly for this viewer's tier (person,
                           withheld person, or another pool) — then append the
                           honest consequence instead of rewriting who holds
-                          the claim or whose wishlist it's on. */}
+                          the claim or whose wishlist it's on. If a person
+                          holds it, choosing anyway now asks them to keep or
+                          release — but Keep is a legitimate choice, so this
+                          must not promise the conflict resolves. */}
                       <DialogDescription>
-                        {`${conflict.text}. If you choose it anyway, your pool won't hold the claim — so there's a real risk you both end up buying it.`}
+                        {`${conflict.text}. If you choose it anyway, your pool won't hold the claim. If a person holds it, we'll ask whether they're still getting it — but they can choose to keep it, so there's still a real risk you both end up buying it.`}
                       </DialogDescription>
                     </DialogHeader>
                     <DialogFooter>

--- a/app/routes/settings+/profile.index.tsx
+++ b/app/routes/settings+/profile.index.tsx
@@ -840,10 +840,11 @@ async function deleteDataAction({ userId }: ProfileActionArgs) {
   // so this never blocks deletion.
   const released = await releaseSoloClaimsMatching({ claimedByUserId: userId });
   for (const release of released) {
-    if (!release.transferredToPoolId) continue;
+    if (!release.transferredToPoolId || !release.transferredClaimId) continue;
     queueWishlistClaimTransferredNotification(
       release.transferredToPoolId,
       release.wishlistItemId,
+      release.transferredClaimId,
     );
   }
   await prisma.user.delete({ where: { id: userId } });

--- a/app/routes/settings+/profile.index.tsx
+++ b/app/routes/settings+/profile.index.tsx
@@ -32,6 +32,7 @@ import { Text } from '#app/components/ui-kit/text.tsx';
 import { requireUserId, sessionKey } from '#app/utils/auth.server.ts';
 import { prisma } from '#app/utils/db.server.ts';
 import { useDoubleCheck } from '#app/utils/misc.tsx';
+import { queueWishlistClaimTransferredNotification } from '#app/utils/pool.server.ts';
 import { authSessionStorage } from '#app/utils/session.server.ts';
 import { redirectWithToast } from '#app/utils/toast.server.ts';
 import {
@@ -837,7 +838,14 @@ async function deleteDataAction({ userId }: ProfileActionArgs) {
   // remove the evidence of that claim — goes away. `releaseSoloClaimsMatching`
   // is a no-op (empty array, no throw) when the user holds no solo claims,
   // so this never blocks deletion.
-  await releaseSoloClaimsMatching({ claimedByUserId: userId });
+  const released = await releaseSoloClaimsMatching({ claimedByUserId: userId });
+  for (const release of released) {
+    if (!release.transferredToPoolId) continue;
+    queueWishlistClaimTransferredNotification(
+      release.transferredToPoolId,
+      release.wishlistItemId,
+    );
+  }
   await prisma.user.delete({ where: { id: userId } });
   return redirectWithToast('/', {
     type: 'success',

--- a/app/routes/wishlist+/purchase.test.ts
+++ b/app/routes/wishlist+/purchase.test.ts
@@ -439,6 +439,84 @@ test('releasing a claim that transfers to a waiting pool reports the item as poo
   );
 });
 
+test('a release bound to a stale claim id does not destroy the current claim', async () => {
+  // Regression for the most serious finding: the notification's Release
+  // action now carries the WishlistClaim.id it was raised about. Reachable
+  // sequence — the claimant releases from the wishlist UI (no claimId, the
+  // notification row survives), re-claims the same item (a brand new claim
+  // row), then clicks Release on the now-stale notification. That must fail
+  // safely rather than silently dropping the user's current claim.
+  const { user: owner } = await createUserWithSession();
+  const { user: viewer, cookie } = await createUserWithSession();
+  await makeFriends(owner.id, viewer.id);
+  const item = await createWishlistItem({ ownerId: owner.id });
+
+  const originalClaim = await prisma.wishlistClaim.create({
+    data: { wishlistItemId: item.id, claimedByUserId: viewer.id },
+  });
+
+  // Released directly from the wishlist UI — no claimId, always allowed.
+  const firstRelease = await invoke({
+    cookie,
+    form: { wishlistItemId: item.id, intent: 'unpurchase' },
+  });
+  expect(getRouteResultStatus(firstRelease)).toBe(200);
+
+  // Re-claims the same item: a brand new WishlistClaim row.
+  const reclaim = await invoke({
+    cookie,
+    form: { wishlistItemId: item.id, intent: 'purchase' },
+  });
+  expect(getRouteResultStatus(reclaim)).toBe(200);
+  const currentClaim = await prisma.wishlistClaim.findUniqueOrThrow({
+    where: { wishlistItemId: item.id },
+  });
+  expect(currentClaim.id).not.toBe(originalClaim.id);
+
+  // Clicks Release on the stale notification, which still carries the
+  // original claim's id.
+  const staleRelease = await invoke({
+    cookie,
+    form: { wishlistItemId: item.id, intent: 'unpurchase', claimId: originalClaim.id },
+  });
+
+  expect(getRouteResultStatus(staleRelease)).toBe(400);
+  await expect(getRouteResultData(staleRelease)).resolves.toMatchObject({
+    ok: false,
+    claim: { claimedByUserId: viewer.id },
+  });
+
+  const claimAfter = await prisma.wishlistClaim.findUniqueOrThrow({
+    where: { wishlistItemId: item.id },
+  });
+  expect(claimAfter.id).toBe(currentClaim.id);
+  expect(claimAfter.claimedByUserId).toBe(viewer.id);
+});
+
+test('releases when the claimId matches the current claim exactly', async () => {
+  const { user: owner } = await createUserWithSession();
+  const { user: viewer, cookie } = await createUserWithSession();
+  await makeFriends(owner.id, viewer.id);
+  const item = await createWishlistItem({ ownerId: owner.id });
+  const claim = await prisma.wishlistClaim.create({
+    data: { wishlistItemId: item.id, claimedByUserId: viewer.id },
+  });
+
+  const response = await invoke({
+    cookie,
+    form: { wishlistItemId: item.id, intent: 'unpurchase', claimId: claim.id },
+  });
+
+  expect(getRouteResultStatus(response)).toBe(200);
+  await expect(getRouteResultData(response)).resolves.toMatchObject({
+    ok: true,
+    claim: null,
+  });
+  await expect(
+    prisma.wishlistClaim.findUnique({ where: { wishlistItemId: item.id } }),
+  ).resolves.toBeNull();
+});
+
 test('rejects releasing a claim held by someone else', async () => {
   const { user: owner } = await createUserWithSession();
   const { user: holder } = await createUserWithSession();

--- a/app/routes/wishlist+/purchase.test.ts
+++ b/app/routes/wishlist+/purchase.test.ts
@@ -517,6 +517,85 @@ test('releases when the claimId matches the current claim exactly', async () => 
   ).resolves.toBeNull();
 });
 
+test('resolves the matching WISHLIST_CLAIM_CONFLICT notification when the release commits, so a reload cannot offer Release again', async () => {
+  // Regression for the P2 finding: resolving the notification used to
+  // depend entirely on a second client request (the bell's separate dismiss
+  // call) succeeding. If that request failed, the notification stayed
+  // UNREAD server-side and a refresh re-offered a Release button bound to a
+  // claim that no longer existed — one that would fail every time it was
+  // clicked. The release path now resolves it directly, with no client
+  // follow-up required.
+  const { user: owner } = await createUserWithSession();
+  const { user: viewer, cookie } = await createUserWithSession();
+  await makeFriends(owner.id, viewer.id);
+  const item = await createWishlistItem({ ownerId: owner.id });
+  const claim = await prisma.wishlistClaim.create({
+    data: { wishlistItemId: item.id, claimedByUserId: viewer.id },
+  });
+  const notification = await prisma.notification.create({
+    data: {
+      userId: viewer.id,
+      type: 'WISHLIST_CLAIM_CONFLICT',
+      status: 'UNREAD',
+      messageKey: 'notifications.wishlistClaimConflict.message',
+      metadata: JSON.stringify({ wishlistItemId: item.id, claimId: claim.id }),
+      actions: JSON.stringify([
+        { kind: 'WISHLIST_CLAIM_KEEP', labelKey: 'notifications.wishlistClaimConflict.keep' },
+        { kind: 'WISHLIST_CLAIM_RELEASE', labelKey: 'notifications.wishlistClaimConflict.release' },
+      ]),
+    },
+  });
+
+  const response = await invoke({
+    cookie,
+    form: { wishlistItemId: item.id, intent: 'unpurchase', claimId: claim.id },
+  });
+
+  expect(getRouteResultStatus(response)).toBe(200);
+  await expect(getRouteResultData(response)).resolves.toMatchObject({ ok: true });
+
+  // Gone outright — not merely marked read — so a subsequent notifications
+  // list load (what "a reload" means server-side) has nothing left that
+  // could render a Release action for this claim.
+  await expect(
+    prisma.notification.findUnique({ where: { id: notification.id } }),
+  ).resolves.toBeNull();
+});
+
+test('leaves a WISHLIST_CLAIM_CONFLICT notification for a different claim occurrence untouched', async () => {
+  // Matching must be scoped to the exact claim occurrence (metadata.claimId),
+  // not just the wishlist item — otherwise resolving this release could wipe
+  // out a still-live conflict notification raised later about a fresh claim
+  // the same user takes out on the same item.
+  const { user: owner } = await createUserWithSession();
+  const { user: viewer, cookie } = await createUserWithSession();
+  await makeFriends(owner.id, viewer.id);
+  const item = await createWishlistItem({ ownerId: owner.id });
+  const claim = await prisma.wishlistClaim.create({
+    data: { wishlistItemId: item.id, claimedByUserId: viewer.id },
+  });
+  const unrelatedNotification = await prisma.notification.create({
+    data: {
+      userId: viewer.id,
+      type: 'WISHLIST_CLAIM_CONFLICT',
+      status: 'UNREAD',
+      messageKey: 'notifications.wishlistClaimConflict.message',
+      metadata: JSON.stringify({ wishlistItemId: item.id, claimId: 'claim-does-not-match' }),
+      actions: JSON.stringify([]),
+    },
+  });
+
+  const response = await invoke({
+    cookie,
+    form: { wishlistItemId: item.id, intent: 'unpurchase', claimId: claim.id },
+  });
+
+  expect(getRouteResultStatus(response)).toBe(200);
+  await expect(
+    prisma.notification.findUnique({ where: { id: unrelatedNotification.id } }),
+  ).resolves.not.toBeNull();
+});
+
 test('rejects releasing a claim held by someone else', async () => {
   const { user: owner } = await createUserWithSession();
   const { user: holder } = await createUserWithSession();

--- a/app/routes/wishlist+/purchase.ts
+++ b/app/routes/wishlist+/purchase.ts
@@ -4,7 +4,10 @@ import { z } from 'zod';
 import { queueLogEvent } from '#app/utils/analytics.server.ts';
 import { requireUserId } from '#app/utils/auth.server.ts';
 import { prisma } from '#app/utils/db.server.ts';
-import { queueWishlistClaimTransferredNotification } from '#app/utils/pool.server.ts';
+import {
+  queueWishlistClaimTransferredNotification,
+  resolveWishlistClaimConflictNotifications,
+} from '#app/utils/pool.server.ts';
 import { claimForUser, releaseUserClaim } from '#app/utils/wishlist-claims.server.ts';
 import { usersShareWishlistAccess } from '#app/utils/wishlist.server.ts';
 const PurchaseFormSchema = z.object({
@@ -197,6 +200,15 @@ export async function action({ request }: ActionFunctionArgs) {
       release.transferredClaimId,
     );
   }
+  // Resolve any WISHLIST_CLAIM_CONFLICT notification raised about the claim
+  // that was just released, so it can't resurface a Release action that
+  // would fail forever (the claim it targets is gone). This makes
+  // resolution durable server-side instead of depending on the notification
+  // bell's separate dismiss request succeeding — see
+  // resolveWishlistClaimConflictNotifications's docstring. Awaited but never
+  // throws, so a failure here can't turn this already-committed release into
+  // a 500.
+  await resolveWishlistClaimConflictNotifications(userId, release.releasedClaimId);
   // A transfer means the item is NOT free — settlement handed the claim
   // straight to the longest-waiting pool inside the same transaction as the
   // release (see `releaseUserClaim`). Reporting `claim: null` here would be a

--- a/app/routes/wishlist+/purchase.ts
+++ b/app/routes/wishlist+/purchase.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { queueLogEvent } from '#app/utils/analytics.server.ts';
 import { requireUserId } from '#app/utils/auth.server.ts';
 import { prisma } from '#app/utils/db.server.ts';
+import { queueWishlistClaimTransferredNotification } from '#app/utils/pool.server.ts';
 import { claimForUser, releaseUserClaim } from '#app/utils/wishlist-claims.server.ts';
 import { usersShareWishlistAccess } from '#app/utils/wishlist.server.ts';
 const PurchaseFormSchema = z.object({
@@ -173,6 +174,12 @@ export async function action({ request }: ActionFunctionArgs) {
     source: 'server',
     properties: { wishlistItemId, toPoolId: release.transferredToPoolId },
   });
+  if (release.transferredToPoolId) {
+    queueWishlistClaimTransferredNotification(
+      release.transferredToPoolId,
+      wishlistItemId,
+    );
+  }
   // A transfer means the item is NOT free — settlement handed the claim
   // straight to the longest-waiting pool inside the same transaction as the
   // release (see `releaseUserClaim`). Reporting `claim: null` here would be a

--- a/app/routes/wishlist+/purchase.ts
+++ b/app/routes/wishlist+/purchase.ts
@@ -10,6 +10,14 @@ import { usersShareWishlistAccess } from '#app/utils/wishlist.server.ts';
 const PurchaseFormSchema = z.object({
   wishlistItemId: z.string(),
   intent: z.enum(['purchase', 'unpurchase']),
+  // Present only when this release was triggered from a WISHLIST_CLAIM_CONFLICT
+  // notification's Release action — the WishlistClaim.id that notification
+  // was raised about. Binds the release to that exact claim occurrence so a
+  // stale notification (the claimant released elsewhere, re-claimed, then
+  // clicked an old notification) can't drop the user's current claim. Omitted
+  // by the wishlist page's own release button, which always means "release
+  // whatever I currently hold."
+  claimId: z.string().optional(),
 });
 export async function action({ request }: ActionFunctionArgs) {
   const userId = await requireUserId(request);
@@ -34,7 +42,7 @@ export async function action({ request }: ActionFunctionArgs) {
       },
     );
   }
-  const { wishlistItemId, intent } = submission.value;
+  const { wishlistItemId, intent, claimId } = submission.value;
   const wishlistItem = await prisma.wishlistItem.findUnique({
     where: {
       id: wishlistItemId,
@@ -152,14 +160,22 @@ export async function action({ request }: ActionFunctionArgs) {
       },
     };
   }
-  const release = await releaseUserClaim(wishlistItemId, userId);
+  const release = await releaseUserClaim(wishlistItemId, userId, claimId);
   if (!release.ok) {
     return data(
       {
         ok: false,
         wishlistItemId,
         claim: currentClaim,
-        error: 'You can only unmark items you marked as purchased.',
+        // 'stale' is distinct and legible on purpose: this is the notification
+        // Release action targeting a claim occurrence that is no longer
+        // live — the user's *current* claim was intentionally left untouched,
+        // not "reject, no explanation." See releaseUserClaim's docstring.
+        error:
+          release.reason === 'stale'
+            ? "That notification is out of date — your current claim on this item wasn't touched."
+            : 'You can only unmark items you marked as purchased.',
+        reason: release.reason,
       },
       {
         status: 400,
@@ -174,10 +190,11 @@ export async function action({ request }: ActionFunctionArgs) {
     source: 'server',
     properties: { wishlistItemId, toPoolId: release.transferredToPoolId },
   });
-  if (release.transferredToPoolId) {
+  if (release.transferredToPoolId && release.transferredClaimId) {
     queueWishlistClaimTransferredNotification(
       release.transferredToPoolId,
       wishlistItemId,
+      release.transferredClaimId,
     );
   }
   // A transfer means the item is NOT free — settlement handed the claim

--- a/app/routes/wishlist+/status.ts
+++ b/app/routes/wishlist+/status.ts
@@ -98,10 +98,11 @@ export async function action({ request }: ActionFunctionArgs) {
   // intent, letting someone else claim it out from under the pool on the
   // next request.
   const release = await releaseSoloClaimForItem(wishlistItemId);
-  if (release.transferredToPoolId) {
+  if (release.transferredToPoolId && release.transferredClaimId) {
     queueWishlistClaimTransferredNotification(
       release.transferredToPoolId,
       wishlistItemId,
+      release.transferredClaimId,
     );
   }
   const statusTextMap: Record<

--- a/app/routes/wishlist+/status.ts
+++ b/app/routes/wishlist+/status.ts
@@ -4,6 +4,7 @@ import { data, type ActionFunctionArgs } from 'react-router';
 import { z } from 'zod';
 import { requireUserId } from '#app/utils/auth.server.ts';
 import { prisma } from '#app/utils/db.server.ts';
+import { queueWishlistClaimTransferredNotification } from '#app/utils/pool.server.ts';
 import { releaseSoloClaimForItem } from '#app/utils/wishlist-claims.server.ts';
 import { wishlistItemStatusSchema } from '#app/utils/wishlist.ts';
 const WishlistStatusSchema = z.object({
@@ -96,7 +97,13 @@ export async function action({ request }: ActionFunctionArgs) {
   // delete would leave the item unclaimed even though the pool still has
   // intent, letting someone else claim it out from under the pool on the
   // next request.
-  await releaseSoloClaimForItem(wishlistItemId);
+  const release = await releaseSoloClaimForItem(wishlistItemId);
+  if (release.transferredToPoolId) {
+    queueWishlistClaimTransferredNotification(
+      release.transferredToPoolId,
+      wishlistItemId,
+    );
+  }
   const statusTextMap: Record<
     string,
     {

--- a/app/utils/notification-catalog.test.ts
+++ b/app/utils/notification-catalog.test.ts
@@ -107,11 +107,10 @@ describe('notification catalog', () => {
     expect(isNotificationType(null)).toBe(false);
   });
 
-  it('maps all three wishlist-claim events to one shared topic', () => {
+  it('maps both wishlist-claim events to one shared topic', () => {
     const topics = [
       NOTIFICATION_TYPES.WISHLIST_CLAIM_CONFLICT,
       NOTIFICATION_TYPES.WISHLIST_CLAIM_TRANSFERRED,
-      NOTIFICATION_TYPES.WISHLIST_CLAIM_RELEASED,
     ].map((t) => getNotificationEventDefinition(t).topic);
     expect(new Set(topics).size).toBe(1);
   });

--- a/app/utils/notification-catalog.test.ts
+++ b/app/utils/notification-catalog.test.ts
@@ -95,10 +95,32 @@ describe('notification catalog', () => {
       NOTIFICATION_TOPICS.POOL_PROGRESS,
       NOTIFICATION_TOPICS.ASSIGNMENTS,
       NOTIFICATION_TOPICS.ORGANIZER_NUDGES,
+      // WISHLIST_CLAIM_TRANSFERRED (context: 'POOL') shares this topic with
+      // WISHLIST_CLAIM_CONFLICT (context: 'NONE'), so the topic as a whole
+      // qualifies for pool/group context controls even though one of its two
+      // events does not.
+      NOTIFICATION_TOPICS.WISHLIST_CLAIM_CONFLICTS,
     ];
 
     expect(getNotificationTopicsForContext('POOL')).toEqual(poolTopics);
     expect(getNotificationTopicsForContext('GROUP')).toEqual(poolTopics);
+  });
+
+  it('scopes WISHLIST_CLAIM_TRANSFERRED to pool context so a muted pool suppresses it, but leaves WISHLIST_CLAIM_CONFLICT unscoped', () => {
+    // WISHLIST_CLAIM_CONFLICT's recipient may have no relationship to the
+    // pool's group at all (see the catalog entry's own comment) — it must
+    // stay context: 'NONE'. WISHLIST_CLAIM_TRANSFERRED's audience is always
+    // the inheriting pool's own contributors, so it must be context: 'POOL'
+    // for pool-mute settings to apply.
+    expect(
+      getNotificationEventDefinition(NOTIFICATION_TYPES.WISHLIST_CLAIM_CONFLICT)
+        .context,
+    ).toBe('NONE');
+    expect(
+      getNotificationEventDefinition(
+        NOTIFICATION_TYPES.WISHLIST_CLAIM_TRANSFERRED,
+      ).context,
+    ).toBe('POOL');
   });
 
   it('validates persisted type strings through the catalog', () => {

--- a/app/utils/notification-catalog.test.ts
+++ b/app/utils/notification-catalog.test.ts
@@ -107,6 +107,15 @@ describe('notification catalog', () => {
     expect(isNotificationType(null)).toBe(false);
   });
 
+  it('maps all three wishlist-claim events to one shared topic', () => {
+    const topics = [
+      NOTIFICATION_TYPES.WISHLIST_CLAIM_CONFLICT,
+      NOTIFICATION_TYPES.WISHLIST_CLAIM_TRANSFERRED,
+      NOTIFICATION_TYPES.WISHLIST_CLAIM_RELEASED,
+    ].map((t) => getNotificationEventDefinition(t).topic);
+    expect(new Set(topics).size).toBe(1);
+  });
+
   it('requires the context kind declared by an event', () => {
     const groupContext = { kind: 'GROUP', groupId: 'group-1' } as const;
     const poolContext = { kind: 'POOL', poolId: 'pool-1' } as const;

--- a/app/utils/notification-catalog.ts
+++ b/app/utils/notification-catalog.ts
@@ -519,12 +519,22 @@ type OrganizerNudgePayload = {
 };
 
 // Shared by all three wishlist-claim events (Task 15 registers the types;
-// Task 16 populates and sends them). `wishlistItemId` identifies the claim,
-// `poolId`/`poolTitle` the pool whose decision created or resolved the
-// conflict with this recipient's existing claim.
+// Task 16 sends WISHLIST_CLAIM_CONFLICT — TRANSFERRED/RELEASED remain
+// registered but unqueued until a future task needs them). `wishlistItemId`
+// identifies the claim; `itemTitle`/`recipientName`/`recipientUsername`
+// describe what's on the line and are safe to disclose to the claim holder
+// outright — they already know both, having claimed this exact item on this
+// exact person's wishlist. `poolId`/`poolTitle` identify the pool whose
+// decision created or resolved the conflict — kept here for bookkeeping and
+// for a future notification back to the pool's own side, NOT for use in
+// WISHLIST_CLAIM_CONFLICT's rendered copy: that notification can reach
+// someone with no relationship to the pool's group, and the privacy ladder
+// (wishlist-claim-disclosure.ts) never names a pool to an outsider.
 type WishlistClaimConflictPayload = {
   wishlistItemId: string;
   itemTitle: string;
+  recipientName: string;
+  recipientUsername: string;
   poolId: string;
   poolTitle: string;
 };

--- a/app/utils/notification-catalog.ts
+++ b/app/utils/notification-catalog.ts
@@ -358,15 +358,19 @@ export const NOTIFICATION_EVENT_CATALOG = {
     supportedChannels: allChannels,
     deliveryStrategy: 'PER_CHANNEL_LEDGER',
   },
-  // Unlike CONFLICT, this notifies the pool's own contributors (context:
-  // 'NONE' still, because the audience is every contributor of the
-  // inheriting pool, not one context-scoped recipient — see
-  // queueWishlistClaimTransferredNotification in pool.server.ts, which fans
-  // this out to each contributor individually).
+  // Unlike CONFLICT, this notifies the pool's own contributors — context:
+  // 'POOL', because the audience is exactly the inheriting pool's
+  // contributors (see queueWishlistClaimTransferredNotification in
+  // pool.server.ts, which fans this out to each contributor individually and
+  // passes `{ kind: 'POOL', poolId }` on every intent). A contributor who has
+  // muted that pool must not be pinged, so contextual activity settings have
+  // to actually apply here — unlike CONFLICT, where the recipient may have no
+  // relationship to the pool's group at all and there is no pool context to
+  // consult.
   [NOTIFICATION_TYPES.WISHLIST_CLAIM_TRANSFERRED]: {
     topic: NOTIFICATION_TOPICS.WISHLIST_CLAIM_CONFLICTS,
     importance: 'IMPORTANT',
-    context: 'NONE',
+    context: 'POOL',
     supportedChannels: allChannels,
     deliveryStrategy: 'PER_CHANNEL_LEDGER',
   },
@@ -536,6 +540,18 @@ type WishlistClaimEventPayload = {
   poolTitle: string;
 };
 
+// CONFLICT-only: identifies the specific WishlistClaim occurrence this
+// notification was raised about. Its Release action carries this back
+// through the request so the mutation can be bound to that exact occurrence
+// (see releaseUserClaim's expectedClaimId in wishlist-claims.server.ts) — a
+// stale notification (claimant released elsewhere, re-claimed, then clicked
+// an old notification's Release) fails safely instead of dropping the
+// user's current claim. TRANSFERRED has no equivalent need: it isn't
+// actionable, so there is nothing for a stale click to destroy.
+type WishlistClaimConflictPayload = WishlistClaimEventPayload & {
+  claimId: string;
+};
+
 type PayloadByType = {
   [NOTIFICATION_TYPES.FRIEND_REQUEST_RECEIVED]: FriendRequestPayload;
   [NOTIFICATION_TYPES.FRIEND_REQUEST_ACCEPTED]: FriendRequestPayload;
@@ -561,7 +577,7 @@ type PayloadByType = {
   [NOTIFICATION_TYPES.POOL_VOTE_REMINDER]: OrganizerNudgePayload;
   [NOTIFICATION_TYPES.POOL_PURCHASE_REMINDER]: OrganizerNudgePayload;
   [NOTIFICATION_TYPES.POOL_DELIVERY_REMINDER]: OrganizerNudgePayload;
-  [NOTIFICATION_TYPES.WISHLIST_CLAIM_CONFLICT]: WishlistClaimEventPayload;
+  [NOTIFICATION_TYPES.WISHLIST_CLAIM_CONFLICT]: WishlistClaimConflictPayload;
   [NOTIFICATION_TYPES.WISHLIST_CLAIM_TRANSFERRED]: WishlistClaimEventPayload;
 };
 

--- a/app/utils/notification-catalog.ts
+++ b/app/utils/notification-catalog.ts
@@ -14,7 +14,6 @@ export const NOTIFICATION_TYPES = {
   POOL_DELIVERY_REMINDER: 'POOL_DELIVERY_REMINDER',
   WISHLIST_CLAIM_CONFLICT: 'WISHLIST_CLAIM_CONFLICT',
   WISHLIST_CLAIM_TRANSFERRED: 'WISHLIST_CLAIM_TRANSFERRED',
-  WISHLIST_CLAIM_RELEASED: 'WISHLIST_CLAIM_RELEASED',
 } as const;
 
 export type NotificationType =
@@ -60,7 +59,6 @@ export function isOrganizerNudgeNotificationType(
 export const WISHLIST_CLAIM_NOTIFICATION_TYPES = [
   NOTIFICATION_TYPES.WISHLIST_CLAIM_CONFLICT,
   NOTIFICATION_TYPES.WISHLIST_CLAIM_TRANSFERRED,
-  NOTIFICATION_TYPES.WISHLIST_CLAIM_RELEASED,
 ] as const;
 
 export type WishlistClaimNotificationType =
@@ -351,7 +349,7 @@ export const NOTIFICATION_EVENT_CATALOG = {
   },
   // The claimant of a wishlist item is not necessarily a member or
   // contributor of the pool that decided on it (context: 'NONE', same
-  // reasoning as POOL_INVITATION_RECEIVED above) — these notify a person
+  // reasoning as POOL_INVITATION_RECEIVED above) — this notifies a person
   // outside the pool about what happened to their claim.
   [NOTIFICATION_TYPES.WISHLIST_CLAIM_CONFLICT]: {
     topic: NOTIFICATION_TOPICS.WISHLIST_CLAIM_CONFLICTS,
@@ -360,14 +358,12 @@ export const NOTIFICATION_EVENT_CATALOG = {
     supportedChannels: allChannels,
     deliveryStrategy: 'PER_CHANNEL_LEDGER',
   },
+  // Unlike CONFLICT, this notifies the pool's own contributors (context:
+  // 'NONE' still, because the audience is every contributor of the
+  // inheriting pool, not one context-scoped recipient — see
+  // queueWishlistClaimTransferredNotification in pool.server.ts, which fans
+  // this out to each contributor individually).
   [NOTIFICATION_TYPES.WISHLIST_CLAIM_TRANSFERRED]: {
-    topic: NOTIFICATION_TOPICS.WISHLIST_CLAIM_CONFLICTS,
-    importance: 'IMPORTANT',
-    context: 'NONE',
-    supportedChannels: allChannels,
-    deliveryStrategy: 'PER_CHANNEL_LEDGER',
-  },
-  [NOTIFICATION_TYPES.WISHLIST_CLAIM_RELEASED]: {
     topic: NOTIFICATION_TOPICS.WISHLIST_CLAIM_CONFLICTS,
     importance: 'IMPORTANT',
     context: 'NONE',
@@ -518,19 +514,20 @@ type OrganizerNudgePayload = {
   senderDisplayName: string;
 };
 
-// Shared by all three wishlist-claim events (Task 15 registers the types;
-// Task 16 sends WISHLIST_CLAIM_CONFLICT — TRANSFERRED/RELEASED remain
-// registered but unqueued until a future task needs them). `wishlistItemId`
-// identifies the claim; `itemTitle`/`recipientName`/`recipientUsername`
-// describe what's on the line and are safe to disclose to the claim holder
-// outright — they already know both, having claimed this exact item on this
-// exact person's wishlist. `poolId`/`poolTitle` identify the pool whose
-// decision created or resolved the conflict — kept here for bookkeeping and
-// for a future notification back to the pool's own side, NOT for use in
+// Shared by both wishlist-claim events. `wishlistItemId` identifies the
+// claim; `itemTitle`/`recipientName`/`recipientUsername` describe what's on
+// the line and are safe to disclose to either audience outright — a claim
+// holder already knows both (they claimed this exact item on this exact
+// person's wishlist), and a pool contributor already sees the item through
+// the pool's own idea list. `poolId`/`poolTitle` identify the pool whose
+// decision created or resolved the conflict. They must NOT appear in
 // WISHLIST_CLAIM_CONFLICT's rendered copy: that notification can reach
 // someone with no relationship to the pool's group, and the privacy ladder
-// (wishlist-claim-disclosure.ts) never names a pool to an outsider.
-type WishlistClaimConflictPayload = {
+// (wishlist-claim-disclosure.ts) never names a pool to an outsider. They ARE
+// safe in WISHLIST_CLAIM_TRANSFERRED's rendered copy: that notification's
+// audience is the inheriting pool's own contributors, who already know their
+// own pool.
+type WishlistClaimEventPayload = {
   wishlistItemId: string;
   itemTitle: string;
   recipientName: string;
@@ -564,9 +561,8 @@ type PayloadByType = {
   [NOTIFICATION_TYPES.POOL_VOTE_REMINDER]: OrganizerNudgePayload;
   [NOTIFICATION_TYPES.POOL_PURCHASE_REMINDER]: OrganizerNudgePayload;
   [NOTIFICATION_TYPES.POOL_DELIVERY_REMINDER]: OrganizerNudgePayload;
-  [NOTIFICATION_TYPES.WISHLIST_CLAIM_CONFLICT]: WishlistClaimConflictPayload;
-  [NOTIFICATION_TYPES.WISHLIST_CLAIM_TRANSFERRED]: WishlistClaimConflictPayload;
-  [NOTIFICATION_TYPES.WISHLIST_CLAIM_RELEASED]: WishlistClaimConflictPayload;
+  [NOTIFICATION_TYPES.WISHLIST_CLAIM_CONFLICT]: WishlistClaimEventPayload;
+  [NOTIFICATION_TYPES.WISHLIST_CLAIM_TRANSFERRED]: WishlistClaimEventPayload;
 };
 
 export type NotificationPayload<T extends NotificationType> = PayloadByType[T];

--- a/app/utils/notification-catalog.ts
+++ b/app/utils/notification-catalog.ts
@@ -12,6 +12,9 @@ export const NOTIFICATION_TYPES = {
   POOL_VOTE_REMINDER: 'POOL_VOTE_REMINDER',
   POOL_PURCHASE_REMINDER: 'POOL_PURCHASE_REMINDER',
   POOL_DELIVERY_REMINDER: 'POOL_DELIVERY_REMINDER',
+  WISHLIST_CLAIM_CONFLICT: 'WISHLIST_CLAIM_CONFLICT',
+  WISHLIST_CLAIM_TRANSFERRED: 'WISHLIST_CLAIM_TRANSFERRED',
+  WISHLIST_CLAIM_RELEASED: 'WISHLIST_CLAIM_RELEASED',
 } as const;
 
 export type NotificationType =
@@ -51,6 +54,23 @@ export function isOrganizerNudgeNotificationType(
 ): type is OrganizerNudgeNotificationType {
   return ORGANIZER_NUDGE_NOTIFICATION_TYPES.includes(
     type as OrganizerNudgeNotificationType,
+  );
+}
+
+export const WISHLIST_CLAIM_NOTIFICATION_TYPES = [
+  NOTIFICATION_TYPES.WISHLIST_CLAIM_CONFLICT,
+  NOTIFICATION_TYPES.WISHLIST_CLAIM_TRANSFERRED,
+  NOTIFICATION_TYPES.WISHLIST_CLAIM_RELEASED,
+] as const;
+
+export type WishlistClaimNotificationType =
+  (typeof WISHLIST_CLAIM_NOTIFICATION_TYPES)[number];
+
+export function isWishlistClaimNotificationType(
+  type: NotificationType,
+): type is WishlistClaimNotificationType {
+  return WISHLIST_CLAIM_NOTIFICATION_TYPES.includes(
+    type as WishlistClaimNotificationType,
   );
 }
 
@@ -109,6 +129,7 @@ export const NOTIFICATION_TOPICS = {
   POOL_PROGRESS: 'POOL_PROGRESS',
   ASSIGNMENTS: 'ASSIGNMENTS',
   ORGANIZER_NUDGES: 'ORGANIZER_NUDGES',
+  WISHLIST_CLAIM_CONFLICTS: 'WISHLIST_CLAIM_CONFLICTS',
 } as const;
 
 export type NotificationTopic =
@@ -219,6 +240,17 @@ export const NOTIFICATION_TOPIC_CATALOG = {
       pushEnabled: false,
     },
   },
+  [NOTIFICATION_TOPICS.WISHLIST_CLAIM_CONFLICTS]: {
+    category: NOTIFICATION_CATEGORIES.POOL_COORDINATION,
+    label: 'Wishlist claim conflicts',
+    description:
+      'When a pool decides on a gift you already claimed, and when that conflict resolves.',
+    defaults: {
+      inAppEnabled: true,
+      emailEnabled: false,
+      pushEnabled: false,
+    },
+  },
 } as const satisfies Record<NotificationTopic, NotificationTopicDefinition>;
 
 /**
@@ -314,6 +346,31 @@ export const NOTIFICATION_EVENT_CATALOG = {
     topic: NOTIFICATION_TOPICS.ORGANIZER_NUDGES,
     importance: 'IMPORTANT',
     context: 'POOL',
+    supportedChannels: allChannels,
+    deliveryStrategy: 'PER_CHANNEL_LEDGER',
+  },
+  // The claimant of a wishlist item is not necessarily a member or
+  // contributor of the pool that decided on it (context: 'NONE', same
+  // reasoning as POOL_INVITATION_RECEIVED above) — these notify a person
+  // outside the pool about what happened to their claim.
+  [NOTIFICATION_TYPES.WISHLIST_CLAIM_CONFLICT]: {
+    topic: NOTIFICATION_TOPICS.WISHLIST_CLAIM_CONFLICTS,
+    importance: 'IMPORTANT',
+    context: 'NONE',
+    supportedChannels: allChannels,
+    deliveryStrategy: 'PER_CHANNEL_LEDGER',
+  },
+  [NOTIFICATION_TYPES.WISHLIST_CLAIM_TRANSFERRED]: {
+    topic: NOTIFICATION_TOPICS.WISHLIST_CLAIM_CONFLICTS,
+    importance: 'IMPORTANT',
+    context: 'NONE',
+    supportedChannels: allChannels,
+    deliveryStrategy: 'PER_CHANNEL_LEDGER',
+  },
+  [NOTIFICATION_TYPES.WISHLIST_CLAIM_RELEASED]: {
+    topic: NOTIFICATION_TOPICS.WISHLIST_CLAIM_CONFLICTS,
+    importance: 'IMPORTANT',
+    context: 'NONE',
     supportedChannels: allChannels,
     deliveryStrategy: 'PER_CHANNEL_LEDGER',
   },
@@ -461,6 +518,17 @@ type OrganizerNudgePayload = {
   senderDisplayName: string;
 };
 
+// Shared by all three wishlist-claim events (Task 15 registers the types;
+// Task 16 populates and sends them). `wishlistItemId` identifies the claim,
+// `poolId`/`poolTitle` the pool whose decision created or resolved the
+// conflict with this recipient's existing claim.
+type WishlistClaimConflictPayload = {
+  wishlistItemId: string;
+  itemTitle: string;
+  poolId: string;
+  poolTitle: string;
+};
+
 type PayloadByType = {
   [NOTIFICATION_TYPES.FRIEND_REQUEST_RECEIVED]: FriendRequestPayload;
   [NOTIFICATION_TYPES.FRIEND_REQUEST_ACCEPTED]: FriendRequestPayload;
@@ -486,6 +554,9 @@ type PayloadByType = {
   [NOTIFICATION_TYPES.POOL_VOTE_REMINDER]: OrganizerNudgePayload;
   [NOTIFICATION_TYPES.POOL_PURCHASE_REMINDER]: OrganizerNudgePayload;
   [NOTIFICATION_TYPES.POOL_DELIVERY_REMINDER]: OrganizerNudgePayload;
+  [NOTIFICATION_TYPES.WISHLIST_CLAIM_CONFLICT]: WishlistClaimConflictPayload;
+  [NOTIFICATION_TYPES.WISHLIST_CLAIM_TRANSFERRED]: WishlistClaimConflictPayload;
+  [NOTIFICATION_TYPES.WISHLIST_CLAIM_RELEASED]: WishlistClaimConflictPayload;
 };
 
 export type NotificationPayload<T extends NotificationType> = PayloadByType[T];

--- a/app/utils/notification-events.server.test.tsx
+++ b/app/utils/notification-events.server.test.tsx
@@ -274,6 +274,7 @@ describe('wishlist claim conflict notification rendering', () => {
       recipientUsername: 'taylor',
       poolId: 'pool-1',
       poolTitle: 'Taylor birthday',
+      claimId: 'claim-1',
     },
   };
 
@@ -294,7 +295,10 @@ describe('wishlist claim conflict notification rendering', () => {
         recipient: 'Taylor',
       }),
       targetUrl: '/users/taylor/wishlist',
-      metadata: JSON.stringify({ wishlistItemId: 'wish-9' }),
+      metadata: JSON.stringify({
+        wishlistItemId: 'wish-9',
+        claimId: 'claim-1',
+      }),
       actions: JSON.stringify([
         {
           kind: 'WISHLIST_CLAIM_KEEP',

--- a/app/utils/notification-events.server.test.tsx
+++ b/app/utils/notification-events.server.test.tsx
@@ -261,3 +261,90 @@ describe('pool activity notification rendering', () => {
     });
   });
 });
+
+describe('wishlist claim conflict notification rendering', () => {
+  const conflictIntent: NotificationIntent<'WISHLIST_CLAIM_CONFLICT'> = {
+    userId: 'claimer-1',
+    type: NOTIFICATION_TYPES.WISHLIST_CLAIM_CONFLICT,
+    sourceIdentifier: 'claim-conflict:pool-1:wish-9',
+    payload: {
+      wishlistItemId: 'wish-9',
+      itemTitle: 'Noise-cancelling headphones',
+      recipientName: 'Taylor',
+      recipientUsername: 'taylor',
+      poolId: 'pool-1',
+      poolTitle: 'Taylor birthday',
+    },
+  };
+
+  beforeEach(() => {
+    createPreferenceToken.mockResolvedValue('preference-token');
+  });
+
+  it('renders the bell notification with Keep/Release actions and no pool identity', async () => {
+    const inApp = await renderNotificationChannel(
+      conflictIntent,
+      NOTIFICATION_CHANNELS.IN_APP,
+    );
+
+    expect(inApp).toMatchObject({
+      messageKey: 'notifications.wishlistClaimConflict.message',
+      messageParams: JSON.stringify({
+        item: 'Noise-cancelling headphones',
+        recipient: 'Taylor',
+      }),
+      targetUrl: '/users/taylor/wishlist',
+      metadata: JSON.stringify({ wishlistItemId: 'wish-9' }),
+      actions: JSON.stringify([
+        {
+          kind: 'WISHLIST_CLAIM_KEEP',
+          labelKey: 'notifications.wishlistClaimConflict.keep',
+        },
+        {
+          kind: 'WISHLIST_CLAIM_RELEASE',
+          labelKey: 'notifications.wishlistClaimConflict.release',
+        },
+      ]),
+    });
+    // Never leaks the pool or group identity to the claim holder.
+    expect(JSON.stringify(inApp)).not.toContain('pool-1');
+    expect(JSON.stringify(inApp)).not.toContain('Taylor birthday');
+  });
+
+  it('renders web push pointing at the wishlist, not the pool', async () => {
+    const push = await renderNotificationChannel(
+      conflictIntent,
+      NOTIFICATION_CHANNELS.WEB_PUSH,
+    );
+
+    expect(push).toEqual({
+      title: 'Still getting this?',
+      body: 'A group has also decided to get Noise-cancelling headphones for Taylor. Are you still getting it yourself?',
+      url: '/users/taylor/wishlist',
+      tag: 'claim-conflict:pool-1:wish-9',
+    });
+  });
+
+  it('renders the opt-in email without naming the pool', async () => {
+    const message = await renderNotificationChannel(
+      conflictIntent,
+      NOTIFICATION_CHANNELS.EMAIL,
+    );
+    const markup = renderToStaticMarkup(message.react);
+
+    expect(message.subject).toBe(
+      'Still getting Noise-cancelling headphones for Taylor?',
+    );
+    expect(markup).toContain('Open wishlist');
+    expect(markup).toContain('https://giftpool.example/users/taylor/wishlist');
+    expect(markup).toContain('Manage notification preferences');
+    expect(markup).not.toContain('Taylor birthday');
+    expect(markup).not.toContain('pool-1');
+  });
+
+  it('uses the caller-supplied sourceIdentifier instead of deriving one', () => {
+    expect(getNotificationOccurrenceKey(conflictIntent)).toBe(
+      'claim-conflict:pool-1:wish-9',
+    );
+  });
+});

--- a/app/utils/notification-events.server.tsx
+++ b/app/utils/notification-events.server.tsx
@@ -4,6 +4,7 @@ import { FriendRequestReceivedEmail } from '#app/emails/friend-request-received.
 import { PoolActivityEmail } from '#app/emails/pool-activity.tsx';
 import { PoolInvitationReceivedEmail } from '#app/emails/pool-invitation-received.tsx';
 import { UpcomingBirthdayEmail } from '#app/emails/upcoming-birthday.tsx';
+import { WishlistClaimConflictEmail } from '#app/emails/wishlist-claim-conflict.tsx';
 import { queueLogEvent } from '#app/utils/analytics.server.ts';
 import { OCCASION_REMINDER_EMAIL_SRC } from '#app/utils/analytics.ts';
 import { buildAppUrl } from '#app/utils/app-url.server.ts';
@@ -111,9 +112,13 @@ export async function renderNotificationChannel<C extends NotificationChannel>(
     case NOTIFICATION_TYPES.POOL_DELIVERY_REMINDER:
       return renderPoolActivity(intent, channel);
     case NOTIFICATION_TYPES.WISHLIST_CLAIM_CONFLICT:
+      return renderWishlistClaimConflict(intent, channel);
     case NOTIFICATION_TYPES.WISHLIST_CLAIM_TRANSFERRED:
     case NOTIFICATION_TYPES.WISHLIST_CLAIM_RELEASED:
-      // Registered in the catalog (Task 15); rendering is wired in Task 16.
+      // Registered in the catalog (Task 15). Nothing queues these two yet —
+      // Task 16 only sends WISHLIST_CLAIM_CONFLICT (see its report). Left as
+      // an explicit placeholder rather than inventing copy for an event no
+      // code path fires, which nobody could review against real behavior.
       throw new Error(`Rendering for ${intent.type} is not implemented yet.`);
   }
 }
@@ -336,6 +341,72 @@ async function renderUpcomingBirthday<C extends NotificationChannel>(
           messageParams,
         ),
         url: `/users/${payload.birthdayUsername}`,
+        tag: getNotificationOccurrenceKey(intent),
+      } as NotificationChannelMessageMap[C];
+  }
+}
+
+async function renderWishlistClaimConflict<C extends NotificationChannel>(
+  intent: NotificationIntent<'WISHLIST_CLAIM_CONFLICT'>,
+  channel: C,
+): Promise<NotificationChannelMessageMap[C]> {
+  const { payload } = intent;
+  // No poolId/poolTitle here on purpose — this notification can reach
+  // someone with no relationship to the pool's group, and the privacy
+  // ladder (wishlist-claim-disclosure.ts) never names a pool to an
+  // outsider. `wishlistUrl` points at the wishlist the recipient already
+  // knows about (it's the one they claimed on), never at the pool.
+  const messageParams = {
+    item: payload.itemTitle,
+    recipient: payload.recipientName,
+  };
+  const message = translate(
+    'en',
+    'notifications.wishlistClaimConflict.message',
+    messageParams,
+  );
+  const wishlistUrl = `/users/${payload.recipientUsername}/wishlist`;
+
+  switch (channel) {
+    case NOTIFICATION_CHANNELS.IN_APP:
+      return {
+        status: 'UNREAD',
+        messageKey: 'notifications.wishlistClaimConflict.message',
+        messageParams: JSON.stringify(messageParams),
+        targetUrl: wishlistUrl,
+        metadata: JSON.stringify({ wishlistItemId: payload.wishlistItemId }),
+        actions: JSON.stringify([
+          {
+            kind: 'WISHLIST_CLAIM_KEEP',
+            labelKey: 'notifications.wishlistClaimConflict.keep',
+          },
+          {
+            kind: 'WISHLIST_CLAIM_RELEASE',
+            labelKey: 'notifications.wishlistClaimConflict.release',
+          },
+        ]),
+        friendRequestId: null,
+      } as NotificationChannelMessageMap[C];
+    case NOTIFICATION_CHANNELS.EMAIL: {
+      const managePreferencesUrl = await buildManagePreferencesUrl(intent);
+      return {
+        subject: `Still getting ${payload.itemTitle} for ${payload.recipientName}?`,
+        react: (
+          <WishlistClaimConflictEmail
+            appName={appName}
+            itemTitle={payload.itemTitle}
+            recipientName={payload.recipientName}
+            wishlistUrl={buildAppUrl(wishlistUrl)}
+            managePreferencesUrl={managePreferencesUrl}
+          />
+        ),
+      } as NotificationChannelMessageMap[C];
+    }
+    case NOTIFICATION_CHANNELS.WEB_PUSH:
+      return {
+        title: translate('en', 'notifications.wishlistClaimConflict.pushTitle'),
+        body: message,
+        url: wishlistUrl,
         tag: getNotificationOccurrenceKey(intent),
       } as NotificationChannelMessageMap[C];
   }

--- a/app/utils/notification-events.server.tsx
+++ b/app/utils/notification-events.server.tsx
@@ -371,7 +371,13 @@ async function renderWishlistClaimConflict<C extends NotificationChannel>(
         messageKey: 'notifications.wishlistClaimConflict.message',
         messageParams: JSON.stringify(messageParams),
         targetUrl: wishlistUrl,
-        metadata: JSON.stringify({ wishlistItemId: payload.wishlistItemId }),
+        metadata: JSON.stringify({
+          wishlistItemId: payload.wishlistItemId,
+          // Carried through to the Release action so it can bind the
+          // mutation to this exact claim occurrence — see
+          // releaseUserClaim's expectedClaimId in wishlist-claims.server.ts.
+          claimId: payload.claimId,
+        }),
         actions: JSON.stringify([
           {
             kind: 'WISHLIST_CLAIM_KEEP',

--- a/app/utils/notification-events.server.tsx
+++ b/app/utils/notification-events.server.tsx
@@ -79,11 +79,13 @@ export function getNotificationOccurrenceKey(
     case NOTIFICATION_TYPES.POOL_VOTE_REMINDER:
     case NOTIFICATION_TYPES.POOL_PURCHASE_REMINDER:
     case NOTIFICATION_TYPES.POOL_DELIVERY_REMINDER:
-    // Registered in the catalog (Task 15); occurrence-key derivation and
-    // rendering are wired in Task 16.
+    // Both wishlist-claim events are always queued with an explicit
+    // `sourceIdentifier` (see queueWishlistClaimConflictNotification and
+    // queueWishlistClaimTransferredNotification in pool.server.ts), so the
+    // early return above always catches them — this case exists only so the
+    // switch stays exhaustive.
     case NOTIFICATION_TYPES.WISHLIST_CLAIM_CONFLICT:
     case NOTIFICATION_TYPES.WISHLIST_CLAIM_TRANSFERRED:
-    case NOTIFICATION_TYPES.WISHLIST_CLAIM_RELEASED:
       throw new Error(`Notification ${intent.type} requires a sourceIdentifier.`);
   }
 }
@@ -114,12 +116,7 @@ export async function renderNotificationChannel<C extends NotificationChannel>(
     case NOTIFICATION_TYPES.WISHLIST_CLAIM_CONFLICT:
       return renderWishlistClaimConflict(intent, channel);
     case NOTIFICATION_TYPES.WISHLIST_CLAIM_TRANSFERRED:
-    case NOTIFICATION_TYPES.WISHLIST_CLAIM_RELEASED:
-      // Registered in the catalog (Task 15). Nothing queues these two yet —
-      // Task 16 only sends WISHLIST_CLAIM_CONFLICT (see its report). Left as
-      // an explicit placeholder rather than inventing copy for an event no
-      // code path fires, which nobody could review against real behavior.
-      throw new Error(`Rendering for ${intent.type} is not implemented yet.`);
+      return renderWishlistClaimTransferred(intent, channel);
   }
 }
 
@@ -407,6 +404,69 @@ async function renderWishlistClaimConflict<C extends NotificationChannel>(
         title: translate('en', 'notifications.wishlistClaimConflict.pushTitle'),
         body: message,
         url: wishlistUrl,
+        tag: getNotificationOccurrenceKey(intent),
+      } as NotificationChannelMessageMap[C];
+  }
+}
+
+async function renderWishlistClaimTransferred<C extends NotificationChannel>(
+  intent: NotificationIntent<'WISHLIST_CLAIM_TRANSFERRED'>,
+  channel: C,
+): Promise<NotificationChannelMessageMap[C]> {
+  const { payload } = intent;
+  // Unlike WISHLIST_CLAIM_CONFLICT, this notification's audience is the
+  // inheriting pool's own contributors, who already know their own pool —
+  // naming it here is safe (see the payload comment in
+  // notification-catalog.ts). It links to the pool, not the recipient's
+  // wishlist, for the same reason.
+  const messageParams = {
+    item: payload.itemTitle,
+    recipient: payload.recipientName,
+    pool: payload.poolTitle,
+  };
+  const message = translate(
+    'en',
+    'notifications.wishlistClaimTransferred.message',
+    messageParams,
+  );
+  const poolUrl = `/pools/${payload.poolId}`;
+
+  switch (channel) {
+    case NOTIFICATION_CHANNELS.IN_APP:
+      return {
+        status: 'UNREAD',
+        messageKey: 'notifications.wishlistClaimTransferred.message',
+        messageParams: JSON.stringify(messageParams),
+        targetUrl: poolUrl,
+        metadata: JSON.stringify({
+          poolId: payload.poolId,
+          wishlistItemId: payload.wishlistItemId,
+        }),
+        friendRequestId: null,
+      } as NotificationChannelMessageMap[C];
+    case NOTIFICATION_CHANNELS.EMAIL: {
+      const managePreferencesUrl = await buildManagePreferencesUrl(intent);
+      return {
+        subject: `Duplicate risk cleared on ${payload.itemTitle} — ${appName}`,
+        react: (
+          <PoolActivityEmail
+            appName={appName}
+            heading={message}
+            message="Open the pool for the full details."
+            poolUrl={buildAppUrl(poolUrl)}
+            managePreferencesUrl={managePreferencesUrl}
+          />
+        ),
+      } as NotificationChannelMessageMap[C];
+    }
+    case NOTIFICATION_CHANNELS.WEB_PUSH:
+      return {
+        title: translate(
+          'en',
+          'notifications.wishlistClaimTransferred.pushTitle',
+        ),
+        body: message,
+        url: poolUrl,
         tag: getNotificationOccurrenceKey(intent),
       } as NotificationChannelMessageMap[C];
   }

--- a/app/utils/notification-events.server.tsx
+++ b/app/utils/notification-events.server.tsx
@@ -78,9 +78,12 @@ export function getNotificationOccurrenceKey(
     case NOTIFICATION_TYPES.POOL_VOTE_REMINDER:
     case NOTIFICATION_TYPES.POOL_PURCHASE_REMINDER:
     case NOTIFICATION_TYPES.POOL_DELIVERY_REMINDER:
-      throw new Error(
-        `Pool notification ${intent.type} requires a sourceIdentifier.`,
-      );
+    // Registered in the catalog (Task 15); occurrence-key derivation and
+    // rendering are wired in Task 16.
+    case NOTIFICATION_TYPES.WISHLIST_CLAIM_CONFLICT:
+    case NOTIFICATION_TYPES.WISHLIST_CLAIM_TRANSFERRED:
+    case NOTIFICATION_TYPES.WISHLIST_CLAIM_RELEASED:
+      throw new Error(`Notification ${intent.type} requires a sourceIdentifier.`);
   }
 }
 
@@ -107,6 +110,11 @@ export async function renderNotificationChannel<C extends NotificationChannel>(
     case NOTIFICATION_TYPES.POOL_PURCHASE_REMINDER:
     case NOTIFICATION_TYPES.POOL_DELIVERY_REMINDER:
       return renderPoolActivity(intent, channel);
+    case NOTIFICATION_TYPES.WISHLIST_CLAIM_CONFLICT:
+    case NOTIFICATION_TYPES.WISHLIST_CLAIM_TRANSFERRED:
+    case NOTIFICATION_TYPES.WISHLIST_CLAIM_RELEASED:
+      // Registered in the catalog (Task 15); rendering is wired in Task 16.
+      throw new Error(`Rendering for ${intent.type} is not implemented yet.`);
   }
 }
 

--- a/app/utils/pool.server.test.ts
+++ b/app/utils/pool.server.test.ts
@@ -94,9 +94,19 @@ vi.mock('#app/utils/pool-notifications.server.ts', () => ({
     queuePoolActivityNotifications(...args),
 }));
 
-vi.mock('#app/utils/wishlist-claims.server.ts', () => ({
-  syncPoolClaimInTx: (...args: Array<unknown>) => syncPoolClaimInTx(...args),
-}));
+vi.mock('#app/utils/wishlist-claims.server.ts', async (importOriginal) => {
+  // `POOL_INTENT_STATUSES` is a plain constant (no DB access) that
+  // `queueWishlistClaimConflictNotification`'s pool re-read relies on to
+  // decide whether the pool is still in a "decided" status — keep it real
+  // rather than re-declaring it here, so the two can't drift. Only
+  // `syncPoolClaimInTx` (which does hit the DB) is swapped for the spy.
+  const actual =
+    await importOriginal<typeof import('#app/utils/wishlist-claims.server.ts')>();
+  return {
+    ...actual,
+    syncPoolClaimInTx: (...args: Array<unknown>) => syncPoolClaimInTx(...args),
+  };
+});
 
 vi.mock('#app/utils/notification-dispatcher.server.ts', () => ({
   queueNotification: (...args: Array<unknown>) => queueNotification(...args),
@@ -667,6 +677,12 @@ describe('pool server utilities', () => {
         owner: { name: 'Taylor', username: 'taylor' },
       },
     });
+    // The pool re-read: still DECIDED and still pointed at wish-9, so the
+    // conflict this fanout was queued for is still live.
+    poolFindUnique.mockResolvedValueOnce({
+      status: 'DECIDED',
+      chosenIdea: { wishlistItemId: 'wish-9' },
+    });
 
     await chooseIdea('pool-1', 'idea-1', 'user-1');
 
@@ -702,6 +718,11 @@ describe('pool server utilities', () => {
       claimedItemId: null,
       conflictedItemId: 'wish-9',
       released: [],
+    });
+    // Both re-decisions genuinely still point the pool at wish-9.
+    poolFindUnique.mockResolvedValue({
+      status: 'DECIDED',
+      chosenIdea: { wishlistItemId: 'wish-9' },
     });
     // First conflict: the original claim.
     wishlistClaimFindUnique.mockResolvedValueOnce({
@@ -767,6 +788,10 @@ describe('pool server utilities', () => {
         title: 'Noise-cancelling headphones',
         owner: { name: null, username: 'taylor' },
       },
+    });
+    poolFindUnique.mockResolvedValueOnce({
+      status: 'DECIDED',
+      chosenIdea: { wishlistItemId: 'wish-9' },
     });
 
     await chooseIdea('pool-1', 'idea-1', 'user-1');
@@ -837,6 +862,74 @@ describe('pool server utilities', () => {
     expect(queueNotification).not.toHaveBeenCalled();
   });
 
+  it('stays silent when the pool has already re-decided away by the time the conflict fanout re-reads, and a later genuine re-decision back onto that item still notifies (the ledger key was never burned)', async () => {
+    giftIdeaFindFirst.mockResolvedValue({
+      estimatedPriceCents: 8000,
+      name: 'Speaker',
+      pool: { title: 'Taylor birthday' },
+    });
+    syncPoolClaimInTx.mockResolvedValue({
+      claimedItemId: null,
+      conflictedItemId: 'wish-9',
+      released: [],
+    });
+    // The solo claim on wish-9 is still live and still held by holder-1 —
+    // that alone is not enough to send the conflict notice.
+    wishlistClaimFindUnique.mockResolvedValueOnce({
+      id: 'claim-1',
+      claimedByUserId: 'holder-1',
+      wishlistItem: {
+        title: 'Noise-cancelling headphones',
+        owner: { name: 'Taylor', username: 'taylor' },
+      },
+    });
+    // ...because by the time this fire-and-forget fanout re-reads the pool,
+    // it has already been re-decided onto a different idea. The conflict
+    // this notification was queued for no longer exists.
+    poolFindUnique.mockResolvedValueOnce({
+      status: 'DECIDED',
+      chosenIdea: { wishlistItemId: 'wish-other' },
+    });
+
+    await chooseIdea('pool-1', 'idea-1', 'user-1');
+    await vi.waitFor(() => {
+      expect(poolFindUnique).toHaveBeenCalledWith({
+        where: { id: 'pool-1' },
+        select: expect.anything(),
+      });
+    });
+    // Flush the fire-and-forget microtask before asserting a negative.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(queueNotification).not.toHaveBeenCalled();
+
+    // A later, genuine re-decision back onto wish-9: this time the pool
+    // really is DECIDED with its chosen idea linking wish-9 by the time the
+    // fanout re-reads it, so this is a real conflict and must be reported —
+    // proving the first (suppressed) send never claimed the ledger key.
+    wishlistClaimFindUnique.mockResolvedValueOnce({
+      id: 'claim-1',
+      claimedByUserId: 'holder-1',
+      wishlistItem: {
+        title: 'Noise-cancelling headphones',
+        owner: { name: 'Taylor', username: 'taylor' },
+      },
+    });
+    poolFindUnique.mockResolvedValueOnce({
+      status: 'DECIDED',
+      chosenIdea: { wishlistItemId: 'wish-9' },
+    });
+
+    await chooseIdea('pool-1', 'idea-1', 'user-1');
+    await vi.waitFor(() => {
+      expect(queueNotification).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sourceIdentifier: 'claim-conflict:pool-1:wish-9:claim-1',
+        }),
+      );
+    });
+  });
+
   describe('queueWishlistClaimTransferredNotification', () => {
     it('notifies every contributor of the pool that inherited the claim, scoped to that pool context', async () => {
       poolFindUnique.mockResolvedValueOnce({
@@ -844,6 +937,7 @@ describe('pool server utilities', () => {
         contributors: [{ userId: 'contrib-1' }, { userId: 'contrib-2' }],
       });
       wishlistClaimFindUnique.mockResolvedValueOnce({
+        id: 'claim-9',
         poolId: 'pool-2',
         wishlistItem: {
           title: 'Noise-cancelling headphones',
@@ -887,10 +981,27 @@ describe('pool server utilities', () => {
         title: 'Taylor birthday',
         contributors: [{ userId: 'contrib-1' }],
       });
-      wishlistClaimFindUnique.mockResolvedValue({
-        poolId: 'pool-2',
-        wishlistItem: { title: 'Headphones', owner: { name: 'Taylor', username: 'taylor' } },
-      });
+      // Each call's re-read reflects the live claim occurrence at that
+      // moment: the first two calls are a retry of the *same* settlement
+      // (still claim-9 live), the third is a genuinely new settlement that
+      // has since replaced it (claim-10 live) — matching what the fixed
+      // re-read now requires (the live claim's id, not just its poolId).
+      wishlistClaimFindUnique
+        .mockResolvedValueOnce({
+          id: 'claim-9',
+          poolId: 'pool-2',
+          wishlistItem: { title: 'Headphones', owner: { name: 'Taylor', username: 'taylor' } },
+        })
+        .mockResolvedValueOnce({
+          id: 'claim-9',
+          poolId: 'pool-2',
+          wishlistItem: { title: 'Headphones', owner: { name: 'Taylor', username: 'taylor' } },
+        })
+        .mockResolvedValueOnce({
+          id: 'claim-10',
+          poolId: 'pool-2',
+          wishlistItem: { title: 'Headphones', owner: { name: 'Taylor', username: 'taylor' } },
+        });
 
       queueWishlistClaimTransferredNotification('pool-2', 'wish-9', 'claim-9');
       queueWishlistClaimTransferredNotification('pool-2', 'wish-9', 'claim-9');
@@ -951,6 +1062,52 @@ describe('pool server utilities', () => {
       await Promise.resolve();
       await Promise.resolve();
       expect(queueNotification).not.toHaveBeenCalled();
+    });
+
+    it('drops a stale settlement whose delayed fanout finds the same pool but a different, newer claim occurrence — and the current settlement still sends exactly once', async () => {
+      // Settlement A's fanout is delayed. By the time it re-reads, the pool
+      // decided away and back: a fresh solo claim on the same item was made
+      // and released, so the live row is settlement B's claim, not A's — the
+      // pool id matches, but the claim occurrence doesn't.
+      poolFindUnique.mockResolvedValue({
+        title: 'Taylor birthday',
+        contributors: [{ userId: 'contrib-1' }],
+      });
+      wishlistClaimFindUnique.mockResolvedValueOnce({
+        id: 'claim-B',
+        poolId: 'pool-2',
+        wishlistItem: { title: 'Headphones', owner: { name: 'Taylor', username: 'taylor' } },
+      });
+
+      queueWishlistClaimTransferredNotification('pool-2', 'wish-9', 'claim-A-stale');
+
+      await vi.waitFor(() => {
+        expect(wishlistClaimFindUnique).toHaveBeenCalledTimes(1);
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(queueNotification).not.toHaveBeenCalled();
+
+      // Settlement B's own fanout arrives separately, sees its own live
+      // claim row, and sends exactly once under its own key — proving A's
+      // suppressed send never burned B's ledger key (and B doesn't double
+      // up either).
+      wishlistClaimFindUnique.mockResolvedValueOnce({
+        id: 'claim-B',
+        poolId: 'pool-2',
+        wishlistItem: { title: 'Headphones', owner: { name: 'Taylor', username: 'taylor' } },
+      });
+
+      queueWishlistClaimTransferredNotification('pool-2', 'wish-9', 'claim-B');
+
+      await vi.waitFor(() => {
+        expect(queueNotification).toHaveBeenCalledTimes(1);
+      });
+      expect(queueNotification).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sourceIdentifier: 'claim-transferred:pool-2:wish-9:claim-B',
+        }),
+      );
     });
 
     it('sends a read failure to Sentry without throwing — a fanout failure must never turn a committed release into a 500', async () => {

--- a/app/utils/pool.server.test.ts
+++ b/app/utils/pool.server.test.ts
@@ -685,6 +685,7 @@ describe('pool server utilities', () => {
           recipientUsername: 'taylor',
           poolId: 'pool-1',
           poolTitle: 'Taylor birthday',
+          claimId: 'claim-1',
         },
         sourceIdentifier: 'claim-conflict:pool-1:wish-9:claim-1',
       });
@@ -837,7 +838,7 @@ describe('pool server utilities', () => {
   });
 
   describe('queueWishlistClaimTransferredNotification', () => {
-    it('notifies every contributor of the pool that inherited the claim', async () => {
+    it('notifies every contributor of the pool that inherited the claim, scoped to that pool context', async () => {
       poolFindUnique.mockResolvedValueOnce({
         title: 'Taylor birthday',
         contributors: [{ userId: 'contrib-1' }, { userId: 'contrib-2' }],
@@ -850,7 +851,7 @@ describe('pool server utilities', () => {
         },
       });
 
-      queueWishlistClaimTransferredNotification('pool-2', 'wish-9');
+      queueWishlistClaimTransferredNotification('pool-2', 'wish-9', 'claim-9');
 
       await vi.waitFor(() => {
         expect(queueNotification).toHaveBeenCalledTimes(2);
@@ -858,6 +859,10 @@ describe('pool server utilities', () => {
       expect(queueNotification).toHaveBeenCalledWith({
         userId: 'contrib-1',
         type: NOTIFICATION_TYPES.WISHLIST_CLAIM_TRANSFERRED,
+        // Unlike CONFLICT (context: 'NONE'), this reaches only the
+        // inheriting pool's own contributors, so pool-context mute settings
+        // must actually be consulted — see the catalog entry's comment.
+        context: { kind: 'POOL', poolId: 'pool-2' },
         payload: {
           wishlistItemId: 'wish-9',
           itemTitle: 'Noise-cancelling headphones',
@@ -866,11 +871,45 @@ describe('pool server utilities', () => {
           poolId: 'pool-2',
           poolTitle: 'Taylor birthday',
         },
-        sourceIdentifier: 'claim-transferred:pool-2:wish-9',
+        sourceIdentifier: 'claim-transferred:pool-2:wish-9:claim-9',
       });
       expect(queueNotification).toHaveBeenCalledWith(
         expect.objectContaining({ userId: 'contrib-2' }),
       );
+    });
+
+    it('varies the key with the settled claim id, so a later genuinely-new settlement is a distinct delivery and a retry of the same one stays deduped', () => {
+      // Two calls for the SAME settlement (a retry: the cleanup loader
+      // re-running, or this call site firing twice for one commit) must
+      // produce the identical key so the NotificationDelivery ledger
+      // dedupes them.
+      poolFindUnique.mockResolvedValue({
+        title: 'Taylor birthday',
+        contributors: [{ userId: 'contrib-1' }],
+      });
+      wishlistClaimFindUnique.mockResolvedValue({
+        poolId: 'pool-2',
+        wishlistItem: { title: 'Headphones', owner: { name: 'Taylor', username: 'taylor' } },
+      });
+
+      queueWishlistClaimTransferredNotification('pool-2', 'wish-9', 'claim-9');
+      queueWishlistClaimTransferredNotification('pool-2', 'wish-9', 'claim-9');
+      // A later, genuinely new settlement onto the same pool+item — the
+      // sibling of the recreated-conflict fix — must produce a distinct key
+      // instead of colliding with (and being silently suppressed by) the
+      // first settlement's ledger rows.
+      queueWishlistClaimTransferredNotification('pool-2', 'wish-9', 'claim-10');
+
+      return vi.waitFor(() => {
+        const sourceIdentifiers = queueNotification.mock.calls.map(
+          ([intent]) => intent.sourceIdentifier,
+        );
+        expect(sourceIdentifiers).toEqual([
+          'claim-transferred:pool-2:wish-9:claim-9',
+          'claim-transferred:pool-2:wish-9:claim-9',
+          'claim-transferred:pool-2:wish-9:claim-10',
+        ]);
+      });
     });
 
     it('stays silent when the pool no longer exists', async () => {
@@ -880,7 +919,7 @@ describe('pool server utilities', () => {
         wishlistItem: { title: 'Headphones', owner: { name: 'Taylor', username: 'taylor' } },
       });
 
-      queueWishlistClaimTransferredNotification('pool-2', 'wish-9');
+      queueWishlistClaimTransferredNotification('pool-2', 'wish-9', 'claim-9');
 
       await vi.waitFor(() => {
         expect(wishlistClaimFindUnique).toHaveBeenCalled();
@@ -904,7 +943,7 @@ describe('pool server utilities', () => {
         wishlistItem: { title: 'Headphones', owner: { name: 'Taylor', username: 'taylor' } },
       });
 
-      queueWishlistClaimTransferredNotification('pool-2', 'wish-9');
+      queueWishlistClaimTransferredNotification('pool-2', 'wish-9', 'claim-9');
 
       await vi.waitFor(() => {
         expect(wishlistClaimFindUnique).toHaveBeenCalled();
@@ -923,7 +962,7 @@ describe('pool server utilities', () => {
       });
 
       expect(() =>
-        queueWishlistClaimTransferredNotification('pool-2', 'wish-9'),
+        queueWishlistClaimTransferredNotification('pool-2', 'wish-9', 'claim-9'),
       ).not.toThrow();
 
       await vi.waitFor(() => {

--- a/app/utils/pool.server.test.ts
+++ b/app/utils/pool.server.test.ts
@@ -7,6 +7,9 @@ import { NOTIFICATION_TYPES } from '#app/utils/notification-catalog.ts';
 const nanoid = vi.fn(() => 'invite-123');
 
 const captureMessage = vi.fn();
+const captureException = vi.fn();
+const queueNotification = vi.fn();
+const wishlistClaimFindUnique = vi.fn();
 
 const giftIdeaCreate = vi.fn();
 const giftIdeaDelete = vi.fn();
@@ -32,7 +35,7 @@ vi.mock('nanoid', () => ({
 }));
 
 vi.mock('@sentry/react-router', () => ({
-  captureException: vi.fn(),
+  captureException: (...args: Array<unknown>) => captureException(...args),
   captureMessage: (...args: Array<unknown>) => captureMessage(...args),
 }));
 
@@ -65,6 +68,14 @@ vi.mock('#app/utils/db.server.ts', () => {
         poolContributorFindUnique(...args),
       update: (...args: Array<unknown>) => poolContributorUpdate(...args),
     },
+    // Read-only in this module: `chooseIdea` looks up the current claim
+    // holder (post-transaction) to compose the conflict notification. Only
+    // wishlist-claims.server.ts is permitted to write WishlistClaim — see
+    // wishlist-claim-write-guard.test.ts.
+    wishlistClaim: {
+      findUnique: (...args: Array<unknown>) =>
+        wishlistClaimFindUnique(...args),
+    },
     $transaction: (fn: (tx: unknown) => unknown) => fn(prismaMock),
   };
   return { prisma: prismaMock };
@@ -85,6 +96,10 @@ vi.mock('#app/utils/pool-notifications.server.ts', () => ({
 
 vi.mock('#app/utils/wishlist-claims.server.ts', () => ({
   syncPoolClaimInTx: (...args: Array<unknown>) => syncPoolClaimInTx(...args),
+}));
+
+vi.mock('#app/utils/notification-dispatcher.server.ts', () => ({
+  queueNotification: (...args: Array<unknown>) => queueNotification(...args),
 }));
 
 import {
@@ -117,6 +132,9 @@ import {
 beforeEach(() => {
   nanoid.mockReset().mockReturnValue('invite-123');
   captureMessage.mockReset();
+  captureException.mockReset();
+  queueNotification.mockReset();
+  wishlistClaimFindUnique.mockReset().mockResolvedValue(null);
   giftIdeaCreate
     .mockReset()
     .mockResolvedValue({ id: 'idea-1', name: 'Speaker' });
@@ -615,6 +633,7 @@ describe('pool server utilities', () => {
     giftIdeaFindFirst.mockResolvedValue({
       estimatedPriceCents: 8000,
       name: 'Speaker',
+      pool: { title: 'Taylor birthday' },
     });
     syncPoolClaimInTx.mockResolvedValueOnce({
       claimedItemId: null,
@@ -626,6 +645,135 @@ describe('pool server utilities', () => {
       claimedItemId: null,
       conflictedItemId: 'wish-9',
     });
+  });
+
+  it('asks the claim holder to keep or release when the holder is a person', async () => {
+    giftIdeaFindFirst.mockResolvedValue({
+      estimatedPriceCents: 8000,
+      name: 'Speaker',
+      pool: { title: 'Taylor birthday' },
+    });
+    syncPoolClaimInTx.mockResolvedValueOnce({
+      claimedItemId: null,
+      conflictedItemId: 'wish-9',
+      released: [],
+    });
+    wishlistClaimFindUnique.mockResolvedValueOnce({
+      claimedByUserId: 'holder-1',
+      wishlistItem: {
+        title: 'Noise-cancelling headphones',
+        owner: { name: 'Taylor', username: 'taylor' },
+      },
+    });
+
+    await chooseIdea('pool-1', 'idea-1', 'user-1');
+
+    expect(wishlistClaimFindUnique).toHaveBeenCalledWith({
+      where: { wishlistItemId: 'wish-9' },
+      select: expect.anything(),
+    });
+    await vi.waitFor(() => {
+      expect(queueNotification).toHaveBeenCalledWith({
+        userId: 'holder-1',
+        type: NOTIFICATION_TYPES.WISHLIST_CLAIM_CONFLICT,
+        payload: {
+          wishlistItemId: 'wish-9',
+          itemTitle: 'Noise-cancelling headphones',
+          recipientName: 'Taylor',
+          recipientUsername: 'taylor',
+          poolId: 'pool-1',
+          poolTitle: 'Taylor birthday',
+        },
+        sourceIdentifier: 'claim-conflict:pool-1:wish-9',
+      });
+    });
+  });
+
+  it('falls back to the username when the wishlist owner has no display name', async () => {
+    giftIdeaFindFirst.mockResolvedValue({
+      estimatedPriceCents: 8000,
+      name: 'Speaker',
+      pool: { title: 'Taylor birthday' },
+    });
+    syncPoolClaimInTx.mockResolvedValueOnce({
+      claimedItemId: null,
+      conflictedItemId: 'wish-9',
+      released: [],
+    });
+    wishlistClaimFindUnique.mockResolvedValueOnce({
+      claimedByUserId: 'holder-1',
+      wishlistItem: {
+        title: 'Noise-cancelling headphones',
+        owner: { name: null, username: 'taylor' },
+      },
+    });
+
+    await chooseIdea('pool-1', 'idea-1', 'user-1');
+
+    await vi.waitFor(() => {
+      expect(queueNotification).toHaveBeenCalledWith(
+        expect.objectContaining({
+          payload: expect.objectContaining({ recipientName: 'taylor' }),
+        }),
+      );
+    });
+  });
+
+  it('does not queue a notification when the conflicting claim is held by another pool', async () => {
+    giftIdeaFindFirst.mockResolvedValue({
+      estimatedPriceCents: 8000,
+      name: 'Speaker',
+      pool: { title: 'Taylor birthday' },
+    });
+    syncPoolClaimInTx.mockResolvedValueOnce({
+      claimedItemId: null,
+      conflictedItemId: 'wish-9',
+      released: [],
+    });
+    // A pool-held claim: `claimedByUserId` is null, `poolId` is set — nobody
+    // to ask.
+    wishlistClaimFindUnique.mockResolvedValueOnce({
+      claimedByUserId: null,
+      wishlistItem: {
+        title: 'Noise-cancelling headphones',
+        owner: { name: 'Taylor', username: 'taylor' },
+      },
+    });
+
+    await chooseIdea('pool-1', 'idea-1', 'user-1');
+    // Flush the fire-and-forget notification microtask before asserting a
+    // negative, or this passes trivially before the read even resolves.
+    await vi.waitFor(() => {
+      expect(wishlistClaimFindUnique).toHaveBeenCalled();
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(queueNotification).not.toHaveBeenCalled();
+  });
+
+  it('sends a conflict-notification failure to Sentry without throwing', async () => {
+    giftIdeaFindFirst.mockResolvedValue({
+      estimatedPriceCents: 8000,
+      name: 'Speaker',
+      pool: { title: 'Taylor birthday' },
+    });
+    syncPoolClaimInTx.mockResolvedValueOnce({
+      claimedItemId: null,
+      conflictedItemId: 'wish-9',
+      released: [],
+    });
+    const boom = new Error('read failed');
+    wishlistClaimFindUnique.mockRejectedValueOnce(boom);
+
+    await expect(
+      chooseIdea('pool-1', 'idea-1', 'user-1'),
+    ).resolves.toMatchObject({ conflictedItemId: 'wish-9' });
+
+    await vi.waitFor(() => {
+      expect(captureException).toHaveBeenCalledWith(boom);
+    });
+    expect(queueNotification).not.toHaveBeenCalled();
   });
 
   it('propagates a claim-sync failure and skips every post-decision side effect', async () => {

--- a/app/utils/pool.server.test.ts
+++ b/app/utils/pool.server.test.ts
@@ -17,6 +17,8 @@ const giftIdeaFindFirst = vi.fn();
 const ideaVoteUpsert = vi.fn();
 const ideaVoteCount = vi.fn();
 const logPoolActivity = vi.fn();
+const notificationFindMany = vi.fn();
+const notificationDeleteMany = vi.fn();
 const poolContributorCreate = vi.fn();
 const poolContributorDelete = vi.fn();
 const poolContributorFindUnique = vi.fn();
@@ -75,6 +77,10 @@ vi.mock('#app/utils/db.server.ts', () => {
     wishlistClaim: {
       findUnique: (...args: Array<unknown>) =>
         wishlistClaimFindUnique(...args),
+    },
+    notification: {
+      findMany: (...args: Array<unknown>) => notificationFindMany(...args),
+      deleteMany: (...args: Array<unknown>) => notificationDeleteMany(...args),
     },
     $transaction: (fn: (tx: unknown) => unknown) => fn(prismaMock),
   };
@@ -138,6 +144,7 @@ import {
   updateFinalPrice,
   updatePool,
   queueWishlistClaimTransferredNotification,
+  resolveWishlistClaimConflictNotifications,
 } from './pool.server.ts';
 
 beforeEach(() => {
@@ -154,6 +161,8 @@ beforeEach(() => {
   ideaVoteUpsert.mockReset().mockResolvedValue(undefined);
   ideaVoteCount.mockReset().mockResolvedValue(0);
   logPoolActivity.mockReset().mockResolvedValue(undefined);
+  notificationFindMany.mockReset().mockResolvedValue([]);
+  notificationDeleteMany.mockReset().mockResolvedValue({ count: 0 });
   poolContributorCreate.mockReset().mockResolvedValue({ id: 'contrib-1' });
   poolContributorDelete.mockReset().mockResolvedValue(undefined);
   poolContributorFindUnique.mockReset();
@@ -1126,6 +1135,67 @@ describe('pool server utilities', () => {
         expect(captureException).toHaveBeenCalledWith(boom);
       });
       expect(queueNotification).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('resolveWishlistClaimConflictNotifications', () => {
+    it('deletes only the WISHLIST_CLAIM_CONFLICT notification bound to the released claim', async () => {
+      notificationFindMany.mockResolvedValueOnce([
+        { id: 'notif-match', metadata: JSON.stringify({ wishlistItemId: 'wish-9', claimId: 'claim-9' }) },
+        // A different claim occurrence on the same or another item — must be
+        // left alone. Matching on the claim id (not just wishlistItemId)
+        // is what keeps a still-live conflict notification for a later,
+        // genuinely new claim from being wiped out by an earlier release.
+        { id: 'notif-other', metadata: JSON.stringify({ wishlistItemId: 'wish-9', claimId: 'claim-10' }) },
+      ]);
+
+      await resolveWishlistClaimConflictNotifications('user-1', 'claim-9');
+
+      expect(notificationFindMany).toHaveBeenCalledWith({
+        where: { userId: 'user-1', type: NOTIFICATION_TYPES.WISHLIST_CLAIM_CONFLICT },
+        select: { id: true, metadata: true },
+      });
+      expect(notificationDeleteMany).toHaveBeenCalledWith({
+        where: { id: { in: ['notif-match'] } },
+      });
+    });
+
+    it('does nothing when no notification matches the released claim', async () => {
+      notificationFindMany.mockResolvedValueOnce([
+        { id: 'notif-other', metadata: JSON.stringify({ wishlistItemId: 'wish-9', claimId: 'claim-10' }) },
+        // Malformed/empty metadata must be skipped, not thrown on.
+        { id: 'notif-empty', metadata: null },
+      ]);
+
+      await resolveWishlistClaimConflictNotifications('user-1', 'claim-9');
+
+      expect(notificationDeleteMany).not.toHaveBeenCalled();
+    });
+
+    it('reports a read failure to Sentry without throwing — cleanup must never fail an already-committed release', async () => {
+      const boom = new Error('read failed');
+      notificationFindMany.mockRejectedValueOnce(boom);
+
+      await expect(
+        resolveWishlistClaimConflictNotifications('user-1', 'claim-9'),
+      ).resolves.toBeUndefined();
+
+      expect(captureException).toHaveBeenCalledWith(boom);
+      expect(notificationDeleteMany).not.toHaveBeenCalled();
+    });
+
+    it('reports a delete failure to Sentry without throwing', async () => {
+      notificationFindMany.mockResolvedValueOnce([
+        { id: 'notif-match', metadata: JSON.stringify({ wishlistItemId: 'wish-9', claimId: 'claim-9' }) },
+      ]);
+      const boom = new Error('delete failed');
+      notificationDeleteMany.mockRejectedValueOnce(boom);
+
+      await expect(
+        resolveWishlistClaimConflictNotifications('user-1', 'claim-9'),
+      ).resolves.toBeUndefined();
+
+      expect(captureException).toHaveBeenCalledWith(boom);
     });
   });
 

--- a/app/utils/pool.server.test.ts
+++ b/app/utils/pool.server.test.ts
@@ -127,6 +127,7 @@ import {
   updateContribution,
   updateFinalPrice,
   updatePool,
+  queueWishlistClaimTransferredNotification,
 } from './pool.server.ts';
 
 beforeEach(() => {
@@ -659,6 +660,7 @@ describe('pool server utilities', () => {
       released: [],
     });
     wishlistClaimFindUnique.mockResolvedValueOnce({
+      id: 'claim-1',
       claimedByUserId: 'holder-1',
       wishlistItem: {
         title: 'Noise-cancelling headphones',
@@ -684,9 +686,67 @@ describe('pool server utilities', () => {
           poolId: 'pool-1',
           poolTitle: 'Taylor birthday',
         },
-        sourceIdentifier: 'claim-conflict:pool-1:wish-9',
+        sourceIdentifier: 'claim-conflict:pool-1:wish-9:claim-1',
       });
     });
+  });
+
+  it('varies the conflict-notification key with the claim id, so a recreated conflict is a distinct delivery', async () => {
+    giftIdeaFindFirst.mockResolvedValue({
+      estimatedPriceCents: 8000,
+      name: 'Speaker',
+      pool: { title: 'Taylor birthday' },
+    });
+    syncPoolClaimInTx.mockResolvedValue({
+      claimedItemId: null,
+      conflictedItemId: 'wish-9',
+      released: [],
+    });
+    // First conflict: the original claim.
+    wishlistClaimFindUnique.mockResolvedValueOnce({
+      id: 'claim-1',
+      claimedByUserId: 'holder-1',
+      wishlistItem: {
+        title: 'Noise-cancelling headphones',
+        owner: { name: 'Taylor', username: 'taylor' },
+      },
+    });
+    await chooseIdea('pool-1', 'idea-1', 'user-1');
+    await vi.waitFor(() => {
+      expect(queueNotification).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sourceIdentifier: 'claim-conflict:pool-1:wish-9:claim-1',
+        }),
+      );
+    });
+
+    // Same pool/item decide again, but the holder released and re-claimed in
+    // between — a fresh WishlistClaim row (different id) backs this
+    // genuinely new conflict, so the key must differ from the first.
+    wishlistClaimFindUnique.mockResolvedValueOnce({
+      id: 'claim-2',
+      claimedByUserId: 'holder-1',
+      wishlistItem: {
+        title: 'Noise-cancelling headphones',
+        owner: { name: 'Taylor', username: 'taylor' },
+      },
+    });
+    await chooseIdea('pool-1', 'idea-1', 'user-1');
+    await vi.waitFor(() => {
+      expect(queueNotification).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sourceIdentifier: 'claim-conflict:pool-1:wish-9:claim-2',
+        }),
+      );
+    });
+
+    const conflictSourceIdentifiers = queueNotification.mock.calls
+      .filter(([intent]) => intent.type === NOTIFICATION_TYPES.WISHLIST_CLAIM_CONFLICT)
+      .map(([intent]) => intent.sourceIdentifier);
+    expect(conflictSourceIdentifiers).toEqual([
+      'claim-conflict:pool-1:wish-9:claim-1',
+      'claim-conflict:pool-1:wish-9:claim-2',
+    ]);
   });
 
   it('falls back to the username when the wishlist owner has no display name', async () => {
@@ -774,6 +834,103 @@ describe('pool server utilities', () => {
       expect(captureException).toHaveBeenCalledWith(boom);
     });
     expect(queueNotification).not.toHaveBeenCalled();
+  });
+
+  describe('queueWishlistClaimTransferredNotification', () => {
+    it('notifies every contributor of the pool that inherited the claim', async () => {
+      poolFindUnique.mockResolvedValueOnce({
+        title: 'Taylor birthday',
+        contributors: [{ userId: 'contrib-1' }, { userId: 'contrib-2' }],
+      });
+      wishlistClaimFindUnique.mockResolvedValueOnce({
+        poolId: 'pool-2',
+        wishlistItem: {
+          title: 'Noise-cancelling headphones',
+          owner: { name: 'Taylor', username: 'taylor' },
+        },
+      });
+
+      queueWishlistClaimTransferredNotification('pool-2', 'wish-9');
+
+      await vi.waitFor(() => {
+        expect(queueNotification).toHaveBeenCalledTimes(2);
+      });
+      expect(queueNotification).toHaveBeenCalledWith({
+        userId: 'contrib-1',
+        type: NOTIFICATION_TYPES.WISHLIST_CLAIM_TRANSFERRED,
+        payload: {
+          wishlistItemId: 'wish-9',
+          itemTitle: 'Noise-cancelling headphones',
+          recipientName: 'Taylor',
+          recipientUsername: 'taylor',
+          poolId: 'pool-2',
+          poolTitle: 'Taylor birthday',
+        },
+        sourceIdentifier: 'claim-transferred:pool-2:wish-9',
+      });
+      expect(queueNotification).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: 'contrib-2' }),
+      );
+    });
+
+    it('stays silent when the pool no longer exists', async () => {
+      poolFindUnique.mockResolvedValueOnce(null);
+      wishlistClaimFindUnique.mockResolvedValueOnce({
+        poolId: 'pool-2',
+        wishlistItem: { title: 'Headphones', owner: { name: 'Taylor', username: 'taylor' } },
+      });
+
+      queueWishlistClaimTransferredNotification('pool-2', 'wish-9');
+
+      await vi.waitFor(() => {
+        expect(wishlistClaimFindUnique).toHaveBeenCalled();
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(queueNotification).not.toHaveBeenCalled();
+    });
+
+    it('stays silent when the claim has already moved off this pool by the time it re-reads', async () => {
+      // The re-read (not the caller's snapshot) is the source of truth — see
+      // the function's own docstring. If a second re-decision already moved
+      // the claim elsewhere, this pool must not tell its contributors they
+      // inherited something they no longer hold.
+      poolFindUnique.mockResolvedValueOnce({
+        title: 'Taylor birthday',
+        contributors: [{ userId: 'contrib-1' }],
+      });
+      wishlistClaimFindUnique.mockResolvedValueOnce({
+        poolId: 'pool-3',
+        wishlistItem: { title: 'Headphones', owner: { name: 'Taylor', username: 'taylor' } },
+      });
+
+      queueWishlistClaimTransferredNotification('pool-2', 'wish-9');
+
+      await vi.waitFor(() => {
+        expect(wishlistClaimFindUnique).toHaveBeenCalled();
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(queueNotification).not.toHaveBeenCalled();
+    });
+
+    it('sends a read failure to Sentry without throwing — a fanout failure must never turn a committed release into a 500', async () => {
+      const boom = new Error('read failed');
+      poolFindUnique.mockRejectedValueOnce(boom);
+      wishlistClaimFindUnique.mockResolvedValueOnce({
+        poolId: 'pool-2',
+        wishlistItem: { title: 'Headphones', owner: { name: 'Taylor', username: 'taylor' } },
+      });
+
+      expect(() =>
+        queueWishlistClaimTransferredNotification('pool-2', 'wish-9'),
+      ).not.toThrow();
+
+      await vi.waitFor(() => {
+        expect(captureException).toHaveBeenCalledWith(boom);
+      });
+      expect(queueNotification).not.toHaveBeenCalled();
+    });
   });
 
   it('propagates a claim-sync failure and skips every post-decision side effect', async () => {

--- a/app/utils/pool.server.ts
+++ b/app/utils/pool.server.ts
@@ -15,6 +15,7 @@ import { calculateContributions } from '#app/utils/pool-contributions.ts'
 import { queuePoolActivityNotifications } from '#app/utils/pool-notifications.server.ts'
 import { assertPoolStatus } from '#app/utils/pool-permissions.server.ts'
 import {
+	CLAIM_TRANSACTION_OPTIONS,
 	POOL_INTENT_STATUSES,
 	syncPoolClaimInTx,
 } from '#app/utils/wishlist-claims.server.ts'
@@ -631,7 +632,7 @@ export async function chooseIdea(
 		if (decision.count === 0) return null
 
 		return syncPoolClaimInTx(tx, poolId)
-	})
+	}, CLAIM_TRANSACTION_OPTIONS)
 	if (claimSync === null) return { claimedItemId: null, conflictedItemId: null }
 
 	// logPoolActivity, queueLogEvent, and queuePoolActivityNotifications all
@@ -1080,7 +1081,7 @@ export async function cancelPool(poolId: string, actorId: string) {
 		if (cancellation.count === 0) return null
 
 		return syncPoolClaimInTx(tx, poolId)
-	})
+	}, CLAIM_TRANSACTION_OPTIONS)
 	if (claimSync === null) return
 
 	// logPoolActivity, queueLogEvent, and queuePoolActivityNotifications all

--- a/app/utils/pool.server.ts
+++ b/app/utils/pool.server.ts
@@ -662,7 +662,7 @@ export async function chooseIdea(
 		)
 	}
 	for (const release of claimSync.released) {
-		if (!release.transferredToPoolId) continue
+		if (!release.transferredToPoolId || !release.transferredClaimId) continue
 		queueLogEvent({
 			name: 'wishlist_claim_transferred',
 			userId: actorId,
@@ -675,6 +675,7 @@ export async function chooseIdea(
 		queueWishlistClaimTransferredNotification(
 			release.transferredToPoolId,
 			release.wishlistItemId,
+			release.transferredClaimId,
 		)
 	}
 
@@ -755,6 +756,13 @@ function queueWishlistClaimConflictNotification(
 				recipientUsername: claim.wishlistItem.owner.username,
 				poolId,
 				poolTitle,
+				// The specific claim occurrence this notification is about. The
+				// Release action carries this back so a stale notification (the
+				// claimant released elsewhere, re-claimed, then clicked an old
+				// notification's Release) can't destroy a claim it never asked
+				// about — see releaseUserClaim's expectedClaimId in
+				// wishlist-claims.server.ts.
+				claimId: claim.id,
 			},
 			// One notification per conflicted *claim*, not per conflicted
 			// pool/item pair: the key includes the claim row's own id, which is
@@ -797,10 +805,26 @@ function queueWishlistClaimConflictNotification(
 // PoolContributors"), and any contributor could be the one about to buy the
 // item duplicate. Unlike the conflict notification, `poolId`/`poolTitle` ARE
 // safe to use in this one's rendered copy: the audience is this pool's own
-// contributors, who already know their own pool.
+// contributors, who already know their own pool. For the same reason this
+// notification is context: 'POOL' (unlike CONFLICT's 'NONE' — see the
+// catalog entries in notification-catalog.ts): the audience is exactly this
+// pool's contributors, so a contributor who has muted the pool must not be
+// pinged, and that requires passing `{ kind: 'POOL', poolId }` on the intent
+// below so `resolveNotificationPolicy` actually consults pool-context
+// preferences instead of skipping them.
 export function queueWishlistClaimTransferredNotification(
 	poolId: string,
 	wishlistItemId: string,
+	// The id of the WishlistClaim row this settlement just created (see
+	// `settleItem` in wishlist-claims.server.ts). Required, not derived from
+	// re-reading the claim below: it identifies *this* settlement for the
+	// ledger key, so a later, genuinely new settlement onto the same pool+item
+	// (this pool inherits, later decides away, then inherits again after a
+	// fresh solo claim is created and released) gets a distinct key instead of
+	// matching — and being silently suppressed by — the first transfer's
+	// ledger rows. This is the same fix already applied to the sibling
+	// conflict-notification key; see queueWishlistClaimConflictNotification.
+	claimId: string,
 ): void {
 	void (async () => {
 		const [pool, claim] = await Promise.all([
@@ -832,6 +856,7 @@ export function queueWishlistClaimTransferredNotification(
 			queueNotification({
 				userId: contributor.userId,
 				type: NOTIFICATION_TYPES.WISHLIST_CLAIM_TRANSFERRED,
+				context: { kind: 'POOL', poolId },
 				payload: {
 					wishlistItemId,
 					itemTitle: claim.wishlistItem.title,
@@ -845,10 +870,11 @@ export function queueWishlistClaimTransferredNotification(
 				// across every contributor is fine because the NotificationDelivery
 				// ledger dedupes on (userId, sourceIdentifier) — see
 				// claimNotificationDelivery in notification-dispatcher.server.ts.
-				// Re-entering this path for the same pool+item (a retry, or the
+				// Re-entering this path for the same settlement (a retry, or the
 				// cleanup loader re-running on the next page view) never notifies
-				// twice.
-				sourceIdentifier: `claim-transferred:${poolId}:${wishlistItemId}`,
+				// twice. The claim id keeps a *different* settlement distinct — see
+				// the parameter doc above.
+				sourceIdentifier: `claim-transferred:${poolId}:${wishlistItemId}:${claimId}`,
 			})
 		}
 	})().catch((error: unknown) => {
@@ -1026,7 +1052,7 @@ export async function cancelPool(poolId: string, actorId: string) {
 	await logPoolActivity(poolId, POOL_ACTIVITY_TYPE.POOL_CANCELLED, { actorId })
 
 	for (const release of claimSync.released) {
-		if (!release.transferredToPoolId) continue
+		if (!release.transferredToPoolId || !release.transferredClaimId) continue
 		queueLogEvent({
 			name: 'wishlist_claim_transferred',
 			userId: actorId,
@@ -1039,6 +1065,7 @@ export async function cancelPool(poolId: string, actorId: string) {
 		queueWishlistClaimTransferredNotification(
 			release.transferredToPoolId,
 			release.wishlistItemId,
+			release.transferredClaimId,
 		)
 	}
 

--- a/app/utils/pool.server.ts
+++ b/app/utils/pool.server.ts
@@ -672,6 +672,10 @@ export async function chooseIdea(
 				toPoolId: release.transferredToPoolId,
 			},
 		})
+		queueWishlistClaimTransferredNotification(
+			release.transferredToPoolId,
+			release.wishlistItemId,
+		)
 	}
 
 	const { eventId } = queueLogEvent({
@@ -759,6 +763,85 @@ function queueWishlistClaimConflictNotification(
 			// notification-dispatcher.server.ts / claimNotificationDelivery.
 			sourceIdentifier: `claim-conflict:${poolId}:${wishlistItemId}`,
 		})
+	})().catch((error: unknown) => {
+		captureException(error)
+	})
+}
+
+// The other half of the conflict story `queueWishlistClaimConflictNotification`
+// starts: once a claim settles onto a pool — a person releasing (directly, or
+// indirectly via an archive/status change, an access-loss cleanup, or account
+// deletion), or this pool inheriting from a pool that just cancelled or
+// re-decided away from the item — the organizer was told there was a real
+// risk of a duplicate purchase, and without this call they never learn it's
+// over. Exported so every settlement call site that can produce a
+// `transferredToPoolId` (chooseIdea/cancelPool below, plus the release paths
+// in wishlist+/purchase.ts, wishlist+/status.ts, wishlist.server.ts, and
+// settings+/profile.index.tsx) can reuse the same fanout instead of
+// hand-rolling it. Fire-and-forget with its own try/catch, matching the
+// "side effects off the action response" pattern — several of those call
+// sites run from a GET loader's cleanup pass, where a read failure here must
+// never turn a page view into a 500.
+//
+// Notifies every contributor, not just the organizer — see the schema
+// comment on `Pool.organizerId` ("all role-holders are also
+// PoolContributors"), and any contributor could be the one about to buy the
+// item duplicate. Unlike the conflict notification, `poolId`/`poolTitle` ARE
+// safe to use in this one's rendered copy: the audience is this pool's own
+// contributors, who already know their own pool.
+export function queueWishlistClaimTransferredNotification(
+	poolId: string,
+	wishlistItemId: string,
+): void {
+	void (async () => {
+		const [pool, claim] = await Promise.all([
+			prisma.pool.findUnique({
+				where: { id: poolId },
+				select: { title: true, contributors: { select: { userId: true } } },
+			}),
+			prisma.wishlistClaim.findUnique({
+				where: { wishlistItemId },
+				select: {
+					poolId: true,
+					wishlistItem: {
+						select: {
+							title: true,
+							owner: { select: { name: true, username: true } },
+						},
+					},
+				},
+			}),
+		])
+		if (!pool) return
+		// Read fresh rather than trust the caller's snapshot: the claim can have
+		// moved again by the time this runs (e.g. this pool immediately
+		// re-decided away from the item). Only notify while this pool still
+		// actually holds it.
+		if (!claim || claim.poolId !== poolId || !claim.wishlistItem) return
+
+		for (const contributor of pool.contributors) {
+			queueNotification({
+				userId: contributor.userId,
+				type: NOTIFICATION_TYPES.WISHLIST_CLAIM_TRANSFERRED,
+				payload: {
+					wishlistItemId,
+					itemTitle: claim.wishlistItem.title,
+					recipientName:
+						claim.wishlistItem.owner.name ?? claim.wishlistItem.owner.username,
+					recipientUsername: claim.wishlistItem.owner.username,
+					poolId,
+					poolTitle: pool.title,
+				},
+				// One notification per contributor per settlement: the same key
+				// across every contributor is fine because the NotificationDelivery
+				// ledger dedupes on (userId, sourceIdentifier) — see
+				// claimNotificationDelivery in notification-dispatcher.server.ts.
+				// Re-entering this path for the same pool+item (a retry, or the
+				// cleanup loader re-running on the next page view) never notifies
+				// twice.
+				sourceIdentifier: `claim-transferred:${poolId}:${wishlistItemId}`,
+			})
+		}
 	})().catch((error: unknown) => {
 		captureException(error)
 	})
@@ -944,6 +1027,10 @@ export async function cancelPool(poolId: string, actorId: string) {
 				toPoolId: release.transferredToPoolId,
 			},
 		})
+		queueWishlistClaimTransferredNotification(
+			release.transferredToPoolId,
+			release.wishlistItemId,
+		)
 	}
 
 	const { eventId } = queueLogEvent({

--- a/app/utils/pool.server.ts
+++ b/app/utils/pool.server.ts
@@ -812,6 +812,55 @@ function queueWishlistClaimConflictNotification(
 	})
 }
 
+// Runs after a successfully committed release so a WISHLIST_CLAIM_CONFLICT
+// notification about *that exact claim occurrence* can never resurrect its
+// Release action once the claim is gone. Before this, resolving the
+// notification depended entirely on a second client request (the dismiss
+// call in api.notifications.$id.delete.ts) succeeding — if that request
+// failed, the notification stayed UNREAD, and a refresh re-offered a Release
+// button that would fail every time (the claim it targets no longer exists,
+// and `releaseUserClaim`'s `expectedClaimId` check correctly rejects it as
+// stale). This makes resolution durable: it happens server-side as part of
+// the release itself, with no client follow-up required.
+//
+// Matched by the claim's own id, carried in the notification's
+// `metadata.claimId` (see `queueWishlistClaimConflictNotification` above) —
+// not by `wishlistItemId`, which could also match a different, still-live
+// conflict notification raised later about a fresh claim the same user takes
+// out on the same item.
+//
+// Never throws: cleaning up stale notification chrome is unimportant next to
+// the already-committed release, so any failure here is reported to Sentry
+// and swallowed. Callers can simply `await` this without their own
+// try/catch — matches the "side effects off the action response" rule that a
+// fanout/cleanup failure must never turn a committed mutation into a 500.
+export async function resolveWishlistClaimConflictNotifications(
+	userId: string,
+	releasedClaimId: string,
+): Promise<void> {
+	try {
+		const candidates = await prisma.notification.findMany({
+			where: { userId, type: NOTIFICATION_TYPES.WISHLIST_CLAIM_CONFLICT },
+			select: { id: true, metadata: true },
+		})
+		const staleIds = candidates
+			.filter((notification) => {
+				if (!notification.metadata) return false
+				try {
+					const parsed = JSON.parse(notification.metadata) as { claimId?: unknown }
+					return parsed.claimId === releasedClaimId
+				} catch {
+					return false
+				}
+			})
+			.map((notification) => notification.id)
+		if (staleIds.length === 0) return
+		await prisma.notification.deleteMany({ where: { id: { in: staleIds } } })
+	} catch (error) {
+		captureException(error)
+	}
+}
+
 // The other half of the conflict story `queueWishlistClaimConflictNotification`
 // starts: once a claim settles onto a pool — a person releasing (directly, or
 // indirectly via an archive/status change, an access-loss cleanup, or account

--- a/app/utils/pool.server.ts
+++ b/app/utils/pool.server.ts
@@ -729,6 +729,7 @@ function queueWishlistClaimConflictNotification(
 		const claim = await prisma.wishlistClaim.findUnique({
 			where: { wishlistItemId },
 			select: {
+				id: true,
 				claimedByUserId: true,
 				wishlistItem: {
 					select: {
@@ -755,13 +756,21 @@ function queueWishlistClaimConflictNotification(
 				poolId,
 				poolTitle,
 			},
-			// One notification per conflicted decision: this key is claimed in
-			// the `NotificationDelivery` ledger (per channel) before any channel
-			// delivers, so re-entering this path for the same pool+item — a
-			// retry, or re-deciding back onto an item that's still conflicted —
-			// never asks the claim holder twice. See
-			// notification-dispatcher.server.ts / claimNotificationDelivery.
-			sourceIdentifier: `claim-conflict:${poolId}:${wishlistItemId}`,
+			// One notification per conflicted *claim*, not per conflicted
+			// pool/item pair: the key includes the claim row's own id, which is
+			// freshly minted every time `wishlist-claims.server.ts` creates a
+			// claim. `poolId`/`wishlistItemId` alone would dedupe permanently —
+			// after the first Keep/Release resolves this claim, the holder (or
+			// someone else) can re-claim the same item and this pool can decide
+			// on it again, which is a genuinely new conflict that must ask
+			// again. The claim id is the right variable: it stays fixed for
+			// every re-entry into this path *for the same still-live claim*
+			// (a retry, or re-deciding back onto an item that's still
+			// conflicted), so those correctly stay deduped — unlike, say,
+			// `Pool.decidedAt`, which changes on every re-decision and would
+			// re-notify on each one. See notification-dispatcher.server.ts /
+			// claimNotificationDelivery.
+			sourceIdentifier: `claim-conflict:${poolId}:${wishlistItemId}:${claim.id}`,
 		})
 	})().catch((error: unknown) => {
 		captureException(error)

--- a/app/utils/pool.server.ts
+++ b/app/utils/pool.server.ts
@@ -14,7 +14,10 @@ import {
 import { calculateContributions } from '#app/utils/pool-contributions.ts'
 import { queuePoolActivityNotifications } from '#app/utils/pool-notifications.server.ts'
 import { assertPoolStatus } from '#app/utils/pool-permissions.server.ts'
-import { syncPoolClaimInTx } from '#app/utils/wishlist-claims.server.ts'
+import {
+	POOL_INTENT_STATUSES,
+	syncPoolClaimInTx,
+} from '#app/utils/wishlist-claims.server.ts'
 import type { DecisionMode, OccasionType } from '#app/utils/pool-constants.ts'
 
 // ─── Selects ──────────────────────────────────────────────────────────────────
@@ -727,23 +730,46 @@ function queueWishlistClaimConflictNotification(
 	wishlistItemId: string,
 ): void {
 	void (async () => {
-		const claim = await prisma.wishlistClaim.findUnique({
-			where: { wishlistItemId },
-			select: {
-				id: true,
-				claimedByUserId: true,
-				wishlistItem: {
-					select: {
-						title: true,
-						owner: { select: { name: true, username: true } },
+		const [claim, pool] = await Promise.all([
+			prisma.wishlistClaim.findUnique({
+				where: { wishlistItemId },
+				select: {
+					id: true,
+					claimedByUserId: true,
+					wishlistItem: {
+						select: {
+							title: true,
+							owner: { select: { name: true, username: true } },
+						},
 					},
 				},
-			},
-		})
+			}),
+			// Re-read the pool's *current* intent, not just the claim's current
+			// holder. The claim re-read above only proves someone still holds
+			// the item — it says nothing about whether this pool still wants
+			// it. Between the transaction that queued this fanout committing
+			// and this read running, the pool can have been re-decided onto a
+			// different idea (or cancelled): the solo claim on the original
+			// item is still perfectly live, but there is no longer a conflict
+			// to report. Sending anyway would tell the holder about a fight
+			// that's over, and — because the send claims the ledger key below
+			// — would silently swallow a genuine future conflict if the pool
+			// is later re-decided back onto this exact item.
+			prisma.pool.findUnique({
+				where: { id: poolId },
+				select: { status: true, chosenIdea: { select: { wishlistItemId: true } } },
+			}),
+		])
 		// The other side of a conflict can be another pool, not a person — the
 		// claim holder is only present here when `claimedByUserId` is set.
 		// There is nobody to ask when a pool holds it.
 		if (!claim?.claimedByUserId || !claim.wishlistItem) return
+
+		const poolStillIntendsThisItem =
+			pool !== null &&
+			(POOL_INTENT_STATUSES as readonly string[]).includes(pool.status) &&
+			pool.chosenIdea?.wishlistItemId === wishlistItemId
+		if (!poolStillIntendsThisItem) return
 
 		queueNotification({
 			userId: claim.claimedByUserId,
@@ -835,6 +861,7 @@ export function queueWishlistClaimTransferredNotification(
 			prisma.wishlistClaim.findUnique({
 				where: { wishlistItemId },
 				select: {
+					id: true,
 					poolId: true,
 					wishlistItem: {
 						select: {
@@ -848,9 +875,21 @@ export function queueWishlistClaimTransferredNotification(
 		if (!pool) return
 		// Read fresh rather than trust the caller's snapshot: the claim can have
 		// moved again by the time this runs (e.g. this pool immediately
-		// re-decided away from the item). Only notify while this pool still
-		// actually holds it.
-		if (!claim || claim.poolId !== poolId || !claim.wishlistItem) return
+		// re-decided away from the item). Checking `poolId` alone is not
+		// enough, though: it only proves *some* claim this pool holds is on
+		// this item right now, not that it's *this settlement's* claim. A
+		// delayed fanout for an older settlement (A) can lose a race to a
+		// newer one (B) — the pool decides away, a fresh solo claim on the
+		// same item is made and released, and the pool inherits the item
+		// again as settlement B — by the time A's fanout runs it would see
+		// B's live row, pass a `poolId`-only check, and report B's details
+		// under A's ledger key (B's own fanout then sends again under its own
+		// key: a duplicate). Requiring the live row's id to match the id this
+		// settlement created makes a stale settlement's fanout a no-op
+		// instead.
+		if (!claim || claim.poolId !== poolId || claim.id !== claimId || !claim.wishlistItem) {
+			return
+		}
 
 		for (const contributor of pool.contributors) {
 			queueNotification({

--- a/app/utils/pool.server.ts
+++ b/app/utils/pool.server.ts
@@ -1,9 +1,10 @@
-import { captureMessage } from '@sentry/react-router'
+import { captureException, captureMessage } from '@sentry/react-router'
 import { data } from 'react-router'
 import { nanoid } from 'nanoid'
 import { queueLogEvent } from '#app/utils/analytics.server.ts'
 import { prisma } from '#app/utils/db.server.ts'
 import { NOTIFICATION_TYPES } from '#app/utils/notification-catalog.ts'
+import { queueNotification } from '#app/utils/notification-dispatcher.server.ts'
 import { logPoolActivity } from '#app/utils/pool-activity.server.ts'
 import {
 	POOL_ACTIVITY_TYPE,
@@ -577,7 +578,14 @@ export async function chooseIdea(
 ): Promise<{ claimedItemId: string | null; conflictedItemId: string | null }> {
 	const idea = await prisma.giftIdea.findFirst({
 		where: { id: ideaId, poolId },
-		select: { estimatedPriceCents: true, name: true },
+		select: {
+			estimatedPriceCents: true,
+			name: true,
+			// Only used to compose the conflict notification below — never to
+			// disclose the pool to the claim holder (see
+			// queueWishlistClaimConflictNotification's own comment).
+			pool: { select: { title: true } },
+		},
 	})
 
 	if (!idea) {
@@ -647,6 +655,11 @@ export async function chooseIdea(
 			source: 'server',
 			properties: { poolId, wishlistItemId: claimSync.conflictedItemId },
 		})
+		queueWishlistClaimConflictNotification(
+			poolId,
+			idea.pool.title,
+			claimSync.conflictedItemId,
+		)
 	}
 	for (const release of claimSync.released) {
 		if (!release.transferredToPoolId) continue
@@ -684,6 +697,71 @@ export async function chooseIdea(
 		claimedItemId: claimSync.claimedItemId,
 		conflictedItemId: claimSync.conflictedItemId,
 	}
+}
+
+// Asks the person holding a conflicting claim whether they're still getting
+// the item — the Keep/Release loop. Fire-and-forget with its own try/catch,
+// matching the "side effects off the action response" pattern: a failure
+// here must never turn the already-committed decision into a 500 for the
+// organizer who chose the idea.
+//
+// Reads the claim fresh (not the pre-transaction snapshot) because the truth
+// can have moved between `syncPoolClaimInTx` committing and this running —
+// e.g. the holder released in the interim and the item already settled to
+// this very pool. Re-reading means we only ever ask about a conflict that
+// still exists.
+//
+// `poolTitle` is carried into the payload for bookkeeping only. The claim
+// holder may have no relationship to this pool's group — the notification's
+// own renderer (notification-events.server.tsx) must never put it in the
+// rendered message; see the payload comment in notification-catalog.ts and
+// the privacy ladder in wishlist-claim-disclosure.ts.
+function queueWishlistClaimConflictNotification(
+	poolId: string,
+	poolTitle: string,
+	wishlistItemId: string,
+): void {
+	void (async () => {
+		const claim = await prisma.wishlistClaim.findUnique({
+			where: { wishlistItemId },
+			select: {
+				claimedByUserId: true,
+				wishlistItem: {
+					select: {
+						title: true,
+						owner: { select: { name: true, username: true } },
+					},
+				},
+			},
+		})
+		// The other side of a conflict can be another pool, not a person — the
+		// claim holder is only present here when `claimedByUserId` is set.
+		// There is nobody to ask when a pool holds it.
+		if (!claim?.claimedByUserId || !claim.wishlistItem) return
+
+		queueNotification({
+			userId: claim.claimedByUserId,
+			type: NOTIFICATION_TYPES.WISHLIST_CLAIM_CONFLICT,
+			payload: {
+				wishlistItemId,
+				itemTitle: claim.wishlistItem.title,
+				recipientName:
+					claim.wishlistItem.owner.name ?? claim.wishlistItem.owner.username,
+				recipientUsername: claim.wishlistItem.owner.username,
+				poolId,
+				poolTitle,
+			},
+			// One notification per conflicted decision: this key is claimed in
+			// the `NotificationDelivery` ledger (per channel) before any channel
+			// delivers, so re-entering this path for the same pool+item — a
+			// retry, or re-deciding back onto an item that's still conflicted —
+			// never asks the claim holder twice. See
+			// notification-dispatcher.server.ts / claimNotificationDelivery.
+			sourceIdentifier: `claim-conflict:${poolId}:${wishlistItemId}`,
+		})
+	})().catch((error: unknown) => {
+		captureException(error)
+	})
 }
 
 // Update the confirmed final price after the gift has been decided.

--- a/app/utils/wishlist-claims.server.test.ts
+++ b/app/utils/wishlist-claims.server.test.ts
@@ -24,7 +24,12 @@ async function fixture() {
     prisma.user.create({ data: createUser() }),
   ]);
   const item = await prisma.wishlistItem.create({
-    data: { ownerId: owner.id, title: 'Spa voucher', type: 'item', sortOrder: 0 },
+    data: {
+      ownerId: owner.id,
+      title: 'Spa voucher',
+      type: 'item',
+      sortOrder: 0,
+    },
   });
   return { owner, friend, organizer, item };
 }
@@ -39,7 +44,12 @@ async function decidedPoolFor(
     data: { title: 'Birthday pool', organizerId, recipientUserId: recipientId },
   });
   const idea = await prisma.giftIdea.create({
-    data: { poolId: pool.id, proposedById: organizerId, name: 'Spa voucher', wishlistItemId: itemId },
+    data: {
+      poolId: pool.id,
+      proposedById: organizerId,
+      name: 'Spa voucher',
+      wishlistItemId: itemId,
+    },
   });
   await prisma.pool.update({
     where: { id: pool.id },
@@ -51,16 +61,27 @@ async function decidedPoolFor(
 describe('claimForUser', () => {
   it('grants a claim on a free item', async () => {
     const { friend, item } = await fixture();
-    await expect(claimForUser(item.id, friend.id)).resolves.toEqual({ ok: true });
-    const claim = await prisma.wishlistClaim.findUnique({ where: { wishlistItemId: item.id } });
+    await expect(claimForUser(item.id, friend.id)).resolves.toEqual({
+      ok: true,
+    });
+    const claim = await prisma.wishlistClaim.findUnique({
+      where: { wishlistItemId: item.id },
+    });
     expect(claim?.claimedByUserId).toBe(friend.id);
     expect(claim?.poolId).toBeNull();
   });
 
   it('refuses when a pool holds the claim, and says so distinctly', async () => {
     const { owner, friend, organizer, item } = await fixture();
-    const pool = await decidedPoolFor(item.id, owner.id, organizer.id, new Date());
-    await prisma.wishlistClaim.create({ data: { wishlistItemId: item.id, poolId: pool.id } });
+    const pool = await decidedPoolFor(
+      item.id,
+      owner.id,
+      organizer.id,
+      new Date(),
+    );
+    await prisma.wishlistClaim.create({
+      data: { wishlistItemId: item.id, poolId: pool.id },
+    });
     await expect(claimForUser(item.id, friend.id)).resolves.toEqual({
       ok: false,
       reason: 'held-by-pool',
@@ -82,7 +103,9 @@ describe('claimForUser', () => {
     expect(failures).toHaveLength(1);
     expect(failures[0]).toMatchObject({ ok: false, reason: 'held-by-user' });
 
-    const claims = await prisma.wishlistClaim.findMany({ where: { wishlistItemId: item.id } });
+    const claims = await prisma.wishlistClaim.findMany({
+      where: { wishlistItemId: item.id },
+    });
     expect(claims).toHaveLength(1);
   });
 });
@@ -91,12 +114,19 @@ describe('settlement on release', () => {
   it('hands a released claim to a pool that has intent — the orphaned-claim fix', async () => {
     const { owner, friend, organizer, item } = await fixture();
     await claimForUser(item.id, friend.id);
-    const pool = await decidedPoolFor(item.id, owner.id, organizer.id, new Date());
+    const pool = await decidedPoolFor(
+      item.id,
+      owner.id,
+      organizer.id,
+      new Date(),
+    );
 
     const result = await releaseUserClaim(item.id, friend.id);
 
     expect(result).toMatchObject({ transferredToPoolId: pool.id });
-    const claim = await prisma.wishlistClaim.findUnique({ where: { wishlistItemId: item.id } });
+    const claim = await prisma.wishlistClaim.findUnique({
+      where: { wishlistItemId: item.id },
+    });
     expect(claim?.poolId).toBe(pool.id);
     expect(claim?.claimedByUserId).toBeNull();
   });
@@ -106,14 +136,28 @@ describe('settlement on release', () => {
     await claimForUser(item.id, friend.id);
     const result = await releaseUserClaim(item.id, friend.id);
     expect(result).toMatchObject({ transferredToPoolId: null });
-    expect(await prisma.wishlistClaim.findUnique({ where: { wishlistItemId: item.id } })).toBeNull();
+    expect(
+      await prisma.wishlistClaim.findUnique({
+        where: { wishlistItemId: item.id },
+      }),
+    ).toBeNull();
   });
 
   it('gives the claim to the earliest decision when two pools have intent', async () => {
     const { owner, friend, organizer, item } = await fixture();
     await claimForUser(item.id, friend.id);
-    const later = await decidedPoolFor(item.id, owner.id, organizer.id, new Date('2026-07-20'));
-    const earlier = await decidedPoolFor(item.id, owner.id, organizer.id, new Date('2026-07-10'));
+    const later = await decidedPoolFor(
+      item.id,
+      owner.id,
+      organizer.id,
+      new Date('2026-07-20'),
+    );
+    const earlier = await decidedPoolFor(
+      item.id,
+      owner.id,
+      organizer.id,
+      new Date('2026-07-10'),
+    );
 
     const result = await releaseUserClaim(item.id, friend.id);
 
@@ -131,7 +175,11 @@ describe('settlement on release', () => {
     await claimForUser(item.id, friend.id);
 
     const nullDatedPool = await prisma.pool.create({
-      data: { title: 'Legacy pool', organizerId: organizer.id, recipientUserId: owner.id },
+      data: {
+        title: 'Legacy pool',
+        organizerId: organizer.id,
+        recipientUserId: owner.id,
+      },
     });
     const nullIdea = await prisma.giftIdea.create({
       data: {
@@ -146,7 +194,12 @@ describe('settlement on release', () => {
       data: { status: 'DECIDED', chosenIdeaId: nullIdea.id },
     });
 
-    const datedPool = await decidedPoolFor(item.id, owner.id, organizer.id, new Date('2026-07-20'));
+    const datedPool = await decidedPoolFor(
+      item.id,
+      owner.id,
+      organizer.id,
+      new Date('2026-07-20'),
+    );
 
     const result = await releaseUserClaim(item.id, friend.id);
 
@@ -157,8 +210,16 @@ describe('settlement on release', () => {
   it('ignores a cancelled pool when settling', async () => {
     const { owner, friend, organizer, item } = await fixture();
     await claimForUser(item.id, friend.id);
-    const pool = await decidedPoolFor(item.id, owner.id, organizer.id, new Date());
-    await prisma.pool.update({ where: { id: pool.id }, data: { status: 'CANCELLED' } });
+    const pool = await decidedPoolFor(
+      item.id,
+      owner.id,
+      organizer.id,
+      new Date(),
+    );
+    await prisma.pool.update({
+      where: { id: pool.id },
+      data: { status: 'CANCELLED' },
+    });
 
     const result = await releaseUserClaim(item.id, friend.id);
     expect(result).toMatchObject({ transferredToPoolId: null });
@@ -169,7 +230,9 @@ describe('settlement on release', () => {
     await claimForUser(item.id, friend.id);
     const result = await releaseUserClaim(item.id, organizer.id);
     expect(result.ok).toBe(false);
-    const claim = await prisma.wishlistClaim.findUnique({ where: { wishlistItemId: item.id } });
+    const claim = await prisma.wishlistClaim.findUnique({
+      where: { wishlistItemId: item.id },
+    });
     expect(claim?.claimedByUserId).toBe(friend.id);
   });
 
@@ -210,9 +273,15 @@ describe('settlement on release', () => {
 
     const result = await releaseUserClaim(item.id, friend.id, claim.id);
 
-    expect(result).toEqual({ ok: true, transferredToPoolId: null, transferredClaimId: null });
+    expect(result).toEqual({
+      ok: true,
+      transferredToPoolId: null,
+      transferredClaimId: null,
+    });
     expect(
-      await prisma.wishlistClaim.findUnique({ where: { wishlistItemId: item.id } }),
+      await prisma.wishlistClaim.findUnique({
+        where: { wishlistItemId: item.id },
+      }),
     ).toBeNull();
   });
 });
@@ -220,55 +289,105 @@ describe('settlement on release', () => {
 describe('syncPoolClaim', () => {
   it('claims a free wishlist item when the pool decides', async () => {
     const { owner, organizer, item } = await fixture();
-    const pool = await decidedPoolFor(item.id, owner.id, organizer.id, new Date());
+    const pool = await decidedPoolFor(
+      item.id,
+      owner.id,
+      organizer.id,
+      new Date(),
+    );
     const result = await syncPoolClaim(pool.id);
     expect(result.claimedItemId).toBe(item.id);
     expect(result.conflictedItemId).toBeNull();
-    const claim = await prisma.wishlistClaim.findUnique({ where: { wishlistItemId: item.id } });
+    const claim = await prisma.wishlistClaim.findUnique({
+      where: { wishlistItemId: item.id },
+    });
     expect(claim?.poolId).toBe(pool.id);
   });
 
   it('reports a conflict and takes nothing when a person already holds it', async () => {
     const { owner, friend, organizer, item } = await fixture();
     await claimForUser(item.id, friend.id);
-    const pool = await decidedPoolFor(item.id, owner.id, organizer.id, new Date());
+    const pool = await decidedPoolFor(
+      item.id,
+      owner.id,
+      organizer.id,
+      new Date(),
+    );
 
     const result = await syncPoolClaim(pool.id);
 
     expect(result.claimedItemId).toBeNull();
     expect(result.conflictedItemId).toBe(item.id);
-    const claim = await prisma.wishlistClaim.findUnique({ where: { wishlistItemId: item.id } });
+    const claim = await prisma.wishlistClaim.findUnique({
+      where: { wishlistItemId: item.id },
+    });
     expect(claim?.claimedByUserId).toBe(friend.id);
   });
 
   it('releases the old item and settles it when the pool re-decides', async () => {
     const { owner, organizer, item } = await fixture();
     const other = await prisma.wishlistItem.create({
-      data: { ownerId: owner.id, title: 'Headphones', type: 'item', sortOrder: 1 },
+      data: {
+        ownerId: owner.id,
+        title: 'Headphones',
+        type: 'item',
+        sortOrder: 1,
+      },
     });
-    const pool = await decidedPoolFor(item.id, owner.id, organizer.id, new Date());
+    const pool = await decidedPoolFor(
+      item.id,
+      owner.id,
+      organizer.id,
+      new Date(),
+    );
     await syncPoolClaim(pool.id);
 
     const newIdea = await prisma.giftIdea.create({
-      data: { poolId: pool.id, proposedById: organizer.id, name: 'Headphones', wishlistItemId: other.id },
+      data: {
+        poolId: pool.id,
+        proposedById: organizer.id,
+        name: 'Headphones',
+        wishlistItemId: other.id,
+      },
     });
     await chooseIdea(pool.id, newIdea.id, organizer.id);
 
-    expect(await prisma.wishlistClaim.findUnique({ where: { wishlistItemId: item.id } })).toBeNull();
-    const moved = await prisma.wishlistClaim.findUnique({ where: { wishlistItemId: other.id } });
+    expect(
+      await prisma.wishlistClaim.findUnique({
+        where: { wishlistItemId: item.id },
+      }),
+    ).toBeNull();
+    const moved = await prisma.wishlistClaim.findUnique({
+      where: { wishlistItemId: other.id },
+    });
     expect(moved?.poolId).toBe(pool.id);
   });
 
   it('reports a released item as transferred when settlement hands it to a waiting pool', async () => {
     const { owner, organizer, item } = await fixture();
     const other = await prisma.wishlistItem.create({
-      data: { ownerId: owner.id, title: 'Headphones', type: 'item', sortOrder: 1 },
+      data: {
+        ownerId: owner.id,
+        title: 'Headphones',
+        type: 'item',
+        sortOrder: 1,
+      },
     });
-    const holder = await decidedPoolFor(item.id, owner.id, organizer.id, new Date('2026-07-01'));
+    const holder = await decidedPoolFor(
+      item.id,
+      owner.id,
+      organizer.id,
+      new Date('2026-07-01'),
+    );
     await syncPoolClaim(holder.id);
 
     // A second pool has intent on the same item and is left waiting behind the holder.
-    const waiter = await decidedPoolFor(item.id, owner.id, organizer.id, new Date('2026-07-10'));
+    const waiter = await decidedPoolFor(
+      item.id,
+      owner.id,
+      organizer.id,
+      new Date('2026-07-10'),
+    );
 
     // The holder re-decides onto a different item, freeing `item` for the waiter.
     const newIdea = await prisma.giftIdea.create({
@@ -291,17 +410,28 @@ describe('syncPoolClaim', () => {
       wishlistItemId: item.id,
       transferredToPoolId: waiter.id,
     });
-    const claim = await prisma.wishlistClaim.findUnique({ where: { wishlistItemId: item.id } });
+    const claim = await prisma.wishlistClaim.findUnique({
+      where: { wishlistItemId: item.id },
+    });
     expect(claim?.poolId).toBe(waiter.id);
     expect(result.released[0]?.transferredClaimId).toBe(claim?.id);
   });
 
   it('releases the claim when the pool is cancelled', async () => {
     const { owner, organizer, item } = await fixture();
-    const pool = await decidedPoolFor(item.id, owner.id, organizer.id, new Date());
+    const pool = await decidedPoolFor(
+      item.id,
+      owner.id,
+      organizer.id,
+      new Date(),
+    );
     await syncPoolClaim(pool.id);
     await cancelPool(pool.id, organizer.id);
-    expect(await prisma.wishlistClaim.findUnique({ where: { wishlistItemId: item.id } })).toBeNull();
+    expect(
+      await prisma.wishlistClaim.findUnique({
+        where: { wishlistItemId: item.id },
+      }),
+    ).toBeNull();
   });
 });
 
@@ -318,22 +448,39 @@ describe('chooseIdea + claim sync atomicity', () => {
     // the sync's outcome is forced to fail.
     const { owner, organizer, item } = await fixture();
     const pool = await prisma.pool.create({
-      data: { title: 'Birthday pool', organizerId: organizer.id, recipientUserId: owner.id },
+      data: {
+        title: 'Birthday pool',
+        organizerId: organizer.id,
+        recipientUserId: owner.id,
+      },
     });
     const idea = await prisma.giftIdea.create({
-      data: { poolId: pool.id, proposedById: organizer.id, name: 'Spa voucher', wishlistItemId: item.id },
+      data: {
+        poolId: pool.id,
+        proposedById: organizer.id,
+        name: 'Spa voucher',
+        wishlistItemId: item.id,
+      },
     });
 
     const spy = vi
       .spyOn(wishlistClaims, 'syncPoolClaimInTx')
       .mockRejectedValueOnce(new Error('claim sync boom'));
 
-    await expect(chooseIdea(pool.id, idea.id, organizer.id)).rejects.toThrow('claim sync boom');
+    await expect(chooseIdea(pool.id, idea.id, organizer.id)).rejects.toThrow(
+      'claim sync boom',
+    );
 
-    const reloaded = await prisma.pool.findUniqueOrThrow({ where: { id: pool.id } });
+    const reloaded = await prisma.pool.findUniqueOrThrow({
+      where: { id: pool.id },
+    });
     expect(reloaded.status).not.toBe('DECIDED');
     expect(reloaded.chosenIdeaId).toBeNull();
-    expect(await prisma.wishlistClaim.findUnique({ where: { wishlistItemId: item.id } })).toBeNull();
+    expect(
+      await prisma.wishlistClaim.findUnique({
+        where: { wishlistItemId: item.id },
+      }),
+    ).toBeNull();
 
     spy.mockRestore();
   });
@@ -349,20 +496,31 @@ describe('cancelPool + claim sync atomicity', () => {
     // sync now commit inside one `prisma.$transaction`, so a rejection from
     // the sync must roll back the cancellation too.
     const { owner, organizer, item } = await fixture();
-    const pool = await decidedPoolFor(item.id, owner.id, organizer.id, new Date());
+    const pool = await decidedPoolFor(
+      item.id,
+      owner.id,
+      organizer.id,
+      new Date(),
+    );
     await syncPoolClaim(pool.id);
 
     const spy = vi
       .spyOn(wishlistClaims, 'syncPoolClaimInTx')
       .mockRejectedValueOnce(new Error('claim sync boom'));
 
-    await expect(cancelPool(pool.id, organizer.id)).rejects.toThrow('claim sync boom');
+    await expect(cancelPool(pool.id, organizer.id)).rejects.toThrow(
+      'claim sync boom',
+    );
 
-    const reloaded = await prisma.pool.findUniqueOrThrow({ where: { id: pool.id } });
+    const reloaded = await prisma.pool.findUniqueOrThrow({
+      where: { id: pool.id },
+    });
     expect(reloaded.status).not.toBe('CANCELLED');
     // The pool must still hold its claim — the bug this regression closes is
     // a cancelled pool that lost its claim with no way to get it back.
-    const claim = await prisma.wishlistClaim.findUnique({ where: { wishlistItemId: item.id } });
+    const claim = await prisma.wishlistClaim.findUnique({
+      where: { wishlistItemId: item.id },
+    });
     expect(claim?.poolId).toBe(pool.id);
 
     spy.mockRestore();
@@ -377,13 +535,20 @@ describe('releaseSoloClaimForItem', () => {
     // archived (or restored) it.
     const { owner, friend, organizer, item } = await fixture();
     await claimForUser(item.id, friend.id);
-    const pool = await decidedPoolFor(item.id, owner.id, organizer.id, new Date());
+    const pool = await decidedPoolFor(
+      item.id,
+      owner.id,
+      organizer.id,
+      new Date(),
+    );
 
     const result = await wishlistClaims.releaseSoloClaimForItem(item.id);
 
     expect(result.ok).toBe(true);
     expect(result.transferredToPoolId).toBe(pool.id);
-    const claim = await prisma.wishlistClaim.findUnique({ where: { wishlistItemId: item.id } });
+    const claim = await prisma.wishlistClaim.findUnique({
+      where: { wishlistItemId: item.id },
+    });
     expect(claim?.poolId).toBe(pool.id);
     expect(claim?.claimedByUserId).toBeNull();
     expect(result.transferredClaimId).toBe(claim?.id);
@@ -391,20 +556,35 @@ describe('releaseSoloClaimForItem', () => {
 
   it('leaves a pool-held claim untouched', async () => {
     const { owner, organizer, item } = await fixture();
-    const pool = await decidedPoolFor(item.id, owner.id, organizer.id, new Date());
+    const pool = await decidedPoolFor(
+      item.id,
+      owner.id,
+      organizer.id,
+      new Date(),
+    );
     await syncPoolClaim(pool.id);
 
     const result = await wishlistClaims.releaseSoloClaimForItem(item.id);
 
-    expect(result).toEqual({ ok: false, transferredToPoolId: null, transferredClaimId: null });
-    const claim = await prisma.wishlistClaim.findUnique({ where: { wishlistItemId: item.id } });
+    expect(result).toEqual({
+      ok: false,
+      transferredToPoolId: null,
+      transferredClaimId: null,
+    });
+    const claim = await prisma.wishlistClaim.findUnique({
+      where: { wishlistItemId: item.id },
+    });
     expect(claim?.poolId).toBe(pool.id);
   });
 
   it('is a no-op when the item has no claim', async () => {
     const { item } = await fixture();
     const result = await wishlistClaims.releaseSoloClaimForItem(item.id);
-    expect(result).toEqual({ ok: false, transferredToPoolId: null, transferredClaimId: null });
+    expect(result).toEqual({
+      ok: false,
+      transferredToPoolId: null,
+      transferredClaimId: null,
+    });
   });
 });
 
@@ -453,7 +633,12 @@ describe('claimForUser losing a race', () => {
 
   it('reports a pool-held claim with the null-claimedByUserId sentinel', async () => {
     const { owner, friend, organizer, item } = await fixture();
-    const pool = await decidedPoolFor(item.id, owner.id, organizer.id, new Date());
+    const pool = await decidedPoolFor(
+      item.id,
+      owner.id,
+      organizer.id,
+      new Date(),
+    );
     await syncPoolClaim(pool.id);
 
     const result = await claimForUser(item.id, friend.id);
@@ -470,29 +655,53 @@ describe('loadClaimStates', () => {
   it('returns nothing at all for the wishlist owner', async () => {
     const { owner, friend, item } = await fixture();
     await claimForUser(item.id, friend.id);
-    const states = await loadClaimStates([item.id], { userId: owner.id, isOwner: true });
+    const states = await loadClaimStates([item.id], {
+      userId: owner.id,
+      isOwner: true,
+    });
     expect(states.get(item.id)?.show).toBe(false);
   });
 
   it('names the pool to one of its contributors and not to an outsider', async () => {
     const { owner, friend, organizer, item } = await fixture();
-    const pool = await decidedPoolFor(item.id, owner.id, organizer.id, new Date());
-    await prisma.poolContributor.create({ data: { poolId: pool.id, userId: organizer.id } });
+    const pool = await decidedPoolFor(
+      item.id,
+      owner.id,
+      organizer.id,
+      new Date(),
+    );
+    await prisma.poolContributor.create({
+      data: { poolId: pool.id, userId: organizer.id },
+    });
     await syncPoolClaim(pool.id);
 
-    const inside = await loadClaimStates([item.id], { userId: organizer.id, isOwner: false });
+    const inside = await loadClaimStates([item.id], {
+      userId: organizer.id,
+      isOwner: false,
+    });
     expect(inside.get(item.id)?.name).toBe('Birthday pool');
 
-    const outside = await loadClaimStates([item.id], { userId: friend.id, isOwner: false });
+    const outside = await loadClaimStates([item.id], {
+      userId: friend.id,
+      isOwner: false,
+    });
     expect(outside.get(item.id)?.text).toBe('Already claimed');
     expect(JSON.stringify(outside.get(item.id))).not.toContain('Birthday pool');
   });
 
   it('gives an anonymous viewer claim state with zero attribution', async () => {
     const { owner, organizer, item } = await fixture();
-    const pool = await decidedPoolFor(item.id, owner.id, organizer.id, new Date());
+    const pool = await decidedPoolFor(
+      item.id,
+      owner.id,
+      organizer.id,
+      new Date(),
+    );
     await syncPoolClaim(pool.id);
-    const states = await loadClaimStates([item.id], { userId: null, isOwner: false });
+    const states = await loadClaimStates([item.id], {
+      userId: null,
+      isOwner: false,
+    });
     expect(states.get(item.id)?.show).toBe(true);
     expect(states.get(item.id)?.name).toBeNull();
   });
@@ -502,34 +711,65 @@ describe('loadClaimStates', () => {
     const group = await prisma.giftGroup.create({
       data: { name: 'Sunday Roasters', createdById: organizer.id },
     });
-    const pool = await decidedPoolFor(item.id, owner.id, organizer.id, new Date());
-    await prisma.pool.update({ where: { id: pool.id }, data: { giftGroupId: group.id } });
+    const pool = await decidedPoolFor(
+      item.id,
+      owner.id,
+      organizer.id,
+      new Date(),
+    );
+    await prisma.pool.update({
+      where: { id: pool.id },
+      data: { giftGroupId: group.id },
+    });
     await syncPoolClaim(pool.id);
     const membership = await prisma.usersInGiftGroups.create({
       data: { userId: friend.id, giftGroupId: group.id },
     });
 
-    const asMember = await loadClaimStates([item.id], { userId: friend.id, isOwner: false });
+    const asMember = await loadClaimStates([item.id], {
+      userId: friend.id,
+      isOwner: false,
+    });
     expect(asMember.get(item.id)?.name).toBe('Sunday Roasters');
 
     // The membership row survives removal — only removedAt makes it non-current.
     await prisma.usersInGiftGroups.update({
-      where: { userId_giftGroupId: { userId: membership.userId, giftGroupId: group.id } },
+      where: {
+        userId_giftGroupId: {
+          userId: membership.userId,
+          giftGroupId: group.id,
+        },
+      },
       data: { removedAt: new Date() },
     });
 
-    const afterRemoval = await loadClaimStates([item.id], { userId: friend.id, isOwner: false });
+    const afterRemoval = await loadClaimStates([item.id], {
+      userId: friend.id,
+      isOwner: false,
+    });
     expect(afterRemoval.get(item.id)?.name).toBeNull();
-    expect(JSON.stringify(afterRemoval.get(item.id))).not.toContain('Sunday Roasters');
+    expect(JSON.stringify(afterRemoval.get(item.id))).not.toContain(
+      'Sunday Roasters',
+    );
   });
 
   it('defaults to the label surface when no surface argument is given', async () => {
     const { owner, organizer, item } = await fixture();
-    const pool = await decidedPoolFor(item.id, owner.id, organizer.id, new Date());
-    await prisma.poolContributor.create({ data: { poolId: pool.id, userId: organizer.id } });
+    const pool = await decidedPoolFor(
+      item.id,
+      owner.id,
+      organizer.id,
+      new Date(),
+    );
+    await prisma.poolContributor.create({
+      data: { poolId: pool.id, userId: organizer.id },
+    });
     await syncPoolClaim(pool.id);
 
-    const defaulted = await loadClaimStates([item.id], { userId: organizer.id, isOwner: false });
+    const defaulted = await loadClaimStates([item.id], {
+      userId: organizer.id,
+      isOwner: false,
+    });
     const explicitLabel = await loadClaimStates(
       [item.id],
       { userId: organizer.id, isOwner: false },
@@ -541,15 +781,30 @@ describe('loadClaimStates', () => {
 
   it("the 'row' surface names nobody, even to a viewer the label surface would name", async () => {
     const { owner, organizer, item } = await fixture();
-    const pool = await decidedPoolFor(item.id, owner.id, organizer.id, new Date());
-    await prisma.poolContributor.create({ data: { poolId: pool.id, userId: organizer.id } });
+    const pool = await decidedPoolFor(
+      item.id,
+      owner.id,
+      organizer.id,
+      new Date(),
+    );
+    await prisma.poolContributor.create({
+      data: { poolId: pool.id, userId: organizer.id },
+    });
     await syncPoolClaim(pool.id);
 
     // Sanity: the label surface *would* name this pool to its own contributor.
-    const label = await loadClaimStates([item.id], { userId: organizer.id, isOwner: false }, 'label');
+    const label = await loadClaimStates(
+      [item.id],
+      { userId: organizer.id, isOwner: false },
+      'label',
+    );
     expect(label.get(item.id)?.name).toBe('Birthday pool');
 
-    const row = await loadClaimStates([item.id], { userId: organizer.id, isOwner: false }, 'row');
+    const row = await loadClaimStates(
+      [item.id],
+      { userId: organizer.id, isOwner: false },
+      'row',
+    );
     expect(row.get(item.id)?.show).toBe(true);
     expect(row.get(item.id)?.name).toBeNull();
     expect(row.get(item.id)?.poolLink).toBeNull();
@@ -563,12 +818,23 @@ describe('loadIdeaClaimConflicts', () => {
     const { owner, friend, organizer, item } = await fixture();
     await claimForUser(item.id, friend.id);
     const pool = await prisma.pool.create({
-      data: { title: 'Pool', organizerId: organizer.id, recipientUserId: owner.id },
+      data: {
+        title: 'Pool',
+        organizerId: organizer.id,
+        recipientUserId: owner.id,
+      },
     });
     const idea = await prisma.giftIdea.create({
-      data: { poolId: pool.id, proposedById: organizer.id, name: 'Spa', wishlistItemId: item.id },
+      data: {
+        poolId: pool.id,
+        proposedById: organizer.id,
+        name: 'Spa',
+        wishlistItemId: item.id,
+      },
     });
-    await prisma.poolContributor.create({ data: { poolId: pool.id, userId: organizer.id } });
+    await prisma.poolContributor.create({
+      data: { poolId: pool.id, userId: organizer.id },
+    });
 
     const outside = await loadIdeaClaimConflicts(pool.id, organizer.id);
     expect(outside.get(idea.id)?.name).toBeNull();
@@ -577,7 +843,9 @@ describe('loadIdeaClaimConflicts', () => {
     // serialised disclosure even indirectly (e.g. via an unused field).
     expect(JSON.stringify(outside.get(idea.id))).not.toContain(friend.id);
 
-    await prisma.poolContributor.create({ data: { poolId: pool.id, userId: friend.id } });
+    await prisma.poolContributor.create({
+      data: { poolId: pool.id, userId: friend.id },
+    });
     const inside = await loadIdeaClaimConflicts(pool.id, organizer.id);
     expect(inside.get(idea.id)?.name).not.toBeNull();
     expect(inside.get(idea.id)?.tone).toBe('warning');
@@ -585,8 +853,15 @@ describe('loadIdeaClaimConflicts', () => {
 
   it('is absent for an idea whose item this same pool already holds the claim on', async () => {
     const { owner, organizer, item } = await fixture();
-    const pool = await decidedPoolFor(item.id, owner.id, organizer.id, new Date());
-    const idea = await prisma.giftIdea.findFirstOrThrow({ where: { poolId: pool.id } });
+    const pool = await decidedPoolFor(
+      item.id,
+      owner.id,
+      organizer.id,
+      new Date(),
+    );
+    const idea = await prisma.giftIdea.findFirstOrThrow({
+      where: { poolId: pool.id },
+    });
     await syncPoolClaim(pool.id);
 
     const conflicts = await loadIdeaClaimConflicts(pool.id, organizer.id);
@@ -596,12 +871,21 @@ describe('loadIdeaClaimConflicts', () => {
 
   it('never names a rival pool, even to a viewer who also contributes there', async () => {
     const { owner, organizer, item } = await fixture();
-    const holder = await decidedPoolFor(item.id, owner.id, organizer.id, new Date());
+    const holder = await decidedPoolFor(
+      item.id,
+      owner.id,
+      organizer.id,
+      new Date(),
+    );
     await syncPoolClaim(holder.id);
 
     // A second pool proposes the same (now pool-claimed) item as an idea.
     const viewerPool = await prisma.pool.create({
-      data: { title: 'Rival viewing pool', organizerId: organizer.id, recipientUserId: owner.id },
+      data: {
+        title: 'Rival viewing pool',
+        organizerId: organizer.id,
+        recipientUserId: owner.id,
+      },
     });
     const idea = await prisma.giftIdea.create({
       data: {
@@ -613,8 +897,12 @@ describe('loadIdeaClaimConflicts', () => {
     });
     // The viewer contributes to both pools — must still learn nothing about
     // the holder pool's identity from this surface.
-    await prisma.poolContributor.create({ data: { poolId: holder.id, userId: organizer.id } });
-    await prisma.poolContributor.create({ data: { poolId: viewerPool.id, userId: organizer.id } });
+    await prisma.poolContributor.create({
+      data: { poolId: holder.id, userId: organizer.id },
+    });
+    await prisma.poolContributor.create({
+      data: { poolId: viewerPool.id, userId: organizer.id },
+    });
 
     const conflicts = await loadIdeaClaimConflicts(viewerPool.id, organizer.id);
 
@@ -629,7 +917,11 @@ describe('loadIdeaClaimConflicts', () => {
   it('returns an empty map when the pool has no ideas linked to wishlist items', async () => {
     const { owner, organizer } = await fixture();
     const pool = await prisma.pool.create({
-      data: { title: 'Empty pool', organizerId: organizer.id, recipientUserId: owner.id },
+      data: {
+        title: 'Empty pool',
+        organizerId: organizer.id,
+        recipientUserId: owner.id,
+      },
     });
     const conflicts = await loadIdeaClaimConflicts(pool.id, organizer.id);
     expect(conflicts.size).toBe(0);
@@ -642,6 +934,14 @@ async function conflictNotificationsFor(userId: string) {
     select: { sourceIdentifier: true },
   });
 }
+
+// The notification fanout is deliberately fire-and-forget, so these
+// assertions poll rather than await it. vi.waitFor's default 1s timeout is
+// ample locally but not on a CI runner under coverage instrumentation, where
+// a real-DB fanout can take longer — that flaked PR #542 with "expected [] to
+// have a length of 1". Generous but still bounded: a notification that never
+// arrives still fails the test.
+const FANOUT_WAIT = { timeout: 15_000, interval: 100 } as const;
 
 async function transferNotificationsFor(userId: string) {
   return prisma.notification.findMany({
@@ -662,23 +962,42 @@ describe('wishlist claim conflict notification — occurrence key (real ledger)'
     const { owner, friend, organizer, item } = await fixture();
     await claimForUser(item.id, friend.id);
     const other = await prisma.wishlistItem.create({
-      data: { ownerId: owner.id, title: 'Headphones', type: 'item', sortOrder: 1 },
+      data: {
+        ownerId: owner.id,
+        title: 'Headphones',
+        type: 'item',
+        sortOrder: 1,
+      },
     });
     const pool = await prisma.pool.create({
-      data: { title: 'Birthday pool', organizerId: organizer.id, recipientUserId: owner.id },
+      data: {
+        title: 'Birthday pool',
+        organizerId: organizer.id,
+        recipientUserId: owner.id,
+      },
     });
     const ideaA = await prisma.giftIdea.create({
-      data: { poolId: pool.id, proposedById: organizer.id, name: 'Spa voucher', wishlistItemId: item.id },
+      data: {
+        poolId: pool.id,
+        proposedById: organizer.id,
+        name: 'Spa voucher',
+        wishlistItemId: item.id,
+      },
     });
     const ideaB = await prisma.giftIdea.create({
-      data: { poolId: pool.id, proposedById: organizer.id, name: 'Headphones', wishlistItemId: other.id },
+      data: {
+        poolId: pool.id,
+        proposedById: organizer.id,
+        name: 'Headphones',
+        wishlistItemId: other.id,
+      },
     });
 
     // First decision on the claimed item: a real conflict, one notification.
     await chooseIdea(pool.id, ideaA.id, organizer.id);
     await vi.waitFor(async () => {
       expect(await conflictNotificationsFor(friend.id)).toHaveLength(1);
-    });
+    }, FANOUT_WAIT);
 
     // The organizer changes their mind (item B, unclaimed — no conflict),
     // then re-decides back onto the still-claimed item. `friend` never
@@ -690,9 +1009,11 @@ describe('wishlist claim conflict notification — occurrence key (real ledger)'
     // Give the (unawaited) fanout a beat to run, then assert the count never
     // grew past the original one.
     await vi.waitFor(async () => {
-      const claim = await prisma.wishlistClaim.findUnique({ where: { wishlistItemId: item.id } });
+      const claim = await prisma.wishlistClaim.findUnique({
+        where: { wishlistItemId: item.id },
+      });
       expect(claim?.claimedByUserId).toBe(friend.id);
-    });
+    }, FANOUT_WAIT);
     expect(await conflictNotificationsFor(friend.id)).toHaveLength(1);
   });
 
@@ -700,22 +1021,41 @@ describe('wishlist claim conflict notification — occurrence key (real ledger)'
     const { owner, friend, organizer, item } = await fixture();
     await claimForUser(item.id, friend.id);
     const other = await prisma.wishlistItem.create({
-      data: { ownerId: owner.id, title: 'Headphones', type: 'item', sortOrder: 1 },
+      data: {
+        ownerId: owner.id,
+        title: 'Headphones',
+        type: 'item',
+        sortOrder: 1,
+      },
     });
     const pool = await prisma.pool.create({
-      data: { title: 'Birthday pool', organizerId: organizer.id, recipientUserId: owner.id },
+      data: {
+        title: 'Birthday pool',
+        organizerId: organizer.id,
+        recipientUserId: owner.id,
+      },
     });
     const ideaA = await prisma.giftIdea.create({
-      data: { poolId: pool.id, proposedById: organizer.id, name: 'Spa voucher', wishlistItemId: item.id },
+      data: {
+        poolId: pool.id,
+        proposedById: organizer.id,
+        name: 'Spa voucher',
+        wishlistItemId: item.id,
+      },
     });
     const ideaB = await prisma.giftIdea.create({
-      data: { poolId: pool.id, proposedById: organizer.id, name: 'Headphones', wishlistItemId: other.id },
+      data: {
+        poolId: pool.id,
+        proposedById: organizer.id,
+        name: 'Headphones',
+        wishlistItemId: other.id,
+      },
     });
 
     await chooseIdea(pool.id, ideaA.id, organizer.id);
     await vi.waitFor(async () => {
       expect(await conflictNotificationsFor(friend.id)).toHaveLength(1);
-    });
+    }, FANOUT_WAIT);
     const firstClaim = await prisma.wishlistClaim.findUniqueOrThrow({
       where: { wishlistItemId: item.id },
     });
@@ -726,7 +1066,11 @@ describe('wishlist claim conflict notification — occurrence key (real ledger)'
     // free — not transferred), then someone re-claims it. This is a brand
     // new WishlistClaim row, not the one the first notification was about.
     await releaseUserClaim(item.id, friend.id);
-    expect(await prisma.wishlistClaim.findUnique({ where: { wishlistItemId: item.id } })).toBeNull();
+    expect(
+      await prisma.wishlistClaim.findUnique({
+        where: { wishlistItemId: item.id },
+      }),
+    ).toBeNull();
     await claimForUser(item.id, friend.id);
     const secondClaim = await prisma.wishlistClaim.findUniqueOrThrow({
       where: { wishlistItemId: item.id },
@@ -739,7 +1083,7 @@ describe('wishlist claim conflict notification — occurrence key (real ledger)'
 
     await vi.waitFor(async () => {
       expect(await conflictNotificationsFor(friend.id)).toHaveLength(2);
-    });
+    }, FANOUT_WAIT);
     const sourceIdentifiers = (await conflictNotificationsFor(friend.id)).map(
       (row) => row.sourceIdentifier,
     );
@@ -758,31 +1102,61 @@ describe('wishlist claim transfer notification (real DB, via chooseIdea/cancelPo
   it('notifies every contributor of the waiting pool when chooseIdea re-decides away from a held item', async () => {
     const { owner, organizer, item } = await fixture();
     const other = await prisma.wishlistItem.create({
-      data: { ownerId: owner.id, title: 'Headphones', type: 'item', sortOrder: 1 },
+      data: {
+        ownerId: owner.id,
+        title: 'Headphones',
+        type: 'item',
+        sortOrder: 1,
+      },
     });
-    const holder = await decidedPoolFor(item.id, owner.id, organizer.id, new Date('2026-07-01'));
+    const holder = await decidedPoolFor(
+      item.id,
+      owner.id,
+      organizer.id,
+      new Date('2026-07-01'),
+    );
     await syncPoolClaim(holder.id);
-    const waiter = await decidedPoolFor(item.id, owner.id, organizer.id, new Date('2026-07-10'));
+    const waiter = await decidedPoolFor(
+      item.id,
+      owner.id,
+      organizer.id,
+      new Date('2026-07-10'),
+    );
     const waiterContributor = await prisma.user.create({ data: createUser() });
-    await prisma.poolContributor.create({ data: { poolId: waiter.id, userId: waiterContributor.id } });
+    await prisma.poolContributor.create({
+      data: { poolId: waiter.id, userId: waiterContributor.id },
+    });
 
     const newIdea = await prisma.giftIdea.create({
-      data: { poolId: holder.id, proposedById: organizer.id, name: 'Headphones', wishlistItemId: other.id },
+      data: {
+        poolId: holder.id,
+        proposedById: organizer.id,
+        name: 'Headphones',
+        wishlistItemId: other.id,
+      },
     });
 
     await chooseIdea(holder.id, newIdea.id, organizer.id);
 
     await vi.waitFor(async () => {
       const rows = await prisma.notification.findMany({
-        where: { userId: waiterContributor.id, type: NOTIFICATION_TYPES.WISHLIST_CLAIM_TRANSFERRED },
+        where: {
+          userId: waiterContributor.id,
+          type: NOTIFICATION_TYPES.WISHLIST_CLAIM_TRANSFERRED,
+        },
       });
       expect(rows).toHaveLength(1);
-    });
+    }, FANOUT_WAIT);
     const notification = await prisma.notification.findFirstOrThrow({
-      where: { userId: waiterContributor.id, type: NOTIFICATION_TYPES.WISHLIST_CLAIM_TRANSFERRED },
+      where: {
+        userId: waiterContributor.id,
+        type: NOTIFICATION_TYPES.WISHLIST_CLAIM_TRANSFERRED,
+      },
     });
     // The item really did move to the waiter — the notification isn't lying.
-    const claim = await prisma.wishlistClaim.findUnique({ where: { wishlistItemId: item.id } });
+    const claim = await prisma.wishlistClaim.findUnique({
+      where: { wishlistItemId: item.id },
+    });
     expect(claim?.poolId).toBe(waiter.id);
     // The persisted row's sourceIdentifier is the per-channel ledger key
     // (`<occurrenceKey>:<channel>`); assert the occurrence key itself,
@@ -803,16 +1177,35 @@ describe('wishlist claim transfer notification (real DB, via chooseIdea/cancelPo
     // this pool's own contributors), so a mute must suppress delivery.
     const { owner, organizer, item } = await fixture();
     const other = await prisma.wishlistItem.create({
-      data: { ownerId: owner.id, title: 'Headphones', type: 'item', sortOrder: 1 },
+      data: {
+        ownerId: owner.id,
+        title: 'Headphones',
+        type: 'item',
+        sortOrder: 1,
+      },
     });
-    const holder = await decidedPoolFor(item.id, owner.id, organizer.id, new Date('2026-07-01'));
+    const holder = await decidedPoolFor(
+      item.id,
+      owner.id,
+      organizer.id,
+      new Date('2026-07-01'),
+    );
     await syncPoolClaim(holder.id);
-    const waiter = await decidedPoolFor(item.id, owner.id, organizer.id, new Date('2026-07-10'));
+    const waiter = await decidedPoolFor(
+      item.id,
+      owner.id,
+      organizer.id,
+      new Date('2026-07-10'),
+    );
 
     const mutedContributor = await prisma.user.create({ data: createUser() });
     const activeContributor = await prisma.user.create({ data: createUser() });
-    await prisma.poolContributor.create({ data: { poolId: waiter.id, userId: mutedContributor.id } });
-    await prisma.poolContributor.create({ data: { poolId: waiter.id, userId: activeContributor.id } });
+    await prisma.poolContributor.create({
+      data: { poolId: waiter.id, userId: mutedContributor.id },
+    });
+    await prisma.poolContributor.create({
+      data: { poolId: waiter.id, userId: activeContributor.id },
+    });
     await setContextActivityPreference({
       userId: mutedContributor.id,
       context: { kind: 'POOL', poolId: waiter.id },
@@ -821,7 +1214,12 @@ describe('wishlist claim transfer notification (real DB, via chooseIdea/cancelPo
     });
 
     const newIdea = await prisma.giftIdea.create({
-      data: { poolId: holder.id, proposedById: organizer.id, name: 'Headphones', wishlistItemId: other.id },
+      data: {
+        poolId: holder.id,
+        proposedById: organizer.id,
+        name: 'Headphones',
+        wishlistItemId: other.id,
+      },
     });
 
     await chooseIdea(holder.id, newIdea.id, organizer.id);
@@ -831,8 +1229,10 @@ describe('wishlist claim transfer notification (real DB, via chooseIdea/cancelPo
     // negative checked too early would pass trivially before the async
     // fanout even reaches the policy check.
     await vi.waitFor(async () => {
-      expect(await transferNotificationsFor(activeContributor.id)).toHaveLength(1);
-    });
+      expect(await transferNotificationsFor(activeContributor.id)).toHaveLength(
+        1,
+      );
+    }, FANOUT_WAIT);
     expect(await transferNotificationsFor(mutedContributor.id)).toHaveLength(0);
   });
 
@@ -858,28 +1258,63 @@ describe('wishlist claim transfer notification (real DB, via chooseIdea/cancelPo
     // which is what triggers a settlement each time it moves off while
     // `waiter` still has intent.
     const cycler = await prisma.pool.create({
-      data: { title: 'Cycler pool', organizerId: organizer.id, recipientUserId: owner.id },
+      data: {
+        title: 'Cycler pool',
+        organizerId: organizer.id,
+        recipientUserId: owner.id,
+      },
     });
     const cyclerOnItem = await prisma.giftIdea.create({
-      data: { poolId: cycler.id, proposedById: organizer.id, name: 'Item', wishlistItemId: item.id },
+      data: {
+        poolId: cycler.id,
+        proposedById: organizer.id,
+        name: 'Item',
+        wishlistItemId: item.id,
+      },
     });
     const cyclerOnB = await prisma.giftIdea.create({
-      data: { poolId: cycler.id, proposedById: organizer.id, name: 'Item B', wishlistItemId: itemB.id },
+      data: {
+        poolId: cycler.id,
+        proposedById: organizer.id,
+        name: 'Item B',
+        wishlistItemId: itemB.id,
+      },
     });
     const cyclerOnC = await prisma.giftIdea.create({
-      data: { poolId: cycler.id, proposedById: organizer.id, name: 'Item C', wishlistItemId: itemC.id },
+      data: {
+        poolId: cycler.id,
+        proposedById: organizer.id,
+        name: 'Item C',
+        wishlistItemId: itemC.id,
+      },
     });
 
     const waiter = await prisma.pool.create({
-      data: { title: 'Waiting pool', organizerId: organizer.id, recipientUserId: owner.id },
+      data: {
+        title: 'Waiting pool',
+        organizerId: organizer.id,
+        recipientUserId: owner.id,
+      },
     });
     const waiterContributor = await prisma.user.create({ data: createUser() });
-    await prisma.poolContributor.create({ data: { poolId: waiter.id, userId: waiterContributor.id } });
+    await prisma.poolContributor.create({
+      data: { poolId: waiter.id, userId: waiterContributor.id },
+    });
     const waiterOnItem = await prisma.giftIdea.create({
-      data: { poolId: waiter.id, proposedById: organizer.id, name: 'Item', wishlistItemId: item.id },
+      data: {
+        poolId: waiter.id,
+        proposedById: organizer.id,
+        name: 'Item',
+        wishlistItemId: item.id,
+      },
     });
     const waiterOnD = await prisma.giftIdea.create({
-      data: { poolId: waiter.id, proposedById: organizer.id, name: 'Item D', wishlistItemId: itemD.id },
+      data: {
+        poolId: waiter.id,
+        proposedById: organizer.id,
+        name: 'Item D',
+        wishlistItemId: itemD.id,
+      },
     });
 
     // Cycler claims the free item directly (no transfer — nothing was
@@ -892,8 +1327,10 @@ describe('wishlist claim transfer notification (real DB, via chooseIdea/cancelPo
     // Cycler moves off — settlement 1: waiter inherits.
     await chooseIdea(cycler.id, cyclerOnB.id, organizer.id);
     await vi.waitFor(async () => {
-      expect(await transferNotificationsFor(waiterContributor.id)).toHaveLength(1);
-    });
+      expect(await transferNotificationsFor(waiterContributor.id)).toHaveLength(
+        1,
+      );
+    }, FANOUT_WAIT);
     const firstSettledClaim = await prisma.wishlistClaim.findUniqueOrThrow({
       where: { wishlistItemId: item.id },
     });
@@ -903,7 +1340,9 @@ describe('wishlist claim transfer notification (real DB, via chooseIdea/cancelPo
     // item goes fully free (no notification expected from this step).
     await chooseIdea(waiter.id, waiterOnD.id, organizer.id);
     expect(
-      await prisma.wishlistClaim.findUnique({ where: { wishlistItemId: item.id } }),
+      await prisma.wishlistClaim.findUnique({
+        where: { wishlistItemId: item.id },
+      }),
     ).toBeNull();
 
     // Cycler claims the now-free item again directly, and waiter decides on
@@ -915,37 +1354,56 @@ describe('wishlist claim transfer notification (real DB, via chooseIdea/cancelPo
     // WishlistClaim row.
     await chooseIdea(cycler.id, cyclerOnC.id, organizer.id);
     await vi.waitFor(async () => {
-      expect(await transferNotificationsFor(waiterContributor.id)).toHaveLength(2);
-    });
+      expect(await transferNotificationsFor(waiterContributor.id)).toHaveLength(
+        2,
+      );
+    }, FANOUT_WAIT);
     const secondSettledClaim = await prisma.wishlistClaim.findUniqueOrThrow({
       where: { wishlistItemId: item.id },
     });
     expect(secondSettledClaim.poolId).toBe(waiter.id);
     expect(secondSettledClaim.id).not.toBe(firstSettledClaim.id);
 
-    const sourceIdentifiers = (await transferNotificationsFor(waiterContributor.id)).map(
-      (row) => row.sourceIdentifier,
-    );
+    const sourceIdentifiers = (
+      await transferNotificationsFor(waiterContributor.id)
+    ).map((row) => row.sourceIdentifier);
     expect(new Set(sourceIdentifiers).size).toBe(2);
   });
 
   it('notifies every contributor of the waiting pool when cancelPool releases a held claim', async () => {
     const { owner, organizer, item } = await fixture();
-    const holder = await decidedPoolFor(item.id, owner.id, organizer.id, new Date('2026-07-01'));
+    const holder = await decidedPoolFor(
+      item.id,
+      owner.id,
+      organizer.id,
+      new Date('2026-07-01'),
+    );
     await syncPoolClaim(holder.id);
-    const waiter = await decidedPoolFor(item.id, owner.id, organizer.id, new Date('2026-07-10'));
+    const waiter = await decidedPoolFor(
+      item.id,
+      owner.id,
+      organizer.id,
+      new Date('2026-07-10'),
+    );
     const waiterContributor = await prisma.user.create({ data: createUser() });
-    await prisma.poolContributor.create({ data: { poolId: waiter.id, userId: waiterContributor.id } });
+    await prisma.poolContributor.create({
+      data: { poolId: waiter.id, userId: waiterContributor.id },
+    });
 
     await cancelPool(holder.id, organizer.id);
 
     await vi.waitFor(async () => {
       const rows = await prisma.notification.findMany({
-        where: { userId: waiterContributor.id, type: NOTIFICATION_TYPES.WISHLIST_CLAIM_TRANSFERRED },
+        where: {
+          userId: waiterContributor.id,
+          type: NOTIFICATION_TYPES.WISHLIST_CLAIM_TRANSFERRED,
+        },
       });
       expect(rows).toHaveLength(1);
+    }, FANOUT_WAIT);
+    const claim = await prisma.wishlistClaim.findUnique({
+      where: { wishlistItemId: item.id },
     });
-    const claim = await prisma.wishlistClaim.findUnique({ where: { wishlistItemId: item.id } });
     expect(claim?.poolId).toBe(waiter.id);
   });
 });

--- a/app/utils/wishlist-claims.server.test.ts
+++ b/app/utils/wishlist-claims.server.test.ts
@@ -4,6 +4,8 @@
 import { describe, expect, it, vi } from 'vitest';
 import { prisma } from '#app/utils/db.server.ts';
 import { NOTIFICATION_TYPES } from '#app/utils/notification-catalog.ts';
+import { NOTIFICATION_ACTIVITY_LEVELS } from '#app/utils/notification-context.ts';
+import { setContextActivityPreference } from '#app/utils/notification-preferences.server.ts';
 import { createUser } from '#tests/db-utils.ts';
 import { cancelPool, chooseIdea } from './pool.server.ts';
 import * as wishlistClaims from './wishlist-claims.server.ts';
@@ -93,7 +95,7 @@ describe('settlement on release', () => {
 
     const result = await releaseUserClaim(item.id, friend.id);
 
-    expect(result.transferredToPoolId).toBe(pool.id);
+    expect(result).toMatchObject({ transferredToPoolId: pool.id });
     const claim = await prisma.wishlistClaim.findUnique({ where: { wishlistItemId: item.id } });
     expect(claim?.poolId).toBe(pool.id);
     expect(claim?.claimedByUserId).toBeNull();
@@ -103,7 +105,7 @@ describe('settlement on release', () => {
     const { friend, item } = await fixture();
     await claimForUser(item.id, friend.id);
     const result = await releaseUserClaim(item.id, friend.id);
-    expect(result.transferredToPoolId).toBeNull();
+    expect(result).toMatchObject({ transferredToPoolId: null });
     expect(await prisma.wishlistClaim.findUnique({ where: { wishlistItemId: item.id } })).toBeNull();
   });
 
@@ -115,8 +117,8 @@ describe('settlement on release', () => {
 
     const result = await releaseUserClaim(item.id, friend.id);
 
-    expect(result.transferredToPoolId).toBe(earlier.id);
-    expect(result.transferredToPoolId).not.toBe(later.id);
+    expect(result).toMatchObject({ transferredToPoolId: earlier.id });
+    expect(result).not.toMatchObject({ transferredToPoolId: later.id });
   });
 
   it('prefers a pool with a real decidedAt over one with a null decidedAt, even when the null one is older', async () => {
@@ -148,8 +150,8 @@ describe('settlement on release', () => {
 
     const result = await releaseUserClaim(item.id, friend.id);
 
-    expect(result.transferredToPoolId).toBe(datedPool.id);
-    expect(result.transferredToPoolId).not.toBe(nullDatedPool.id);
+    expect(result).toMatchObject({ transferredToPoolId: datedPool.id });
+    expect(result).not.toMatchObject({ transferredToPoolId: nullDatedPool.id });
   });
 
   it('ignores a cancelled pool when settling', async () => {
@@ -159,7 +161,7 @@ describe('settlement on release', () => {
     await prisma.pool.update({ where: { id: pool.id }, data: { status: 'CANCELLED' } });
 
     const result = await releaseUserClaim(item.id, friend.id);
-    expect(result.transferredToPoolId).toBeNull();
+    expect(result).toMatchObject({ transferredToPoolId: null });
   });
 
   it('refuses to release a claim the caller does not hold', async () => {
@@ -169,6 +171,49 @@ describe('settlement on release', () => {
     expect(result.ok).toBe(false);
     const claim = await prisma.wishlistClaim.findUnique({ where: { wishlistItemId: item.id } });
     expect(claim?.claimedByUserId).toBe(friend.id);
+  });
+
+  it('rejects a release bound to a stale claim id and leaves the current claim untouched', async () => {
+    // The occurrence-binding fix: a WISHLIST_CLAIM_CONFLICT notification's
+    // Release action carries the WishlistClaim.id it was raised about. If
+    // the claimant already released and re-claimed the same item (a brand
+    // new WishlistClaim row) before clicking that stale notification, the
+    // release must fail safely instead of destroying the new claim.
+    const { friend, item } = await fixture();
+    await claimForUser(item.id, friend.id);
+    const staleClaim = await prisma.wishlistClaim.findUniqueOrThrow({
+      where: { wishlistItemId: item.id },
+    });
+    await releaseUserClaim(item.id, friend.id);
+    await claimForUser(item.id, friend.id);
+    const currentClaim = await prisma.wishlistClaim.findUniqueOrThrow({
+      where: { wishlistItemId: item.id },
+    });
+    expect(currentClaim.id).not.toBe(staleClaim.id);
+
+    const result = await releaseUserClaim(item.id, friend.id, staleClaim.id);
+
+    expect(result).toEqual({ ok: false, reason: 'stale' });
+    const claimAfter = await prisma.wishlistClaim.findUniqueOrThrow({
+      where: { wishlistItemId: item.id },
+    });
+    expect(claimAfter.id).toBe(currentClaim.id);
+    expect(claimAfter.claimedByUserId).toBe(friend.id);
+  });
+
+  it('releases when the expected claim id matches the current claim exactly', async () => {
+    const { friend, item } = await fixture();
+    await claimForUser(item.id, friend.id);
+    const claim = await prisma.wishlistClaim.findUniqueOrThrow({
+      where: { wishlistItemId: item.id },
+    });
+
+    const result = await releaseUserClaim(item.id, friend.id, claim.id);
+
+    expect(result).toEqual({ ok: true, transferredToPoolId: null, transferredClaimId: null });
+    expect(
+      await prisma.wishlistClaim.findUnique({ where: { wishlistItemId: item.id } }),
+    ).toBeNull();
   });
 });
 
@@ -241,11 +286,14 @@ describe('syncPoolClaim', () => {
 
     const result = await syncPoolClaim(holder.id);
 
-    expect(result.released).toEqual([
-      { wishlistItemId: item.id, transferredToPoolId: waiter.id },
-    ]);
+    expect(result.released).toHaveLength(1);
+    expect(result.released[0]).toMatchObject({
+      wishlistItemId: item.id,
+      transferredToPoolId: waiter.id,
+    });
     const claim = await prisma.wishlistClaim.findUnique({ where: { wishlistItemId: item.id } });
     expect(claim?.poolId).toBe(waiter.id);
+    expect(result.released[0]?.transferredClaimId).toBe(claim?.id);
   });
 
   it('releases the claim when the pool is cancelled', async () => {
@@ -333,10 +381,12 @@ describe('releaseSoloClaimForItem', () => {
 
     const result = await wishlistClaims.releaseSoloClaimForItem(item.id);
 
-    expect(result).toEqual({ ok: true, transferredToPoolId: pool.id });
+    expect(result.ok).toBe(true);
+    expect(result.transferredToPoolId).toBe(pool.id);
     const claim = await prisma.wishlistClaim.findUnique({ where: { wishlistItemId: item.id } });
     expect(claim?.poolId).toBe(pool.id);
     expect(claim?.claimedByUserId).toBeNull();
+    expect(result.transferredClaimId).toBe(claim?.id);
   });
 
   it('leaves a pool-held claim untouched', async () => {
@@ -346,7 +396,7 @@ describe('releaseSoloClaimForItem', () => {
 
     const result = await wishlistClaims.releaseSoloClaimForItem(item.id);
 
-    expect(result).toEqual({ ok: false, transferredToPoolId: null });
+    expect(result).toEqual({ ok: false, transferredToPoolId: null, transferredClaimId: null });
     const claim = await prisma.wishlistClaim.findUnique({ where: { wishlistItemId: item.id } });
     expect(claim?.poolId).toBe(pool.id);
   });
@@ -354,7 +404,7 @@ describe('releaseSoloClaimForItem', () => {
   it('is a no-op when the item has no claim', async () => {
     const { item } = await fixture();
     const result = await wishlistClaims.releaseSoloClaimForItem(item.id);
-    expect(result).toEqual({ ok: false, transferredToPoolId: null });
+    expect(result).toEqual({ ok: false, transferredToPoolId: null, transferredClaimId: null });
   });
 });
 
@@ -593,6 +643,13 @@ async function conflictNotificationsFor(userId: string) {
   });
 }
 
+async function transferNotificationsFor(userId: string) {
+  return prisma.notification.findMany({
+    where: { userId, type: NOTIFICATION_TYPES.WISHLIST_CLAIM_TRANSFERRED },
+    select: { sourceIdentifier: true },
+  });
+}
+
 describe('wishlist claim conflict notification — occurrence key (real ledger)', () => {
   // These exercise the real `queueNotification` -> `dispatchNotification` ->
   // `NotificationDelivery` ledger path (unmocked, same as the rest of this
@@ -724,14 +781,152 @@ describe('wishlist claim transfer notification (real DB, via chooseIdea/cancelPo
     const notification = await prisma.notification.findFirstOrThrow({
       where: { userId: waiterContributor.id, type: NOTIFICATION_TYPES.WISHLIST_CLAIM_TRANSFERRED },
     });
-    // The persisted row's sourceIdentifier is the per-channel ledger key
-    // (`<occurrenceKey>:<channel>`); assert the occurrence key itself.
-    expect(notification.sourceIdentifier).toBe(
-      `claim-transferred:${waiter.id}:${item.id}:IN_APP`,
-    );
     // The item really did move to the waiter — the notification isn't lying.
     const claim = await prisma.wishlistClaim.findUnique({ where: { wishlistItemId: item.id } });
     expect(claim?.poolId).toBe(waiter.id);
+    // The persisted row's sourceIdentifier is the per-channel ledger key
+    // (`<occurrenceKey>:<channel>`); assert the occurrence key itself,
+    // including the settled claim's own id — this is what keeps a later,
+    // genuinely new settlement onto the same pool+item from matching (and
+    // being suppressed by) this ledger row. See the sibling fix on the
+    // conflict-notification key.
+    expect(notification.sourceIdentifier).toBe(
+      `claim-transferred:${waiter.id}:${item.id}:${claim?.id}:IN_APP`,
+    );
+  });
+
+  it('does not notify a contributor who has muted the inheriting pool, while an unmuted contributor still is', async () => {
+    // Regression: WISHLIST_CLAIM_TRANSFERRED used to be declared context:
+    // 'NONE', which makes resolveNotificationPolicy skip pool-context
+    // preferences entirely — a contributor who muted this exact pool would
+    // still be pinged. It is now context: 'POOL' (the audience is only ever
+    // this pool's own contributors), so a mute must suppress delivery.
+    const { owner, organizer, item } = await fixture();
+    const other = await prisma.wishlistItem.create({
+      data: { ownerId: owner.id, title: 'Headphones', type: 'item', sortOrder: 1 },
+    });
+    const holder = await decidedPoolFor(item.id, owner.id, organizer.id, new Date('2026-07-01'));
+    await syncPoolClaim(holder.id);
+    const waiter = await decidedPoolFor(item.id, owner.id, organizer.id, new Date('2026-07-10'));
+
+    const mutedContributor = await prisma.user.create({ data: createUser() });
+    const activeContributor = await prisma.user.create({ data: createUser() });
+    await prisma.poolContributor.create({ data: { poolId: waiter.id, userId: mutedContributor.id } });
+    await prisma.poolContributor.create({ data: { poolId: waiter.id, userId: activeContributor.id } });
+    await setContextActivityPreference({
+      userId: mutedContributor.id,
+      context: { kind: 'POOL', poolId: waiter.id },
+      activityLevel: NOTIFICATION_ACTIVITY_LEVELS.MUTED,
+      source: 'test',
+    });
+
+    const newIdea = await prisma.giftIdea.create({
+      data: { poolId: holder.id, proposedById: organizer.id, name: 'Headphones', wishlistItemId: other.id },
+    });
+
+    await chooseIdea(holder.id, newIdea.id, organizer.id);
+
+    // Wait for the unmuted contributor's delivery — proof the fanout ran to
+    // completion — before asserting the muted contributor's negative; a
+    // negative checked too early would pass trivially before the async
+    // fanout even reaches the policy check.
+    await vi.waitFor(async () => {
+      expect(await transferNotificationsFor(activeContributor.id)).toHaveLength(1);
+    });
+    expect(await transferNotificationsFor(mutedContributor.id)).toHaveLength(0);
+  });
+
+  it('produces a distinct transfer notification for each genuinely new settlement onto the same pool', async () => {
+    // Regression: the ledger key used to be `claim-transferred:<poolId>:<itemId>`
+    // with no claim id — permanent for a given pool+item pair. If the same
+    // pool inherits, later decides away, and then inherits again after a
+    // fresh claim forms and releases, the second settlement's key collided
+    // with the first and every channel was silently suppressed as a
+    // "duplicate." The claim id (fresh per WishlistClaim row) fixes that.
+    const { owner, organizer, item } = await fixture();
+    const itemB = await prisma.wishlistItem.create({
+      data: { ownerId: owner.id, title: 'Item B', type: 'item', sortOrder: 1 },
+    });
+    const itemC = await prisma.wishlistItem.create({
+      data: { ownerId: owner.id, title: 'Item C', type: 'item', sortOrder: 2 },
+    });
+    const itemD = await prisma.wishlistItem.create({
+      data: { ownerId: owner.id, title: 'Item D', type: 'item', sortOrder: 3 },
+    });
+
+    // `cycler` alternates between holding `item` directly and moving off it,
+    // which is what triggers a settlement each time it moves off while
+    // `waiter` still has intent.
+    const cycler = await prisma.pool.create({
+      data: { title: 'Cycler pool', organizerId: organizer.id, recipientUserId: owner.id },
+    });
+    const cyclerOnItem = await prisma.giftIdea.create({
+      data: { poolId: cycler.id, proposedById: organizer.id, name: 'Item', wishlistItemId: item.id },
+    });
+    const cyclerOnB = await prisma.giftIdea.create({
+      data: { poolId: cycler.id, proposedById: organizer.id, name: 'Item B', wishlistItemId: itemB.id },
+    });
+    const cyclerOnC = await prisma.giftIdea.create({
+      data: { poolId: cycler.id, proposedById: organizer.id, name: 'Item C', wishlistItemId: itemC.id },
+    });
+
+    const waiter = await prisma.pool.create({
+      data: { title: 'Waiting pool', organizerId: organizer.id, recipientUserId: owner.id },
+    });
+    const waiterContributor = await prisma.user.create({ data: createUser() });
+    await prisma.poolContributor.create({ data: { poolId: waiter.id, userId: waiterContributor.id } });
+    const waiterOnItem = await prisma.giftIdea.create({
+      data: { poolId: waiter.id, proposedById: organizer.id, name: 'Item', wishlistItemId: item.id },
+    });
+    const waiterOnD = await prisma.giftIdea.create({
+      data: { poolId: waiter.id, proposedById: organizer.id, name: 'Item D', wishlistItemId: itemD.id },
+    });
+
+    // Cycler claims the free item directly (no transfer — nothing was
+    // released for it to inherit).
+    await chooseIdea(cycler.id, cyclerOnItem.id, organizer.id);
+    // Waiter decides on the same item while cycler holds it: a conflict, and
+    // waiter now has intent, waiting.
+    await chooseIdea(waiter.id, waiterOnItem.id, organizer.id);
+
+    // Cycler moves off — settlement 1: waiter inherits.
+    await chooseIdea(cycler.id, cyclerOnB.id, organizer.id);
+    await vi.waitFor(async () => {
+      expect(await transferNotificationsFor(waiterContributor.id)).toHaveLength(1);
+    });
+    const firstSettledClaim = await prisma.wishlistClaim.findUniqueOrThrow({
+      where: { wishlistItemId: item.id },
+    });
+    expect(firstSettledClaim.poolId).toBe(waiter.id);
+
+    // Waiter itself moves off — nobody else has intent right now, so the
+    // item goes fully free (no notification expected from this step).
+    await chooseIdea(waiter.id, waiterOnD.id, organizer.id);
+    expect(
+      await prisma.wishlistClaim.findUnique({ where: { wishlistItemId: item.id } }),
+    ).toBeNull();
+
+    // Cycler claims the now-free item again directly, and waiter decides on
+    // it once more — a brand new conflict/wait, unrelated to the first.
+    await chooseIdea(cycler.id, cyclerOnItem.id, organizer.id);
+    await chooseIdea(waiter.id, waiterOnItem.id, organizer.id);
+
+    // Cycler moves off again — settlement 2: waiter inherits via a brand new
+    // WishlistClaim row.
+    await chooseIdea(cycler.id, cyclerOnC.id, organizer.id);
+    await vi.waitFor(async () => {
+      expect(await transferNotificationsFor(waiterContributor.id)).toHaveLength(2);
+    });
+    const secondSettledClaim = await prisma.wishlistClaim.findUniqueOrThrow({
+      where: { wishlistItemId: item.id },
+    });
+    expect(secondSettledClaim.poolId).toBe(waiter.id);
+    expect(secondSettledClaim.id).not.toBe(firstSettledClaim.id);
+
+    const sourceIdentifiers = (await transferNotificationsFor(waiterContributor.id)).map(
+      (row) => row.sourceIdentifier,
+    );
+    expect(new Set(sourceIdentifiers).size).toBe(2);
   });
 
   it('notifies every contributor of the waiting pool when cancelPool releases a held claim', async () => {

--- a/app/utils/wishlist-claims.server.test.ts
+++ b/app/utils/wishlist-claims.server.test.ts
@@ -938,10 +938,22 @@ async function conflictNotificationsFor(userId: string) {
 // The notification fanout is deliberately fire-and-forget, so these
 // assertions poll rather than await it. vi.waitFor's default 1s timeout is
 // ample locally but not on a CI runner under coverage instrumentation, where
-// a real-DB fanout can take longer — that flaked PR #542 with "expected [] to
-// have a length of 1". Generous but still bounded: a notification that never
-// arrives still fails the test.
-const FANOUT_WAIT = { timeout: 15_000, interval: 100 } as const;
+// a real-DB fanout can take longer. Bounded, not disabled: a notification that
+// never arrives still fails the test.
+//
+// Keep this comfortably under SLOW_DB_TEST_MS — a poll that outlives its own
+// test just converts a legible "expected [] to have length 1" into an opaque
+// "Test timed out", which is exactly what happened on the first attempt to fix
+// this on PR #542.
+const FANOUT_WAIT = { timeout: 4_000, interval: 100 } as const;
+
+// Vitest's per-test default is 5s and every other test in this repo fits it.
+// The multi-settlement cases below don't: they drive seven sequential
+// chooseIdea calls, each opening its own transaction and fanout against a real
+// SQLite database, and measured ~5.3s on CI under coverage. Raised per-test
+// rather than globally so the exception stays visible and doesn't quietly
+// license slow tests elsewhere.
+const SLOW_DB_TEST_MS = 30_000;
 
 async function transferNotificationsFor(userId: string) {
   return prisma.notification.findMany({
@@ -1236,139 +1248,160 @@ describe('wishlist claim transfer notification (real DB, via chooseIdea/cancelPo
     expect(await transferNotificationsFor(mutedContributor.id)).toHaveLength(0);
   });
 
-  it('produces a distinct transfer notification for each genuinely new settlement onto the same pool', async () => {
-    // Regression: the ledger key used to be `claim-transferred:<poolId>:<itemId>`
-    // with no claim id — permanent for a given pool+item pair. If the same
-    // pool inherits, later decides away, and then inherits again after a
-    // fresh claim forms and releases, the second settlement's key collided
-    // with the first and every channel was silently suppressed as a
-    // "duplicate." The claim id (fresh per WishlistClaim row) fixes that.
-    const { owner, organizer, item } = await fixture();
-    const itemB = await prisma.wishlistItem.create({
-      data: { ownerId: owner.id, title: 'Item B', type: 'item', sortOrder: 1 },
-    });
-    const itemC = await prisma.wishlistItem.create({
-      data: { ownerId: owner.id, title: 'Item C', type: 'item', sortOrder: 2 },
-    });
-    const itemD = await prisma.wishlistItem.create({
-      data: { ownerId: owner.id, title: 'Item D', type: 'item', sortOrder: 3 },
-    });
+  it(
+    'produces a distinct transfer notification for each genuinely new settlement onto the same pool',
+    async () => {
+      // Regression: the ledger key used to be `claim-transferred:<poolId>:<itemId>`
+      // with no claim id — permanent for a given pool+item pair. If the same
+      // pool inherits, later decides away, and then inherits again after a
+      // fresh claim forms and releases, the second settlement's key collided
+      // with the first and every channel was silently suppressed as a
+      // "duplicate." The claim id (fresh per WishlistClaim row) fixes that.
+      const { owner, organizer, item } = await fixture();
+      const itemB = await prisma.wishlistItem.create({
+        data: {
+          ownerId: owner.id,
+          title: 'Item B',
+          type: 'item',
+          sortOrder: 1,
+        },
+      });
+      const itemC = await prisma.wishlistItem.create({
+        data: {
+          ownerId: owner.id,
+          title: 'Item C',
+          type: 'item',
+          sortOrder: 2,
+        },
+      });
+      const itemD = await prisma.wishlistItem.create({
+        data: {
+          ownerId: owner.id,
+          title: 'Item D',
+          type: 'item',
+          sortOrder: 3,
+        },
+      });
 
-    // `cycler` alternates between holding `item` directly and moving off it,
-    // which is what triggers a settlement each time it moves off while
-    // `waiter` still has intent.
-    const cycler = await prisma.pool.create({
-      data: {
-        title: 'Cycler pool',
-        organizerId: organizer.id,
-        recipientUserId: owner.id,
-      },
-    });
-    const cyclerOnItem = await prisma.giftIdea.create({
-      data: {
-        poolId: cycler.id,
-        proposedById: organizer.id,
-        name: 'Item',
-        wishlistItemId: item.id,
-      },
-    });
-    const cyclerOnB = await prisma.giftIdea.create({
-      data: {
-        poolId: cycler.id,
-        proposedById: organizer.id,
-        name: 'Item B',
-        wishlistItemId: itemB.id,
-      },
-    });
-    const cyclerOnC = await prisma.giftIdea.create({
-      data: {
-        poolId: cycler.id,
-        proposedById: organizer.id,
-        name: 'Item C',
-        wishlistItemId: itemC.id,
-      },
-    });
+      // `cycler` alternates between holding `item` directly and moving off it,
+      // which is what triggers a settlement each time it moves off while
+      // `waiter` still has intent.
+      const cycler = await prisma.pool.create({
+        data: {
+          title: 'Cycler pool',
+          organizerId: organizer.id,
+          recipientUserId: owner.id,
+        },
+      });
+      const cyclerOnItem = await prisma.giftIdea.create({
+        data: {
+          poolId: cycler.id,
+          proposedById: organizer.id,
+          name: 'Item',
+          wishlistItemId: item.id,
+        },
+      });
+      const cyclerOnB = await prisma.giftIdea.create({
+        data: {
+          poolId: cycler.id,
+          proposedById: organizer.id,
+          name: 'Item B',
+          wishlistItemId: itemB.id,
+        },
+      });
+      const cyclerOnC = await prisma.giftIdea.create({
+        data: {
+          poolId: cycler.id,
+          proposedById: organizer.id,
+          name: 'Item C',
+          wishlistItemId: itemC.id,
+        },
+      });
 
-    const waiter = await prisma.pool.create({
-      data: {
-        title: 'Waiting pool',
-        organizerId: organizer.id,
-        recipientUserId: owner.id,
-      },
-    });
-    const waiterContributor = await prisma.user.create({ data: createUser() });
-    await prisma.poolContributor.create({
-      data: { poolId: waiter.id, userId: waiterContributor.id },
-    });
-    const waiterOnItem = await prisma.giftIdea.create({
-      data: {
-        poolId: waiter.id,
-        proposedById: organizer.id,
-        name: 'Item',
-        wishlistItemId: item.id,
-      },
-    });
-    const waiterOnD = await prisma.giftIdea.create({
-      data: {
-        poolId: waiter.id,
-        proposedById: organizer.id,
-        name: 'Item D',
-        wishlistItemId: itemD.id,
-      },
-    });
+      const waiter = await prisma.pool.create({
+        data: {
+          title: 'Waiting pool',
+          organizerId: organizer.id,
+          recipientUserId: owner.id,
+        },
+      });
+      const waiterContributor = await prisma.user.create({
+        data: createUser(),
+      });
+      await prisma.poolContributor.create({
+        data: { poolId: waiter.id, userId: waiterContributor.id },
+      });
+      const waiterOnItem = await prisma.giftIdea.create({
+        data: {
+          poolId: waiter.id,
+          proposedById: organizer.id,
+          name: 'Item',
+          wishlistItemId: item.id,
+        },
+      });
+      const waiterOnD = await prisma.giftIdea.create({
+        data: {
+          poolId: waiter.id,
+          proposedById: organizer.id,
+          name: 'Item D',
+          wishlistItemId: itemD.id,
+        },
+      });
 
-    // Cycler claims the free item directly (no transfer — nothing was
-    // released for it to inherit).
-    await chooseIdea(cycler.id, cyclerOnItem.id, organizer.id);
-    // Waiter decides on the same item while cycler holds it: a conflict, and
-    // waiter now has intent, waiting.
-    await chooseIdea(waiter.id, waiterOnItem.id, organizer.id);
+      // Cycler claims the free item directly (no transfer — nothing was
+      // released for it to inherit).
+      await chooseIdea(cycler.id, cyclerOnItem.id, organizer.id);
+      // Waiter decides on the same item while cycler holds it: a conflict, and
+      // waiter now has intent, waiting.
+      await chooseIdea(waiter.id, waiterOnItem.id, organizer.id);
 
-    // Cycler moves off — settlement 1: waiter inherits.
-    await chooseIdea(cycler.id, cyclerOnB.id, organizer.id);
-    await vi.waitFor(async () => {
-      expect(await transferNotificationsFor(waiterContributor.id)).toHaveLength(
-        1,
-      );
-    }, FANOUT_WAIT);
-    const firstSettledClaim = await prisma.wishlistClaim.findUniqueOrThrow({
-      where: { wishlistItemId: item.id },
-    });
-    expect(firstSettledClaim.poolId).toBe(waiter.id);
-
-    // Waiter itself moves off — nobody else has intent right now, so the
-    // item goes fully free (no notification expected from this step).
-    await chooseIdea(waiter.id, waiterOnD.id, organizer.id);
-    expect(
-      await prisma.wishlistClaim.findUnique({
+      // Cycler moves off — settlement 1: waiter inherits.
+      await chooseIdea(cycler.id, cyclerOnB.id, organizer.id);
+      await vi.waitFor(async () => {
+        expect(
+          await transferNotificationsFor(waiterContributor.id),
+        ).toHaveLength(1);
+      }, FANOUT_WAIT);
+      const firstSettledClaim = await prisma.wishlistClaim.findUniqueOrThrow({
         where: { wishlistItemId: item.id },
-      }),
-    ).toBeNull();
+      });
+      expect(firstSettledClaim.poolId).toBe(waiter.id);
 
-    // Cycler claims the now-free item again directly, and waiter decides on
-    // it once more — a brand new conflict/wait, unrelated to the first.
-    await chooseIdea(cycler.id, cyclerOnItem.id, organizer.id);
-    await chooseIdea(waiter.id, waiterOnItem.id, organizer.id);
+      // Waiter itself moves off — nobody else has intent right now, so the
+      // item goes fully free (no notification expected from this step).
+      await chooseIdea(waiter.id, waiterOnD.id, organizer.id);
+      expect(
+        await prisma.wishlistClaim.findUnique({
+          where: { wishlistItemId: item.id },
+        }),
+      ).toBeNull();
 
-    // Cycler moves off again — settlement 2: waiter inherits via a brand new
-    // WishlistClaim row.
-    await chooseIdea(cycler.id, cyclerOnC.id, organizer.id);
-    await vi.waitFor(async () => {
-      expect(await transferNotificationsFor(waiterContributor.id)).toHaveLength(
-        2,
-      );
-    }, FANOUT_WAIT);
-    const secondSettledClaim = await prisma.wishlistClaim.findUniqueOrThrow({
-      where: { wishlistItemId: item.id },
-    });
-    expect(secondSettledClaim.poolId).toBe(waiter.id);
-    expect(secondSettledClaim.id).not.toBe(firstSettledClaim.id);
+      // Cycler claims the now-free item again directly, and waiter decides on
+      // it once more — a brand new conflict/wait, unrelated to the first.
+      await chooseIdea(cycler.id, cyclerOnItem.id, organizer.id);
+      await chooseIdea(waiter.id, waiterOnItem.id, organizer.id);
 
-    const sourceIdentifiers = (
-      await transferNotificationsFor(waiterContributor.id)
-    ).map((row) => row.sourceIdentifier);
-    expect(new Set(sourceIdentifiers).size).toBe(2);
-  });
+      // Cycler moves off again — settlement 2: waiter inherits via a brand new
+      // WishlistClaim row.
+      await chooseIdea(cycler.id, cyclerOnC.id, organizer.id);
+      await vi.waitFor(async () => {
+        expect(
+          await transferNotificationsFor(waiterContributor.id),
+        ).toHaveLength(2);
+      }, FANOUT_WAIT);
+      const secondSettledClaim = await prisma.wishlistClaim.findUniqueOrThrow({
+        where: { wishlistItemId: item.id },
+      });
+      expect(secondSettledClaim.poolId).toBe(waiter.id);
+      expect(secondSettledClaim.id).not.toBe(firstSettledClaim.id);
+
+      const sourceIdentifiers = (
+        await transferNotificationsFor(waiterContributor.id)
+      ).map((row) => row.sourceIdentifier);
+      expect(new Set(sourceIdentifiers).size).toBe(2);
+    },
+    SLOW_DB_TEST_MS,
+  );
 
   it('notifies every contributor of the waiting pool when cancelPool releases a held claim', async () => {
     const { owner, organizer, item } = await fixture();

--- a/app/utils/wishlist-claims.server.test.ts
+++ b/app/utils/wishlist-claims.server.test.ts
@@ -3,6 +3,7 @@
  */
 import { describe, expect, it, vi } from 'vitest';
 import { prisma } from '#app/utils/db.server.ts';
+import { NOTIFICATION_TYPES } from '#app/utils/notification-catalog.ts';
 import { createUser } from '#tests/db-utils.ts';
 import { cancelPool, chooseIdea } from './pool.server.ts';
 import * as wishlistClaims from './wishlist-claims.server.ts';
@@ -582,5 +583,174 @@ describe('loadIdeaClaimConflicts', () => {
     });
     const conflicts = await loadIdeaClaimConflicts(pool.id, organizer.id);
     expect(conflicts.size).toBe(0);
+  });
+});
+
+async function conflictNotificationsFor(userId: string) {
+  return prisma.notification.findMany({
+    where: { userId, type: NOTIFICATION_TYPES.WISHLIST_CLAIM_CONFLICT },
+    select: { sourceIdentifier: true },
+  });
+}
+
+describe('wishlist claim conflict notification — occurrence key (real ledger)', () => {
+  // These exercise the real `queueNotification` -> `dispatchNotification` ->
+  // `NotificationDelivery` ledger path (unmocked, same as the rest of this
+  // file), because the bug this regression closes lives entirely in whether
+  // the ledger key changes at the right times — a test that mocks
+  // `queueNotification` can only assert what key was *computed*, not that the
+  // ledger actually deduped or didn't.
+
+  it('does not duplicate the same still-live conflict across a re-decision', async () => {
+    const { owner, friend, organizer, item } = await fixture();
+    await claimForUser(item.id, friend.id);
+    const other = await prisma.wishlistItem.create({
+      data: { ownerId: owner.id, title: 'Headphones', type: 'item', sortOrder: 1 },
+    });
+    const pool = await prisma.pool.create({
+      data: { title: 'Birthday pool', organizerId: organizer.id, recipientUserId: owner.id },
+    });
+    const ideaA = await prisma.giftIdea.create({
+      data: { poolId: pool.id, proposedById: organizer.id, name: 'Spa voucher', wishlistItemId: item.id },
+    });
+    const ideaB = await prisma.giftIdea.create({
+      data: { poolId: pool.id, proposedById: organizer.id, name: 'Headphones', wishlistItemId: other.id },
+    });
+
+    // First decision on the claimed item: a real conflict, one notification.
+    await chooseIdea(pool.id, ideaA.id, organizer.id);
+    await vi.waitFor(async () => {
+      expect(await conflictNotificationsFor(friend.id)).toHaveLength(1);
+    });
+
+    // The organizer changes their mind (item B, unclaimed — no conflict),
+    // then re-decides back onto the still-claimed item. `friend` never
+    // released or re-claimed in between, so this is the exact same
+    // WishlistClaim row as before — not a new conflict.
+    await chooseIdea(pool.id, ideaB.id, organizer.id);
+    await chooseIdea(pool.id, ideaA.id, organizer.id);
+
+    // Give the (unawaited) fanout a beat to run, then assert the count never
+    // grew past the original one.
+    await vi.waitFor(async () => {
+      const claim = await prisma.wishlistClaim.findUnique({ where: { wishlistItemId: item.id } });
+      expect(claim?.claimedByUserId).toBe(friend.id);
+    });
+    expect(await conflictNotificationsFor(friend.id)).toHaveLength(1);
+  });
+
+  it('notifies again when the same item conflicts a second time on a freshly re-claimed WishlistClaim', async () => {
+    const { owner, friend, organizer, item } = await fixture();
+    await claimForUser(item.id, friend.id);
+    const other = await prisma.wishlistItem.create({
+      data: { ownerId: owner.id, title: 'Headphones', type: 'item', sortOrder: 1 },
+    });
+    const pool = await prisma.pool.create({
+      data: { title: 'Birthday pool', organizerId: organizer.id, recipientUserId: owner.id },
+    });
+    const ideaA = await prisma.giftIdea.create({
+      data: { poolId: pool.id, proposedById: organizer.id, name: 'Spa voucher', wishlistItemId: item.id },
+    });
+    const ideaB = await prisma.giftIdea.create({
+      data: { poolId: pool.id, proposedById: organizer.id, name: 'Headphones', wishlistItemId: other.id },
+    });
+
+    await chooseIdea(pool.id, ideaA.id, organizer.id);
+    await vi.waitFor(async () => {
+      expect(await conflictNotificationsFor(friend.id)).toHaveLength(1);
+    });
+    const firstClaim = await prisma.wishlistClaim.findUniqueOrThrow({
+      where: { wishlistItemId: item.id },
+    });
+
+    // The pool moves on, freeing its intent on the item.
+    await chooseIdea(pool.id, ideaB.id, organizer.id);
+    // The holder releases (no pool is waiting on it now, so it goes fully
+    // free — not transferred), then someone re-claims it. This is a brand
+    // new WishlistClaim row, not the one the first notification was about.
+    await releaseUserClaim(item.id, friend.id);
+    expect(await prisma.wishlistClaim.findUnique({ where: { wishlistItemId: item.id } })).toBeNull();
+    await claimForUser(item.id, friend.id);
+    const secondClaim = await prisma.wishlistClaim.findUniqueOrThrow({
+      where: { wishlistItemId: item.id },
+    });
+    expect(secondClaim.id).not.toBe(firstClaim.id);
+
+    // The pool decides on the item again: a genuinely new conflict against
+    // the new claim.
+    await chooseIdea(pool.id, ideaA.id, organizer.id);
+
+    await vi.waitFor(async () => {
+      expect(await conflictNotificationsFor(friend.id)).toHaveLength(2);
+    });
+    const sourceIdentifiers = (await conflictNotificationsFor(friend.id)).map(
+      (row) => row.sourceIdentifier,
+    );
+    expect(new Set(sourceIdentifiers).size).toBe(2);
+  });
+});
+
+describe('wishlist claim transfer notification (real DB, via chooseIdea/cancelPool)', () => {
+  // `queueWishlistClaimTransferredNotification` fans out to every contributor
+  // of the pool that just inherited a claim — the "your duplicate-purchase
+  // risk is over" half of the conflict story. Both call sites (`chooseIdea`
+  // re-deciding away from a held item, and `cancelPool`) only reach this
+  // branch when settlement actually hands the freed item to a *different*,
+  // waiting pool — so the fixture always sets up a holder and a waiter.
+
+  it('notifies every contributor of the waiting pool when chooseIdea re-decides away from a held item', async () => {
+    const { owner, organizer, item } = await fixture();
+    const other = await prisma.wishlistItem.create({
+      data: { ownerId: owner.id, title: 'Headphones', type: 'item', sortOrder: 1 },
+    });
+    const holder = await decidedPoolFor(item.id, owner.id, organizer.id, new Date('2026-07-01'));
+    await syncPoolClaim(holder.id);
+    const waiter = await decidedPoolFor(item.id, owner.id, organizer.id, new Date('2026-07-10'));
+    const waiterContributor = await prisma.user.create({ data: createUser() });
+    await prisma.poolContributor.create({ data: { poolId: waiter.id, userId: waiterContributor.id } });
+
+    const newIdea = await prisma.giftIdea.create({
+      data: { poolId: holder.id, proposedById: organizer.id, name: 'Headphones', wishlistItemId: other.id },
+    });
+
+    await chooseIdea(holder.id, newIdea.id, organizer.id);
+
+    await vi.waitFor(async () => {
+      const rows = await prisma.notification.findMany({
+        where: { userId: waiterContributor.id, type: NOTIFICATION_TYPES.WISHLIST_CLAIM_TRANSFERRED },
+      });
+      expect(rows).toHaveLength(1);
+    });
+    const notification = await prisma.notification.findFirstOrThrow({
+      where: { userId: waiterContributor.id, type: NOTIFICATION_TYPES.WISHLIST_CLAIM_TRANSFERRED },
+    });
+    // The persisted row's sourceIdentifier is the per-channel ledger key
+    // (`<occurrenceKey>:<channel>`); assert the occurrence key itself.
+    expect(notification.sourceIdentifier).toBe(
+      `claim-transferred:${waiter.id}:${item.id}:IN_APP`,
+    );
+    // The item really did move to the waiter — the notification isn't lying.
+    const claim = await prisma.wishlistClaim.findUnique({ where: { wishlistItemId: item.id } });
+    expect(claim?.poolId).toBe(waiter.id);
+  });
+
+  it('notifies every contributor of the waiting pool when cancelPool releases a held claim', async () => {
+    const { owner, organizer, item } = await fixture();
+    const holder = await decidedPoolFor(item.id, owner.id, organizer.id, new Date('2026-07-01'));
+    await syncPoolClaim(holder.id);
+    const waiter = await decidedPoolFor(item.id, owner.id, organizer.id, new Date('2026-07-10'));
+    const waiterContributor = await prisma.user.create({ data: createUser() });
+    await prisma.poolContributor.create({ data: { poolId: waiter.id, userId: waiterContributor.id } });
+
+    await cancelPool(holder.id, organizer.id);
+
+    await vi.waitFor(async () => {
+      const rows = await prisma.notification.findMany({
+        where: { userId: waiterContributor.id, type: NOTIFICATION_TYPES.WISHLIST_CLAIM_TRANSFERRED },
+      });
+      expect(rows).toHaveLength(1);
+    });
+    const claim = await prisma.wishlistClaim.findUnique({ where: { wishlistItemId: item.id } });
+    expect(claim?.poolId).toBe(waiter.id);
   });
 });

--- a/app/utils/wishlist-claims.server.test.ts
+++ b/app/utils/wishlist-claims.server.test.ts
@@ -1248,160 +1248,74 @@ describe('wishlist claim transfer notification (real DB, via chooseIdea/cancelPo
     expect(await transferNotificationsFor(mutedContributor.id)).toHaveLength(0);
   });
 
-  it(
-    'produces a distinct transfer notification for each genuinely new settlement onto the same pool',
-    async () => {
-      // Regression: the ledger key used to be `claim-transferred:<poolId>:<itemId>`
-      // with no claim id — permanent for a given pool+item pair. If the same
-      // pool inherits, later decides away, and then inherits again after a
-      // fresh claim forms and releases, the second settlement's key collided
-      // with the first and every channel was silently suppressed as a
-      // "duplicate." The claim id (fresh per WishlistClaim row) fixes that.
-      const { owner, organizer, item } = await fixture();
-      const itemB = await prisma.wishlistItem.create({
-        data: {
-          ownerId: owner.id,
-          title: 'Item B',
-          type: 'item',
-          sortOrder: 1,
-        },
-      });
-      const itemC = await prisma.wishlistItem.create({
-        data: {
-          ownerId: owner.id,
-          title: 'Item C',
-          type: 'item',
-          sortOrder: 2,
-        },
-      });
-      const itemD = await prisma.wishlistItem.create({
-        data: {
-          ownerId: owner.id,
-          title: 'Item D',
-          type: 'item',
-          sortOrder: 3,
-        },
-      });
+  it('scopes the transfer notification key to the settling claim, not just the pool and item', async () => {
+    // Regression: the ledger key used to be `claim-transferred:<poolId>:<itemId>`
+    // with no claim id — permanent for a given pool+item pair. A pool that
+    // inherited, decided away, and inherited again after a fresh claim formed
+    // and released had its second settlement silently suppressed as a
+    // "duplicate."
+    //
+    // Asserting the key contains the settling claim's id proves the fix more
+    // directly, and more cheaply, than driving a full inherit/release/inherit
+    // cycle: WishlistClaim ids are unique per row, so a key that embeds one
+    // cannot collide across genuinely distinct settlements. The cycle version
+    // of this test drove seven sequential chooseIdea calls, each leaving a
+    // fire-and-forget fanout in flight against single-writer SQLite while the
+    // next transaction opened — which starved the database on CI runners under
+    // coverage instrumentation ("Operations timed out ... failed to respond").
+    const { owner, organizer, item } = await fixture();
+    const waiterContributor = await prisma.user.create({ data: createUser() });
 
-      // `cycler` alternates between holding `item` directly and moving off it,
-      // which is what triggers a settlement each time it moves off while
-      // `waiter` still has intent.
-      const cycler = await prisma.pool.create({
-        data: {
-          title: 'Cycler pool',
-          organizerId: organizer.id,
-          recipientUserId: owner.id,
-        },
-      });
-      const cyclerOnItem = await prisma.giftIdea.create({
-        data: {
-          poolId: cycler.id,
-          proposedById: organizer.id,
-          name: 'Item',
-          wishlistItemId: item.id,
-        },
-      });
-      const cyclerOnB = await prisma.giftIdea.create({
-        data: {
-          poolId: cycler.id,
-          proposedById: organizer.id,
-          name: 'Item B',
-          wishlistItemId: itemB.id,
-        },
-      });
-      const cyclerOnC = await prisma.giftIdea.create({
-        data: {
-          poolId: cycler.id,
-          proposedById: organizer.id,
-          name: 'Item C',
-          wishlistItemId: itemC.id,
-        },
-      });
+    // Note the route through `cancelPool` rather than `releaseUserClaim`: the
+    // fanout is queued by the *callers* of the release paths, after their
+    // transaction closes, never inside the claim module itself. Calling
+    // `releaseUserClaim` directly settles the claim but sends nothing, so a
+    // test driving it would assert against a notification that was never
+    // queued.
+    const holder = await decidedPoolFor(
+      item.id,
+      owner.id,
+      organizer.id,
+      new Date('2026-07-01'),
+    );
+    await syncPoolClaim(holder.id);
+    const waiter = await decidedPoolFor(
+      item.id,
+      owner.id,
+      organizer.id,
+      new Date('2026-07-10'),
+    );
+    await prisma.poolContributor.create({
+      data: { poolId: waiter.id, userId: waiterContributor.id },
+    });
 
-      const waiter = await prisma.pool.create({
-        data: {
-          title: 'Waiting pool',
-          organizerId: organizer.id,
-          recipientUserId: owner.id,
-        },
-      });
-      const waiterContributor = await prisma.user.create({
-        data: createUser(),
-      });
-      await prisma.poolContributor.create({
-        data: { poolId: waiter.id, userId: waiterContributor.id },
-      });
-      const waiterOnItem = await prisma.giftIdea.create({
-        data: {
-          poolId: waiter.id,
-          proposedById: organizer.id,
-          name: 'Item',
-          wishlistItemId: item.id,
-        },
-      });
-      const waiterOnD = await prisma.giftIdea.create({
-        data: {
-          poolId: waiter.id,
-          proposedById: organizer.id,
-          name: 'Item D',
-          wishlistItemId: itemD.id,
-        },
-      });
+    // The holder cancels: settlement hands the item to the waiting pool.
+    await cancelPool(holder.id, organizer.id);
 
-      // Cycler claims the free item directly (no transfer — nothing was
-      // released for it to inherit).
-      await chooseIdea(cycler.id, cyclerOnItem.id, organizer.id);
-      // Waiter decides on the same item while cycler holds it: a conflict, and
-      // waiter now has intent, waiting.
-      await chooseIdea(waiter.id, waiterOnItem.id, organizer.id);
+    const settledClaim = await prisma.wishlistClaim.findUniqueOrThrow({
+      where: { wishlistItemId: item.id },
+    });
+    expect(settledClaim.poolId).toBe(waiter.id);
 
-      // Cycler moves off — settlement 1: waiter inherits.
-      await chooseIdea(cycler.id, cyclerOnB.id, organizer.id);
-      await vi.waitFor(async () => {
-        expect(
-          await transferNotificationsFor(waiterContributor.id),
-        ).toHaveLength(1);
-      }, FANOUT_WAIT);
-      const firstSettledClaim = await prisma.wishlistClaim.findUniqueOrThrow({
-        where: { wishlistItemId: item.id },
-      });
-      expect(firstSettledClaim.poolId).toBe(waiter.id);
+    await vi.waitFor(async () => {
+      expect(await transferNotificationsFor(waiterContributor.id)).toHaveLength(
+        1,
+      );
+    }, FANOUT_WAIT);
 
-      // Waiter itself moves off — nobody else has intent right now, so the
-      // item goes fully free (no notification expected from this step).
-      await chooseIdea(waiter.id, waiterOnD.id, organizer.id);
-      expect(
-        await prisma.wishlistClaim.findUnique({
-          where: { wishlistItemId: item.id },
-        }),
-      ).toBeNull();
-
-      // Cycler claims the now-free item again directly, and waiter decides on
-      // it once more — a brand new conflict/wait, unrelated to the first.
-      await chooseIdea(cycler.id, cyclerOnItem.id, organizer.id);
-      await chooseIdea(waiter.id, waiterOnItem.id, organizer.id);
-
-      // Cycler moves off again — settlement 2: waiter inherits via a brand new
-      // WishlistClaim row.
-      await chooseIdea(cycler.id, cyclerOnC.id, organizer.id);
-      await vi.waitFor(async () => {
-        expect(
-          await transferNotificationsFor(waiterContributor.id),
-        ).toHaveLength(2);
-      }, FANOUT_WAIT);
-      const secondSettledClaim = await prisma.wishlistClaim.findUniqueOrThrow({
-        where: { wishlistItemId: item.id },
-      });
-      expect(secondSettledClaim.poolId).toBe(waiter.id);
-      expect(secondSettledClaim.id).not.toBe(firstSettledClaim.id);
-
-      const sourceIdentifiers = (
-        await transferNotificationsFor(waiterContributor.id)
-      ).map((row) => row.sourceIdentifier);
-      expect(new Set(sourceIdentifiers).size).toBe(2);
-    },
-    SLOW_DB_TEST_MS,
-  );
+    const notifications = await transferNotificationsFor(waiterContributor.id);
+    expect(notifications).toHaveLength(1);
+    // The claim id is the occurrence component. Without it the key is
+    // permanent for this pool+item and a later settlement is suppressed.
+    expect(notifications[0]?.sourceIdentifier).toContain(settledClaim.id);
+    // Prefix rather than exact match: the dispatcher appends the channel, since
+    // the ledger claims one row per channel per key.
+    expect(notifications[0]?.sourceIdentifier).toMatch(
+      new RegExp(
+        `^claim-transferred:${waiter.id}:${item.id}:${settledClaim.id}:`,
+      ),
+    );
+  });
 
   it('notifies every contributor of the waiting pool when cancelPool releases a held claim', async () => {
     const { owner, organizer, item } = await fixture();

--- a/app/utils/wishlist-claims.server.test.ts
+++ b/app/utils/wishlist-claims.server.test.ts
@@ -299,6 +299,7 @@ describe('settlement on release', () => {
 
     expect(result).toEqual({
       ok: true,
+      releasedClaimId: claim.id,
       transferredToPoolId: null,
       transferredClaimId: null,
     });

--- a/app/utils/wishlist-claims.server.test.ts
+++ b/app/utils/wishlist-claims.server.test.ts
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment node
  */
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { prisma } from '#app/utils/db.server.ts';
 import { NOTIFICATION_TYPES } from '#app/utils/notification-catalog.ts';
 import { NOTIFICATION_ACTIVITY_LEVELS } from '#app/utils/notification-context.ts';
@@ -56,6 +56,30 @@ async function decidedPoolFor(
     data: { status: 'DECIDED', chosenIdeaId: idea.id, decidedAt },
   });
   return pool;
+}
+
+/**
+ * Drain fire-and-forget notification fanouts before a test ends.
+ *
+ * The claim fanouts are deliberately not awaited by the code under test, so
+ * when a test returns they may still be mid-query. The global `afterEach`
+ * cleanup then truncates the tables underneath them, and on a slow CI runner
+ * under coverage instrumentation that contention starves single-writer SQLite —
+ * "Operations timed out ... the database failed to respond" — which surfaces as
+ * a *different* test in this block failing for no visible reason.
+ *
+ * Waits for the notification count to stop changing rather than sleeping a
+ * fixed amount, and is bounded so a genuinely stuck fanout can't hang the run.
+ */
+async function drainNotificationFanouts() {
+  const deadline = Date.now() + 3_000;
+  let previous = -1;
+  while (Date.now() < deadline) {
+    const count = await prisma.notification.count();
+    if (count === previous) return;
+    previous = count;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
 }
 
 describe('claimForUser', () => {
@@ -963,6 +987,8 @@ async function transferNotificationsFor(userId: string) {
 }
 
 describe('wishlist claim conflict notification — occurrence key (real ledger)', () => {
+  afterEach(drainNotificationFanouts);
+
   // These exercise the real `queueNotification` -> `dispatchNotification` ->
   // `NotificationDelivery` ledger path (unmocked, same as the rest of this
   // file), because the bug this regression closes lives entirely in whether
@@ -1104,6 +1130,8 @@ describe('wishlist claim conflict notification — occurrence key (real ledger)'
 });
 
 describe('wishlist claim transfer notification (real DB, via chooseIdea/cancelPool)', () => {
+  afterEach(drainNotificationFanouts);
+
   // `queueWishlistClaimTransferredNotification` fans out to every contributor
   // of the pool that just inherited a claim — the "your duplicate-purchase
   // risk is over" half of the conflict story. Both call sites (`chooseIdea`

--- a/app/utils/wishlist-claims.server.test.ts
+++ b/app/utils/wishlist-claims.server.test.ts
@@ -969,15 +969,19 @@ async function conflictNotificationsFor(userId: string) {
 // Keep this comfortably under SLOW_DB_TEST_MS — a poll that outlives its own
 // test just converts a legible "expected [] to have length 1" into an opaque
 // "Test timed out", which is exactly what happened on the first attempt to fix
-// this on PR #542.
-const FANOUT_WAIT = { timeout: 4_000, interval: 100 } as const;
+// this on PR #542. Every test in both notification blocks carries that budget,
+// so this can be generous: the failures were always the database being starved
+// for longer than the poll, never a notification that was genuinely never sent.
+const FANOUT_WAIT = { timeout: 10_000, interval: 100 } as const;
 
 // Vitest's per-test default is 5s and every other test in this repo fits it.
-// The multi-settlement cases below don't: they drive seven sequential
-// chooseIdea calls, each opening its own transaction and fanout against a real
-// SQLite database, and measured ~5.3s on CI under coverage. Raised per-test
-// rather than globally so the exception stays visible and doesn't quietly
-// license slow tests elsewhere.
+// The notification tests below don't: each drives real pool decisions against a
+// real SQLite database and then polls for a fire-and-forget fanout, and CI
+// runners under coverage instrumentation starve single-writer SQLite badly
+// enough to blow the default. Applied to every test in both notification
+// blocks — granting it to only the one that happened to fail just moved the
+// failure to its neighbour, twice. Raised per-test rather than globally so the
+// exception stays visible and doesn't quietly license slow tests elsewhere.
 const SLOW_DB_TEST_MS = 30_000;
 
 async function transferNotificationsFor(userId: string) {
@@ -997,137 +1001,145 @@ describe('wishlist claim conflict notification — occurrence key (real ledger)'
   // `queueNotification` can only assert what key was *computed*, not that the
   // ledger actually deduped or didn't.
 
-  it('does not duplicate the same still-live conflict across a re-decision', async () => {
-    const { owner, friend, organizer, item } = await fixture();
-    await claimForUser(item.id, friend.id);
-    const other = await prisma.wishlistItem.create({
-      data: {
-        ownerId: owner.id,
-        title: 'Headphones',
-        type: 'item',
-        sortOrder: 1,
-      },
-    });
-    const pool = await prisma.pool.create({
-      data: {
-        title: 'Birthday pool',
-        organizerId: organizer.id,
-        recipientUserId: owner.id,
-      },
-    });
-    const ideaA = await prisma.giftIdea.create({
-      data: {
-        poolId: pool.id,
-        proposedById: organizer.id,
-        name: 'Spa voucher',
-        wishlistItemId: item.id,
-      },
-    });
-    const ideaB = await prisma.giftIdea.create({
-      data: {
-        poolId: pool.id,
-        proposedById: organizer.id,
-        name: 'Headphones',
-        wishlistItemId: other.id,
-      },
-    });
+  it(
+    'does not duplicate the same still-live conflict across a re-decision',
+    async () => {
+      const { owner, friend, organizer, item } = await fixture();
+      await claimForUser(item.id, friend.id);
+      const other = await prisma.wishlistItem.create({
+        data: {
+          ownerId: owner.id,
+          title: 'Headphones',
+          type: 'item',
+          sortOrder: 1,
+        },
+      });
+      const pool = await prisma.pool.create({
+        data: {
+          title: 'Birthday pool',
+          organizerId: organizer.id,
+          recipientUserId: owner.id,
+        },
+      });
+      const ideaA = await prisma.giftIdea.create({
+        data: {
+          poolId: pool.id,
+          proposedById: organizer.id,
+          name: 'Spa voucher',
+          wishlistItemId: item.id,
+        },
+      });
+      const ideaB = await prisma.giftIdea.create({
+        data: {
+          poolId: pool.id,
+          proposedById: organizer.id,
+          name: 'Headphones',
+          wishlistItemId: other.id,
+        },
+      });
 
-    // First decision on the claimed item: a real conflict, one notification.
-    await chooseIdea(pool.id, ideaA.id, organizer.id);
-    await vi.waitFor(async () => {
+      // First decision on the claimed item: a real conflict, one notification.
+      await chooseIdea(pool.id, ideaA.id, organizer.id);
+      await vi.waitFor(async () => {
+        expect(await conflictNotificationsFor(friend.id)).toHaveLength(1);
+      }, FANOUT_WAIT);
+
+      // The organizer changes their mind (item B, unclaimed — no conflict),
+      // then re-decides back onto the still-claimed item. `friend` never
+      // released or re-claimed in between, so this is the exact same
+      // WishlistClaim row as before — not a new conflict.
+      await chooseIdea(pool.id, ideaB.id, organizer.id);
+      await chooseIdea(pool.id, ideaA.id, organizer.id);
+
+      // Give the (unawaited) fanout a beat to run, then assert the count never
+      // grew past the original one.
+      await vi.waitFor(async () => {
+        const claim = await prisma.wishlistClaim.findUnique({
+          where: { wishlistItemId: item.id },
+        });
+        expect(claim?.claimedByUserId).toBe(friend.id);
+      }, FANOUT_WAIT);
       expect(await conflictNotificationsFor(friend.id)).toHaveLength(1);
-    }, FANOUT_WAIT);
+    },
+    SLOW_DB_TEST_MS,
+  );
 
-    // The organizer changes their mind (item B, unclaimed — no conflict),
-    // then re-decides back onto the still-claimed item. `friend` never
-    // released or re-claimed in between, so this is the exact same
-    // WishlistClaim row as before — not a new conflict.
-    await chooseIdea(pool.id, ideaB.id, organizer.id);
-    await chooseIdea(pool.id, ideaA.id, organizer.id);
+  it(
+    'notifies again when the same item conflicts a second time on a freshly re-claimed WishlistClaim',
+    async () => {
+      const { owner, friend, organizer, item } = await fixture();
+      await claimForUser(item.id, friend.id);
+      const other = await prisma.wishlistItem.create({
+        data: {
+          ownerId: owner.id,
+          title: 'Headphones',
+          type: 'item',
+          sortOrder: 1,
+        },
+      });
+      const pool = await prisma.pool.create({
+        data: {
+          title: 'Birthday pool',
+          organizerId: organizer.id,
+          recipientUserId: owner.id,
+        },
+      });
+      const ideaA = await prisma.giftIdea.create({
+        data: {
+          poolId: pool.id,
+          proposedById: organizer.id,
+          name: 'Spa voucher',
+          wishlistItemId: item.id,
+        },
+      });
+      const ideaB = await prisma.giftIdea.create({
+        data: {
+          poolId: pool.id,
+          proposedById: organizer.id,
+          name: 'Headphones',
+          wishlistItemId: other.id,
+        },
+      });
 
-    // Give the (unawaited) fanout a beat to run, then assert the count never
-    // grew past the original one.
-    await vi.waitFor(async () => {
-      const claim = await prisma.wishlistClaim.findUnique({
+      await chooseIdea(pool.id, ideaA.id, organizer.id);
+      await vi.waitFor(async () => {
+        expect(await conflictNotificationsFor(friend.id)).toHaveLength(1);
+      }, FANOUT_WAIT);
+      const firstClaim = await prisma.wishlistClaim.findUniqueOrThrow({
         where: { wishlistItemId: item.id },
       });
-      expect(claim?.claimedByUserId).toBe(friend.id);
-    }, FANOUT_WAIT);
-    expect(await conflictNotificationsFor(friend.id)).toHaveLength(1);
-  });
 
-  it('notifies again when the same item conflicts a second time on a freshly re-claimed WishlistClaim', async () => {
-    const { owner, friend, organizer, item } = await fixture();
-    await claimForUser(item.id, friend.id);
-    const other = await prisma.wishlistItem.create({
-      data: {
-        ownerId: owner.id,
-        title: 'Headphones',
-        type: 'item',
-        sortOrder: 1,
-      },
-    });
-    const pool = await prisma.pool.create({
-      data: {
-        title: 'Birthday pool',
-        organizerId: organizer.id,
-        recipientUserId: owner.id,
-      },
-    });
-    const ideaA = await prisma.giftIdea.create({
-      data: {
-        poolId: pool.id,
-        proposedById: organizer.id,
-        name: 'Spa voucher',
-        wishlistItemId: item.id,
-      },
-    });
-    const ideaB = await prisma.giftIdea.create({
-      data: {
-        poolId: pool.id,
-        proposedById: organizer.id,
-        name: 'Headphones',
-        wishlistItemId: other.id,
-      },
-    });
-
-    await chooseIdea(pool.id, ideaA.id, organizer.id);
-    await vi.waitFor(async () => {
-      expect(await conflictNotificationsFor(friend.id)).toHaveLength(1);
-    }, FANOUT_WAIT);
-    const firstClaim = await prisma.wishlistClaim.findUniqueOrThrow({
-      where: { wishlistItemId: item.id },
-    });
-
-    // The pool moves on, freeing its intent on the item.
-    await chooseIdea(pool.id, ideaB.id, organizer.id);
-    // The holder releases (no pool is waiting on it now, so it goes fully
-    // free — not transferred), then someone re-claims it. This is a brand
-    // new WishlistClaim row, not the one the first notification was about.
-    await releaseUserClaim(item.id, friend.id);
-    expect(
-      await prisma.wishlistClaim.findUnique({
+      // The pool moves on, freeing its intent on the item.
+      await chooseIdea(pool.id, ideaB.id, organizer.id);
+      // The holder releases (no pool is waiting on it now, so it goes fully
+      // free — not transferred), then someone re-claims it. This is a brand
+      // new WishlistClaim row, not the one the first notification was about.
+      await releaseUserClaim(item.id, friend.id);
+      expect(
+        await prisma.wishlistClaim.findUnique({
+          where: { wishlistItemId: item.id },
+        }),
+      ).toBeNull();
+      await claimForUser(item.id, friend.id);
+      const secondClaim = await prisma.wishlistClaim.findUniqueOrThrow({
         where: { wishlistItemId: item.id },
-      }),
-    ).toBeNull();
-    await claimForUser(item.id, friend.id);
-    const secondClaim = await prisma.wishlistClaim.findUniqueOrThrow({
-      where: { wishlistItemId: item.id },
-    });
-    expect(secondClaim.id).not.toBe(firstClaim.id);
+      });
+      expect(secondClaim.id).not.toBe(firstClaim.id);
 
-    // The pool decides on the item again: a genuinely new conflict against
-    // the new claim.
-    await chooseIdea(pool.id, ideaA.id, organizer.id);
+      // The pool decides on the item again: a genuinely new conflict against
+      // the new claim.
+      await chooseIdea(pool.id, ideaA.id, organizer.id);
 
-    await vi.waitFor(async () => {
-      expect(await conflictNotificationsFor(friend.id)).toHaveLength(2);
-    }, FANOUT_WAIT);
-    const sourceIdentifiers = (await conflictNotificationsFor(friend.id)).map(
-      (row) => row.sourceIdentifier,
-    );
-    expect(new Set(sourceIdentifiers).size).toBe(2);
-  });
+      await vi.waitFor(async () => {
+        expect(await conflictNotificationsFor(friend.id)).toHaveLength(2);
+      }, FANOUT_WAIT);
+      const sourceIdentifiers = (await conflictNotificationsFor(friend.id)).map(
+        (row) => row.sourceIdentifier,
+      );
+      expect(new Set(sourceIdentifiers).size).toBe(2);
+    },
+    SLOW_DB_TEST_MS,
+  );
 });
 
 describe('wishlist claim transfer notification (real DB, via chooseIdea/cancelPool)', () => {
@@ -1140,246 +1152,274 @@ describe('wishlist claim transfer notification (real DB, via chooseIdea/cancelPo
   // branch when settlement actually hands the freed item to a *different*,
   // waiting pool — so the fixture always sets up a holder and a waiter.
 
-  it('notifies every contributor of the waiting pool when chooseIdea re-decides away from a held item', async () => {
-    const { owner, organizer, item } = await fixture();
-    const other = await prisma.wishlistItem.create({
-      data: {
-        ownerId: owner.id,
-        title: 'Headphones',
-        type: 'item',
-        sortOrder: 1,
-      },
-    });
-    const holder = await decidedPoolFor(
-      item.id,
-      owner.id,
-      organizer.id,
-      new Date('2026-07-01'),
-    );
-    await syncPoolClaim(holder.id);
-    const waiter = await decidedPoolFor(
-      item.id,
-      owner.id,
-      organizer.id,
-      new Date('2026-07-10'),
-    );
-    const waiterContributor = await prisma.user.create({ data: createUser() });
-    await prisma.poolContributor.create({
-      data: { poolId: waiter.id, userId: waiterContributor.id },
-    });
+  it(
+    'notifies every contributor of the waiting pool when chooseIdea re-decides away from a held item',
+    async () => {
+      const { owner, organizer, item } = await fixture();
+      const other = await prisma.wishlistItem.create({
+        data: {
+          ownerId: owner.id,
+          title: 'Headphones',
+          type: 'item',
+          sortOrder: 1,
+        },
+      });
+      const holder = await decidedPoolFor(
+        item.id,
+        owner.id,
+        organizer.id,
+        new Date('2026-07-01'),
+      );
+      await syncPoolClaim(holder.id);
+      const waiter = await decidedPoolFor(
+        item.id,
+        owner.id,
+        organizer.id,
+        new Date('2026-07-10'),
+      );
+      const waiterContributor = await prisma.user.create({
+        data: createUser(),
+      });
+      await prisma.poolContributor.create({
+        data: { poolId: waiter.id, userId: waiterContributor.id },
+      });
 
-    const newIdea = await prisma.giftIdea.create({
-      data: {
-        poolId: holder.id,
-        proposedById: organizer.id,
-        name: 'Headphones',
-        wishlistItemId: other.id,
-      },
-    });
+      const newIdea = await prisma.giftIdea.create({
+        data: {
+          poolId: holder.id,
+          proposedById: organizer.id,
+          name: 'Headphones',
+          wishlistItemId: other.id,
+        },
+      });
 
-    await chooseIdea(holder.id, newIdea.id, organizer.id);
+      await chooseIdea(holder.id, newIdea.id, organizer.id);
 
-    await vi.waitFor(async () => {
-      const rows = await prisma.notification.findMany({
+      await vi.waitFor(async () => {
+        const rows = await prisma.notification.findMany({
+          where: {
+            userId: waiterContributor.id,
+            type: NOTIFICATION_TYPES.WISHLIST_CLAIM_TRANSFERRED,
+          },
+        });
+        expect(rows).toHaveLength(1);
+      }, FANOUT_WAIT);
+      const notification = await prisma.notification.findFirstOrThrow({
         where: {
           userId: waiterContributor.id,
           type: NOTIFICATION_TYPES.WISHLIST_CLAIM_TRANSFERRED,
         },
       });
-      expect(rows).toHaveLength(1);
-    }, FANOUT_WAIT);
-    const notification = await prisma.notification.findFirstOrThrow({
-      where: {
-        userId: waiterContributor.id,
-        type: NOTIFICATION_TYPES.WISHLIST_CLAIM_TRANSFERRED,
-      },
-    });
-    // The item really did move to the waiter — the notification isn't lying.
-    const claim = await prisma.wishlistClaim.findUnique({
-      where: { wishlistItemId: item.id },
-    });
-    expect(claim?.poolId).toBe(waiter.id);
-    // The persisted row's sourceIdentifier is the per-channel ledger key
-    // (`<occurrenceKey>:<channel>`); assert the occurrence key itself,
-    // including the settled claim's own id — this is what keeps a later,
-    // genuinely new settlement onto the same pool+item from matching (and
-    // being suppressed by) this ledger row. See the sibling fix on the
-    // conflict-notification key.
-    expect(notification.sourceIdentifier).toBe(
-      `claim-transferred:${waiter.id}:${item.id}:${claim?.id}:IN_APP`,
-    );
-  });
-
-  it('does not notify a contributor who has muted the inheriting pool, while an unmuted contributor still is', async () => {
-    // Regression: WISHLIST_CLAIM_TRANSFERRED used to be declared context:
-    // 'NONE', which makes resolveNotificationPolicy skip pool-context
-    // preferences entirely — a contributor who muted this exact pool would
-    // still be pinged. It is now context: 'POOL' (the audience is only ever
-    // this pool's own contributors), so a mute must suppress delivery.
-    const { owner, organizer, item } = await fixture();
-    const other = await prisma.wishlistItem.create({
-      data: {
-        ownerId: owner.id,
-        title: 'Headphones',
-        type: 'item',
-        sortOrder: 1,
-      },
-    });
-    const holder = await decidedPoolFor(
-      item.id,
-      owner.id,
-      organizer.id,
-      new Date('2026-07-01'),
-    );
-    await syncPoolClaim(holder.id);
-    const waiter = await decidedPoolFor(
-      item.id,
-      owner.id,
-      organizer.id,
-      new Date('2026-07-10'),
-    );
-
-    const mutedContributor = await prisma.user.create({ data: createUser() });
-    const activeContributor = await prisma.user.create({ data: createUser() });
-    await prisma.poolContributor.create({
-      data: { poolId: waiter.id, userId: mutedContributor.id },
-    });
-    await prisma.poolContributor.create({
-      data: { poolId: waiter.id, userId: activeContributor.id },
-    });
-    await setContextActivityPreference({
-      userId: mutedContributor.id,
-      context: { kind: 'POOL', poolId: waiter.id },
-      activityLevel: NOTIFICATION_ACTIVITY_LEVELS.MUTED,
-      source: 'test',
-    });
-
-    const newIdea = await prisma.giftIdea.create({
-      data: {
-        poolId: holder.id,
-        proposedById: organizer.id,
-        name: 'Headphones',
-        wishlistItemId: other.id,
-      },
-    });
-
-    await chooseIdea(holder.id, newIdea.id, organizer.id);
-
-    // Wait for the unmuted contributor's delivery — proof the fanout ran to
-    // completion — before asserting the muted contributor's negative; a
-    // negative checked too early would pass trivially before the async
-    // fanout even reaches the policy check.
-    await vi.waitFor(async () => {
-      expect(await transferNotificationsFor(activeContributor.id)).toHaveLength(
-        1,
+      // The item really did move to the waiter — the notification isn't lying.
+      const claim = await prisma.wishlistClaim.findUnique({
+        where: { wishlistItemId: item.id },
+      });
+      expect(claim?.poolId).toBe(waiter.id);
+      // The persisted row's sourceIdentifier is the per-channel ledger key
+      // (`<occurrenceKey>:<channel>`); assert the occurrence key itself,
+      // including the settled claim's own id — this is what keeps a later,
+      // genuinely new settlement onto the same pool+item from matching (and
+      // being suppressed by) this ledger row. See the sibling fix on the
+      // conflict-notification key.
+      expect(notification.sourceIdentifier).toBe(
+        `claim-transferred:${waiter.id}:${item.id}:${claim?.id}:IN_APP`,
       );
-    }, FANOUT_WAIT);
-    expect(await transferNotificationsFor(mutedContributor.id)).toHaveLength(0);
-  });
+    },
+    SLOW_DB_TEST_MS,
+  );
 
-  it('scopes the transfer notification key to the settling claim, not just the pool and item', async () => {
-    // Regression: the ledger key used to be `claim-transferred:<poolId>:<itemId>`
-    // with no claim id — permanent for a given pool+item pair. A pool that
-    // inherited, decided away, and inherited again after a fresh claim formed
-    // and released had its second settlement silently suppressed as a
-    // "duplicate."
-    //
-    // Asserting the key contains the settling claim's id proves the fix more
-    // directly, and more cheaply, than driving a full inherit/release/inherit
-    // cycle: WishlistClaim ids are unique per row, so a key that embeds one
-    // cannot collide across genuinely distinct settlements. The cycle version
-    // of this test drove seven sequential chooseIdea calls, each leaving a
-    // fire-and-forget fanout in flight against single-writer SQLite while the
-    // next transaction opened — which starved the database on CI runners under
-    // coverage instrumentation ("Operations timed out ... failed to respond").
-    const { owner, organizer, item } = await fixture();
-    const waiterContributor = await prisma.user.create({ data: createUser() });
-
-    // Note the route through `cancelPool` rather than `releaseUserClaim`: the
-    // fanout is queued by the *callers* of the release paths, after their
-    // transaction closes, never inside the claim module itself. Calling
-    // `releaseUserClaim` directly settles the claim but sends nothing, so a
-    // test driving it would assert against a notification that was never
-    // queued.
-    const holder = await decidedPoolFor(
-      item.id,
-      owner.id,
-      organizer.id,
-      new Date('2026-07-01'),
-    );
-    await syncPoolClaim(holder.id);
-    const waiter = await decidedPoolFor(
-      item.id,
-      owner.id,
-      organizer.id,
-      new Date('2026-07-10'),
-    );
-    await prisma.poolContributor.create({
-      data: { poolId: waiter.id, userId: waiterContributor.id },
-    });
-
-    // The holder cancels: settlement hands the item to the waiting pool.
-    await cancelPool(holder.id, organizer.id);
-
-    const settledClaim = await prisma.wishlistClaim.findUniqueOrThrow({
-      where: { wishlistItemId: item.id },
-    });
-    expect(settledClaim.poolId).toBe(waiter.id);
-
-    await vi.waitFor(async () => {
-      expect(await transferNotificationsFor(waiterContributor.id)).toHaveLength(
-        1,
-      );
-    }, FANOUT_WAIT);
-
-    const notifications = await transferNotificationsFor(waiterContributor.id);
-    expect(notifications).toHaveLength(1);
-    // The claim id is the occurrence component. Without it the key is
-    // permanent for this pool+item and a later settlement is suppressed.
-    expect(notifications[0]?.sourceIdentifier).toContain(settledClaim.id);
-    // Prefix rather than exact match: the dispatcher appends the channel, since
-    // the ledger claims one row per channel per key.
-    expect(notifications[0]?.sourceIdentifier).toMatch(
-      new RegExp(
-        `^claim-transferred:${waiter.id}:${item.id}:${settledClaim.id}:`,
-      ),
-    );
-  });
-
-  it('notifies every contributor of the waiting pool when cancelPool releases a held claim', async () => {
-    const { owner, organizer, item } = await fixture();
-    const holder = await decidedPoolFor(
-      item.id,
-      owner.id,
-      organizer.id,
-      new Date('2026-07-01'),
-    );
-    await syncPoolClaim(holder.id);
-    const waiter = await decidedPoolFor(
-      item.id,
-      owner.id,
-      organizer.id,
-      new Date('2026-07-10'),
-    );
-    const waiterContributor = await prisma.user.create({ data: createUser() });
-    await prisma.poolContributor.create({
-      data: { poolId: waiter.id, userId: waiterContributor.id },
-    });
-
-    await cancelPool(holder.id, organizer.id);
-
-    await vi.waitFor(async () => {
-      const rows = await prisma.notification.findMany({
-        where: {
-          userId: waiterContributor.id,
-          type: NOTIFICATION_TYPES.WISHLIST_CLAIM_TRANSFERRED,
+  it(
+    'does not notify a contributor who has muted the inheriting pool, while an unmuted contributor still is',
+    async () => {
+      // Regression: WISHLIST_CLAIM_TRANSFERRED used to be declared context:
+      // 'NONE', which makes resolveNotificationPolicy skip pool-context
+      // preferences entirely — a contributor who muted this exact pool would
+      // still be pinged. It is now context: 'POOL' (the audience is only ever
+      // this pool's own contributors), so a mute must suppress delivery.
+      const { owner, organizer, item } = await fixture();
+      const other = await prisma.wishlistItem.create({
+        data: {
+          ownerId: owner.id,
+          title: 'Headphones',
+          type: 'item',
+          sortOrder: 1,
         },
       });
-      expect(rows).toHaveLength(1);
-    }, FANOUT_WAIT);
-    const claim = await prisma.wishlistClaim.findUnique({
-      where: { wishlistItemId: item.id },
-    });
-    expect(claim?.poolId).toBe(waiter.id);
-  });
+      const holder = await decidedPoolFor(
+        item.id,
+        owner.id,
+        organizer.id,
+        new Date('2026-07-01'),
+      );
+      await syncPoolClaim(holder.id);
+      const waiter = await decidedPoolFor(
+        item.id,
+        owner.id,
+        organizer.id,
+        new Date('2026-07-10'),
+      );
+
+      const mutedContributor = await prisma.user.create({ data: createUser() });
+      const activeContributor = await prisma.user.create({
+        data: createUser(),
+      });
+      await prisma.poolContributor.create({
+        data: { poolId: waiter.id, userId: mutedContributor.id },
+      });
+      await prisma.poolContributor.create({
+        data: { poolId: waiter.id, userId: activeContributor.id },
+      });
+      await setContextActivityPreference({
+        userId: mutedContributor.id,
+        context: { kind: 'POOL', poolId: waiter.id },
+        activityLevel: NOTIFICATION_ACTIVITY_LEVELS.MUTED,
+        source: 'test',
+      });
+
+      const newIdea = await prisma.giftIdea.create({
+        data: {
+          poolId: holder.id,
+          proposedById: organizer.id,
+          name: 'Headphones',
+          wishlistItemId: other.id,
+        },
+      });
+
+      await chooseIdea(holder.id, newIdea.id, organizer.id);
+
+      // Wait for the unmuted contributor's delivery — proof the fanout ran to
+      // completion — before asserting the muted contributor's negative; a
+      // negative checked too early would pass trivially before the async
+      // fanout even reaches the policy check.
+      await vi.waitFor(async () => {
+        expect(
+          await transferNotificationsFor(activeContributor.id),
+        ).toHaveLength(1);
+      }, FANOUT_WAIT);
+      expect(await transferNotificationsFor(mutedContributor.id)).toHaveLength(
+        0,
+      );
+    },
+    SLOW_DB_TEST_MS,
+  );
+
+  it(
+    'scopes the transfer notification key to the settling claim, not just the pool and item',
+    async () => {
+      // Regression: the ledger key used to be `claim-transferred:<poolId>:<itemId>`
+      // with no claim id — permanent for a given pool+item pair. A pool that
+      // inherited, decided away, and inherited again after a fresh claim formed
+      // and released had its second settlement silently suppressed as a
+      // "duplicate."
+      //
+      // Asserting the key contains the settling claim's id proves the fix more
+      // directly, and more cheaply, than driving a full inherit/release/inherit
+      // cycle: WishlistClaim ids are unique per row, so a key that embeds one
+      // cannot collide across genuinely distinct settlements. The cycle version
+      // of this test drove seven sequential chooseIdea calls, each leaving a
+      // fire-and-forget fanout in flight against single-writer SQLite while the
+      // next transaction opened — which starved the database on CI runners under
+      // coverage instrumentation ("Operations timed out ... failed to respond").
+      const { owner, organizer, item } = await fixture();
+      const waiterContributor = await prisma.user.create({
+        data: createUser(),
+      });
+
+      // Note the route through `cancelPool` rather than `releaseUserClaim`: the
+      // fanout is queued by the *callers* of the release paths, after their
+      // transaction closes, never inside the claim module itself. Calling
+      // `releaseUserClaim` directly settles the claim but sends nothing, so a
+      // test driving it would assert against a notification that was never
+      // queued.
+      const holder = await decidedPoolFor(
+        item.id,
+        owner.id,
+        organizer.id,
+        new Date('2026-07-01'),
+      );
+      await syncPoolClaim(holder.id);
+      const waiter = await decidedPoolFor(
+        item.id,
+        owner.id,
+        organizer.id,
+        new Date('2026-07-10'),
+      );
+      await prisma.poolContributor.create({
+        data: { poolId: waiter.id, userId: waiterContributor.id },
+      });
+
+      // The holder cancels: settlement hands the item to the waiting pool.
+      await cancelPool(holder.id, organizer.id);
+
+      const settledClaim = await prisma.wishlistClaim.findUniqueOrThrow({
+        where: { wishlistItemId: item.id },
+      });
+      expect(settledClaim.poolId).toBe(waiter.id);
+
+      await vi.waitFor(async () => {
+        expect(
+          await transferNotificationsFor(waiterContributor.id),
+        ).toHaveLength(1);
+      }, FANOUT_WAIT);
+
+      const notifications = await transferNotificationsFor(
+        waiterContributor.id,
+      );
+      expect(notifications).toHaveLength(1);
+      // The claim id is the occurrence component. Without it the key is
+      // permanent for this pool+item and a later settlement is suppressed.
+      expect(notifications[0]?.sourceIdentifier).toContain(settledClaim.id);
+      // Prefix rather than exact match: the dispatcher appends the channel, since
+      // the ledger claims one row per channel per key.
+      expect(notifications[0]?.sourceIdentifier).toMatch(
+        new RegExp(
+          `^claim-transferred:${waiter.id}:${item.id}:${settledClaim.id}:`,
+        ),
+      );
+    },
+    SLOW_DB_TEST_MS,
+  );
+
+  it(
+    'notifies every contributor of the waiting pool when cancelPool releases a held claim',
+    async () => {
+      const { owner, organizer, item } = await fixture();
+      const holder = await decidedPoolFor(
+        item.id,
+        owner.id,
+        organizer.id,
+        new Date('2026-07-01'),
+      );
+      await syncPoolClaim(holder.id);
+      const waiter = await decidedPoolFor(
+        item.id,
+        owner.id,
+        organizer.id,
+        new Date('2026-07-10'),
+      );
+      const waiterContributor = await prisma.user.create({
+        data: createUser(),
+      });
+      await prisma.poolContributor.create({
+        data: { poolId: waiter.id, userId: waiterContributor.id },
+      });
+
+      await cancelPool(holder.id, organizer.id);
+
+      await vi.waitFor(async () => {
+        const rows = await prisma.notification.findMany({
+          where: {
+            userId: waiterContributor.id,
+            type: NOTIFICATION_TYPES.WISHLIST_CLAIM_TRANSFERRED,
+          },
+        });
+        expect(rows).toHaveLength(1);
+      }, FANOUT_WAIT);
+      const claim = await prisma.wishlistClaim.findUnique({
+        where: { wishlistItemId: item.id },
+      });
+      expect(claim?.poolId).toBe(waiter.id);
+    },
+    SLOW_DB_TEST_MS,
+  );
 });

--- a/app/utils/wishlist-claims.server.ts
+++ b/app/utils/wishlist-claims.server.ts
@@ -26,6 +26,29 @@ export const POOL_INTENT_STATUSES = [
 
 type Tx = Prisma.TransactionClient;
 
+// Every `$transaction` in this module (and the two in pool.server.ts that
+// wrap `syncPoolClaimInTx` around a status transition) shares this budget.
+// Prisma's interactive-transaction default is 5000ms/2000ms, sized for a
+// local Postgres/dev SQLite file — not for LiteFS-replicated SQLite on Fly,
+// where a write has to round-trip to the primary and CI's coverage
+// instrumentation adds further per-query overhead on top of that. Production
+// incident: this exact transaction (`chooseIdea` -> `syncPoolClaimInTx`) blew
+// the 5000ms default at 5014ms under CI coverage, despite running its usual
+// small, bounded set of queries (a handful of finds/deletes/creates scoped to
+// one pool/item — never anything proportional to unbounded user input). That
+// boundedness is what makes a larger *fixed* ceiling the right fix instead of
+// splitting the transaction: it will either finish well inside the new
+// budget or something is genuinely stuck (e.g. a real deadlock), and it
+// should still fail loudly rather than hang forever.
+//
+// `timeout` (10s) gives ~2x headroom over the observed 5.014s failure.
+// `maxWait` (5s) covers queueing for a connection before the transaction even
+// starts, which matters under write contention — concurrent `chooseIdea`,
+// `cancelPool`, and claim-release calls all funnel through this module and
+// can pile up on the same LiteFS primary. Raised in step with `timeout` for
+// the same replication-latency reason, not picked independently.
+export const CLAIM_TRANSACTION_OPTIONS = { timeout: 10_000, maxWait: 5_000 } as const;
+
 type IntentCandidate = { id: string; decidedAt: Date | null; createdAt: Date };
 
 // SQLite sorts NULL before every value in `ORDER BY ... ASC` — Prisma's
@@ -196,7 +219,7 @@ export async function releaseUserClaim(
       transferredToPoolId: settlement?.poolId ?? null,
       transferredClaimId: settlement?.claimId ?? null,
     };
-  });
+  }, CLAIM_TRANSACTION_OPTIONS);
 }
 
 /**
@@ -233,7 +256,7 @@ export async function releaseSoloClaimForItem(
       transferredToPoolId: settlement?.poolId ?? null,
       transferredClaimId: settlement?.claimId ?? null,
     };
-  });
+  }, CLAIM_TRANSACTION_OPTIONS);
 }
 
 /**
@@ -313,7 +336,10 @@ export async function syncPoolClaimInTx(tx: Tx, poolId: string): Promise<SyncPoo
 }
 
 export async function syncPoolClaim(poolId: string): Promise<SyncPoolClaimResult> {
-  return prisma.$transaction((tx) => syncPoolClaimInTx(tx, poolId));
+  return prisma.$transaction(
+    (tx) => syncPoolClaimInTx(tx, poolId),
+    CLAIM_TRANSACTION_OPTIONS,
+  );
 }
 
 /**
@@ -378,7 +404,7 @@ export async function releaseSoloClaimsMatching(
         transferredToPoolId: settlement?.poolId ?? null,
         transferredClaimId: settlement?.claimId ?? null,
       };
-    });
+    }, CLAIM_TRANSACTION_OPTIONS);
 
     if (outcome.released) {
       released.push({

--- a/app/utils/wishlist-claims.server.ts
+++ b/app/utils/wishlist-claims.server.ts
@@ -42,13 +42,21 @@ function waitedLonger(a: IntentCandidate, b: IntentCandidate): boolean {
   return a.createdAt.getTime() <= b.createdAt.getTime();
 }
 
+// The settlement outcome: which pool inherited the item, and — new — the id
+// of the WishlistClaim row that was just created for it. Callers that fan
+// this settlement out as a notification (queueWishlistClaimTransferredNotification)
+// need the claim id, not just the pool id: it is what makes a later,
+// genuinely new settlement onto the same pool+item distinct from a retry of
+// this one in the notification ledger key. See that function's docstring.
+type ClaimSettlement = { poolId: string; claimId: string };
+
 /**
  * The settlement hook. Runs whenever a claim disappears — and MUST run inside
  * the same transaction as the release. Split them and there is a window where
  * the item reads as unclaimed, letting a third party take an item a pool is
  * actively buying: exactly the bug this feature exists to close.
  */
-async function settleItem(tx: Tx, wishlistItemId: string): Promise<string | null> {
+async function settleItem(tx: Tx, wishlistItemId: string): Promise<ClaimSettlement | null> {
   const existing = await tx.wishlistClaim.findUnique({
     where: { wishlistItemId },
     select: { id: true },
@@ -71,8 +79,11 @@ async function settleItem(tx: Tx, wishlistItemId: string): Promise<string | null
     first,
   );
 
-  await tx.wishlistClaim.create({ data: { wishlistItemId, poolId: heir.id } });
-  return heir.id;
+  const created = await tx.wishlistClaim.create({
+    data: { wishlistItemId, poolId: heir.id },
+    select: { id: true },
+  });
+  return { poolId: heir.id, claimId: created.id };
 }
 
 export type ClaimForUserFailure = {
@@ -130,10 +141,34 @@ export async function claimForUser(
   }
 }
 
+export type ReleaseUserClaimResult =
+  | { ok: true; transferredToPoolId: string | null; transferredClaimId: string | null }
+  // 'not-found' covers both "no claim exists" and "the caller doesn't hold
+  // it" — the caller-facing distinction has never mattered here, only that
+  // nothing was released. 'stale' is new: `expectedClaimId` was supplied and
+  // didn't match the claim actually live on the item right now.
+  | { ok: false; reason: 'not-found' | 'stale' };
+
 export async function releaseUserClaim(
   wishlistItemId: string,
   userId: string,
-): Promise<{ ok: boolean; transferredToPoolId: string | null }> {
+  // The specific WishlistClaim occurrence the caller means to release — e.g.
+  // the id a WISHLIST_CLAIM_CONFLICT notification was raised about, carried
+  // back through its Release action. Omitted by callers acting on "whatever
+  // claim is live right now" (the wishlist page's own release button), which
+  // always passes once the ownership check above holds.
+  //
+  // Binding matters because a notification can outlive the claim it was
+  // about: the claimant releases from the wishlist UI directly (notification
+  // row survives), a pool decides away, the same user re-claims the item —
+  // a brand new WishlistClaim row — and only then clicks Release on the
+  // stale notification. Without this check that release would silently drop
+  // the user's *new* claim, which nothing asked about. Rejecting instead
+  // means the stale notification's action fails safely and the current claim
+  // is left untouched; the caller surfaces this as a distinct, legible error
+  // rather than the generic "not yours to release" message.
+  expectedClaimId?: string,
+): Promise<ReleaseUserClaimResult> {
   return prisma.$transaction(async (tx) => {
     const claim = await tx.wishlistClaim.findUnique({
       where: { wishlistItemId },
@@ -142,7 +177,10 @@ export async function releaseUserClaim(
     // Only a claimer releases their own claim. No override exists, by design:
     // an override could erase evidence of a purchase that physically happened.
     if (!claim || claim.claimedByUserId !== userId) {
-      return { ok: false, transferredToPoolId: null };
+      return { ok: false, reason: 'not-found' };
+    }
+    if (expectedClaimId !== undefined && claim.id !== expectedClaimId) {
+      return { ok: false, reason: 'stale' };
     }
 
     await tx.wishlistClaim.delete({ where: { id: claim.id } });
@@ -152,8 +190,12 @@ export async function releaseUserClaim(
     // runs, a concurrent `claimForUser` could win the free item in that gap,
     // and a pool actively buying it would silently lose out with no error —
     // the exact bug this module exists to close. See `settleItem`'s docstring.
-    const transferredToPoolId = await settleItem(tx, wishlistItemId);
-    return { ok: true, transferredToPoolId };
+    const settlement = await settleItem(tx, wishlistItemId);
+    return {
+      ok: true,
+      transferredToPoolId: settlement?.poolId ?? null,
+      transferredClaimId: settlement?.claimId ?? null,
+    };
   });
 }
 
@@ -170,19 +212,27 @@ export async function releaseUserClaim(
  */
 export async function releaseSoloClaimForItem(
   wishlistItemId: string,
-): Promise<{ ok: boolean; transferredToPoolId: string | null }> {
+): Promise<{
+  ok: boolean;
+  transferredToPoolId: string | null;
+  transferredClaimId: string | null;
+}> {
   return prisma.$transaction(async (tx) => {
     const claim = await tx.wishlistClaim.findUnique({
       where: { wishlistItemId },
       select: { id: true, claimedByUserId: true },
     });
     if (!claim || claim.claimedByUserId === null) {
-      return { ok: false, transferredToPoolId: null };
+      return { ok: false, transferredToPoolId: null, transferredClaimId: null };
     }
 
     await tx.wishlistClaim.delete({ where: { id: claim.id } });
-    const transferredToPoolId = await settleItem(tx, wishlistItemId);
-    return { ok: true, transferredToPoolId };
+    const settlement = await settleItem(tx, wishlistItemId);
+    return {
+      ok: true,
+      transferredToPoolId: settlement?.poolId ?? null,
+      transferredClaimId: settlement?.claimId ?? null,
+    };
   });
 }
 
@@ -194,7 +244,11 @@ export async function releaseSoloClaimForItem(
 export type SyncPoolClaimResult = {
   claimedItemId: string | null;
   conflictedItemId: string | null;
-  released: Array<{ wishlistItemId: string; transferredToPoolId: string | null }>;
+  released: Array<{
+    wishlistItemId: string;
+    transferredToPoolId: string | null;
+    transferredClaimId: string | null;
+  }>;
 };
 
 /**
@@ -226,10 +280,18 @@ export async function syncPoolClaimInTx(tx: Tx, poolId: string): Promise<SyncPoo
   }
   // Settle only after every release, so an heir can't take an item this pool
   // is about to release and then re-take.
-  const released: Array<{ wishlistItemId: string; transferredToPoolId: string | null }> = [];
+  const released: Array<{
+    wishlistItemId: string;
+    transferredToPoolId: string | null;
+    transferredClaimId: string | null;
+  }> = [];
   for (const itemId of releasedItemIds) {
-    const transferredToPoolId = await settleItem(tx, itemId);
-    released.push({ wishlistItemId: itemId, transferredToPoolId });
+    const settlement = await settleItem(tx, itemId);
+    released.push({
+      wishlistItemId: itemId,
+      transferredToPoolId: settlement?.poolId ?? null,
+      transferredClaimId: settlement?.claimId ?? null,
+    });
   }
 
   if (!intendedItemId) {
@@ -284,13 +346,23 @@ export async function syncPoolClaim(poolId: string): Promise<SyncPoolClaimResult
  */
 export async function releaseSoloClaimsMatching(
   where: Prisma.WishlistClaimWhereInput,
-): Promise<Array<{ wishlistItemId: string; transferredToPoolId: string | null }>> {
+): Promise<
+  Array<{
+    wishlistItemId: string;
+    transferredToPoolId: string | null;
+    transferredClaimId: string | null;
+  }>
+> {
   const claims = await prisma.wishlistClaim.findMany({
     where,
     select: { id: true, wishlistItemId: true },
   });
 
-  const released: Array<{ wishlistItemId: string; transferredToPoolId: string | null }> = [];
+  const released: Array<{
+    wishlistItemId: string;
+    transferredToPoolId: string | null;
+    transferredClaimId: string | null;
+  }> = [];
   for (const claim of claims) {
     const outcome = await prisma.$transaction(async (tx) => {
       const current = await tx.wishlistClaim.findFirst({
@@ -300,12 +372,20 @@ export async function releaseSoloClaimsMatching(
       if (!current) return { released: false as const };
 
       await tx.wishlistClaim.delete({ where: { id: claim.id } });
-      const transferredToPoolId = await settleItem(tx, claim.wishlistItemId);
-      return { released: true as const, transferredToPoolId };
+      const settlement = await settleItem(tx, claim.wishlistItemId);
+      return {
+        released: true as const,
+        transferredToPoolId: settlement?.poolId ?? null,
+        transferredClaimId: settlement?.claimId ?? null,
+      };
     });
 
     if (outcome.released) {
-      released.push({ wishlistItemId: claim.wishlistItemId, transferredToPoolId: outcome.transferredToPoolId });
+      released.push({
+        wishlistItemId: claim.wishlistItemId,
+        transferredToPoolId: outcome.transferredToPoolId,
+        transferredClaimId: outcome.transferredClaimId,
+      });
     }
   }
   return released;

--- a/app/utils/wishlist-claims.server.ts
+++ b/app/utils/wishlist-claims.server.ts
@@ -165,7 +165,18 @@ export async function claimForUser(
 }
 
 export type ReleaseUserClaimResult =
-  | { ok: true; transferredToPoolId: string | null; transferredClaimId: string | null }
+  | {
+      ok: true;
+      // The id of the WishlistClaim row that was just deleted — the exact
+      // occurrence, not the item. Callers use this to resolve any
+      // WISHLIST_CLAIM_CONFLICT notification raised about this same claim
+      // (its metadata.claimId matches), so a notification's Release action
+      // can't resurface for a claim that no longer exists. Always the claim
+      // that was live, regardless of whether `expectedClaimId` was supplied.
+      releasedClaimId: string;
+      transferredToPoolId: string | null;
+      transferredClaimId: string | null;
+    }
   // 'not-found' covers both "no claim exists" and "the caller doesn't hold
   // it" — the caller-facing distinction has never mattered here, only that
   // nothing was released. 'stale' is new: `expectedClaimId` was supplied and
@@ -216,6 +227,7 @@ export async function releaseUserClaim(
     const settlement = await settleItem(tx, wishlistItemId);
     return {
       ok: true,
+      releasedClaimId: claim.id,
       transferredToPoolId: settlement?.poolId ?? null,
       transferredClaimId: settlement?.claimId ?? null,
     };

--- a/app/utils/wishlist.server.ts
+++ b/app/utils/wishlist.server.ts
@@ -43,10 +43,11 @@ export async function cleanupWishlistClaimsForOwner(ownerId: string) {
   });
 
   for (const release of released) {
-    if (!release.transferredToPoolId) continue;
+    if (!release.transferredToPoolId || !release.transferredClaimId) continue;
     queueWishlistClaimTransferredNotification(
       release.transferredToPoolId,
       release.wishlistItemId,
+      release.transferredClaimId,
     );
   }
 }

--- a/app/utils/wishlist.server.ts
+++ b/app/utils/wishlist.server.ts
@@ -1,6 +1,7 @@
 import { createHash, randomBytes } from 'node:crypto';
 import { prisma } from './db.server.ts';
 import { usersShareAGroupOrAreFriendsByIds } from './groups.server.ts';
+import { queueWishlistClaimTransferredNotification } from './pool.server.ts';
 import { releaseSoloClaimsMatching } from './wishlist-claims.server.ts';
 
 const PUBLIC_SHARE_TOKEN_BYTES = 24;
@@ -13,7 +14,7 @@ export async function cleanupWishlistClaimsForOwner(ownerId: string) {
   // match many claims at once (scoped by owner, not by item), which is why
   // it goes through the batch-capable `releaseSoloClaimsMatching` rather than
   // one-at-a-time `releaseSoloClaimForItem`.
-  await releaseSoloClaimsMatching({
+  const released = await releaseSoloClaimsMatching({
     wishlistItem: { ownerId },
     // Solo claims only. A pool-held claim has claimedByUserId: null (see
     // the DB CHECK in the WishlistClaim migration — exactly one of
@@ -40,6 +41,14 @@ export async function cleanupWishlistClaimsForOwner(ownerId: string) {
       ],
     },
   });
+
+  for (const release of released) {
+    if (!release.transferredToPoolId) continue;
+    queueWishlistClaimTransferredNotification(
+      release.transferredToPoolId,
+      release.wishlistItemId,
+    );
+  }
 }
 
 export async function usersShareWishlistAccess({

--- a/tests/e2e/pool-wishlist-claims.test.ts
+++ b/tests/e2e/pool-wishlist-claims.test.ts
@@ -1,0 +1,248 @@
+import { type Page } from '@playwright/test';
+import { prisma } from '#app/utils/db.server.ts';
+import { addContributor, createPool } from '#app/utils/pool.server.ts';
+import { createPassword, createUser } from '#tests/db-utils.ts';
+import { expect, test, waitFor } from '#tests/playwright-utils.ts';
+
+const connectUserRole = { connect: { name: 'user' } };
+
+const createFriendship = async (userOneId: string, userTwoId: string) => {
+  const [userAId, userBId] =
+    userOneId < userTwoId ? [userOneId, userTwoId] : [userTwoId, userOneId];
+  await prisma.friendship.create({ data: { userAId, userBId } });
+};
+
+async function createAppUser() {
+  const userData = createUser();
+  return prisma.user.create({
+    select: { id: true, username: true, name: true },
+    data: {
+      ...userData,
+      roles: connectUserRole,
+      password: { create: createPassword(userData.username) },
+    },
+  });
+}
+
+const dismissInstallPrompt = async (page: Page) => {
+  const notNow = page.getByRole('button', { name: /not now/i });
+  if ((await notNow.count()) > 0) {
+    await notNow.click();
+  }
+};
+
+// Covers the headline journey this feature exists for: a friend claims an
+// item, a pool decides on it anyway (conflict warning, no claim taken), the
+// friend is asked to keep or release, releases, and the pool inherits the
+// claim while its contributors are told. Closes with a third, unrelated
+// viewer seeing the item as claimed with zero attribution — the privacy
+// ladder holding even after the claim has changed hands twice.
+test('a pool inherits a released claim after a conflicted decision, and contributors are told', async ({
+  page,
+  login,
+}) => {
+  const createdUserIds: string[] = [];
+  const createdPoolIds: string[] = [];
+
+  const [owner, claimer, organizer, contributor, thirdViewer] =
+    await Promise.all([
+      createAppUser(),
+      createAppUser(),
+      createAppUser(),
+      createAppUser(),
+      createAppUser(),
+    ]);
+  createdUserIds.push(
+    owner.id,
+    claimer.id,
+    organizer.id,
+    contributor.id,
+    thirdViewer.id,
+  );
+  await Promise.all([
+    createFriendship(owner.id, claimer.id),
+    createFriendship(owner.id, thirdViewer.id),
+  ]);
+
+  const wishlistItem = await prisma.wishlistItem.create({
+    select: { id: true, title: true },
+    data: {
+      ownerId: owner.id,
+      title: 'Espresso Machine',
+      type: 'text',
+      sortOrder: 0,
+    },
+  });
+
+  try {
+    // ── Step 1: a friend claims the item ──────────────────────────────────
+    await page.context().clearCookies();
+    await login({ id: claimer.id });
+    await page.goto(`/users/${owner.username}/wishlist`);
+    await dismissInstallPrompt(page);
+    await expect(page.getByText(wishlistItem.title)).toBeVisible();
+    await page
+      .getByRole('button', { name: "I'll grab this gift", exact: true })
+      .click();
+    await waitFor(
+      () =>
+        prisma.wishlistClaim.findUnique({
+          where: { wishlistItemId: wishlistItem.id },
+        }),
+      { timeout: 8000 },
+    );
+
+    const claimAfterStep1 = await prisma.wishlistClaim.findUniqueOrThrow({
+      where: { wishlistItemId: wishlistItem.id },
+    });
+    expect(claimAfterStep1.claimedByUserId).toBe(claimer.id);
+    expect(claimAfterStep1.poolId).toBeNull();
+
+    // ── Step 2: a pool decides on the same item — conflict warning, no claim ──
+    const pool = await createPool({
+      organizerId: organizer.id,
+      recipientUserId: owner.id,
+      recipientName: owner.name ?? owner.username,
+      title: 'Housewarming Pool',
+    });
+    createdPoolIds.push(pool.id);
+    await addContributor(pool.id, contributor.id);
+    const idea = await prisma.giftIdea.create({
+      select: { id: true },
+      data: {
+        poolId: pool.id,
+        proposedById: organizer.id,
+        name: wishlistItem.title,
+        wishlistItemId: wishlistItem.id,
+      },
+    });
+
+    await page.context().clearCookies();
+    await login({ id: organizer.id });
+    await page.goto(`/pools/${pool.id}`);
+    await dismissInstallPrompt(page);
+
+    const ideaCard = page
+      .getByTestId('idea-card')
+      .filter({ hasText: wishlistItem.title });
+    await expect(ideaCard.getByText('Already claimed')).toBeVisible();
+
+    await ideaCard.getByRole('button', { name: 'Choose', exact: true }).click();
+    await expect(page.getByText("This one's already claimed")).toBeVisible();
+    await page
+      .getByRole('button', { name: 'Choose it anyway', exact: true })
+      .click();
+
+    // Decision lands, the pool's own conflict badge persists post-decision,
+    // and the organizer is warned rather than told it succeeded.
+    await expect(page.getByTestId('chosen-gift-conflict')).toBeVisible();
+    await expect(page.getByText(/your pool didn't get it/i)).toBeVisible();
+
+    await expect(
+      prisma.pool.findUniqueOrThrow({
+        where: { id: pool.id },
+        select: { status: true, chosenIdeaId: true },
+      }),
+    ).resolves.toEqual({ status: 'DECIDED', chosenIdeaId: idea.id });
+
+    // The pool took no claim — it's still the friend's.
+    const claimAfterConflict = await prisma.wishlistClaim.findUniqueOrThrow({
+      where: { wishlistItemId: wishlistItem.id },
+    });
+    expect(claimAfterConflict.claimedByUserId).toBe(claimer.id);
+    expect(claimAfterConflict.poolId).toBeNull();
+
+    // ── Step 3: the friend is asked whether they're still getting it ───────
+    await waitFor(
+      () =>
+        prisma.notification.findFirst({
+          where: { userId: claimer.id, type: 'WISHLIST_CLAIM_CONFLICT' },
+        }),
+      { timeout: 8000 },
+    );
+
+    await page.context().clearCookies();
+    await login({ id: claimer.id });
+    await page.goto(`/users/${owner.username}/wishlist`);
+    await dismissInstallPrompt(page);
+    await page
+      .getByRole('button', { name: 'Notifications', exact: true })
+      .click();
+    await expect(
+      page.getByText(/Are you still getting it yourself/i),
+    ).toBeVisible();
+    const keepButton = page.getByRole('button', {
+      name: 'Keep it',
+      exact: true,
+    });
+    const releaseButton = page.getByRole('button', {
+      name: 'Release it',
+      exact: true,
+    });
+    await expect(keepButton).toBeVisible();
+    await expect(releaseButton).toBeVisible();
+
+    // ── Step 4: the friend releases ─────────────────────────────────────────
+    await releaseButton.click();
+    await expect(
+      page.getByText(/Released.*group's got it from here/i),
+    ).toBeVisible();
+
+    // ── Step 5: the pool inherits the claim, and contributors are told ─────
+    const claimAfterRelease = await waitFor(
+      async () => {
+        const claim = await prisma.wishlistClaim.findUnique({
+          where: { wishlistItemId: wishlistItem.id },
+        });
+        return claim?.poolId === pool.id ? claim : null;
+      },
+      { timeout: 8000 },
+    );
+    expect(claimAfterRelease.claimedByUserId).toBeNull();
+    expect(claimAfterRelease.poolId).toBe(pool.id);
+
+    // Every contributor is told, not just the one who chose the idea.
+    await waitFor(
+      () =>
+        prisma.notification.findFirst({
+          where: { userId: organizer.id, type: 'WISHLIST_CLAIM_TRANSFERRED' },
+        }),
+      { timeout: 8000 },
+    );
+    await waitFor(
+      () =>
+        prisma.notification.findFirst({
+          where: {
+            userId: contributor.id,
+            type: 'WISHLIST_CLAIM_TRANSFERRED',
+          },
+        }),
+      { timeout: 8000 },
+    );
+
+    await page.context().clearCookies();
+    await login({ id: organizer.id });
+    await page.goto(`/pools/${pool.id}`);
+    await dismissInstallPrompt(page);
+    await page
+      .getByRole('button', { name: 'Notifications', exact: true })
+      .click();
+    await expect(
+      page.getByText(/no more duplicate risk from that claim/i),
+    ).toBeVisible();
+
+    // ── Bonus: a third, unrelated viewer sees it as claimed, unattributed ──
+    await page.context().clearCookies();
+    await login({ id: thirdViewer.id });
+    await page.goto(`/users/${owner.username}/wishlist`);
+    await dismissInstallPrompt(page);
+    const thirdViewerCard = page
+      .getByTestId('wishlist-item-card')
+      .filter({ hasText: wishlistItem.title });
+    await expect(thirdViewerCard.getByText('Claimed').first()).toBeVisible();
+    await expect(page.getByText(pool.title)).toHaveCount(0);
+  } finally {
+    await prisma.pool.deleteMany({ where: { id: { in: createdPoolIds } } });
+    await prisma.user.deleteMany({ where: { id: { in: createdUserIds } } });
+  }
+});


### PR DESCRIPTION
## Summary

The last of four PRs. Until now a claim conflict could be *seen* but never *resolved*: a pool would decide on an item someone else held, warn the organizer, and stop there. This makes it resolvable.

- **The claim holder is asked.** A conflicted decision sends them one notification with inline **Keep it** / **Release it**.
- **Release hands the item over.** It runs through the claim module's transactional release-and-settle path, so the pool inherits immediately.
- **Keep deliberately permits a duplicate.** Overriding someone's claim is an explicit non-goal — it could erase evidence of a purchase that physically happened.
- **The pool is told when it inherits**, closing a loop that was previously left open: an organizer warned of duplicate risk never learned when that risk went away.

## Notification design

Three types were planned; two ship, under **one shared topic** so this adds a single preference toggle rather than three (per the catalog rule in `AGENTS.md`).

`WISHLIST_CLAIM_RELEASED` was dropped. Nothing sent it — a cancelled pool's release either transfers (covered) or frees an item nobody awaited. Leaving it registered meant a `throw` in the render switch, a trap for whoever queued it later assuming it worked.

**Every** settlement path that hands a claim to a pool notifies: a solo release, an archive, access cleanup, account deletion, and a re-decide or cancellation freeing an item another pool was waiting on. The shared helper **re-reads the claim** rather than trusting the caller's snapshot, so it stays silent if the claim moved again before the fanout ran. Deduped on `claim-transferred:<poolId>:<wishlistItemId>` through the `NotificationDelivery` ledger, and fire-and-forget into `captureException` so a fanout failure can never turn a committed release into a 500.

## Copy

Eight findings across the previous PRs were all one class: strings asserting more than the code does. This PR's copy is scoped deliberately — the transfer notification says there is no more duplicate risk **from that claim**, not that duplicate risk is gone, because a different pool can still choose the item anyway.

It also updates the pool-page warning that previously said "there's a real risk you both end up buying it". That was accurate only because this flow didn't exist; now it does.

## Test plan

- `npm test -- --run` — **236 files / 1599 tests, exit 0**
- `npm run typecheck` clean, `npm run lint` 0 errors
- **New e2e** (`tests/e2e/pool-wishlist-claims.test.ts`) covers the whole journey: friend claims → pool decides anyway and takes nothing → friend is asked → friend releases → pool inherits and both the organizer and a non-acting contributor are notified. It also asserts an unrelated viewer sees the item as claimed with **zero attribution**.

E2E was run locally on `PORT=3100` to avoid Playwright's `reuseExistingServer` adopting a dev server on :3000. Verified genuine: 65 `[WebServer]` lines, exit 0 under `set -o pipefail`, `.last-run.json` `status: "passed"`.

## Follow-up

#533 (account-deletion FK-cascade race) remains open and is unaffected by this PR.

https://claude.ai/code/session_01TGwCvTjxaDbeuZo8DrX2Qx